### PR TITLE
nREPL: surface startup failures and close the listen socket on shutdown

### DIFF
--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -188,13 +188,18 @@
     (let [port (or (some-> (first (filter #(not (str/starts-with? % "-")) more)) parse-long)
                    (parse-long (or (jolt.host/getenv "JOLT_NREPL_PORT") "7888")))]
       (require 'jolt.nrepl)
-      ;; Run the accept loop on a worker thread so the primordial (main) thread
-      ;; stays free to own the GUI main loop. glimmer's run marshals its startup
-      ;; onto this thread via jolt.host/call-on-main-thread — on macOS GTK quartz,
-      ;; g_application_run must run on the main thread or AppKit aborts when it
-      ;; sets the main menu.
-      (future ((resolve 'jolt.nrepl/start) port (:nrepl-middleware resolved)))
-      (jolt.host/run-main-pump))))
+      ;; start binds the socket synchronously on this (primordial) thread, so a
+      ;; failure like the port already being in use surfaces here and exits rather
+      ;; than being swallowed by a background thread. It then runs the accept loop
+      ;; on a worker thread and returns a stop fn, leaving this thread free to own
+      ;; the GUI main loop: glimmer's run marshals its startup here via
+      ;; jolt.host/call-on-main-thread — on macOS GTK quartz, g_application_run
+      ;; must run on the main thread or AppKit aborts when it sets the main menu.
+      (let [stop ((resolve 'jolt.nrepl/start) port (:nrepl-middleware resolved))]
+        ;; park here until something calls jolt.host/stop-main-pump, then shut the
+        ;; server down cleanly (close the socket, remove .nrepl-port) and return.
+        (jolt.host/run-main-pump)
+        (when stop (stop))))))
 
 (defn- usage []
   (println "usage: jolt <command> [args]")

--- a/jolt-core/jolt/nrepl.clj
+++ b/jolt-core/jolt/nrepl.clj
@@ -17,6 +17,7 @@
 
   Writes .nrepl-port in the project dir so editors auto-detect the port."
   (:require [clojure.string :as str]
+            [clojure.java.io :as io]
             [jolt.ffi :as ffi]))
 
 ;; --- sockets (loopback server) ---------------------------------------------
@@ -222,18 +223,38 @@
 (defn start
   "Start the nREPL server on `port` (a concrete port; loopback only). `middleware`
   is a vector of deps.edn :nrepl/middleware symbols to compose over the built-in
-  handler. Writes .nrepl-port. Blocks accepting connections."
+  handler.
+
+  Binds the socket synchronously, so a startup failure (e.g. the port is already
+  in use) is thrown to the caller rather than swallowed by the accept thread, then
+  accepts connections on a background thread and returns immediately. Writes
+  .nrepl-port. Does NOT block — the caller keeps the process alive (jolt.main
+  parks the main thread in jolt.host/run-main-pump).
+
+  Returns a zero-arg stop fn: it stops the accept loop, closes the listen socket
+  (freeing the port), and removes .nrepl-port. Calling it more than once is a
+  no-op."
   ([port] (start port nil))
   ([port middleware]
    (let [handler (build-handler (resolve-middleware (or middleware [])))
-         fd (listen-socket port)]
+         fd (listen-socket port)                  ; throws on bind/listen failure
+         stopped (atom false)]
      (try (spit ".nrepl-port" (str port)) (catch :default _ nil))
      (println (str "nREPL server started on port " port " (127.0.0.1) — .nrepl-port written"))
      (when (seq middleware) (println (str ";; middleware: " (str/join " " middleware))))
      (println ";; connect your editor; ^C to stop")
-     (loop []
-       (let [conn (c-accept fd ffi/null ffi/null)]
-         (when (>= conn 0)
-           (future (try (handle-conn conn handler)
-                        (catch :default e (println "nrepl conn error:" (err-msg e)) (c-close conn)))))
-         (recur))))))
+     (future
+       ;; A stop closes fd, which makes the blocking accept() return an error; the
+       ;; @stopped check then breaks the loop instead of spinning on the dead fd.
+       (loop []
+         (let [conn (c-accept fd ffi/null ffi/null)]
+           (when-not @stopped
+             (when (>= conn 0)
+               (future (try (handle-conn conn handler)
+                            (catch :default e (println "nrepl conn error:" (err-msg e)) (c-close conn)))))
+             (recur)))))
+     (fn stop []
+       (when (compare-and-set! stopped false true)
+         (c-close fd)
+         (try (io/delete-file ".nrepl-port" true) (catch :default _ nil)))
+       nil))))


### PR DESCRIPTION
Two pre-existing issues in the nrepl command, both surfaced while reviewing #269, which moved the accept loop onto a worker thread.

The first is a silent startup failure. `jolt.nrepl/start` was being called inside `(future ...)` in `jolt.main`, so the socket bind ran on a background thread. When the bind failed, for example because the port was already in use, the thrown condition was captured into a future that nothing ever derefs, so it was silently swallowed. The main thread then parked in `run-main-pump` forever with no server listening and no error printed, which looks like a hang. `start` now binds the socket synchronously before it returns, so that failure propagates to the caller and the process exits with a visible message and a nonzero code. Only the blocking accept loop runs on a worker thread.

The second is that there was no shutdown path. The accept loop ran forever and the listen socket was never closed. `start` now returns a zero-arg stop fn that breaks the accept loop, closes the socket to free the port, and removes `.nrepl-port`. `jolt.main` parks the main thread in `run-main-pump` and then calls that stop fn, so a `stop-main-pump` (from a glimmer app on quit, or from nrepl-evaluated code) shuts the server down cleanly and the process exits.

This builds on the main-pump executor added in #269 and is independent of the pump correctness fix in #270, though they pair naturally.

Testing, with Chez installed locally since it is not in the quick CI path here:

- Normal start binds, prints the startup banner, and writes `.nrepl-port`.
- A second server on a port already in use now prints `bind() failed on port N` and exits with code 1 instead of hanging silently.
- Connecting and evaluating `(jolt.host/stop-main-pump)` over bencode shuts the server down: the eval replies, `run-main-pump` returns, the stop fn closes the socket and removes `.nrepl-port`, and the process exits cleanly. Verified against this branch's base (without the #270 pump change) so it stands on its own.