### PR TITLE
host: JOLT_BAKE_ENV_ALLOWLIST scrubs the env during image bakes (jolt-s3j)

### DIFF
--- a/src/jolt/evaluator.janet
+++ b/src/jolt/evaluator.janet
@@ -493,7 +493,26 @@
                      "user.home" (os/getenv "HOME")
                      "java.io.tmpdir" (or (os/getenv "TMPDIR") "/tmp")
                      dflt))
-   "getenv" (fn [&opt k] (if k (os/getenv k) (os/environ)))
+   # JOLT_BAKE_ENV_ALLOWLIST (jolt-s3j): during an image bake (jpm build of a
+   # native executable, set by the project's build.sh) the env snapshot that
+   # libraries like config.core capture at load gets MARSHALED INTO THE BINARY
+   # — GitHub push protection once flagged real API tokens inside an example's
+   # build output. With the var set, System/getenv serves only the listed
+   # comma-separated names (single-var reads of unlisted names return nil), so
+   # nothing secret can bake. Unset (the normal runtime case), reads are live
+   # and unfiltered.
+   "getenv" (fn [&opt k]
+              (def allow (os/getenv "JOLT_BAKE_ENV_ALLOWLIST"))
+              (if (nil? allow)
+                (if k (os/getenv k) (os/environ))
+                (let [names (string/split "," allow)
+                      ok @{}]
+                  (each n names (put ok (string/trim n) true))
+                  (if k
+                    (when (get ok k) (os/getenv k))
+                    (let [e (os/environ) out @{}]
+                      (eachp [ek ev] e (when (get ok ek) (put out ek ev)))
+                      out)))))
    # the property subset getProperty serves, as an iterable map
    "getProperties" (fn []
                      {"os.name" (case (os/which)

--- a/test/spec/host-interop-spec.janet
+++ b/test/spec/host-interop-spec.janet
@@ -186,3 +186,16 @@
   ["replace fn gets group vector" "\"v=k\""
    "(do (require (quote [clojure.string :as s9])) (s9/replace \"k=v\" #\"(\\w+)=(\\w+)\" (fn [[_ k v]] (str v \"=\" k))))"]
   ["indexOf int needle is a char code" "1" "(.indexOf \"a=b\" 61)"])
+
+# JOLT_BAKE_ENV_ALLOWLIST (jolt-s3j): with the allowlist set, System/getenv
+# serves only the listed names — so an image bake can't marshal the builder's
+# secrets into the binary. Unset, reads are live and unfiltered.
+(defspec "host-interop / bake env scrub"
+  ["unlisted name reads nil under the allowlist" "nil"
+   "(do (janet.os/setenv \"JOLT_BAKE_ENV_ALLOWLIST\" \"PATH\") (let [r (System/getenv \"HOME\")] (janet.os/setenv \"JOLT_BAKE_ENV_ALLOWLIST\" nil) r))"]
+  ["listed name still reads" "true"
+   "(do (janet.os/setenv \"JOLT_BAKE_ENV_ALLOWLIST\" \"HOME\") (let [r (System/getenv \"HOME\")] (janet.os/setenv \"JOLT_BAKE_ENV_ALLOWLIST\" nil) (string? r)))"]
+  ["full snapshot filtered to the allowlist" "true"
+   "(do (janet.os/setenv \"JOLT_BAKE_ENV_ALLOWLIST\" \"HOME\") (let [e (System/getenv)] (janet.os/setenv \"JOLT_BAKE_ENV_ALLOWLIST\" nil) (and (contains? (set (keys e)) \"HOME\") (= 1 (count (keys e))))))"]
+  ["no allowlist: unfiltered live reads" "true"
+   "(string? (System/getenv \"HOME\"))"])


### PR DESCRIPTION
Closes jolt-s3j (P1). Native builds bake the ctx; config.core-style load-time env snapshots get marshaled into the executable — push protection caught real tokens inside an example binary. With the allowlist set (build.sh exports it during bake), System/getenv serves only listed names; unset, runtime reads stay live and unfiltered (so reload-env at startup sees the real env). A/B-verified on ring-app with a planted token: 1 hit unscrubbed, 0 scrubbed, app still serves. 4 spec rows.