### PR TITLE
JOLT_TRACE: honor the env at runtime in a built joltc

### DIFF
--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -145,11 +145,10 @@
 (scheme-start
   (lambda args
     (set-source-roots! (list \"jolt-core\" \"stdlib\"))
-    (guard (v (#t (jolt-report-throwable v (current-error-port))
-                  (let ((bt (jolt-backtrace-string v)))
-                    (when bt (display \"  trace:\\n\" (current-error-port))
-                          (display bt (current-error-port))))
-                  (exit 1)))
+    ;; JOLT_TRACE at RUNTIME (the env is unset at heap-build), before any app ns
+    ;; compiles, so a `-M:run` traces the app's own code.
+    (jolt-trace-init-from-env!)
+    (guard (v (#t (jolt-report-throwable v (current-error-port)) (exit 1)))
       (cond
         ((and (= (length args) 2) (string=? (car args) \"-e\"))
          (let ((result (jolt-final-str

--- a/host/chez/cli.ss
+++ b/host/chez/cli.ss
@@ -66,6 +66,9 @@
       (when bt (display "  trace:\n" port) (display bt port)))
     (exit 1)))
 
+;; JOLT_TRACE opt-in, at runtime (before any app ns compiles) so the app is traced.
+(jolt-trace-init-from-env!)
+
 (guard (v (#t (jolt-report-uncaught v)))
   (cond
     ;; -e EXPR — evaluate one expression and print it (blank for nil). Wrapped in

--- a/host/chez/compile-eval.ss
+++ b/host/chez/compile-eval.ss
@@ -132,11 +132,16 @@
 ;; push is baked in at compile time, only code compiled after this call is traced —
 ;; which is exactly the code you eval / reload in a live session.
 (def-var! "jolt.host" "enable-trace!" jolt-enable-trace!)
-;; Explicit opt-in for a whole run (JOLT_TRACE=1): enable at load, BEFORE any app
-;; namespace is compiled, so a plain `-M:run` traces the app's own code too. Only an
-;; affirmative value (set, non-empty, not falsey) forces it on here.
-(let ((e (getenv "JOLT_TRACE")))
-  (when (and e (fx>? (string-length e) 0) (not (jolt-trace-env-off? e))) (jolt-enable-trace!)))
+;; Explicit opt-in for a whole run (JOLT_TRACE=1): turn tracing on BEFORE any app
+;; namespace is compiled, so a plain `-M:run` traces the app's own code too. Called
+;; from the runtime entrypoints (cli.ss, and the built joltc launcher) — NOT at load
+;; time: a built joltc runs top-level forms at heap-build time, where JOLT_TRACE is
+;; always unset, so a load-time check would never see the user's runtime env. Only an
+;; affirmative value (set, non-empty, not falsey) forces it on.
+(define (jolt-trace-init-from-env!)
+  (let ((e (getenv "JOLT_TRACE")))
+    (when (and e (fx>? (string-length e) 0) (not (jolt-trace-env-off? e)))
+      (jolt-enable-trace!))))
 
 ;; (with-meta sym m) -> sym, else x — an (ns ^:no-doc name …) yields the name with
 ;; reader metadata as a with-meta form; strip it to read the bare ns symbol.

--- a/host/chez/joltc-selfbuild-smoke.sh
+++ b/host/chez/joltc-selfbuild-smoke.sh
@@ -42,6 +42,20 @@ if [ "$got_e" != "45" ]; then
   exit 1
 fi
 
+# 2b. JOLT_TRACE must take effect in the BUILT binary. The env check runs at
+# runtime (the launcher), NOT at heap-build where JOLT_TRACE is always unset — so
+# an uncaught error shows a tail-frame trace recovering the TCO-elided chain, and
+# exactly ONE trace block (the launcher must not double-print it).
+got_tr="$(env -i HOME="$HOME" JOLT_TRACE=1 "$joltc" -e '(defn a [x] (+ x 1)) (defn b [x] (a x)) (b :x)' 2>&1)"
+if ! printf '%s' "$got_tr" | grep -q '  trace:' || ! printf '%s' "$got_tr" | grep -q 'b'; then
+  echo "  FAIL: JOLT_TRACE=1 in the built joltc produced no tail-frame trace"
+  echo "--- got ---"; echo "$got_tr"; exit 1
+fi
+if [ "$(printf '%s' "$got_tr" | grep -c '  trace:')" != "1" ]; then
+  echo "  FAIL: built joltc double-printed the trace block"
+  echo "--- got ---"; echo "$got_tr"; exit 1
+fi
+
 # 3. Build an app through the distributed joltc with an EMPTY environment — no
 # PATH at all, so no chez, no cc, no shell tools are reachable. This is the core
 # guarantee: joltc compiles apps entirely on its own.


### PR DESCRIPTION
## The bug

`JOLT_TRACE=1 joltc -M:run` produced **no trace from the distributed (AOT) joltc binary** — the exact case a user hits after `brew install`. It worked only under the source-loaded dev launcher (`bin/joltc`), which is why it passed in testing.

Root cause: the `JOLT_TRACE` opt-in was a **top-level form** in `compile-eval.ss`. In a self-contained joltc that form runs at *heap-build* time, where `JOLT_TRACE` is always unset, and never re-runs at runtime. (REPL/nREPL tracing was unaffected — those enable at runtime.)

## Fix

- Move the env check into `jolt-trace-init-from-env!`, called from the two **runtime** entrypoints — the `cli.ss` dispatch and the built-joltc launcher — before any app namespace compiles, so the app's own code is traced.
- Drop a redundant trace print in the joltc launcher: `jolt-report-throwable` already emits the trace, so the launcher's extra copy double-printed it once tracing actually produced one.

## Verified

- AOT binary (`target/release/joltc`): `JOLT_TRACE=1 -M:run` now shows a single tail-frame trace; unset → Tier-0 continuation; `JOLT_TRACE=0` → off.
- `joltc-selfbuild-smoke` now asserts `JOLT_TRACE=1` through the **built** binary yields exactly one trace block.
- smoke 38/38, joltcsmoke pass, buildsmoke green, selfhost fixpoint. No seed change.

Needs a 0.1.5 release to reach the Homebrew binary (0.1.4's shipped binary has the bug).