### PR TITLE
Loud boundary validation; atomic spit; port/buffer lifecycle

### DIFF
--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -112,9 +112,11 @@
 (define (ffi-string->ptr s)
   (let* ((bv (string->utf8 (jolt-str-render-one s))) (n (bytevector-length bv))
          (p (foreign-alloc (+ n 1))))
-    (do ((i 0 (+ i 1))) ((= i n)) (foreign-set! 'unsigned-8 p i (bytevector-u8-ref bv i)))
-    (foreign-set! 'unsigned-8 p n 0)
-    p))
+    ;; free on a mid-copy throw — the caller only ever sees a whole buffer
+    (guard (e (#t (guard (_ (#t #f)) (foreign-free p)) (raise e)))
+      (do ((i 0 (+ i 1))) ((= i n)) (foreign-set! 'unsigned-8 p i (bytevector-u8-ref bv i)))
+      (foreign-set! 'unsigned-8 p n 0)
+      p)))
 
 ;; --- callbacks: receive calls FROM C ----------------------------------------
 ;; jolt.ffi/foreign-callable lowers to (jolt-ffi-register-callable! (foreign-callable …)).

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -297,8 +297,8 @@
     ((or (jfile? output) (string? output))
      (let ((bv (and (not (string? input)) (not (jfile? input)) (input-bytes input))))
        (if bv
-           (let ((port (open-file-output-port (path-of output) (file-options no-fail) (buffer-mode block))))
-             (put-bytevector port bv) (close-port port))
+           (with-port (open-file-output-port (path-of output) (file-options no-fail) (buffer-mode block))
+             (lambda (port) (put-bytevector port bv)))
            (jolt-spit output (input-text input)))))
     ;; a byte-output-stream shim (a host tagged-table with :jolt/output-stream,
     ;; e.g. http-client's ByteArrayOutputStream): write through its .write method,

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -42,21 +42,25 @@
   (let ((v (hashtable-ref embedded-resources name #f)))
     (and (bytevector? v) v)))
 
+;; --- with-port: open a port, do work, close on success or throw ----------------
+(define (with-port port proc)
+  (guard (e (#t (guard (_ (#t #f)) (close-port port)) (raise e)))
+    (let ((result (proc port)))
+      (close-port port)
+      result)))
+
 ;; Read a whole file as a bytevector ("" -> empty). Used to slurp boot/stub files.
 (define (read-file-bytes path)
-  (let ((p (open-file-input-port path)))
-    (let ((bv (get-bytevector-all p)))
-      (close-port p)
-      (if (eof-object? bv) (bytevector) bv))))
+  (with-port (open-file-input-port path)
+    (lambda (p) (let ((bv (get-bytevector-all p))) (if (eof-object? bv) (bytevector) bv)))))
 
 ;; Write an embedded bytevector resource out to a path. make-boot-file needs the
 ;; petite/scheme boots as files, so they are spilled to scratch before the call.
 (define (jolt-spill-embedded! name path)
   (let ((bv (jolt-embedded-bytes name)))
     (unless bv (error 'jolt-spill-embedded! "no embedded bytes for" name))
-    (let ((p (open-file-output-port path (file-options no-fail) (buffer-mode block))))
-      (put-bytevector p bv)
-      (close-port p))))
+    (with-port (open-file-output-port path (file-options no-fail) (buffer-mode block))
+      (lambda (p) (put-bytevector p bv)))))
 
 ;; Frame an app boot onto a file that already holds the stub bytes. Layout:
 ;; [stub][boot][boot-length:le64]["JOLTBOOT"]. The stub (host/chez/stub/launcher.c)
@@ -65,15 +69,15 @@
 ;; magic bytes can't be mistaken for the frame.
 (define jolt-payload-magic (string->utf8 "JOLTBOOT"))
 (define (jolt-append-payload! path boot-bv)
-  (let ((head (read-file-bytes path)))           ; the stub bytes already written
-    (let ((p (open-file-output-port path (file-options no-fail) (buffer-mode block)))
-          (lb (make-bytevector 8 0)))
-      (bytevector-u64-set! lb 0 (bytevector-length boot-bv) (endianness little))
-      (put-bytevector p head)
-      (put-bytevector p boot-bv)
-      (put-bytevector p lb)
-      (put-bytevector p jolt-payload-magic)
-      (close-port p))))
+  (let* ((head (read-file-bytes path))           ; the stub bytes already written
+         (lb (make-bytevector 8 0)))
+    (bytevector-u64-set! lb 0 (bytevector-length boot-bv) (endianness little))
+    (with-port (open-file-output-port path (file-options no-fail) (buffer-mode block))
+      (lambda (p)
+        (put-bytevector p head)
+        (put-bytevector p boot-bv)
+        (put-bytevector p lb)
+        (put-bytevector p jolt-payload-magic)))))
 
 ;; chmod 0755 via libc, so the produced binary is executable. load-shared-object
 ;; with #f pulls the running process's own symbols (chmod is in libc, linked into
@@ -283,8 +287,8 @@
 
 ;; --- slurp / spit / flush ---------------------------------------------------
 (define (read-file-string path)
-  (let ((p (open-input-file path)))
-    (let ((s (get-string-all p))) (close-port p) (if (eof-object? s) "" s))))
+  (with-port (open-input-file path)
+    (lambda (p) (let ((s (get-string-all p))) (if (eof-object? s) "" s)))))
 
 ;; Drain a jhost reader (StringReader / PushbackReader): read code units from the
 ;; current position to EOF (-1) and assemble the string. Used by slurp; advances
@@ -372,11 +376,25 @@
                 (jolt-truthy? (cadr o))) #t)
           (else (loop (cddr o))))))
 
+(define spit-tmp-counter 0)
 (define (jolt-spit path content . opts)
+  ;; Render BEFORE any file is touched — a throwing toString used to leave the
+  ;; target truncated. The non-append write goes to a temp file in the same
+  ;; directory and renames over the target, so a mid-write failure (disk full)
+  ;; never destroys the original. Append keeps writing in place.
   (let* ((p (project-relative (file-path-of path)))
-         (port (open-output-file p (if (spit-append? opts) 'append 'truncate))))
-    (put-string port (jolt-str-render-one content))
-    (close-port port)
+         (text (jolt-str-render-one content)))
+    (if (spit-append? opts)
+        (with-port (open-output-file p 'append)
+          (lambda (port) (put-string port text)))
+        (let ((tmp (string-append p ".spit-tmp-"
+                                   (number->string (real-time)) "-"
+                                   (number->string (begin (set! spit-tmp-counter (+ spit-tmp-counter 1))
+                                                          spit-tmp-counter)))))
+          (with-port (open-output-file tmp 'replace)
+            (lambda (port) (put-string port text)))
+          (guard (e (#t (guard (_ (#t #f)) (delete-file tmp)) (raise e)))
+            (rename-file tmp p))))
     jolt-nil))
 
 (define (jolt-flush) (flush-output-port (current-output-port)) jolt-nil)

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -1237,6 +1237,11 @@
       (if f (jolt-invoke f v)
           (let ((s (jrec-pr v))) (substring s 1 (string-length s)))))))
 
+;; a reify with a toString method renders through it, like the JVM.
+(register-str-render! (lambda (v) (and (jreify? v) (reified-methods v)
+                                       (hashtable-ref (reified-methods v) "toString" #f) #t))
+  (lambda (v) (jolt-invoke (hashtable-ref (reified-methods v) "toString" #f) v)))
+
 ;; `type` lives in natives-meta.ss: it needs jolt-meta for the :type
 ;; override and a total value->taxonomy mapping, so it sits with meta — a record
 ;; yields (jolt-symbol #f (jrec-tag x)), the ns.Name class-name symbol.

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -193,6 +193,29 @@ else
   fails=$((fails + 1))
 fi
 
+# A malformed PROJECT deps.edn is a hard error naming the file; a git dep
+# without :git/sha names the coordinate.
+bp="$(mktemp -d)/badproj"; mkdir -p "$bp/src"
+printf '{:paths ["src" :oops\n' > "$bp/deps.edn"
+berr="$(JOLT_PWD="$bp" bin/joltc run -m app 2>&1)"
+if printf '%s' "$berr" | grep -q 'deps.edn'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: malformed project deps.edn should be a hard error naming the file"
+  fails=$((fails + 1))
+fi
+gp="$(mktemp -d)/gitproj"; mkdir -p "$gp/src"
+printf '{:paths ["src"] :deps {some/dep {:git/url "https://example.com/x.git"}}}\n' > "$gp/deps.edn"
+printf '(ns app)\n(defn -main [& _] (println :ok))\n' > "$gp/src/app.clj"
+gerr="$(JOLT_PWD="$gp" bin/joltc run -m app 2>&1)"
+if printf '%s' "$gerr" | grep -q 'needs :git/sha'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a git dep without :git/sha should say so"
+  echo "    got: $(printf '%s' "$gerr" | head -1)"
+  fails=$((fails + 1))
+fi
+
 # jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
 # move, mtime round-trip, which). The file self-checks and prints one marker.
 fs_out="$(bin/joltc run test/chez/fs-test.clj 2>/dev/null)"

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -15,12 +15,13 @@
 (defn- file-exists? [p] (jolt.host/file-exists? p))
 (defn- sh [cmd] (jolt.host/sh cmd))           ; exit code, inherits stdout/stderr
 (defn- sh-out [cmd] (jolt.host/sh-out cmd))   ; captured stdout
-(defn- warn [& xs] (println (str "[jolt.deps] " (apply str xs))))
+(defn- warn [& xs] (binding [*out* *err*] (println (str "[jolt.deps] " (apply str xs)))))
 
 (defn- read-edn [path]
   (when (file-exists? path)
     (try (edn/read-string (slurp path))
-         (catch :default e (warn "could not read " path ": " (ex-message e)) nil))))
+         (catch :default e
+           (throw (ex-info (str path ": " (ex-message e)) {:path path :error e}))))))
 
 (defn- abspath [dir p]
   (if (str/starts-with? p "/") p (str dir "/" p)))
@@ -52,7 +53,8 @@
         (when-not (zero? (sh (str "git -C " (pr-str dir) " checkout --quiet " (pr-str sha))))
           (throw (ex-info (str "git checkout failed: " sha " in " url) {:url url :sha sha})))
         ;; submodules are pinned in the checkout; pull them if the dep uses any.
-        (sh (str "git -C " (pr-str dir) " submodule update --init --recursive --quiet"))
+        (when-not (zero? (sh (str "git -C " (pr-str dir) " submodule update --init --recursive --quiet")))
+          (throw (ex-info (str "git submodule update failed for " url) {:url url})))
         dir))))
 
 ;; --- coordinate -> root dir -------------------------------------------------
@@ -64,6 +66,8 @@
     (and (:git/url spec) (:git/sha spec))
     (let [checkout (ensure-git (:git/url spec) (:git/sha spec))]
       (if-let [root (:deps/root spec)] (str checkout "/" root) checkout))
+    (:git/url spec)
+    (throw (ex-info (str "git dep " coord " needs :git/sha") {:coord coord :spec spec}))
     (:jolt/module spec)
     (do (warn "skipping janet dependency " coord " (:jolt/module is obsolete on Chez)") nil)
     ;; jolt IS Clojure — a dependency on org.clojure/clojure is satisfied
@@ -77,7 +81,8 @@
   "Source roots a resolved dep contributes: its deps.edn :paths (default [\"src\"])
   resolved under its root dir."
   [root]
-  (let [edn (read-edn (str root "/deps.edn"))
+  (let [edn (try (read-edn (str root "/deps.edn"))
+                 (catch :default e (warn (ex-message e)) nil))
         paths (or (:paths edn) ["src"])]
     (map #(abspath root %) paths)))
 
@@ -127,8 +132,15 @@
           (let [root (coord-root coord spec bd)]
             (if (nil? root)
               (recur queue i (conj seen coord) roots natives)
-              (let [edn (read-edn (str root "/deps.edn"))
-                    child (mapv (fn [[c s]] [c s root]) (seq (:deps edn)))]
+              ;; a DEP repo's malformed deps.edn warns and contributes nothing;
+              ;; only the project's own deps.edn is a hard error (resolve-project).
+              (let [edn (try (read-edn (str root "/deps.edn"))
+                             (catch :default e (warn (ex-message e)) nil))
+                    deps (:deps edn)
+                    _ (when (and edn deps (not (map? deps)))
+                        (throw (ex-info (str "malformed :deps in " root "/deps.edn: expected a map")
+                                        {:path root :given (class deps)})))
+                    child (mapv (fn [[c s]] [c s root]) (seq deps))]
                 (recur (into queue child)
                        i
                        (conj seen coord)

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -278,8 +278,12 @@
   ;; built-in handler — sessions / interruptible-eval / completion etc.
   (let [resolved (deps/resolve-project (project-dir))]
     (apply-project! resolved)
-    (let [port (or (some-> (first (filter #(not (str/starts-with? % "-")) more)) parse-long)
-                   (parse-long (or (jolt.host/getenv "JOLT_NREPL_PORT") "7888")))]
+    (let [raw-port (first (filter #(not (str/starts-with? % "-")) more))
+          parsed (some-> raw-port parse-long)
+          default (parse-long (or (jolt.host/getenv "JOLT_NREPL_PORT") "7888"))
+          port (or parsed default)]
+      (when (and raw-port (nil? parsed))
+        (println (str "warning: ignoring invalid nREPL port '" raw-port "', using " default)))
       (require 'jolt.nrepl)
       ;; start binds the socket synchronously on this (primordial) thread, so a
       ;; failure like the port already being in use surfaces here and exits rather

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1914,6 +1914,7 @@
   {:suite "regex / literals & predicate" :label "escaped ] in a char class" :expected "\"]x\"" :actual "(re-find #\"[\\]]x\" \"]x\")" :portability :common}
   {:suite "regex / literals & predicate" :label "escaped ] amid class members" :expected "\")\"" :actual "(re-find #\"[\\.\\,\\s\\]\\}\\)]\" \")\")" :portability :common}
   {:suite "regex / literals & predicate" :label "replacement backslash escape" :expected "4" :actual "(count (clojure.string/replace \"abc\" #\"b\" \"\\\\\\\\d\"))" :portability :common}
+  {:suite "interop / String methods" :label "str of a reify with toString" :expected "\"xyz\"" :actual "(str (reify Object (toString [_] \"xyz\")))" :portability :jvm}
   {:suite "regex / literals & predicate" :label "replacement escaped dollar" :expected "3" :actual "(count (clojure.string/replace \"abc\" #\"b\" \"\\\\$\"))" :portability :common}
   {:suite "regex / literals & predicate" :label "escaped digits" :expected "\"42\"" :actual "(re-find #\"\\d+\" \"x42y\")" :portability :common}
   {:suite "regex / literals & predicate" :label "escaped ws/non-ws" :expected "\"x a\"" :actual "(re-find #\"\\S\\s\\S\" \"x a b y\")" :portability :common}

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -357,6 +357,9 @@
   {:suite "reader" :expr "(do (require (quote [clojure.edn :as e0])) (= :end (e0/read-string {:eof :end} \"\")))" :expected "true"}
   {:suite "reader" :expr "(do (require (quote [clojure.edn :as e0])) (= [:custom 5] (e0/read-string {:readers {(quote custom) (fn [v] [:custom v])}} \"#custom 5\")))" :expected "true"}
   {:suite "reader" :expr "(do (require (quote clojure.edn)) (= {:a 1 :b 2} (clojure.edn/read-string \"{:a 1\\n :b 2}\")))" :expected "true"}
+  ;; atomic spit: a throwing render (or failed write) leaves the original file
+  ;; intact — deliberately STRONGER than the JVM, whose spit truncates first.
+  {:suite "atomic-spit" :expr "(let [f (java.io.File/createTempFile \"spt\" \".t\")] (spit f \"ok\") (try (spit f (reify Object (toString [_] (throw (ex-info \"b\" {}))))) (catch Exception _ nil)) (let [r (slurp f)] (.delete f) r))" :expected "ok"}
   {:suite "reader-errors" :expr "(try (read-string \"\\\"unterminated\") (catch Exception e [(:line (ex-data e)) (:column (ex-data e))]))" :expected "[1 14]"}
   {:suite "reader-errors" :expr "(try (read-string \"[1 2 3\") (catch Exception e [(:line (ex-data e)) (:column (ex-data e))]))" :expected "[1 7]"}
   {:suite "reader-errors" :expr "(try (read-string \"#?\") (catch Exception e [(:line (ex-data e)) (:column (ex-data e))]))" :expected "[1 3]"}


### PR DESCRIPTION
General-audit epic (jolt-njdd, beads jolt-ml7d + jolt-d38k).

**deps.edn/CLI validation** — malformed input fails loudly instead of degrading: a malformed *project* deps.edn is a hard error naming the file (with the reader's new line:column); a *dep* repo's malformed deps.edn warns to stderr and contributes nothing; `:deps` of the wrong shape reports "malformed :deps in <path>" instead of a bare destructure error; a git dep missing `:git/sha` names the coordinate instead of silently dropping; the submodule-update exit code is checked like clone/checkout; a garbage nREPL port argument warns before falling back to the default.

**Atomic spit** — render before touching the file, write to a same-dir temp, rename over the target: a throwing `toString` or a mid-write failure no longer destroys the original. Deliberately stronger than the JVM (which truncates first and leaves an empty file — verified); a unit row pins jolt's behavior. One `with-port` helper (close on success or throw) replaces the open/operate/close pattern across the io read/write sites, and `ffi-string->ptr` frees its buffer if the copy loop throws.

**Bonus parity fix** — `str` of a reify with a `toString` method now renders through it like the JVM (surfaced by the spit test; JVM-certified corpus row).

All runtime, no re-mint. cli smoke pins the new error messages; `make ci` green.