### PR TITLE
core: Stage 3 — the *in* reader family is Clojure (50-io tier)

### DIFF
--- a/jolt-core/clojure/core/50-io.clj
+++ b/jolt-core/clojure/core/50-io.clj
@@ -1,0 +1,100 @@
+;; clojure.core — IO tier: the *in* reader family (jolt-0d9).
+;;
+;; *in* is a dynamic var holding a READER: a plain map whose two ops close
+;; over their source — :read-line-fn (next line, newline
+;; stripped, nil at EOF) and :read-fn (next FORM, advancing past exactly that
+;; form; the eof sentinel at end of input). The default *in* reads real stdin
+;; through the host seam __stdin-read-line, with a shared leftover buffer so
+;; read and read-line interleave; with-in-str rebinds *in* to a string reader
+;; over one atom-held buffer, so (read) consumes its form and a following
+;; (read-line) returns the REST of that line — as in Clojure.
+;;
+;; Forms are parsed by the host seam __parse-next (one form + the rest of the
+;; string, nil when only whitespace remains). Known wart shared with that
+;; contract: input that is only a comment reads as nil rather than EOF.
+
+(def ^:private reader-eof :jolt/reader-eof)
+
+(defn __string-reader
+  "A reader over string s (the with-in-str expansion calls this)."
+  [s]
+  (let [buf (atom s)]
+    {:read-line-fn
+     (fn []
+       (let [cur @buf]
+         (when (pos? (count cur))
+           (let [i (str-find "\n" cur)]
+             (if (nil? i)
+               (do (reset! buf "") cur)
+               (do (reset! buf (subs cur (inc i))) (subs cur 0 i)))))))
+     :read-fn
+     (fn []
+       (let [r (__parse-next @buf)]
+         (if (nil? r)
+           reader-eof
+           (do (reset! buf (nth r 1)) (nth r 0)))))}))
+
+;; Real stdin, with a leftover buffer shared by read and read-line: read may
+;; pull a whole line to parse a form and must hand the remainder to the next
+;; read/read-line.
+(def ^:private stdin-buf (atom ""))
+
+(def ^:dynamic *in*
+  {:read-line-fn
+   (fn []
+     (let [cur @stdin-buf]
+       (if (pos? (count cur))
+         (let [i (str-find "\n" cur)]
+           (if (nil? i)
+             (do (reset! stdin-buf "") cur)
+             (do (reset! stdin-buf (subs cur (inc i))) (subs cur 0 i))))
+         (__stdin-read-line))))
+   :read-fn
+   (fn []
+     (loop []
+       (let [r (__parse-next @stdin-buf)]
+         (if (nil? r)
+           (let [line (__stdin-read-line)]
+             (if (nil? line)
+               reader-eof
+               (do (swap! stdin-buf (fn [b] (str b line "\n"))) (recur))))
+           (do (reset! stdin-buf (nth r 1)) (nth r 0))))))})
+
+(defn read-line
+  "Reads the next line from the stream that is the current value of *in*.
+  Returns nil at EOF."
+  []
+  ((:read-line-fn *in*)))
+
+(defn read
+  "Reads the next object from stream (defaults to *in*). At EOF, throws —
+  or returns eof-value when eof-error? is false."
+  ([] (read *in*))
+  ([stream]
+   (let [v ((:read-fn stream))]
+     (if (= v reader-eof)
+       (throw (ex-info "EOF while reading" {}))
+       v)))
+  ([stream eof-error? eof-value]
+   (let [v ((:read-fn stream))]
+     (if (= v reader-eof)
+       (if eof-error? (throw (ex-info "EOF while reading" {})) eof-value)
+       v))))
+
+(defmacro with-in-str
+  "Evaluates body with *in* bound to a fresh reader over string s."
+  [s & body]
+  `(binding [*in* (__string-reader ~s)]
+     ~@body))
+
+(defn line-seq
+  "Returns the lines of text from rdr as a lazy sequence of strings, as by
+  read-line. (Jolt extension kept from the old kernel stub: a plain string
+  splits into its lines.)"
+  [rdr]
+  (if (string? rdr)
+    (seq (str-split "\n" rdr))
+    (lazy-seq
+      (let [line ((:read-line-fn rdr))]
+        (when line
+          (cons line (line-seq rdr)))))))

--- a/src/jolt/api.janet
+++ b/src/jolt/api.janet
@@ -61,7 +61,8 @@
    {:ns "clojure.core.20-coll"   :kernel false}
    {:ns "clojure.core.25-sorted" :kernel false}
    {:ns "clojure.core.30-macros" :kernel false}
-   {:ns "clojure.core.40-lazy"   :kernel false}])
+   {:ns "clojure.core.40-lazy"   :kernel false}
+   {:ns "clojure.core.50-io"     :kernel false}])
 
 (defn- eval-overlay-source [ctx src]
   (var s src)

--- a/src/jolt/core.janet
+++ b/src/jolt/core.janet
@@ -2566,8 +2566,8 @@
 (defn core-enumeration-seq [x] (core-seq x))
 (defn core-iterator-seq [x] (core-seq x))
 # xml-seq now lives in the Clojure collection tier (core/20-coll.clj).
-(defn core-line-seq [rdr]
-  (if (string? rdr) (core-seq (string/split "\n" rdr)) nil))
+# line-seq now lives in the Clojure IO tier (core/50-io.clj), over the reader
+# protocol of the *in* family.
 (defn core-re-matcher [re s] @{:jolt/type :jolt/matcher :re re :s s :pos 0})
 
 # JVM reflection / proxies — not applicable on a Janet host; resolve-only.
@@ -3106,7 +3106,6 @@
     "test" core-test
     "enumeration-seq" core-enumeration-seq
     "iterator-seq" core-iterator-seq
-    "line-seq" core-line-seq
     "re-matcher" core-re-matcher
     "bean" core-bean
     "print-method" core-print-method

--- a/src/jolt/evaluator.janet
+++ b/src/jolt/evaluator.janet
@@ -1122,6 +1122,20 @@
   # Reader / expansion as plain fns: read-string parses one form; macroexpand-1
   # expands a (quoted, already-evaluated) call form once via its macro var.
   (ns-intern core "read-string" (fn [s] (parse-string s)))
+  # The *in* reader family's host seams. __stdin-read-line: one line from real
+  # stdin, newline stripped, nil at EOF. __parse-next: one form off a string ->
+  # [form rest-of-string], nil when only whitespace remains. *in*, read-line,
+  # read, with-in-str, and line-seq are Clojure over these (core/50-io.clj).
+  (ns-intern core "__stdin-read-line"
+    (fn []
+      (let [l (file/read stdin :line)]
+        (if (nil? l) nil
+          (let [s (string l)]
+            (if (string/has-suffix? "\n" s) (string/slice s 0 -2) s))))))
+  (ns-intern core "__parse-next"
+    (fn [s]
+      (if (= 0 (length (string/trim s))) nil
+        (let [r (parse-next s)] (tuple (r 0) (r 1))))))
   (def expand-1 (fn [the-form]
     (if (and (array? the-form) (> (length the-form) 0)
              (struct? (first the-form)) (= :symbol ((first the-form) :jolt/type)))

--- a/test/spec/io-spec.janet
+++ b/test/spec/io-spec.janet
@@ -24,3 +24,33 @@
   ["str of coll"     "\"[1 2]\""   "(str [1 2])"]
   ["format d/s"      "\"5-x\""     "(format \"%d-%s\" 5 \"x\")"]
   ["format float"    "\"3.14\""    "(format \"%.2f\" 3.14159)"])
+
+# The *in* reader family (jolt-0d9): *in* is a dynamic var holding a reader;
+# with-in-str rebinds it to a string reader over one shared buffer, so read
+# (consumes exactly one form) and read-line (rest of that line) interleave
+# correctly, as in Clojure.
+(defspec "io / *in* + with-in-str + read-line"
+  ["read-line one line"   "\"hello\""        "(with-in-str \"hello\" (read-line))"]
+  ["read-line strips nl"  "\"a\""            "(with-in-str \"a\\nb\" (read-line))"]
+  ["read-line sequential" "[\"a\" \"b\"]"    "(with-in-str \"a\\nb\" [(read-line) (read-line)])"]
+  ["read-line EOF nil"    "nil"              "(with-in-str \"\" (read-line))"]
+  ["read-line after last" "[\"x\" nil]"      "(with-in-str \"x\" [(read-line) (read-line)])"]
+  ["empty line"           "[\"\" \"y\"]"     "(with-in-str \"\\ny\" [(read-line) (read-line)])"]
+  ["*in* is bound"        "true"             "(with-in-str \"\" (map? *in*))"])
+
+(defspec "io / read"
+  ["read a form"          "42"               "(with-in-str \"42\" (read))"]
+  ["read a list form"     "(quote (+ 1 2))"  "(with-in-str \"(+ 1 2)\" (read))"]
+  ["read two forms"       "[1 2]"            "(with-in-str \"1 2\" [(read) (read)])"]
+  ["read then read-line"  "[1 \" rest\"]"    "(with-in-str \"1 rest\\nnext\" [(read) (read-line)])"]
+  ["read vector"          "[1 2]"            "(with-in-str \"[1 2]\" (read))"]
+  ["read nil literal"     "nil"              "(with-in-str \"nil\" (read))"]
+  ["read EOF throws"      :throws            "(with-in-str \"\" (read))"]
+  ["read EOF value"       ":done"            "(with-in-str \"\" (read *in* false :done))"]
+  ["read eval data"       "3"                "(with-in-str \"(+ 1 2)\" (eval (read)))"])
+
+(defspec "io / line-seq"
+  ["line-seq"             "[\"a\" \"b\" \"c\"]" "(with-in-str \"a\\nb\\nc\" (vec (line-seq *in*)))"]
+  ["line-seq empty"       "nil"              "(with-in-str \"\" (seq (line-seq *in*)))"]
+  ["line-seq is lazy seq" "true"             "(with-in-str \"a\\nb\" (seq? (line-seq *in*)))"]
+  ["line-seq count"       "3"                "(with-in-str \"1\\n2\\n3\" (count (line-seq *in*)))"])


### PR DESCRIPTION
Re-opened after #44 merged (the original #45 was stacked on the sorted branch and got auto-closed with it; now rebased onto main).

*in*/read-line/read/with-in-str/line-seq as a new overlay IO tier (core/50-io.clj); the seed grows two seams (__stdin-read-line, __parse-next) and loses the line-seq stub. read and read-line interleave on one shared buffer (string and stdin readers), as in Clojure. 20 new io-spec rows; gate green (conformance 326x3, suite 4577, full jpm test). Tracker: jolt-0d9.