### PR TITLE
CI: bump checkout/cache actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       # spiking doesn't time out and drop total-pass below the baseline.
       JOLT_SUITE_TIMEOUT: "20"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Submodules: vendor/sci (SCI bootstrap/runtime tests) and
           # vendor/clojure-test-suite (the cross-dialect conformance battery,
@@ -25,7 +25,7 @@ jobs:
 
       - name: Cache Janet build
         id: cache-janet
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/janet
           key: janet-${{ env.JANET_VERSION }}-${{ runner.os }}


### PR DESCRIPTION
GitHub forces Node 24 for JS actions starting June 16 2026; v4 runs on deprecated Node 20. The CI run on this PR validates the bump.