### PR TITLE
Surface swallowed exceptions in go/thread bodies, Thread.start, data-reader loads

### DIFF
--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -114,7 +114,9 @@
 (define (ac-close! ch)
   (unless (async-chan-closed? ch)
     (async-chan-closed?-set! ch #t)
-    (when (async-chan-xrf ch) (guard (e (#t #f)) (ac-xrf-apply ch)))
+    (when (async-chan-xrf ch)
+      (guard (e (#t (async-report-uncaught! "transducer completion on close!" e)))
+        (ac-xrf-apply ch)))
     (condition-broadcast (async-chan-cv ch)))
   jolt-nil)
 (define (jolt-async-close! ch) (with-mutex (async-chan-mu ch) (ac-close! ch)))
@@ -263,13 +265,26 @@
 ;; (go-spawn thunk) — run thunk on a thread; return a buffered(1) channel that
 ;; conveys its value once then closes (a nil result just closes). Dynamic bindings
 ;; are conveyed (Chez inherits the thread-parameter at fork; we install explicitly).
+
+;; Print an uncaught-exception report to stderr — the JVM routes a thread body's
+;; throw to the default uncaught-exception handler; silence here made a throwing
+;; worker indistinguishable from one that returned nil. Reporting failures are
+;; themselves swallowed (a worker must never die reporting).
+(define (async-report-uncaught! where e)
+  (guard (_ (#t #f))
+    (display (string-append "Exception in " where ":\n") (current-error-port))
+    (jolt-report-throwable e (current-error-port)))
+  #f)
+
 (define (async-go-spawn thunk)
   (let ((w (ac-make 1 'fixed #f)) (snap (dyn-binding-stack)))
     (fork-thread
      (lambda ()
        (dyn-binding-stack snap)
        (let ((r (guard (e (#t (cons #f e))) (cons #t (jolt-invoke thunk)))))
-         (when (and (car r) (not (jolt-nil? (cdr r)))) (jolt-async-give w (cdr r)))
+         (if (car r)
+             (when (not (jolt-nil? (cdr r))) (jolt-async-give w (cdr r)))
+             (async-report-uncaught! "go/thread body (channel closed)" (cdr r)))
          (jolt-async-close! w))))
     w))
 

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -394,7 +394,13 @@
           (let ((st (jhost-state self)) (snap (dyn-binding-stack)))
             (fork-thread (lambda ()
               (dyn-binding-stack snap)
-              (guard (e (#t #f)) (jolt-invoke (vector-ref st 0)))
+              ;; surface a thread body's throw like the JVM's default uncaught-
+              ;; exception handler; the thread still completes (isAlive/join
+              ;; semantics unchanged). Reporting failures are swallowed.
+              (guard (e (#t (guard (_ (#t #f))
+                              (display "Exception in Thread body:\n" (current-error-port))
+                              (jolt-report-throwable e (current-error-port)))))
+                (jolt-invoke (vector-ref st 0)))
               (with-mutex (vector-ref st 2)
                 (vector-set! st 1 #t)
                 (condition-broadcast (vector-ref st 3)))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -107,7 +107,18 @@
       ;; eagerly load each reader fn's namespace so the rewritten call resolves.
       (pmap-fold m (lambda (k v a)
                      (when (and (symbol-t? v) (symbol-t-ns v) (not (jolt-nil? (symbol-t-ns v))))
-                       (guard (e (#t #f)) (load-namespace (symbol-t-ns v))))
+                       ;; tolerant — a data_readers entry must not kill the project
+                       ;; load — but say WHICH reader ns failed and why, or the
+                       ;; miss surfaces later as an unrelated unresolved-var error
+                       ;; at first #tag read.
+                       (guard (e (#t (display
+                                      (string-append "jolt: warning: data-reader namespace "
+                                                     (symbol-t-ns v) " failed to load: "
+                                                     (guard (_ (#t "(unprintable error)"))
+                                                       ((var-deref "jolt.host" "condition-message") e))
+                                                     "\n")
+                                      (current-error-port))))
+                         (load-namespace (symbol-t-ns v))))
                      a)
                  #f)))))
 (define (load-data-readers!)

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -161,6 +161,25 @@ else
   fails=$((fails + 1))
 fi
 
+# A throwing go/thread body reports to stderr (the JVM's uncaught-exception
+# handler behavior) while the channel still just closes: <!! stays nil.
+thr_out="$(bin/joltc -e "(do (require '[clojure.core.async :as a]) (pr (a/<!! (a/thread (/ 1 0)))))" 2>/tmp/jolt-smoke-thr-err)"
+if [ "$thr_out" = "nil" ] && grep -q "Exception in go/thread body" /tmp/jolt-smoke-thr-err; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: throwing (thread ...) should print an uncaught report and <!! nil"
+  echo "    stdout \`$thr_out\`; stderr: $(head -1 /tmp/jolt-smoke-thr-err)"
+  fails=$((fails + 1))
+fi
+# Same for a raw Thread body.
+bin/joltc -e '(do (.start (Thread. (fn [] (throw (ex-info "boom" {}))))) (Thread/sleep 200))' 2>/tmp/jolt-smoke-thr2-err >/dev/null
+if grep -q "Exception in Thread body" /tmp/jolt-smoke-thr2-err; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a throwing Thread body should print an uncaught report"
+  fails=$((fails + 1))
+fi
+
 # jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
 # move, mtime round-trip, which). The file self-checks and prints one marker.
 fs_out="$(bin/joltc run test/chez/fs-test.clj 2>/dev/null)"


### PR DESCRIPTION
First round of the general-audit epic (jolt-njdd, bead jolt-fh0f).

A throwing `go`/`thread` body was captured and discarded — the channel just closed, making a failing worker indistinguishable from one that returned nil (`(<!! (thread (/ 1 0)))` → nil, total silence). All four swallow-sites now print an uncaught-exception report to stderr, matching the JVM's default uncaught-exception handler behavior, while value semantics stay exactly as they were:

- `go`/`thread` bodies (both route through `async-go-spawn`) — report, then close the channel; `<!!` still returns nil.
- Raw `(.start (Thread. f))` bodies — report; `isAlive`/`join` unchanged.
- A stateful transducer's completion step failing at `close!` — report.
- A data-reader namespace failing to load — still tolerant (a `data_readers.clj` entry must not kill the project load), but one warning names the namespace and the underlying error instead of surfacing later as an unrelated unresolved-var error at the first `#tag` read.

Reporting failures are themselves swallowed — a worker must never die reporting. All runtime `.ss`, no re-mint. cli smoke pins the stderr reports and the preserved nil semantics; `make ci` green.