### PR TITLE
libraries: add data.json, spec.alpha, tick

### DIFF
--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -53,3 +53,12 @@ Libraries confirmed to load and pass their conformance checks on Jolt
   [hiccup-app example](https://github.com/jolt-lang/examples/tree/main/hiccup-app).
   Element tags, attribute maps, nested elements, and `for` comprehensions; its
   `html` macro pre-compiles the markup (a good compiler stress test).
+* [clojure.data.json](https://github.com/clojure/data.json) — JSON reading and
+  writing; `read-str`/`write-str` with key/value fns and options. Its own test
+  suite passes 138/139.
+* [clojure.spec.alpha](https://github.com/clojure/spec.alpha) — data specs;
+  `s/def`, `s/valid?`, `s/conform`, `s/cat`/`s/keys`, `s/explain-str`, and
+  `s/check-asserts` work over the registry.
+* [tick](https://github.com/juxt/tick) — date/time over Jolt's `java.time`. The
+  API test suite passes 353/359; the remaining failures are named-zone DST (full
+  tzdb) and locale-specific formatting.


### PR DESCRIPTION
List clojure.data.json, clojure.spec.alpha, and tick on the supported-libraries page now that they load and run. Same three added to the website (jolt-lang.github.io).

- data.json: read-str/write-str, suite 138/139
- spec.alpha: s/def, valid?, conform, cat/keys, explain-str, check-asserts over the registry
- tick: date/time over java.time, api test 353/359 (remaining: named-zone DST tzdb + locale formatting)