### PR TITLE
Fix doc/ -> docs/ references missed in the consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jpm build                     # builds build/jolt and build/jolt-deps
 ```
 
 Requires `jpm` and a recent Janet (CI-tested against 1.41). See
-[doc/building-and-deps.md](doc/building-and-deps.md) for build details, the
+[docs/building-and-deps.md](docs/building-and-deps.md) for build details, the
 `jpm clean` caveat, how namespaces are resolved (`JOLT_PATH`), and pulling
 Clojure libraries from a `deps.edn` with the `jolt-deps` tool.
 
@@ -226,7 +226,7 @@ are `["label" expected actual]`, compared with Jolt's own `=`) plus
 `expect=`/`expect-throws` for unit tests.
 
 The syntactic half of the contract — the surface syntax the reader accepts — is
-specified as an EBNF grammar in [`doc/grammar.ebnf`](doc/grammar.ebnf), with
+specified as an EBNF grammar in [`docs/grammar.ebnf`](docs/grammar.ebnf), with
 Jolt-vs-Clojure deviations noted inline. `test/spec/reader-syntax-spec.janet`
 exercises it.
 

--- a/test/integration/deps-conformance-test.janet
+++ b/test/integration/deps-conformance-test.janet
@@ -2,7 +2,7 @@
 # git libraries and check that their namespaces load and a sample call works.
 #
 # Network-gated: set JOLT_CONFORMANCE=1 to run (it clones from GitHub). Skipped by
-# default so CI stays offline. Findings are summarized in doc/tools-deps.md.
+# default so CI stays offline. Findings are summarized in docs/tools-deps.md.
 
 (use ../../src/jolt/api)
 (use ../../src/jolt/types)


### PR DESCRIPTION
The doc/ directory moved to docs/ in #31 but the README and deps-conformance-test path references were dropped from that commit. Two-line fix.