### PR TITLE
Dead code sweep: eleven unreferenced definitions

### DIFF
--- a/host/chez/converters.ss
+++ b/host/chez/converters.ss
@@ -153,9 +153,6 @@
                  (string-append (if (string? p) p (jolt-str-render-one p))
                                 (number->string jolt-gensym-counter)))))
 
-;; int/long: truncate toward zero to an EXACT integer (= JVM long). char -> code
-;; point (exact). double: always a flonum (= JVM double).
-(define (jolt-int x) (if (char? x) (char->integer x) (exact (truncate x))))
 ;; a numeric type outside Chez's tower converts through this hook (bigdec).
 (define (jolt-double-slow x) (jolt-num-cast-throw x))
 (define (jolt-double x)
@@ -166,8 +163,6 @@
 ;; compare: 3-way, returns an EXACT integer (= JVM compare -> int).
 (define (jolt-cmp3 x y) (cond ((< x y) -1) ((> x y) 1) (else 0)))
 (define (jolt-strcmp a b) (cond ((string<? a b) -1) ((string>? a b) 1) (else 0)))
-(define (jolt-kw->string k)
-  (let ((ns (keyword-t-ns k))) (if ns (string-append ns "/" (keyword-t-name k)) (keyword-t-name k))))
 (define (jolt-sym-ns-string s)
   (let ((n (symbol-t-ns s))) (if (or (jolt-nil? n) (not n) (eq? n '())) "" n)))
 ;; compare returns an EXACT integer -1/0/1 (= JVM compare -> int).

--- a/host/chez/dyn-binding.ss
+++ b/host/chez/dyn-binding.ss
@@ -117,7 +117,6 @@
 ;; defined (ns.ss loaded earlier); chez-current-ns consults it too.
 (set! star-ns-cell (jolt-var "clojure.core" "*ns*"))
 
-(define %dyn-rt-var-deref var-deref)
 (set! var-deref
   (lambda (ns name)
     (let ((cell (jolt-var ns name)))

--- a/host/chez/host-contract.ss
+++ b/host/chez/host-contract.ss
@@ -36,7 +36,6 @@
 (define hc-kw-num-ret (keyword #f "num-ret"))
 (define hc-kw-double (keyword #f "double"))
 (define hc-kw-long (keyword #f "long"))
-(define hc-kw-regex (keyword #f "regex"))
 (define hc-kw-inst  (keyword #f "#inst"))
 (define hc-kw-uuid  (keyword #f "#uuid"))
 (define hc-kw-bigdec (keyword #f "bigdec"))

--- a/host/chez/java/inst-time.ss
+++ b/host/chez/java/inst-time.ss
@@ -364,9 +364,6 @@
     (make-jhost "local-date-time" (vector ed (* mod 1000000)))))
 ;; local-date from epoch-ms: the epoch-day of the UTC day containing ms.
 (define (mk-local-date ms) (make-jhost "local-date" (vector (inst-floor-div (exact (truncate ms)) 86400000))))
-;; start of the UTC day containing ms.
-(define (start-of-utc-day ms)
-  (* (inst-floor-div (exact (truncate ms)) 86400000) 86400000))
 ;; a formatter carries its pattern and a locale id (default "en"); the locale
 ;; selects month/day names in the java-time.ss format engine.
 (define (mk-formatter pat . loc) (make-jhost "dt-formatter" (vector pat (if (null? loc) "en" (car loc)))))

--- a/host/chez/java/java-time.ss
+++ b/host/chez/java/java-time.ss
@@ -98,19 +98,6 @@
                        (string-append ":" (pad2 s) (if (= nano 0) "" (string-append "." (frac-digits nano))))))))
 (define (iso-datetime-str ed nod)
   (string-append (iso-date-str ed) "T" (iso-time-str nod)))
-;; Instant: always UTC with a trailing Z; seconds always shown, millis only when nonzero.
-(define (iso-instant-str ms)
-  (let* ((ems (exact (truncate ms)))
-         (secs (jt-floor-div ems 1000))
-         (frac (- ems (* secs 1000)))
-         (ed (jt-floor-div secs 86400))
-         (sod (jt-floor-mod secs 86400))
-         (nod (* (+ (* (quotient sod 3600) 3600) (* (quotient (modulo sod 3600) 60) 60) (modulo sod 60))
-                 nanos-per-sec)))
-    (string-append (iso-date-str ed) "T"
-                   (pad2 (quotient sod 3600)) ":" (pad2 (modulo (quotient sod 60) 60)) ":" (pad2 (modulo sod 60))
-                   (if (= frac 0) "" (string-append "." (frac-digits (* frac 1000000))))
-                   "Z")))
 ;; nano-precise ISO instant. The fraction is shown in groups of 3 digits (millis,
 ;; micros, or nanos), matching DateTimeFormatter.ISO_INSTANT.
 (define (iso-instant-str-nanos en)
@@ -1209,10 +1196,6 @@
            (and (member f '("YEAR" "MONTH_OF_YEAR" "PROLEPTIC_MONTH" "YEAR_OF_ERA" "ERA")) #t))
           (else #f))))
 
-;; isSupported / get / getLong / with / range / plus / minus / until accept a
-;; chrono-unit OR chrono-field jhost (or a string). These method names extend the
-;; existing per-tag tables.
-(define (unit-or-field-arg x) x)
 (define (arg-is-unit? x) (and (jhost? x) (string=? (jhost-tag x) "chrono-unit")))
 (define (arg-is-field? x) (and (jhost? x) (string=? (jhost-tag x) "chrono-field")))
 (define (arg-is-amount? x) (and (jhost? x) (member (jhost-tag x) '("duration" "period"))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -122,8 +122,7 @@
 ;; --- namespace -> file path -------------------------------------------------
 ;; "app.commonmark-test" -> "app/commonmark_test": split on '.', munge '-'->'_'
 ;; per segment, join with '/'. Matches Clojure's ns->file munging.
-(define (ns-seg-munge seg)
-  (list->string (map (lambda (c) (if (char=? c #\-) #\_ c)) (string->list seg))))
+(define (ns-seg-munge seg) (jch-munge-segments seg)) ; shared with the class graph
 (define (ns-name->rel name)
   (let loop ((cs (string->list name)) (seg '()) (segs '()))
     (cond

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -73,10 +73,6 @@
 (define chez-tag-desc (make-hashtable string-hash string=?))
 ;; type-tag STRING -> fixed-arity ctor procedure: (lambda (f0 .. fn) (make-jrec ...))
 ;; with one arg per field, no rest-list walk. Used by the backend's emit-invoke
-;; for direct ctor calls. Built alongside the variadic ctor in make-deftype-ctor.
-(define chez-deftype-fixed-ctor-tbl (make-hashtable string-hash string=?))
-(define (deftype-fixed-ctor tag)
-  (hashtable-ref chez-deftype-fixed-ctor-tbl tag #f))
 ;; a jrec that is coll? — a record, or a deftype implementing a collection
 ;; interface (its seq/count/nth/valAt/cons method is registered). find-method-any-
 ;; protocol is defined later; resolved at call time. An opaque deftype is not coll?.
@@ -362,11 +358,6 @@
              (find-method-any-protocol (jrec-tag v) method)))
         ((jreify? v) (let ((rm (reified-methods v))) (and rm (hashtable-ref rm method #f))))
         (else #f)))
-;; Call METHOD on V with ARGS (a list, `this` excluded) if V declares it, else run
-;; FALLBACK. The one seam a core fn's deftype/reify arm collapses to.
-(define (iface-call v method args fallback)
-  (let ((m (iface-method v method (+ 1 (length args)))))
-    (if m (apply jolt-invoke m v args) (fallback))))
 (define %r-jolt-count jolt-count)
 (set! jolt-count (lambda (coll)
   (cond ((jrec-cl coll "count") => (lambda (m) (jolt-invoke m coll)))
@@ -683,7 +674,6 @@
         ((jrec? obj) (list (jrec-tag obj) "Object"))
         (else '("Object"))))
 
-(define (record-tag obj) (and (jrec? obj) (jrec-tag obj)))
 
 ;; ---- the native that handles the analyzer/overlay call ----------------------
 ;; make-deftype-ctor: (name-sym field-kws field-tags field-muts) -> ctor closure.
@@ -717,21 +707,7 @@
                                          (if (and (fx< i ndbl) (vector-ref dbl-flags i)
                                                   (number? a) (not (flonum? a)))
                                              (exact->inexact a) a))
-                            (loop (cdr as) (+ i 1))))))))
-          (fixed-ctor
-            ;; Fixed-arity positional ctor: one arg per field, no rest-list walk.
-            ;; The backend emits a direct call to this when it recognizes a ctor call
-            ;; with matching arity, bypassing jolt-invoke / var-deref / list alloc.
-            ;; For >6 fields, fall back to the variadic ctor (rare in practice).
-            (case nf
-              ((0) (lambda ()                  (make-jrec desc (vector) jolt-nil)))
-              ((1) (lambda (a0)                (let ((v (vector a0)))               (coerce-double-fields! v dbl-flags) (make-jrec desc v jolt-nil))))
-              ((2) (lambda (a0 a1)             (let ((v (vector a0 a1)))            (coerce-double-fields! v dbl-flags) (make-jrec desc v jolt-nil))))
-              ((3) (lambda (a0 a1 a2)          (let ((v (vector a0 a1 a2)))         (coerce-double-fields! v dbl-flags) (make-jrec desc v jolt-nil))))
-              ((4) (lambda (a0 a1 a2 a3)       (let ((v (vector a0 a1 a2 a3)))      (coerce-double-fields! v dbl-flags) (make-jrec desc v jolt-nil))))
-              ((5) (lambda (a0 a1 a2 a3 a4)    (let ((v (vector a0 a1 a2 a3 a4)))   (coerce-double-fields! v dbl-flags) (make-jrec desc v jolt-nil))))
-              ((6) (lambda (a0 a1 a2 a3 a4 a5) (let ((v (vector a0 a1 a2 a3 a4 a5))) (coerce-double-fields! v dbl-flags) (make-jrec desc v jolt-nil))))
-              (else #f))))
+                            (loop (cdr as) (+ i 1)))))))))
     ;; Register the ctor under its fully-qualified tag ("ns.Name") — a bare
     ;; (Name. …) in the DEFINING ns is qualified to this by the analyzer, so a
     ;; deftype whose simple name collides with a built-in host class (tools.reader's
@@ -752,8 +728,6 @@
     ;; right after) replaces the row with the record interface set.
     (jch-set-supers! tag '("clojure.lang.IType"))
     (hashtable-set! chez-deftype-ctor-tag ctor tag)
-    ;; register fixed-arity ctor for direct-call emit (or clear stale on redef)
-    (hashtable-set! chez-deftype-fixed-ctor-tbl tag fixed-ctor)
     ;; record the shape for whole-program inference, keyed by the positional
     ;; ctor var "ns/->Name" the analyzer resolves a (->Name …) call to.
     (register-record-shape! (string-append (chez-current-ns) "/->" (symbol-t-name name-sym))

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -14,7 +14,6 @@
 (defn- getenv [n] (jolt.host/getenv n))
 (defn- file-exists? [p] (jolt.host/file-exists? p))
 (defn- sh [cmd] (jolt.host/sh cmd))           ; exit code, inherits stdout/stderr
-(defn- sh-out [cmd] (jolt.host/sh-out cmd))   ; captured stdout
 (defn- warn [& xs] (println (str "[jolt.deps] " (apply str xs))))
 
 (defn- read-edn [path]


### PR DESCRIPTION
General-audit epic (jolt-njdd, bead jolt-bxv7).

Exact-token verified — each definition was the only occurrence repo-wide, including the backend's emission strings and the test gates:

- the deftype fixed-arity ctor cluster (table, reader, per-type closures, registration) superseded by inline ctor emission during the perf round
- `iface-call` (orphaned seam; `iface-method` stays — it feeds the reduce path)
- `record-tag`, `%dyn-rt-var-deref`, `hc-kw-regex`, `jolt-int` (`int` binds `jolt-int-cast`), `jolt-kw->string`, `iso-instant-str` (the nanos variant is live), `start-of-utc-day`, `unit-or-field-arg`, and jolt.deps' private `sh-out` wrapper (the public `jolt.host/sh-out` seam stays)
- loader's `ns-seg-munge` now delegates to the class graph's byte-identical `jch-munge-segments`

Deletion-only plus one alias; no re-mint (seed untouched — selfhost/shakesmoke in CI prove it). `make ci` green.