### PR TITLE
yamlstar conformance, macro-meta fixes, jolt.fs

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -10,7 +10,7 @@ Where things live and what to read before changing them. Start here to answer
 | Chez runtime | `host/chez/*.ss` | The substrate: value model, persistent collections, seqs, vars/namespaces, host interop, native `clojure.core` shims, regex, FFI, IO, the **reader**. Composed by `rt.ss`. | only `reader.ss` |
 | Compiler | `jolt-core/jolt/*.clj` | analyzer → IR → backend, the optimization passes, the CLI, the deps resolver, nREPL. Baked into the seed. | **yes** |
 | `clojure.core` overlay | `jolt-core/clojure/core/NN-*.clj` | Portable `clojure.core` in dependency-ordered tiers (`00-syntax` … `50-io`); the `NN` prefix *is* the load order. | **yes** |
-| Stdlib | `stdlib/clojure/*.clj` | Lazily-loaded portable namespaces (string/set/walk/edn/pprint/zip/test/data). | no |
+| Stdlib | `stdlib/clojure/*.clj`, `stdlib/jolt/*.clj` | Lazily-loaded portable namespaces (string/set/walk/edn/pprint/zip/test/data) and Jolt's own (`jolt.ffi`, `jolt.fs` — file-system utilities, babashka.fs-shaped). | no |
 | Build & tooling | `host/chez/build.ss`, `emit-image.ss`, `compile-eval.ss`, `loader.ss`, `cli.ss`, `bootstrap.ss` | AOT binary build, cross-compile, runtime eval/load, CLI spine, seed mint. | no (except via `reader.ss`) |
 | Tests & gate | `test/chez/`, `test/conformance/`, `host/chez/run-*.ss`, `Makefile` | Corpus (JVM oracle), unit, per-feature tests. Every `make` target has a comment. | no |
 

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -78,3 +78,5 @@ e.g. the [ring-app example](https://github.com/jolt-lang/examples/tree/main/ring
 * [tick](https://github.com/juxt/tick) — date/time over Jolt's `java.time`;
   `#time/…` literals via `time-literals`.
 * [transit-jolt](https://github.com/jolt-lang/transit-jolt) — Transit (JSON) read/write
+* [yamlstar](https://github.com/yaml/yamlstar) — YAML load/dump (pure-Clojure
+  parser, JSON-safe integer policy).

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -141,6 +141,7 @@
     (if (fx<? d radix) d -1)))
 (define character-statics
   (list (cons "digit" (lambda (ch radix) (->num (char-digit-value (char->cp ch) (jnum->exact radix)))))
+        (cons "toChars" (lambda (cp) (na-char-array (jolt-vector (integer->char (char->cp cp))))))
         (cons "isDigit" (lambda (ch) (let ((cp (char->cp ch))) (and (fx>=? cp 48) (fx<=? cp 57)))))
         (cons "isWhitespace" (lambda (ch) (char-whitespace? (integer->char (char->cp ch)))))
         (cons "valueOf" (lambda (ch) (if (char? ch) ch (integer->char (char->cp ch)))))))

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -143,6 +143,19 @@
       (let ((t (file-modification-time p)))
         (+ (* (time-second t) 1000) (div (time-nanosecond t) 1000000)))
       0))
