### PR TITLE
Class model: derive from the canonical graph, delete legacy tables

### DIFF
--- a/host/chez/host-table.ss
+++ b/host/chez/host-table.ss
@@ -167,10 +167,8 @@
 (define %h-value-host-tags value-host-tags)
 (set! value-host-tags (lambda (obj)
   (cond
-    ((htable-sorted-map? obj) '("PersistentTreeMap" "Sorted" "IPersistentMap" "Associative"
-                                "Map" "java.util.Map" "IPersistentCollection" "Object"))
-    ((htable-sorted-set? obj) '("PersistentTreeSet" "Sorted" "IPersistentSet"
-                                "Set" "java.util.Set" "Collection" "IPersistentCollection" "Object"))
+    ((htable-sorted-map? obj) (jch-tags "clojure.lang.PersistentTreeMap"))
+    ((htable-sorted-set? obj) (jch-tags "clojure.lang.PersistentTreeSet"))
     (else (%h-value-host-tags obj)))))
 
 ;; (class e) on a throwable tagged-table (a library's ex-info envelope carrying a

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -254,7 +254,35 @@
 (jch-register-supers! "javax.net.ssl.SSLException" '("java.io.IOException"))
 (jch-register-supers! "java.lang.Error" '("java.lang.Throwable"))
 (jch-register-supers! "java.lang.AssertionError" '("java.lang.Error"))
-;; Throwable's only super is Object (universal), so no row needed for it.
+;; leaf/root classes with only Object as super
+(jch-register-supers! "java.lang.Object" '())
+(jch-register-supers! "java.lang.Throwable" '())
+(jch-register-supers! "java.lang.Byte" '("java.lang.Number"))
+(jch-register-supers! "java.lang.Short" '("java.lang.Number"))
+(jch-register-supers! "java.io.InputStream" '())
+(jch-register-supers! "java.io.OutputStream" '())
+(jch-register-supers! "java.io.Reader" '())
+(jch-register-supers! "java.io.Writer" '())
+(jch-register-supers! "java.io.File" '())
+(jch-register-supers! "java.io.StringReader" '("java.io.Reader"))
+(jch-register-supers! "java.io.StringWriter" '("java.io.Writer"))
+(jch-register-supers! "java.lang.StringBuilder" '())
+(jch-register-supers! "java.util.StringTokenizer" '())
+(jch-register-supers! "java.nio.charset.Charset" '())
+(jch-register-supers! "java.util.Base64" '())
+(jch-register-supers! "clojure.lang.MapEntry" '())
+(jch-register-supers! "clojure.lang.Namespace" '())
+(jch-register-supers! "java.util.regex.Pattern" '())
+(jch-register-supers! "java.net.URI" '())
+(jch-register-supers! "java.util.ArrayList" '())
+;; base interfaces used as super targets — need keys for simple-name resolution
+(jch-register-supers! "java.lang.Number" '())
+(jch-register-supers! "java.lang.Iterable" '())
+(jch-register-supers! "java.util.Map" '())
+(jch-register-supers! "java.lang.CharSequence" '())
+(jch-register-supers! "java.lang.Comparable" '())
+(jch-register-supers! "java.lang.Runnable" '())
+(jch-register-supers! "java.util.concurrent.Callable" '())
 
 ;; Public seam: libraries extend the modeled hierarchy.
 (def-var! "jolt.host" "register-class-supers!"

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -181,8 +181,8 @@
 (jch-register-supers! "clojure.lang.IPersistentSet" '("clojure.lang.IPersistentCollection" "clojure.lang.Counted"))
 (jch-register-supers! "clojure.lang.IPersistentList" '("clojure.lang.Sequential" "clojure.lang.IPersistentStack"))
 (jch-register-supers! "clojure.lang.IObj" '("clojure.lang.IMeta"))
-(jch-register-supers! "clojure.lang.IFn" '("java.lang.Runnable" "java.util.concurrent.Callable"))
-(jch-register-supers! "clojure.lang.Fn" '("clojure.lang.IFn"))
+(jch-register-supers! "clojure.lang.IFn" '("clojure.lang.Fn" "java.lang.Runnable" "java.util.concurrent.Callable"))
+;; Fn is a marker interface (no supers).
 (jch-register-supers! "clojure.lang.AFn" '("clojure.lang.IFn"))
 (jch-register-supers! "clojure.lang.AFunction" '("clojure.lang.AFn" "clojure.lang.Fn"))
 ;; java.util collection interfaces

--- a/host/chez/java/host-class.ss
+++ b/host/chez/java/host-class.ss
@@ -109,60 +109,20 @@
     (if (not (jolt-nil? override)) override (jolt-class x))))
 (def-var! "clojure.core" "type" jolt-type-pub)
 
-;; bare class-name tokens -> canonical JVM class-name strings.
+;; bare class-name tokens -> canonical JVM class-name strings, derived from the
+;; modeled class graph (jvm-class-parents) so this list stays current with any
+;; additions to class-hierarchy.ss.
 (define class-token-alist
-  '(("String" . "java.lang.String") ("Number" . "java.lang.Number")
-    ("Boolean" . "java.lang.Boolean") ("Long" . "java.lang.Long")
-    ("Integer" . "java.lang.Integer") ("Double" . "java.lang.Double")
-    ("Float" . "java.lang.Float") ("Byte" . "java.lang.Byte") ("Short" . "java.lang.Short")
-    ("Object" . "java.lang.Object") ("Character" . "java.lang.Character")
-    ("InputStream" . "java.io.InputStream") ("OutputStream" . "java.io.OutputStream")
-    ("File" . "java.io.File") ("Reader" . "java.io.Reader") ("Writer" . "java.io.Writer")
-    ("ISeq" . "clojure.lang.ISeq") ("Keyword" . "clojure.lang.Keyword")
-    ("Symbol" . "clojure.lang.Symbol") ("MapEntry" . "clojure.lang.MapEntry")
-    ("StringReader" . "java.io.StringReader") ("StringWriter" . "java.io.StringWriter")
-    ("StringBuilder" . "java.lang.StringBuilder")
-    ("StringTokenizer" . "java.util.StringTokenizer")
-    ("Charset" . "java.nio.charset.Charset") ("Base64" . "java.util.Base64")
-    ("Exception" . "java.lang.Exception")
-    ("IllegalArgumentException" . "java.lang.IllegalArgumentException")
-    ("ArityException" . "clojure.lang.ArityException")
-    ("IllegalStateException" . "java.lang.IllegalStateException")
-    ("RuntimeException" . "java.lang.RuntimeException")
-    ("UnsupportedOperationException" . "java.lang.UnsupportedOperationException")
-    ("InterruptedException" . "java.lang.InterruptedException")
-    ("IOException" . "java.io.IOException")
-    ("UnknownHostException" . "java.net.UnknownHostException")
-    ("ConnectException" . "java.net.ConnectException")
-    ("SocketTimeoutException" . "java.net.SocketTimeoutException")
-    ("MalformedURLException" . "java.net.MalformedURLException")
-    ("SSLException" . "javax.net.ssl.SSLException")
-    ("ExceptionInfo" . "clojure.lang.ExceptionInfo")
-    ("IExceptionInfo" . "clojure.lang.IExceptionInfo")
-    ("Pattern" . "java.util.regex.Pattern")
-    ("URI" . "java.net.URI") ("UUID" . "java.util.UUID")
-    ("ArrayList" . "java.util.ArrayList") ("PersistentQueue" . "clojure.lang.PersistentQueue")
-    ("NumberFormatException" . "java.lang.NumberFormatException")
-    ("ArithmeticException" . "java.lang.ArithmeticException")
-    ("NullPointerException" . "java.lang.NullPointerException")
-    ("ClassCastException" . "java.lang.ClassCastException")
-    ("IndexOutOfBoundsException" . "java.lang.IndexOutOfBoundsException")
-    ("UnsupportedEncodingException" . "java.io.UnsupportedEncodingException")
-    ("FileNotFoundException" . "java.io.FileNotFoundException")
-    ("Throwable" . "java.lang.Throwable")
-    ;; clojure.lang / java.util types that class-based multimethods dispatch on.
-    ("Fn" . "clojure.lang.Fn") ("IFn" . "clojure.lang.IFn")
-    ("Namespace" . "clojure.lang.Namespace") ("Named" . "clojure.lang.Named")
-    ("Set" . "java.util.Set") ("List" . "java.util.List") ("Map" . "java.util.Map")
-    ("Collection" . "java.util.Collection") ("Iterable" . "java.lang.Iterable")
-    ("CharSequence" . "java.lang.CharSequence") ("Comparable" . "java.lang.Comparable")
-    ("Runnable" . "java.lang.Runnable") ("Callable" . "java.util.concurrent.Callable")
-    ("IPersistentSet" . "clojure.lang.IPersistentSet")
-    ("IPersistentVector" . "clojure.lang.IPersistentVector")
-    ("IPersistentMap" . "clojure.lang.IPersistentMap")
-    ("IPersistentCollection" . "clojure.lang.IPersistentCollection")
-    ("Sequential" . "clojure.lang.Sequential") ("Seqable" . "clojure.lang.Seqable")
-    ("Associative" . "clojure.lang.Associative")))
+  (let-values (((keys vals) (hashtable-entries jvm-class-parents)))
+    (let ((result '()) (seen (make-hashtable string-hash string=?)))
+      (vector-for-each
+        (lambda (k _)
+          (let ((s (jch-last-segment k)))
+            (when (not (hashtable-ref seen s #f))
+              (hashtable-set! seen s #t)
+              (set! result (cons (cons s k) result)))))
+        keys vals)
+      (reverse result))))
 (for-each
   (lambda (pair) (def-var! "clojure.core" (car pair) (cdr pair)))
   class-token-alist)
@@ -183,23 +143,12 @@
 ;; which downstream code (e.g. SCI) references as protocols/interfaces.
 (for-each
   (lambda (nm) (def-var! "clojure.core" nm nm))
-  '("java.lang.Long" "java.lang.Integer" "java.lang.Double" "java.lang.Float"
-    "java.lang.Byte" "java.lang.Short"
-    "java.lang.Number" "java.lang.String" "java.lang.Boolean" "java.lang.Character"
-    "java.lang.Object"
-    ;; exception classes compared against (class e): (= java.net.SocketTimeoutException (class e))
-    "java.lang.Exception" "java.lang.Throwable" "java.lang.RuntimeException"
-    "java.lang.IllegalArgumentException" "java.lang.IllegalStateException"
-    "java.lang.UnsupportedOperationException" "java.io.IOException"
-    "java.net.UnknownHostException" "java.net.ConnectException"
-    "java.net.SocketTimeoutException" "java.net.MalformedURLException"
-    "javax.net.ssl.SSLException"
-    "java.lang.NumberFormatException" "java.lang.ArithmeticException"
-    "java.lang.NullPointerException" "java.lang.ClassCastException"
-    "java.lang.IndexOutOfBoundsException" "java.io.FileNotFoundException"
-    "java.io.UnsupportedEncodingException"
-    ;; clojure.lang.ExceptionInfo / IExceptionInfo compared against (class e)
-    "clojure.lang.ExceptionInfo" "clojure.lang.IExceptionInfo" "clojure.lang.ArityException"
-    "java.util.regex.Pattern" "java.net.URI" "java.util.UUID"
-    "clojure.lang.PersistentQueue"
-    "clojure.lang.Keyword" "clojure.lang.Symbol" "clojure.lang.Ratio" "clojure.lang.Atom"))
+  (let-values (((keys vals) (hashtable-entries jvm-class-parents)))
+    (let ((result '()))
+      (vector-for-each
+        (lambda (k _)
+          (when (or (not (jch-interface? k))
+                    (string=? k "clojure.lang.IExceptionInfo"))
+            (set! result (cons k result))))
+        keys vals)
+      (reverse result))))

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -772,55 +772,16 @@
             (or (member (symbol-t-name type-sym) tags) (member iface tags)))
           #t
       (let ((hit (cond
+                   ;; IObj/IMeta — metadata-bearing values not tagged via jch-tags
+                   ;; (cseq, empty-list, procedure, sorted-map/set)
                    ((or (string=? iface "IObj") (string=? iface "IMeta")) (hsc-imeta? val))
                    ((or (string=? iface "IMapEntry") (string=? iface "MapEntry")) (jolt-map-entry? val))
                    ((string=? iface "IRecord") (jrec? val))
-                   ((string=? iface "IPersistentMap") (or (pmap? val) (htable-sorted-map? val)))
-                   ((string=? iface "IPersistentVector") (and (pvec? val) (not (jolt-map-entry? val))))
-                   ((string=? iface "IPersistentSet") (or (pset? val) (htable-sorted-set? val)))
-                   ((string=? iface "ISeq")
-                    (or (cseq? val) (empty-list-t? val) (jolt-lazyseq? val)))
-                   ((string=? iface "LazySeq") (jolt-lazyseq? val))
-                   ;; Seqable is anything (seq x) works on — every persistent
-                   ;; collection, not just seqs (a vector IS Seqable, not an ISeq).
-                   ((string=? iface "Seqable")
-                    (or (cseq? val) (empty-list-t? val) (jolt-lazyseq? val)
-                        (pvec? val) (pmap? val) (pset? val)
-                        (htable-sorted-map? val) (htable-sorted-set? val)))
-                   ((string=? iface "Sequential")
-                    (or (pvec? val) (cseq? val) (empty-list-t? val) (jolt-lazyseq? val)))
+                   ;; IFn — maps/sets/vectors are callable in jolt beyond the JVM
+                   ;; class hierarchy, so jch-tags doesn't cover them for these types.
                    ((string=? iface "IFn")
                     (or (procedure? val) (keyword? val) (symbol-t? val)
                         (pmap? val) (pset? val) (pvec? val)))
-                   ;; host-class interfaces libraries branch on (data.json, etc.).
-                   ;; Matched by last segment, so java.util.Map and Map both hit.
-                   ((string=? iface "Named") (or (keyword? val) (symbol-t? val)))
-                   ((string=? iface "CharSequence") (string? val))
-                   ((string=? iface "Number") (number? val))
-                   ((string=? iface "Map") (or (pmap? val) (htable-sorted-map? val)))
-                   ((string=? iface "Set") (or (pset? val) (htable-sorted-set? val)))
-                   ;; a Java List is a vector or a seq/list — not a set or map.
-                   ((string=? iface "List")
-                    (or (and (pvec? val) (not (jolt-map-entry? val)))
-                        (cseq? val) (empty-list-t? val) (jolt-lazyseq? val)))
-                   ;; a Java Collection is any of those plus a set — but NOT a map.
-                   ((string=? iface "Collection")
-                    (or (pvec? val) (pset? val) (cseq? val) (empty-list-t? val)
-                        (jolt-lazyseq? val) (htable-sorted-set? val)))
-                   ((string=? iface "Associative")
-                    (or (pmap? val) (htable-sorted-map? val)
-                        (and (pvec? val) (not (jolt-map-entry? val)))))
-                   ;; ILookup (valAt): maps and vectors; Indexed (nth): vectors;
-                   ;; Counted: the counted collections. A deftype that declares one
-                   ;; is matched by type-satisfies? in instance-check-base.
-                   ((string=? iface "ILookup")
-                    (or (pmap? val) (htable-sorted-map? val)
-                        (and (pvec? val) (not (jolt-map-entry? val)))))
-                   ((string=? iface "Indexed")
-                    (and (pvec? val) (not (jolt-map-entry? val))))
-                   ((string=? iface "Counted")
-                    (or (pmap? val) (pset? val) (pvec? val)
-                        (htable-sorted-map? val) (htable-sorted-set? val)))
                    ;; reader jhosts — data.json re-wraps a reader in a new
                    ;; PushbackReader unless (instance? PushbackReader r), so this
                    ;; must hold for repeated reads from one reader to work.

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -940,74 +940,20 @@
                   (lambda (a b) (and (opt? a) (opt? b) (eq? (opt-present? a) (opt-present? b))
                                      (or (not (opt-present? a)) (jolt=2 (opt-value a) (opt-value b))))))
 
-;; --- minimal JVM class/interface ancestry -----------------------------------
-;; A handful of libraries reflect over the class hierarchy — e.g. core.memoize
-;; validates its first argument with (some #{IFn AFn Runnable Callable}
-;; (ancestors (class f))). jolt models a class as its name string and has no
-;; reflection, so supers/ancestors return nothing on their own. This table gives
-;; the common interfaces the direct supers the JVM reports, and the overlay's
-;; supers/ancestors fold it in. Keyed by canonical class name; value = direct
-;; supers. Extend as more interfaces are exercised.
-(define class-supers-tbl (make-hashtable string-hash string=?))
-(define (reg-class-supers! name supers) (hashtable-set! class-supers-tbl name supers))
-(reg-class-supers! "clojure.lang.IFn" '("java.lang.Runnable" "java.util.concurrent.Callable"))
-(reg-class-supers! "clojure.lang.AFn" '("clojure.lang.IFn" "java.lang.Runnable" "java.util.concurrent.Callable"))
-(reg-class-supers! "clojure.lang.AFunction" '("clojure.lang.AFn" "clojure.lang.IFn" "clojure.lang.Fn"
-                                              "java.lang.Runnable" "java.util.concurrent.Callable"))
-;; common exception hierarchy, so (instance? IOException e) / (catch IOException e)
-;; match a more specific throwable a library threw (e.g. http-client's
-;; UnknownHostException, caught by clj-http-lite's :ignore-unknown-host?).
-(reg-class-supers! "java.lang.Throwable" '("java.lang.Object"))
-(reg-class-supers! "java.lang.Exception" '("java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.lang.RuntimeException" '("java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.io.IOException" '("java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.io.InterruptedIOException" '("java.io.IOException" "java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.net.SocketException" '("java.io.IOException" "java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.net.UnknownHostException" '("java.io.IOException" "java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.net.ConnectException" '("java.net.SocketException" "java.io.IOException" "java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-(reg-class-supers! "java.net.SocketTimeoutException" '("java.io.InterruptedIOException" "java.io.IOException" "java.lang.Exception" "java.lang.Throwable" "java.lang.Object"))
-;; clojure.lang / java.util ancestry for the builtins (class) reports, so a
-;; class-keyed multimethod / (isa? (class x) SomeClass) dispatches like the JVM.
-;; (Object is supplied universally by class-isa?, so it need not be listed.)
-(reg-class-supers! "clojure.lang.IFn" '("clojure.lang.Fn" "java.lang.Runnable" "java.util.concurrent.Callable"))
-;; Keyword and Symbol implement IFn (they are callable: (:k m) / ('s m)), so a
-;; (class x)-dispatched multimethod with an IFn method matches them, like the JVM.
-(reg-class-supers! "clojure.lang.Keyword" '("clojure.lang.Named" "java.lang.Comparable"
-                                            "clojure.lang.IFn" "clojure.lang.Fn"
-                                            "java.lang.Runnable" "java.util.concurrent.Callable"))
-(reg-class-supers! "clojure.lang.Symbol" '("clojure.lang.Named" "java.lang.Comparable"
-                                           "clojure.lang.IFn" "clojure.lang.Fn"
-                                           "java.lang.Runnable" "java.util.concurrent.Callable"))
-(reg-class-supers! "java.lang.String" '("java.lang.CharSequence" "java.lang.Comparable"))
-(reg-class-supers! "clojure.lang.PersistentHashSet" '("clojure.lang.APersistentSet" "clojure.lang.IPersistentSet" "clojure.lang.IPersistentCollection" "java.util.Set" "java.util.Collection" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.PersistentTreeSet" '("clojure.lang.APersistentSet" "clojure.lang.IPersistentSet" "clojure.lang.IPersistentCollection" "java.util.Set" "java.util.Collection" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.PersistentVector" '("clojure.lang.APersistentVector" "clojure.lang.IPersistentVector" "clojure.lang.IPersistentCollection" "clojure.lang.Sequential" "clojure.lang.Associative" "java.util.List" "java.util.Collection" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.PersistentArrayMap" '("clojure.lang.APersistentMap" "clojure.lang.IPersistentMap" "clojure.lang.IPersistentCollection" "clojure.lang.Associative" "java.util.Map" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.PersistentHashMap" '("clojure.lang.APersistentMap" "clojure.lang.IPersistentMap" "clojure.lang.IPersistentCollection" "clojure.lang.Associative" "java.util.Map" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.PersistentList" '("clojure.lang.ASeq" "clojure.lang.ISeq" "clojure.lang.IPersistentCollection" "clojure.lang.Sequential" "clojure.lang.Seqable" "java.util.List" "java.util.Collection" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.LazySeq" '("clojure.lang.ISeq" "clojure.lang.IPersistentCollection" "clojure.lang.Sequential" "clojure.lang.Seqable" "java.lang.Iterable"))
-(reg-class-supers! "clojure.lang.Cons" '("clojure.lang.ASeq" "clojure.lang.ISeq" "clojure.lang.Sequential" "clojure.lang.Seqable" "java.lang.Iterable"))
-
+;; class hierarchy lives in class-hierarchy.ss (jvm-class-parents).
+;; fn classes (ns$name) inherit AFunction.
 ;; A munged fn class name "ns$name" (jolt-class for a def'd fn) isn't in the table;
 ;; like the JVM (a fn extends clojure.lang.AFunction) its super is AFunction, whose
 ;; registered supers give AFn / IFn / Fn / Runnable / Callable transitively.
 (define (str-has-dollar? s)
   (let loop ((i 0)) (and (< i (string-length s)) (or (char=? (string-ref s i) #\$) (loop (+ i 1))))))
 (define (class-direct-supers name)
-  ;; union the modeled class graph (jch, direct edges) with any legacy table entry,
-  ;; so isa?/supers/ancestors see the single hierarchy source plus anything not yet
-  ;; migrated. The closure below traverses these to the full transitive set.
-  (let ((jch (jch-direct-supers name))
-        (old (hashtable-ref class-supers-tbl name #f)))
-    (cond ((and (pair? jch) old)
-           (let merge ((ss old) (acc jch))
-             (cond ((null? ss) acc)
-                   ((member (car ss) acc) (merge (cdr ss) acc))
-                   (else (merge (cdr ss) (append acc (list (car ss))))))))
-          ((pair? jch) jch)
-          (old old)
-          ((str-has-dollar? name) '("clojure.lang.AFunction"))
-          (else '()))))
+  ;; reads the modeled class graph (jch, direct edges) only — the legacy table has
+  ;; been folded into class-hierarchy.ss.
+  (let ((jch (jch-direct-supers name)))
+    (if (pair? jch) jch
+        (if (str-has-dollar? name) '("clojure.lang.AFunction")
+            '()))))
 ;; transitive closure of direct supers (set semantics via an accumulator list)
 (define (class-ancestors-list name)
   (let loop ((pending (class-direct-supers name)) (seen '()))
@@ -1057,7 +1003,6 @@
 (define (hsc-class-known? name)
   (or (string=? name "java.lang.Object")
       (jch-known? name)
-      (and (hashtable-ref class-supers-tbl name #f) #t)
       (str-has-dollar? name)))
 
 ;; transitive ancestry, rooted at Object for a concrete class like (supers c);

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -337,22 +337,16 @@
 ;; class object; anything else throws a catchable ClassNotFoundException, like the
 ;; JVM — so the common `(try (Class/forName "optional.Dep") (catch …))` probe a
 ;; library uses to detect an absent dependency works (e.g. ring's joda-time check).
-;; java.* / clojure.* packages jolt does NOT back, even though the broad prefix
-;; below would otherwise claim them — optional backends a library feature-probes
-;; with (Class/forName …) (e.g. tools.logging's java.util.logging / log4j). Listing
-;; them here keeps class-found? honest so the probe sees them absent and skips the
-;; backend (jolt has its own logging) instead of trying to use it and crashing.
-(define forname-absent-prefixes
-  '("java.util.logging." "javax.management." "java.lang.management."))
+;; java.* / clojure.* packages jolt models in the class graph are known;
+;; optional backends a library feature-probes with (Class/forName …) (e.g.
+;; tools.logging's java.util.logging) are absent from the graph and get
+;; a definitive ClassNotFoundException.
 (define (forname-known? nm)
   ;; exact lookups only — lookup-class would fall back to the short class name, so
   ;; any "x.y.Class" would spuriously match the registered java.lang.Class.
   (or (hashtable-ref class-statics-tbl nm #f)
       (hashtable-ref class-ctors-tbl nm #f)
-      (let ((pre? (lambda (p) (and (>= (string-length nm) (string-length p))
-                                   (string=? (substring nm 0 (string-length p)) p)))))
-        (and (or (pre? "java.") (pre? "clojure.") (pre? "jolt."))
-             (not (exists pre? forname-absent-prefixes))))))
+      (jch-known? nm)))
 (register-class-statics! "Class"
   (list (cons "forName"
               (lambda (nm . _)


### PR DESCRIPTION
General-audit epic (jolt-njdd, bead jolt-134m). The canonical class graph (class-hierarchy.ss) was built to be the single source for "what classes does this value satisfy", but four hand-kept tables still bypassed it. All now derive:

- `class-supers-tbl` (25 entries of hand-flattened transitive closures, self-described as "legacy") folded into the graph as direct supers and deleted; `class-direct-supers` reads the graph alone. Fixed a real edge-direction bug on the way (`IFn ← Fn`). The public `jolt.host/register-class-supers!` hook is unchanged — it registers into the graph, and jolt-lang/xml verified working end-to-end through it.
- The three hand-kept simple↔FQN maps (`class-token-alist` ~70 entries, `class-hint-table`, the self-evaluating-FQN list) now build from the graph's keys; ~30 classes the alist knew but the graph didn't are graph rows now.
- 18 redundant branches of the instance? interface cond deleted — `value-host-tags` already derives those answers via `jch-tags`; the jhost-reader arms and the genuinely-outside-the-graph cases stay.
- Sorted-map/set tag lists → `(jch-tags "clojure.lang.PersistentTreeMap"/"…TreeSet")`.
- `Class/forName` answers from the graph + registered ctors/statics instead of a package-prefix guess with a hand-grown denylist (separate commit; corpus/cts verified the probe flips).

Verification: corpus 3429 pass / 0 new divergences, unit 616/616, cts matches baseline across 243 namespaces, certify 0 new / 0 stale, full make test green independently re-run at review.