### PR TITLE
Freeze the punt set: fallback-zero asserts the exhaustive fallback surface

### DIFF
--- a/test/integration/fallback-zero-test.janet
+++ b/test/integration/fallback-zero-test.janet
@@ -72,12 +72,32 @@
    "(defonce fz-once 1)" "(read-string \"[1 2]\")"
    "(macroexpand-1 (quote (when true 1)))"])
 
-# --- Intentional fallback (sanity sample): these SHOULD punt to the interpreter.
-# The remaining frozen/uncompiled set keeps the harness honest in the punt
-# direction: defmacro + set! (frozen host-coupled), and letfn (needs letrec IR).
+# --- THE FROZEN PUNT SET (Stage 2 complete) ---------------------------------
+# These are the ONLY heads that may reach the interpreter, exhaustively:
+#   defmacro          — definitional host seam (the EXPANDERS are compiled;
+#                       see backend/recompile-macros!)
+#   set!              — host var-cell mutation special
+#   letfn             — needs letrec IR (sequential let* can't express mutual
+#                       recursion); permanent-interpret unless the IR gains it
+#   eval              — compile-and-run entry (also loader stateful-head?)
+#   . / new / Foo. /  — thin host-interop heads the back end doesn't model
+#   .method
+#   gen-class, monitor-enter, monitor-exit — JVM-compat stubs
+# Growing this list is a REGRESSION: a new punt means the compiler lost
+# coverage. Shrinking it (e.g. letfn via letrec IR) is progress — move the
+# form to must-compile.
 (def must-punt
   ["(defmacro m [x] x)"
-   "(set! *warn-on-reflection* true)" "(letfn [(f [n] (g n)) (g [n] (f n))] (f 1))"])
+   "(set! *warn-on-reflection* true)"
+   "(letfn [(f [n] (g n)) (g [n] (f n))] (f 1))"
+   "(eval (quote (+ 1 2)))"
+   "(.method obj)"
+   "(.-field obj)"
+   "(new Foo 1)"
+   "(Foo. 1)"
+   "(gen-class :name X)"
+   "(monitor-enter x)"
+   "(monitor-exit x)"])
 
 (var fails @[])
 (each s must-compile


### PR DESCRIPTION
With tiers 6a–6c done, the interpreter punt surface is down to the frozen curated set: defmacro, set!, letfn (needs letrec IR), eval, the host-interop heads (./new/Foo./.method), and the JVM-compat stubs (gen-class, monitor-enter/exit). must-punt now enumerates it exhaustively — growing the list is a regression; shrinking it is progress. Stage 2 definition-of-done for the special-names tail. 73 must-compile + 11 must-punt, 0 failures; conformance 296×3, fixpoint green.