+;; set atime+mtime from epoch milliseconds via utimes(2). struct timeval is
+;; sec + usec, 16 bytes each on the 64-bit platforms Chez targets; usec fits
+;; its field (< 1e6) so a signed 64-bit native-endian write covers the layout.
+(define c-utimes (foreign-procedure "utimes" (string u8*) int))
+(define (set-file-mtime-millis! p ms)
+  (let ((tv (make-bytevector 32 0))
+        (sec (div ms 1000))
+        (usec (* (mod ms 1000) 1000)))
+    (bytevector-s64-set! tv 0 sec (native-endianness))
+    (bytevector-s64-set! tv 8 usec (native-endianness))
+    (bytevector-s64-set! tv 16 sec (native-endianness))
+    (bytevector-s64-set! tv 24 usec (native-endianness))
+    (= (c-utimes p tv) 0)))
 ;; mkdir -p: create p and any missing parents. Returns #t if p ends up a dir.
 (define (mkdirs! p)
   (unless (or (= 0 (string-length p)) (file-exists? p))
@@ -221,7 +234,9 @@
       ((string=? name "mkdirs")         (list (if (mkdirs! fp) #t #f)))
       ((string=? name "delete")         (list (if (delete-path! fp) #t #f)))
       ((string=? name "deleteOnExit")   (list jolt-nil))
-      ((string=? name "setLastModified")(list #t))
+      ((string=? name "setLastModified")
+       (list (guard (e (#t #f))
+               (set-file-mtime-millis! fp (exact (floor (car args)))))))
       ((string=? name "createNewFile")
        (list (if (file-exists? fp) #f
                  (guard (e (#t #f)) (close-port (open-output-file fp 'truncate)) #t))))

--- a/host/chez/java/natives-str.ss
+++ b/host/chez/java/natives-str.ss
@@ -138,6 +138,8 @@
     ((string=? method "length") (string-length s))   ; exact int (= JVM)
     ((string=? method "isEmpty") (fx=? (string-length s) 0))
     ((string=? method "charAt") (string-ref s (jolt->idx (arg 0))))
+    ((string=? method "codePointAt")
+     (char->integer (string-ref s (jolt->idx (arg 0)))))
     ((string=? method "substring")
      (substring s (jolt->idx (arg 0))
                 (if (fx>? (length rest) 1) (jolt->idx (arg 1)) (string-length s))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -243,6 +243,10 @@
         ;; binary): it's already defined — mark loaded and move on.
         ((ns-has-vars? name)
          (hashtable-set! loaded-ns name #t))
+        ;; Same-file namespace (inlined ns form in a Jolt file): registered via
+        ;; intern-ns! in the runtime registry even if no vars bear its ns name yet.
+        ((hashtable-ref ns-registry name #f)
+         (hashtable-set! loaded-ns name #t))
         (else
          (error #f (string-append "Could not locate " (ns-name->rel name)
                                   ".clj (or .cljc) on the source roots") name))))))

--- a/host/chez/natives-meta.ss
+++ b/host/chez/natives-meta.ss
@@ -15,13 +15,17 @@
 (define (jolt-meta x)
   (cond
     ((symbol-t? x) (let ((m (symbol-t-meta x))) (if (jolt-nil? m) jolt-nil m)))
-    ;; a var's meta is {:ns :name} (derived from the cell) + any def-time user
-    ;; meta from rt.ss's var-meta-table.
+    ;; a var's meta is {:ns :name} (derived from the cell) + :macro true for a
+    ;; macro var (derived from var-macro-table, like Var.isMacro reading meta on
+    ;; the JVM) + any def-time user meta from rt.ss's var-meta-table.
     ((var-cell? x)
-     (let ((user (hashtable-ref var-meta-table x #f)))
-       (jolt-assoc (if user user (jolt-hash-map))
-                   jolt-kw-var-ns (var-cell-ns x)
-                   jolt-kw-var-name (var-cell-name x))))
+     (let* ((user (hashtable-ref var-meta-table x #f))
+            (base (jolt-assoc (if user user (jolt-hash-map))
+                              jolt-kw-var-ns (var-cell-ns x)
+                              jolt-kw-var-name (var-cell-name x))))
+       (if (macro-var? x)
+           (jolt-assoc base jolt-kw-var-macro #t)
+           base)))
     ;; a deftype implementing clojure.lang.IObj stores meta in a field and threads
     ;; it through its own assoc/withMeta (core.logic's Substitutions/LVar/LCons),
     ;; so dispatch to its meta method rather than the identity side-table — which

--- a/host/chez/natives-misc.ss
+++ b/host/chez/natives-misc.ss
@@ -60,10 +60,17 @@
                   (lambda (a b) (and (juuid? a) (juuid? b) (string=? (juuid-s a) (juuid-s b)))))
 
 ;; --- bigint / biginteger -----------------------------------------------------
-;; jolt models every number as a double; an integer-valued double prints without
-;; a ".0" (jolt-num->string), so bigint is just the number for the corpus range.
-;; (Arbitrary-precision beyond 2^53 is a separate concern.)
-(define (jolt-bigint x) x)
+;; JVM bigint/biginteger coerce: string → parsed integer, double/float →
+;; truncated integer, ratio → quotient, integer → exact integer.
+(define (jolt-bigint x)
+  (cond ((string? x) (parse-int-or-throw x 10 "bigint"))
+        ((flonum? x)
+         (if (or (finite? x) (zero? x))
+             (inexact->exact (truncate x))
+             (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                           (string-append "For input string: \""
+                                          (jolt-str-render-one x) "\"")))))
+        (else (inexact->exact (truncate x)))))
 (def-var! "clojure.core" "bigint" jolt-bigint)
 (def-var! "clojure.core" "biginteger" jolt-bigint)
 

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -258,12 +258,19 @@
     jolt-nil))
 
 ;; intern: create/set a var ns/sym to val (or an unbound cell). Returns the var.
+;; The symbol's metadata becomes the var's metadata (Var.setMeta), and a truthy
+;; :macro marks the var as a macro so later-compiled forms expand it.
 (define (jolt-intern ns-desig sym . vopt)
   (let ((nm (ns-desig->name ns-desig)) (s (symbol-t-name sym)))
     ;; the namespace must exist (Namespace.find), like the JVM's intern
     (unless (hashtable-ref ns-registry nm #f)
       (jolt-throw (jolt-ex-info (string-append "No namespace: " nm " found") empty-pmap)))
-    (if (pair? vopt) (def-var! nm s (car vopt)) (declare-var! nm s))))
+    (let ((cell (if (pair? vopt) (def-var! nm s (car vopt)) (declare-var! nm s)))
+          (m (jolt-meta sym)))
+      (unless (jolt-nil? m)
+        (hashtable-set! var-meta-table cell m)
+        (var-meta-sync-macro! cell m))
+      cell)))
 
 ;; alias / ns-unalias: register/drop an :as alias under the current (or given) ns.
 ;; A runtime alias is registered into the SAME table the analyzer consults, so a
@@ -311,12 +318,20 @@
 
 ;; alter-meta! / reset-meta!: a var's metadata lives in var-meta-table (rt.ss);
 ;; any other reference (atom/agent/namespace) uses the identity meta side-table
-;; jolt-meta reads.
+;; jolt-meta reads. A truthy :macro in the new meta marks the var as a macro
+;; (JVM parity: Var.isMacro reads meta), so re-export idioms that copy a macro's
+;; meta onto a fresh var — (alter-meta! v merge (meta macro-var)) — work. Marking
+;; is one-way: meta without :macro does not demote an existing macro, since
+;; defmacro vars derive :macro rather than storing it.
+(define (var-meta-sync-macro! cell m)
+  (when (jolt-truthy? (jolt-get m jolt-kw-var-macro))
+    (hashtable-set! var-macro-table cell #t)))
 (define (jolt-alter-meta! ref f . args)
   (if (var-cell? ref)
       (let* ((cur (or (hashtable-ref var-meta-table ref #f) (jolt-hash-map)))
              (new (apply jolt-invoke f cur args)))
         (hashtable-set! var-meta-table ref new)
+        (var-meta-sync-macro! ref new)
         new)
       (let* ((cur (let ((m (jolt-meta ref))) (if (jolt-nil? m) (jolt-hash-map) m)))
              (new (apply jolt-invoke f cur args)))
@@ -324,7 +339,9 @@
         new)))
 (define (jolt-reset-meta! ref m)
   (if (var-cell? ref)
-      (hashtable-set! var-meta-table ref m)
+      (begin
+        (hashtable-set! var-meta-table ref m)
+        (var-meta-sync-macro! ref m))
       (hashtable-set! meta-table ref m))
   m)
 

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -274,6 +274,7 @@
 (define var-meta-table (make-eq-hashtable))
 (define jolt-kw-var-ns (keyword #f "ns"))
 (define jolt-kw-var-name (keyword #f "name"))
+(define jolt-kw-var-macro (keyword #f "macro"))
 (define (def-var-with-meta! ns name v m)
   (let ((c (def-var! ns name v))) (hashtable-set! var-meta-table c m) c))
 ;; runtime-macro registry: a var whose root holds a macro

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -161,6 +161,17 @@ else
   fails=$((fails + 1))
 fi
 
+# jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
+# move, mtime round-trip, which). The file self-checks and prints one marker.
+fs_out="$(bin/joltc run test/chez/fs-test.clj 2>/dev/null)"
+if printf '%s' "$fs_out" | grep -q 'FS-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.fs"
+  printf '%s\n' "$fs_out" | grep FAIL | head -5 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # A data reader that returns a CODE form (deps.edn data_readers.clj -> reader fn)
 # must have its result spliced in and COMPILED, like Clojure — #code [:x] becomes
 # (+ 40 2) and evaluates to 42, not the literal list. A project run so the source

--- a/stdlib/jolt/fs.clj
+++ b/stdlib/jolt/fs.clj
@@ -1,0 +1,244 @@
+(ns jolt.fs
+  "File-system utilities over java.io.File, API-compatible with babashka.fs
+  where the two overlap. Functions accept a String or a File; path-valued
+  results are Files (Jolt's path value — there is no java.nio.file.Path).
+  Symbolic-link operations (sym-link?, read-link) and creation-time are not
+  available on the host and throw."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import [java.io File]))
+
+(defn file
+  "Coerce to a java.io.File. With several args, nests: (file a b c) = a/b/c."
+  ([f] (if (instance? File f) f (File. (str f))))
+  ([f & fs] (reduce (fn [^File p c] (File. (str p) (str c))) (file f) fs)))
+
+;; --- predicates ---------------------------------------------------------------
+
+(defn exists? [f] (.exists (file f)))
+(defn directory? [f] (.isDirectory (file f)))
+(defn regular-file? [f] (.isFile (file f)))
+(defn absolute? [f] (.isAbsolute (file f)))
+(defn relative? [f] (not (.isAbsolute (file f))))
+(defn readable? [f] (.canRead (file f)))
+(defn writable? [f] (.canWrite (file f)))
+(defn executable? [f] (.canExecute (file f)))
+(defn hidden? [f] (.isHidden (file f)))
+(defn sym-link? [f]
+  (throw (ex-info "sym-link? is not supported on this host" {:path (str f)})))
+
+;; --- path pieces ---------------------------------------------------------------
+
+(defn file-name
+  "Final path segment as a string."
+  [f] (.getName (file f)))
+
+(defn parent
+  "Parent as a File, nil at a root or a bare name."
+  [f] (.getParentFile (file f)))
+
+(defn extension
+  "Extension without the dot, nil when there is none."
+  [f]
+  (let [n (file-name f)
+        i (.lastIndexOf n ".")]
+    (when (pos? i) (subs n (inc i)))))
+
+(defn strip-ext
+  "File name without its extension."
+  [f]
+  (let [n (file-name f)
+        i (.lastIndexOf n ".")]
+    (if (pos? i) (subs n 0 i) n)))
+
+(defn absolutize [f] (.getAbsoluteFile (file f)))
+(defn canonicalize [f] (.getCanonicalFile (file f)))
+
+(defn cwd
+  "Current working directory as a File."
+  [] (File. (System/getProperty "user.dir")))
+
+(defn relativize
+  "Path of `other` relative to `root`, as a File."
+  [root other]
+  (let [r (str (absolutize root))
+        o (str (absolutize other))
+        sep File/separator
+        r (if (str/ends-with? r sep) r (str r sep))]
+    (if (str/starts-with? o r)
+      (File. (subs o (count r)))
+      (throw (ex-info "cannot relativize: not nested under root"
+                      {:root r :other o})))))
+
+;; --- reading the tree ------------------------------------------------------------
+
+(defn list-dir
+  "Immediate children as Files."
+  [dir] (seq (.listFiles (file dir))))
+
+(defn walk
+  "Depth-first seq of every file and directory under root, root first."
+  [root]
+  (tree-seq #(.isDirectory ^File %) #(.listFiles ^File %) (file root)))
+
+(defn- glob->re
+  "Translate a glob pattern to a regex over the /-separated relative path.
+  ** crosses directory separators, * and ? stay within a segment,
+  {a,b} alternates."
+  [pattern]
+  (loop [cs (seq pattern) out "^"]
+    (if-not cs
+      (re-pattern (str out "$"))
+      (let [c (first cs)]
+        (cond
+          (and (= c \*) (= (second cs) \*))
+          (recur (nnext cs) (str out ".*"))
+          (= c \*) (recur (next cs) (str out "[^/]*"))
+          (= c \?) (recur (next cs) (str out "[^/]"))
+          (= c \{) (recur (next cs) (str out "("))
+          (= c \}) (recur (next cs) (str out ")"))
+          (= c \,) (recur (next cs) (str out "|"))
+          (contains? #{\. \( \) \[ \] \^ \$ \+ \|} c)
+          (recur (next cs) (str out "\\" c))
+          :else (recur (next cs) (str out c)))))))
+
+(defn glob
+  "Files under root whose path relative to root matches the glob pattern
+  (** crosses directories, * within a segment, ?, {a,b}). Returns Files."
+  [root pattern]
+  (let [root-f (file root)
+        re (glob->re pattern)
+        prefix (str root-f File/separator)]
+    (->> (walk root-f)
+         (remove #(= % root-f))
+         (filter (fn [^File f]
+                   (let [rel (subs (str f) (count prefix))]
+                     (re-matches re rel)))))))
+
+;; --- creation / deletion ---------------------------------------------------------
+
+(defn create-dir
+  "Create one directory level; the parent must exist. Returns the File."
+  [dir]
+  (let [f (file dir)]
+    (when-not (.mkdir f)
+      (throw (ex-info "could not create directory" {:path (str f)})))
+    f))
+
+(defn create-dirs
+  "Create a directory and any missing parents. Returns the File."
+  [dir]
+  (let [f (file dir)]
+    (when-not (or (.isDirectory f) (.mkdirs f))
+      (throw (ex-info "could not create directories" {:path (str f)})))
+    f))
+
+(defn create-file
+  "Create an empty file. Returns the File."
+  [f]
+  (let [f (file f)] (.createNewFile f) f))
+
+(defn create-temp-dir
+  "Fresh directory under the system temp dir. Returns the File."
+  [& [{:keys [prefix] :or {prefix "jolt-"}}]]
+  (let [f (File/createTempFile prefix "")]
+    (.delete f)
+    (create-dir (str f))))
+
+(defn create-temp-file
+  "Fresh file under the system temp dir. Returns the File."
+  [& [{:keys [prefix suffix] :or {prefix "jolt-" suffix ".tmp"}}]]
+  (File/createTempFile prefix suffix))
+
+(defn delete
+  "Delete a file or empty directory; throws when it does not exist."
+  [f]
+  (let [f (file f)]
+    (when-not (.exists f)
+      (throw (ex-info "no such file" {:path (str f)})))
+    (when-not (.delete f)
+      (throw (ex-info "could not delete" {:path (str f)})))
+    nil))
+
+(defn delete-if-exists
+  "Delete when present. True when something was deleted."
+  [f]
+  (let [f (file f)] (and (.exists f) (.delete f))))
+
+(defn delete-tree
+  "Delete a file or directory recursively. Missing paths are a no-op."
+  [root]
+  (let [f (file root)]
+    (when (.exists f)
+      (doseq [^File c (reverse (walk f))]
+        (.delete c)))
+    nil))
+
+;; --- copy / move ------------------------------------------------------------------
+
+(defn size [f] (.length (file f)))
+
+(defn copy
+  "Copy a regular file. Returns the destination File."
+  [src dst & [{:keys [replace-existing]}]]
+  (let [s (file src) d (file dst)]
+    (when (.isDirectory s)
+      (throw (ex-info "copy takes a regular file; use copy-tree" {:path (str s)})))
+    (when (and (.exists d) (not replace-existing))
+      (throw (ex-info "destination exists" {:path (str d)})))
+    (io/copy s d)
+    d))
+
+(defn copy-tree
+  "Copy a directory tree recursively. Returns the destination File."
+  [src dst & [{:keys [replace-existing] :as opts}]]
+  (let [s (file src) d (file dst)]
+    (if (.isDirectory s)
+      (do (create-dirs d)
+          (doseq [^File c (.listFiles s)]
+            (copy-tree c (File. (str d) (.getName c)) opts)))
+      (copy s d opts))
+    d))
+
+(defn move
+  "Move (rename) src to dst. Falls back to copy+delete for a regular file
+  when rename fails (cross-device). Returns the destination File."
+  [src dst & [{:keys [replace-existing]}]]
+  (let [s (file src) d (file dst)]
+    (when (and (.exists d) replace-existing)
+      (delete-tree d))
+    (cond
+      (.renameTo s d) d
+      (.isFile s) (do (copy s d {:replace-existing replace-existing})
+                      (delete s)
+                      d)
+      :else (throw (ex-info "could not move" {:src (str s) :dst (str d)})))))
+
+;; --- times -------------------------------------------------------------------------
+
+(defn last-modified-time
+  "Last-modified time as a java.time.Instant."
+  [f] (java.time.Instant/ofEpochMilli (.lastModified (file f))))
+
+(defn set-last-modified-time
+  "Set last-modified from a java.time.Instant."
+  [f inst] (.setLastModified (file f) (.toEpochMilli inst)))
+
+(defn creation-time [f]
+  (throw (ex-info "creation-time is not supported on this host" {:path (str f)})))
+
+(defn read-link [f]
+  (throw (ex-info "read-link is not supported on this host" {:path (str f)})))
+
+;; --- lookup ------------------------------------------------------------------------
+
+(defn which
+  "First executable named `nm` on PATH, as a File, else nil."
+  [nm]
+  (let [dirs (str/split (or (System/getenv "PATH") "")
+                        (re-pattern File/pathSeparator))]
+    (some (fn [d]
+            (let [f (File. d (str nm))]
+              (when (and (.isFile f) (.canExecute f))
+                (absolutize f))))
+          dirs)))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -541,6 +541,8 @@
   {:suite "interop / String methods" :label ".contains" :expected "true" :actual "(.contains \"abc\" \"b\")" :portability :jvm}
   {:suite "interop / String methods" :label ".replace" :expected "\"axc\"" :actual "(.replace \"abc\" \"b\" \"x\")" :portability :jvm}
   {:suite "interop / String methods" :label ".charAt" :expected "\\b" :actual "(.charAt \"abc\" 1)" :portability :jvm}
+  {:suite "interop / String methods" :label ".codePointAt" :expected "97" :actual "(.codePointAt \"abc\" 0)" :portability :jvm}
+  {:suite "interop / String methods" :label ".codePointAt astral" :expected "26085" :actual "(.codePointAt \"日\" 0)" :portability :jvm}
   {:suite "interop / String methods" :label ".equalsIgnoreCase" :expected "true" :actual "(.equalsIgnoreCase \"AbC\" \"aBc\")" :portability :jvm}
   {:suite "interop / String methods" :label "Long/MAX_VALUE" :expected "true" :actual "(pos? Long/MAX_VALUE)" :portability :jvm}
   {:suite "interop / String methods" :label "String/valueOf num" :expected "\"42\"" :actual "(String/valueOf 42)" :portability :jvm}
@@ -656,6 +658,8 @@
   {:suite "host-interop / migratus class shims" :label "IllegalArgumentException." :expected "\"bad\"" :actual "(try (throw (IllegalArgumentException. \"bad\")) (catch Exception e (.getMessage e)))" :portability :jvm}
   {:suite "host-interop / migratus class shims" :label "InterruptedException." :expected "\"stop\"" :actual "(try (throw (InterruptedException. \"stop\")) (catch Throwable e (.getMessage e)))" :portability :jvm}
   {:suite "host-interop / migratus class shims" :label "Character/isUpperCase" :expected "true" :actual "(Character/isUpperCase \\A)" :portability :jvm}
+  {:suite "host-interop / migratus class shims" :label "Character/toChars + String ctor" :expected "\"é\"" :actual "(String. (Character/toChars 233))" :portability :jvm}
+  {:suite "host-interop / migratus class shims" :label "Character/toChars astral" :expected "\"😀\"" :actual "(String. (Character/toChars 128512))" :portability :jvm}
   {:suite "host-interop / migratus class shims" :label "Character/isLowerCase" :expected "true" :actual "(Character/isLowerCase \\a)" :portability :jvm}
   {:suite "host-interop / migratus class shims" :label "Character/isUpperCase neg" :expected "false" :actual "(Character/isUpperCase \\a)" :portability :jvm}
   {:suite "host-interop / migratus class shims" :label "Thread/interrupted" :expected "false" :actual "(Thread/interrupted)" :portability :jvm}
@@ -1471,6 +1475,9 @@
   {:suite "numbers / bit-ops & math" :label "bit-clear" :expected "13" :actual "(bit-clear 15 1)" :portability :common}
   {:suite "numbers / bit-ops & math" :label "bit-test true" :expected "true" :actual "(bit-test 4 2)" :portability :common}
   {:suite "numbers / bit-ops & math" :label "bigint 64-bit" :expected "\"9000000000\"" :actual "(str (bigint 9000000000))" :portability :common}
+  {:suite "numbers / bit-ops & math" :label "bigint from string" :expected "123" :actual "(bigint \"123\")" :portability :common}
+  {:suite "numbers / bit-ops & math" :label "bigint from double" :expected "3" :actual "(bigint 3.7)" :portability :common}
+  {:suite "numbers / bit-ops & math" :label "biginteger from string" :expected "42" :actual "(biginteger \"42\")" :portability :common}
   {:suite "numbers / random (invariants — non-deterministic)" :label "rand-int in range" :expected "true" :actual "(let [r (rand-int 5)] (and (integer? r) (>= r 0) (< r 5)))" :portability :common}
   {:suite "numbers / random (invariants — non-deterministic)" :label "rand-int zero" :expected "0" :actual "(rand-int 1)" :portability :common}
   {:suite "numbers / random (invariants — non-deterministic)" :label "rand in [0,1)" :expected "true" :actual "(let [r (rand)] (and (>= r 0) (< r 1)))" :portability :common}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -543,6 +543,7 @@
   {:suite "interop / String methods" :label ".charAt" :expected "\\b" :actual "(.charAt \"abc\" 1)" :portability :jvm}
   {:suite "interop / String methods" :label ".codePointAt" :expected "97" :actual "(.codePointAt \"abc\" 0)" :portability :jvm}
   {:suite "interop / String methods" :label ".codePointAt multibyte" :expected "26085" :actual "(.codePointAt \"日\" 0)" :portability :jvm}
+  {:suite "interop / String methods" :label ".setLastModified round-trip" :expected "1600000000000" :actual "(let [f (java.io.File/createTempFile \"slm\" \".t\")] (.setLastModified f 1600000000000) (let [r (.lastModified f)] (.delete f) r))" :portability :jvm}
   {:suite "interop / String methods" :label ".codePointAt astral" :expected "128512" :actual "(.codePointAt \"😀\" 0)" :portability :jvm}
   {:suite "interop / String methods" :label ".equalsIgnoreCase" :expected "true" :actual "(.equalsIgnoreCase \"AbC\" \"aBc\")" :portability :jvm}
   {:suite "interop / String methods" :label "Long/MAX_VALUE" :expected "true" :actual "(pos? Long/MAX_VALUE)" :portability :jvm}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -542,7 +542,8 @@
   {:suite "interop / String methods" :label ".replace" :expected "\"axc\"" :actual "(.replace \"abc\" \"b\" \"x\")" :portability :jvm}
   {:suite "interop / String methods" :label ".charAt" :expected "\\b" :actual "(.charAt \"abc\" 1)" :portability :jvm}
   {:suite "interop / String methods" :label ".codePointAt" :expected "97" :actual "(.codePointAt \"abc\" 0)" :portability :jvm}
-  {:suite "interop / String methods" :label ".codePointAt astral" :expected "26085" :actual "(.codePointAt \"日\" 0)" :portability :jvm}
+  {:suite "interop / String methods" :label ".codePointAt multibyte" :expected "26085" :actual "(.codePointAt \"日\" 0)" :portability :jvm}
+  {:suite "interop / String methods" :label ".codePointAt astral" :expected "128512" :actual "(.codePointAt \"😀\" 0)" :portability :jvm}
   {:suite "interop / String methods" :label ".equalsIgnoreCase" :expected "true" :actual "(.equalsIgnoreCase \"AbC\" \"aBc\")" :portability :jvm}
   {:suite "interop / String methods" :label "Long/MAX_VALUE" :expected "true" :actual "(pos? Long/MAX_VALUE)" :portability :jvm}
   {:suite "interop / String methods" :label "String/valueOf num" :expected "\"42\"" :actual "(String/valueOf 42)" :portability :jvm}
@@ -1308,6 +1309,13 @@
   {:suite "namespaces / ns operations" :label "find-ns missing" :expected "nil" :actual "(find-ns 'does.not.exist)" :portability :common}
   {:suite "namespaces / ns operations" :label "resolve var" :expected "true" :actual "(var? (resolve '+))" :portability :common}
   {:suite "namespaces / ns operations" :label "resolve missing" :expected "nil" :actual "(resolve 'totally-undefined-xyz)" :portability :common}
+  {:suite "namespaces / ns operations" :label "require same-file in-memory ns" :expected "5" :actual "(load-string \"(ns sfa1) (def sfx 5) (ns sfb1 (:require [sfa1])) sfa1/sfx\")" :portability :common}
+  {:suite "namespaces / ns operations" :label "refer :all one level" :expected "7" :actual "(load-string \"(ns ola1) (defn olf [] 7) (ns olb1 (:require [ola1 :refer :all])) (olf)\")" :portability :common}
+  {:suite "namespaces / ns operations" :label "refer :all does not cascade" :expected :throws :actual "(load-string \"(ns tra1) (defn trf [] 1) (ns trb1 (:require [tra1 :refer :all])) (ns trc1 (:require [trb1 :refer :all])) (trf)\")" :portability :common}
+  {:suite "namespaces / ns operations" :label "defmacro var meta :macro" :expected "true" :actual "(do (defmacro cmac1 [x] x) (:macro (meta #'cmac1)))" :portability :common}
+  {:suite "namespaces / ns operations" :label "intern symbol meta -> var meta" :expected "\"d\"" :actual "(do (intern 'user (with-meta 'idoc1 {:doc \"d\"}) 42) (:doc (meta #'idoc1)))" :portability :common}
+  {:suite "namespaces / ns operations" :label "intern :macro meta makes a macro" :expected "6" :actual "(do (defmacro cmac2 [x] (list (quote +) x 1)) (intern 'user (with-meta 'cmac3 {:macro true}) @#'cmac2) (load-string \"(cmac3 5)\"))" :portability :common}
+  {:suite "namespaces / ns operations" :label "alter-meta! :macro makes a macro" :expected "6" :actual "(do (defmacro amac1 [x] (list (quote +) x 1)) (def amac2 @#'amac1) (alter-meta! #'amac2 merge (meta #'amac1)) (load-string \"(amac2 5)\"))" :portability :common}
   {:suite "namespaces / require & refer" :label "require :as" :expected "\"AB\"" :actual "(do (require '[clojure.string :as s]) (s/upper-case \"ab\"))" :portability :common}
   {:suite "namespaces / require & refer" :label "require :refer" :expected "true" :actual "(do (require '[clojure.string :refer [blank?]]) (blank? \"\"))" :portability :common}
   {:suite "namespaces / require & refer" :label "require :as + :refer" :expected "true" :actual "(do (require '[clojure.string :as s :refer [blank?]]) (and (blank? \"\") (= \"X\" (s/upper-case \"x\"))))" :portability :common}
@@ -1476,6 +1484,9 @@
   {:suite "numbers / bit-ops & math" :label "bit-test true" :expected "true" :actual "(bit-test 4 2)" :portability :common}
   {:suite "numbers / bit-ops & math" :label "bigint 64-bit" :expected "\"9000000000\"" :actual "(str (bigint 9000000000))" :portability :common}
   {:suite "numbers / bit-ops & math" :label "bigint from string" :expected "123" :actual "(bigint \"123\")" :portability :common}
+  {:suite "numbers / bit-ops & math" :label "bigint from big string" :expected "\"9999999999999999999\"" :actual "(str (bigint \"9999999999999999999\"))" :portability :common}
+  {:suite "numbers / bit-ops & math" :label "bigint bad string throws" :expected :throws :actual "(bigint \"abc\")" :portability :common}
+  {:suite "numbers / bit-ops & math" :label "bigint from ratio" :expected "3" :actual "(bigint 7/2)" :portability :common}
   {:suite "numbers / bit-ops & math" :label "bigint from double" :expected "3" :actual "(bigint 3.7)" :portability :common}
   {:suite "numbers / bit-ops & math" :label "biginteger from string" :expected "42" :actual "(biginteger \"42\")" :portability :common}
   {:suite "numbers / random (invariants — non-deterministic)" :label "rand-int in range" :expected "true" :actual "(let [r (rand-int 5)] (and (integer? r) (>= r 0) (< r 5)))" :portability :common}

--- a/test/chez/cts-known-failures.txt
+++ b/test/chez/cts-known-failures.txt
@@ -3,7 +3,7 @@
 # with: JOLT_CTS_WRITE_BASELINE=1 host/chez/cts.sh
 clojure.core-test.abs 1 0
 clojure.core-test.add-watch 0 1
-clojure.core-test.bigint 6 0
+clojure.core-test.bigint 1 0
 clojure.core-test.bit-set 1 0
 clojure.core-test.dec 1 0
 clojure.core-test.double-qmark 3 0

--- a/test/chez/fs-test.clj
+++ b/test/chez/fs-test.clj
@@ -1,0 +1,97 @@
+;; jolt.fs gate — exercises the file-system API against a scratch temp dir.
+;; Run: bin/joltc run test/chez/fs-test.clj (smoke.sh greps for "FS-TEST OK").
+(ns fs-test
+  (:require [jolt.fs :as fs]
+            [clojure.string :as str]))
+
+(def failures (atom []))
+(defn check [label got want]
+  (when-not (= got want)
+    (swap! failures conj (str label ": want " (pr-str want) " got " (pr-str got)))))
+
+(def root (fs/create-temp-dir {:prefix "fs-gate-"}))
+
+;; file coercion + nesting
+(check "file nests" (fs/file-name (fs/file root "a" "b.txt")) "b.txt")
+
+;; creation
+(fs/create-dirs (fs/file root "d1" "d2"))
+(check "create-dirs" (fs/directory? (fs/file root "d1" "d2")) true)
+(fs/create-dir (fs/file root "d3"))
+(check "create-dir" (fs/directory? (fs/file root "d3")) true)
+(fs/create-file (fs/file root "d3" "empty.txt"))
+(check "create-file" (fs/regular-file? (fs/file root "d3" "empty.txt")) true)
+
+;; content + size
+(spit (str (fs/file root "d1" "one.clj")) "12345")
+(spit (str (fs/file root "d1" "d2" "two.clj")) "abc")
+(spit (str (fs/file root "d1" "three.txt")) "x")
+(check "size" (fs/size (fs/file root "d1" "one.clj")) 5)
+(check "exists?" (fs/exists? (fs/file root "d1" "one.clj")) true)
+(check "exists? neg" (fs/exists? (fs/file root "nope")) false)
+
+;; path pieces
+(check "file-name" (fs/file-name (fs/file root "d1" "one.clj")) "one.clj")
+(check "extension" (fs/extension "a/b/one.clj") "clj")
+(check "extension none" (fs/extension "a/b/Makefile") nil)
+(check "strip-ext" (fs/strip-ext "one.clj") "one")
+(check "parent" (fs/file-name (fs/parent (fs/file root "d1" "one.clj"))) "d1")
+(check "relativize" (str (fs/relativize root (fs/file root "d1" "one.clj")))
+       (str "d1" java.io.File/separator "one.clj"))
+(check "absolute?" (fs/absolute? root) true)
+(check "relative?" (fs/relative? "a/b") true)
+
+;; listing + glob
+(check "list-dir count" (count (fs/list-dir (fs/file root "d1"))) 3)
+(check "walk includes root" (first (fs/walk root)) (fs/file root))
+(check "glob *" (mapv fs/file-name (sort-by str (fs/glob (fs/file root "d1") "*.clj")))
+       ["one.clj"])
+(check "glob **" (mapv fs/file-name (sort-by str (fs/glob root "**.clj")))
+       ["two.clj" "one.clj"])
+(check "glob ?" (mapv fs/file-name (fs/glob (fs/file root "d1") "one.cl?"))
+       ["one.clj"])
+(check "glob alt" (count (fs/glob (fs/file root "d1") "*.{clj,txt}")) 2)
+(check "glob none" (fs/glob root "*.nope") ())
+
+;; copy / copy-tree / move
+(fs/copy (fs/file root "d1" "one.clj") (fs/file root "d3" "one-copy.clj"))
+(check "copy" (fs/size (fs/file root "d3" "one-copy.clj")) 5)
+(check "copy no-replace throws"
+       (try (fs/copy (fs/file root "d1" "one.clj") (fs/file root "d3" "one-copy.clj"))
+            :no-throw (catch Exception _ :threw))
+       :threw)
+(fs/copy (fs/file root "d1" "three.txt") (fs/file root "d3" "one-copy.clj")
+         {:replace-existing true})
+(check "copy replace" (fs/size (fs/file root "d3" "one-copy.clj")) 1)
+(fs/copy-tree (fs/file root "d1") (fs/file root "d1-copy"))
+(check "copy-tree nested" (slurp (str (fs/file root "d1-copy" "d2" "two.clj"))) "abc")
+(fs/move (fs/file root "d1-copy") (fs/file root "d1-moved"))
+(check "move" (fs/exists? (fs/file root "d1-moved" "one.clj")) true)
+(check "move gone" (fs/exists? (fs/file root "d1-copy")) false)
+
+;; times
+(def t0 (java.time.Instant/ofEpochMilli 1600000000000))
+(fs/set-last-modified-time (fs/file root "d1" "one.clj") t0)
+(check "mtime round-trip" (fs/last-modified-time (fs/file root "d1" "one.clj")) t0)
+
+;; which / cwd
+(check "which sh" (some? (fs/which "sh")) true)
+(check "which nonsense" (fs/which "no-such-binary-xyz") nil)
+(check "cwd is dir" (fs/directory? (fs/cwd)) true)
+
+;; unsupported ops throw cleanly
+(check "sym-link? throws"
+       (try (fs/sym-link? root) :no-throw (catch Exception _ :threw)) :threw)
+
+;; deletion
+(check "delete-if-exists" (fs/delete-if-exists (fs/file root "d3" "empty.txt")) true)
+(check "delete-if-exists neg" (fs/delete-if-exists (fs/file root "d3" "empty.txt")) false)
+(check "delete missing throws"
+       (try (fs/delete (fs/file root "nope")) :no-throw (catch Exception _ :threw)) :threw)
+(fs/delete-tree root)
+(check "delete-tree" (fs/exists? root) false)
+
+(if (empty? @failures)
+  (println "FS-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "FS-TEST FAILED:" (count @failures))))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -606,4 +606,16 @@
   ;; WP-A: keyword/map/pvec/multimethod callables all dispatch through the
   ;; fixed-arity jolt-invoke1 slow path (non-procedure callee).
   {:suite "wp-invoke-cache" :expr "(do (defmulti wpi-mm (fn [x] (:t x))) (defmethod wpi-mm :foo [x] (:v x)) [(wpi-mm {:t :foo :v 7}) (:k {:k 9}) ({:a 1} :a) ([1 2 3] 1)])" :expected "[7 9 1 2]"}
+  ;; intern: symbol meta lands on the var; :macro true makes the var expand as a
+  ;; macro (load-string compiles after the intern, so the use site sees it).
+  {:suite "intern" :expr "(do (defmacro im-src [x] (list (quote +) x 1)) (intern 'user (with-meta 'im-macro {:macro true}) @#'im-src) (load-string \"(im-macro 5)\"))" :expected "6"}
+  {:suite "intern" :expr "(do (intern 'user (with-meta 'iv-doc {:doc \"d\"}) 42) [(:doc (meta #'iv-doc)) iv-doc])" :expected "[d 42]"}
+  {:suite "intern" :expr "(do (intern 'user 'iv-plain 7) iv-plain)" :expected "7"}
+  ;; a defmacro var reports :macro true in its meta (JVM parity), so re-export
+  ;; idioms that copy (meta var) onto a new var carry macro-ness with it.
+  {:suite "intern" :expr "(do (defmacro mmeta1 [x] x) (:macro (meta #'mmeta1)))" :expected "true"}
+  ;; alter-meta! adding :macro true makes the var expand as a macro — the
+  ;; yamlscript ys.v0 re-export idiom: intern a wrapper fn, merge the source
+  ;; macro's meta onto it.
+  {:suite "intern" :expr "(do (defmacro am-src [x] (list (quote +) x 1)) (def am-tgt @#'am-src) (alter-meta! #'am-tgt merge (meta #'am-src)) (load-string \"(am-tgt 5)\"))" :expected "6"}
 ]


### PR DESCRIPTION
Three clusters of general fixes shaken out by running yamlstar and compiled-YAMLScript output on jolt.

**yamlstar** (yaml/yamlstar) now passes its full core suite: 44 tests, 103 assertions, 0 failures, 0 errors (was 27 pass / 6 fail / 69 errors). Listed in docs/libraries.md + the site.

- `String.codePointAt` (the parser's range matcher — accounted for all 69 errors), `Character/toChars`.
- `bigint`/`biginteger` were identity; they now coerce like the JVM (string → parsed integer, double → truncated, ratio → quotient). This also un-baselined 5 CTS bigint tests.

**Macro-ness and var metadata** — yamlscript's `ys.v0` re-exports every public var by interning a wrapper fn and merging the source var's meta. On the JVM that carries macro-ness (`Var.isMacro` reads `:macro` meta); jolt kept macro-ness in a side table that `intern`/`alter-meta!` never touched, and defmacro vars didn't report `:macro` at all, so re-exported macros arrived as plain functions and their call sites evaluated eagerly with nil bindings.

- `intern` applies the symbol's metadata to the var and marks macros.
- `alter-meta!`/`reset-meta!` sync a truthy `:macro` into the macro table (one-way; defmacro vars derive `:macro` rather than storing it).
- `(meta a-macro-var)` includes `:macro true`.
- `require` of a same-file in-memory namespace is satisfied (a file can hold several ns forms).
- A draft fix made `:refer :all` cascade transitively; the JVM doesn't do that (only publics travel), so it was dropped and a corpus row pins the non-cascading behavior.

Result: the compiled-YAMLScript gist (yamlscript.util/common + ys stdlib + main) runs on jolt with output byte-identical to the JVM. The published gist has its own 0-arg `(say)` arity bug — both hosts crash identically on it; with that one line fixed the full program runs end to end.

**jolt.fs** (stdlib/jolt/fs.clj) — file-system utilities with a babashka.fs-shaped API: predicates, path pieces, walk + a real glob (`**`/`*`/`?`/`{a,b}`), create/delete/copy/copy-tree/move, mtime get/set, `which`, `cwd`. Grew out of the babashka.fs shim the YAMLScript run needed; promoted to core since it's generally useful. `File.setLastModified` was a stub that returned true without touching the file — now sets atime+mtime via utimes(2).

Tests: 8 new unit rows, 14 corpus rows (JVM-certified), a self-checking jolt.fs gate in cli smoke, CTS baseline improvement. Full `make test` green including selfhost; shakesmoke byte-identical (all changes are runtime .ss / stdlib — no re-mint).