### PR TITLE
jolt build: default output under target/{debug,release}

### DIFF
--- a/docs/tools-deps.md
+++ b/docs/tools-deps.md
@@ -74,10 +74,15 @@ project inherits its dependencies' `:jolt/native`.
 
 ## Standalone binaries
 
-`joltc build -m NS -o OUT` compiles the app and every library into one
-executable (the runtime + compiler are baked in). It loads the resolved
-`:jolt/native` libs at startup, so an FFI app — sockets, SQLite — runs with no
-jolt or Chez on the path.
+`joltc build -m NS` compiles the app and every library into one executable (the
+runtime + compiler are baked in). It loads the resolved `:jolt/native` libs at
+startup, so an FFI app — sockets, SQLite — runs with no jolt or Chez on the path.
+
+Output goes under the project's `target/`, cargo-style: `target/release/<project>`
+by default and with `--opt`, `target/debug/<project>` with `--dev` (the
+`<name>.build` scratch dir sits beside it). `-o PATH` overrides — absolute as-is,
+relative against the project dir. Paths resolve against the project (`JOLT_PWD`),
+not the CLI's cwd, since `bin/joltc` runs from the jolt repo.
 
 `:jolt/build {:embed ["resources" …]}` bakes those directories' files into the
 binary; `io/resource` serves them from the image with no files on disk. Resources

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -149,7 +149,21 @@
                       :else                  "release")]
       (when (nil? entry)
         (throw (ex-info "build needs an entry: -m NS" {})))
-      (let [out (or (:out opts) (first (str/split entry #"\.")))
+      ;; Output paths resolve against the project dir (JOLT_PWD), not the CLI's
+      ;; cwd — bin/joltc cd's to the jolt repo, so a bare relative path would land
+      ;; there. Default output is cargo-style under target/: --dev -> target/debug,
+      ;; release/--opt -> target/release, the binary named after the project dir
+      ;; (falling back to the entry's first segment). The <name>.build scratch dir
+      ;; the driver creates sits next to it, so it lands under the same target dir.
+      ;; An explicit -o is honored: absolute as-is, relative against the project.
+      (let [pdir (project-dir)
+            proj (let [seg (last (str/split pdir #"/"))]
+                   (if (or (str/blank? seg) (= "." seg)) (first (str/split entry #"\.")) seg))
+            out (let [o (:out opts)]
+                  (cond
+                    (nil? o) (str pdir "/target/" (if (= mode "dev") "debug" "release") "/" proj)
+                    (str/starts-with? o "/") o
+                    :else (str pdir "/" o)))
             natives (encode-natives (:natives resolved))]
         ;; embed-dirs (absolute) are walked + baked into the binary by the driver;
         ;; project-paths (relative) become runtime io/resource roots (ship-alongside).


### PR DESCRIPTION
Build output resolved against the CLI's cwd (the jolt repo, since bin/joltc cd's there), so a bare -o path or the default binary landed in the wrong place. Now output resolves against the project (JOLT_PWD) and defaults cargo-style under the project's target/: target/release for release/--opt, target/debug for --dev, named after the project dir; the <name>.build scratch dir sits beside it. -o overrides (absolute as-is, relative against the project). Gate green (selfhost holds, buildsmoke release+optimized, 0 new divergences).