### PR TITLE
io/copy: drain a byte-input-stream shim source

### DIFF
--- a/host/chez/io-streams.ss
+++ b/host/chez/io-streams.ss
@@ -275,6 +275,10 @@
   (cond ((in-stream? input) (let ((bv (get-bytevector-all (in-stream-port input)))) (if (eof-object? bv) (make-bytevector 0) bv)))
         ((bytevector? input) input)
         ((and (jolt-array? input) (eq? (jolt-array-kind input) 'byte)) (na-bytearray->bv input))
+        ;; a byte-input-stream shim (host tagged-table, :jolt/input-stream — e.g.
+        ;; http-client's ByteArrayInputStream): drain it byte-exact, like slurp.
+        ((and (htable? input) (jolt-truthy? (jolt-ref-get input (keyword "jolt" "input-stream"))))
+         (drain-byte-stream input))
         (else #f)))
 (define (input-text input)
   (cond ((string? input) input)


### PR DESCRIPTION
`io/copy`'s `input-bytes` handled in-stream/bytevector/byte-array sources but not a host byte-input-stream table (`:jolt/input-stream`, e.g. http-client's ByteArrayInputStream shim) — so it rendered the stream as text (`#[chez-htable …]`) instead of draining its bytes. Drain it like `slurp`. Fixes jolt-bjbi: http-client's suite goes 100-pass/16-fail → **116/0**, and ring-chez-adapter's suite passes. `make test` green.