### PR TITLE
Make main-pump shutdown graceful and stop-main-pump race-free

### DIFF
--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -413,6 +413,13 @@
 ;;   pump can't deadlock on itself.
 ;; - Otherwise the thunk is enqueued; the caller blocks until the pump runs it,
 ;;   then receives the value, or the thrown condition is re-raised.
+;;
+;; stop-main-pump is the graceful-shutdown / external API: it tells the pump to
+;; drain whatever is queued and return. The pump-active flag is flipped to #f
+;; under jolt-main-queue-mu in the same critical section that decides to exit, and
+;; call-on-main-thread reads that flag and enqueues under the SAME mutex, so a job
+;; can never slip in after the pump has decided to leave — a call that loses the
+;; race simply runs inline instead of blocking forever on a pump that is gone.
 
 (define jolt-main-queue-mu (make-mutex))
 (define jolt-main-queue-cv (make-condition))
@@ -427,52 +434,73 @@
   (nongenerative jolt-main-job-v1))
 
 (define (jolt-call-on-main-thread thunk)
-  (cond
-    ((jolt-in-main-pump?)               ; reentrant — already on the pump
-     (jolt-invoke thunk))
-    ((not (unbox jolt-main-pump-active)) ; no pump — inline, like -M:run
-     (jolt-invoke thunk))
-    (else
-     (let ((job (make-jolt-main-job thunk #f #f jolt-nil (make-mutex) (make-condition))))
-       (with-mutex jolt-main-queue-mu
-         (set! jolt-main-queue (append jolt-main-queue (list job)))
-         (condition-signal jolt-main-queue-cv))
-       (with-mutex (jolt-main-job-mu job)
-         (let wait ()
-           (unless (jolt-main-job-done? job)
-             (condition-wait (jolt-main-job-cv job) (jolt-main-job-mu job))
-             (wait))))
-       (if (jolt-main-job-ok? job)
-           (jolt-main-job-val job)
-           (raise (jolt-main-job-val job)))))))
+  (if (jolt-in-main-pump?)              ; reentrant — already on the pump
+      (jolt-invoke thunk)
+      ;; Decide-and-enqueue atomically: read pump-active and (if active) push the
+      ;; job under jolt-main-queue-mu, the same lock the pump holds when it flips
+      ;; active to #f on exit. So we either get queued before the pump leaves, or
+      ;; we see #f and fall through to inline — never enqueue onto a dead pump.
+      (let ((job (with-mutex jolt-main-queue-mu
+                   (and (unbox jolt-main-pump-active)
+                        (let ((j (make-jolt-main-job thunk #f #f jolt-nil
+                                                     (make-mutex) (make-condition))))
+                          (set! jolt-main-queue (append jolt-main-queue (list j)))
+                          (condition-signal jolt-main-queue-cv)
+                          j)))))
+        (if (not job)
+            (jolt-invoke thunk)         ; no pump (or stopped) — inline, like -M:run
+            (begin
+              (with-mutex (jolt-main-job-mu job)
+                (let wait ()
+                  (unless (jolt-main-job-done? job)
+                    (condition-wait (jolt-main-job-cv job) (jolt-main-job-mu job))
+                    (wait))))
+              (if (jolt-main-job-ok? job)
+                  (jolt-main-job-val job)
+                  (raise (jolt-main-job-val job))))))))
 
 (define (jolt-run-main-pump)
-  (set-box! jolt-main-pump-stop #f)
-  (set-box! jolt-main-pump-active #t)
-  (let loop ()
-    (let ((job (with-mutex jolt-main-queue-mu
-                 (let wait ()
-                   (cond
-                     ((not (null? jolt-main-queue))
-                      (let ((j (car jolt-main-queue)))
-                        (set! jolt-main-queue (cdr jolt-main-queue))
-                        j))
-                     ((unbox jolt-main-pump-stop) #f)  ; drain done, told to exit
-                     (else (condition-wait jolt-main-queue-cv jolt-main-queue-mu)
-                           (wait)))))))
-      (when job
-        (let ((r (dynamic-wind
-                   (lambda () (jolt-in-main-pump? #t))
-                   (lambda ()
-                     (guard (e (#t (cons #f e)))
-                       (cons #t (jolt-invoke (jolt-main-job-thunk job)))))
-                   (lambda () (jolt-in-main-pump? #f)))))
-          (with-mutex (jolt-main-job-mu job)
-            (jolt-main-job-ok?-set! job (car r))
-            (jolt-main-job-val-set! job (cdr r))
-            (jolt-main-job-done?-set! job #t)
-            (condition-broadcast (jolt-main-job-cv job))))
-        (loop)))))
+  (with-mutex jolt-main-queue-mu
+    (set-box! jolt-main-pump-stop #f)
+    (set-box! jolt-main-pump-active #t))
+  ;; dynamic-wind guarantees active is cleared even if the pump escapes abnormally,
+  ;; so a later run-main-pump starts clean and call-on-main-thread never sees a
+  ;; stale #t. The clean-exit path below also clears it under the mutex (the flip
+  ;; that races call-on-main-thread); this is the belt-and-suspenders for escapes.
+  (dynamic-wind
+    (lambda () #f)
+    (lambda ()
+      (let loop ()
+        (let ((job (with-mutex jolt-main-queue-mu
+                     (let wait ()
+                       (cond
+                         ((not (null? jolt-main-queue))
+                          (let ((j (car jolt-main-queue)))
+                            (set! jolt-main-queue (cdr jolt-main-queue))
+                            j))
+                         ((unbox jolt-main-pump-stop)
+                          ;; drain done, told to exit — clear active in the same
+                          ;; critical section so no job can be enqueued after.
+                          (set-box! jolt-main-pump-active #f)
+                          #f)
+                         (else (condition-wait jolt-main-queue-cv jolt-main-queue-mu)
+                               (wait)))))))
+          (when job
+            (let ((r (dynamic-wind
+                       (lambda () (jolt-in-main-pump? #t))
+                       (lambda ()
+                         (guard (e (#t (cons #f e)))
+                           (cons #t (jolt-invoke (jolt-main-job-thunk job)))))
+                       (lambda () (jolt-in-main-pump? #f)))))
+              (with-mutex (jolt-main-job-mu job)
+                (jolt-main-job-ok?-set! job (car r))
+                (jolt-main-job-val-set! job (cdr r))
+                (jolt-main-job-done?-set! job #t)
+                (condition-broadcast (jolt-main-job-cv job))))
+            (loop)))))
+    (lambda ()
+      (with-mutex jolt-main-queue-mu (set-box! jolt-main-pump-active #f))))
+  jolt-nil)
 
 (define (jolt-stop-main-pump)
   (with-mutex jolt-main-queue-mu


### PR DESCRIPTION
Follow-up to #269, which added the main-thread executor (`call-on-main-thread`, `run-main-pump`, `stop-main-pump`) in `host/chez/java/concurrency.ss` so the nREPL accept loop can run on a worker thread while the primordial thread owns the GUI main loop.

That landed `stop-main-pump` as the intended graceful-shutdown and external API, but two things kept it from actually working.

`run-main-pump` set `jolt-main-pump-active` to `#t` on entry and never cleared it on exit. Once the pump returned, the flag stayed `#t` forever, so any later `call-on-main-thread` would enqueue a job and block on a pump that was no longer draining. On top of that, `call-on-main-thread` read the active flag outside the queue mutex, so even with a reset there was a window where a job could be enqueued right as the pump decided to leave.

This change moves both decisions under `jolt-main-queue-mu`. The pump clears `active` in the same critical section where it observes the stop flag with an empty queue, and `call-on-main-thread` reads `active` and enqueues atomically under that same lock. A caller that loses the race sees the pump inactive and runs the thunk inline, which is the same fallback used when no pump is running, instead of blocking. A `dynamic-wind` around the loop also clears `active` on an abnormal exit so a later `run-main-pump` starts from a clean state.

With this, `stop-main-pump` drains whatever is queued, `run-main-pump` returns, and the process can exit cleanly. It also makes the trio safe to use from external code such as a glimmer app calling `stop-main-pump` on window close.

Testing: Chez is not in CI's quick path locally, so I exercised the pump with a standalone harness that stubs the runtime primitives and includes the pump source verbatim. It covers inline execution with no pump, marshaling a value back from the pump thread, re-raising a thunk's exception to the caller, reentrant calls running inline without self-deadlock, and the two fixed behaviors: `active` resets to `#f` after `stop-main-pump`, and `call-on-main-thread` runs inline rather than hanging once the pump is gone. All pass. I also confirmed the full image still loads (`joltc run`) and that `joltc --nrepl-server` starts cleanly with the accept loop in a future and the main thread in the pump.