### PR TITLE
clojure.core dynamic vars: close the earmuff gap; ns-map/ns-refers JVM semantics

### DIFF
--- a/host/chez/dynamic-var-defaults.ss
+++ b/host/chez/dynamic-var-defaults.ss
@@ -68,3 +68,21 @@
 (def-var! "clojure.core" "*2" jolt-nil)
 (def-var! "clojure.core" "*3" jolt-nil)
 (def-var! "clojure.core" "*e" jolt-nil)
+
+;; *agent* — the agent whose action is currently running; the agent worker
+;; binds it around each action (concurrency.ss), nil elsewhere like the JVM.
+(def-var! "clojure.core" "*agent*" jolt-nil)
+;; *repl* — true inside an interactive session; joltc's repl and the nREPL
+;; eval path bind it. False in a plain run, like clojure.main.
+(def-var! "clojure.core" "*repl*" #f)
+;; Compiler/loader flags with no separate machinery here — the defaults match
+;; the JVM so reads and (binding …) behave; setting them has no further effect.
+(def-var! "clojure.core" "*allow-unresolved-vars*" #f)
+(def-var! "clojure.core" "*compile-path*" "classes")
+(def-var! "clojure.core" "*compiler-options*" jolt-nil)
+(def-var! "clojure.core" "*fn-loader*" jolt-nil)
+(def-var! "clojure.core" "*reader-resolver*" jolt-nil)
+(def-var! "clojure.core" "*source-path*" "NO_SOURCE_FILE")
+(def-var! "clojure.core" "*suppress-read*" jolt-nil)
+(def-var! "clojure.core" "*use-context-classloader*" #t)
+(def-var! "clojure.core" "*verbose-defrecords*" #f)

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -190,6 +190,21 @@
       (vector-set! q 0 (reverse (vector-ref q 1))) (vector-set! q 1 '()))
     (let ((out (vector-ref q 0))) (vector-set! q 0 (cdr out)) (car out))))
 
+;; Each action runs with *agent* bound to its agent, like the JVM's action
+;; binding frame — (send a (fn [s] (send *agent* …))) works. The cell resolves
+;; lazily (dynamic-var-defaults.ss loads after this file).
+(define agent-star-cell #f)
+(define (with-agent-binding a thunk)
+  (let ((cell (or agent-star-cell
+                  (let ((c (var-cell-lookup "clojure.core" "*agent*")))
+                    (set! agent-star-cell c) c))))
+    (if (not cell)
+        (thunk)
+        (dynamic-wind
+          (lambda () (dyn-binding-stack (cons (list (cons cell a)) (dyn-binding-stack))))
+          thunk
+          (lambda () (dyn-binding-stack (cdr (dyn-binding-stack))))))))
+
 ;; Drain the queue, applying each action (f state arg*) outside the lock (an action
 ;; may send/deref the same agent). A validator rejection or a thrown action puts the
 ;; agent in an error state and halts the queue (JVM :fail mode).
@@ -205,7 +220,8 @@
                         (jolt-agent-err-set! a e)
                         (condition-broadcast (jolt-agent-cv a)))))
           (let* ((old (jolt-agent-state a))
-                 (nv (apply jolt-invoke (car act) old (cdr act))))
+                 (nv (with-agent-binding a
+                       (lambda () (apply jolt-invoke (car act) old (cdr act))))))
             (let ((vf (jolt-agent-validator a)))
               (when (and (not (jolt-nil? vf)) (jolt-not (jolt-invoke vf nv)))
                 (jolt-iref-state-throw)))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -218,22 +218,48 @@
 ;; comment — yields rdr-eof but still advances. parse-next collapses that to "no
 ;; more forms", which would silently drop the entire rest of the file; here we
 ;; skip the no-op form and continue to true end-of-string.
+;; A file load binds *file* to the path and *source-path* to the bare file
+;; name around its forms (the reference binds both in Compiler.load), so loaded
+;; code can read its own location. Cells resolve lazily — the vars' defaults
+;; load after this file.
+(define ldr-file-cell #f)
+(define ldr-spath-cell #f)
+(define (ldr-with-file-vars path thunk)
+  (unless ldr-file-cell
+    (set! ldr-file-cell (var-cell-lookup "clojure.core" "*file*"))
+    (set! ldr-spath-cell (var-cell-lookup "clojure.core" "*source-path*")))
+  (if (not (and ldr-file-cell ldr-spath-cell))
+      (thunk)
+      (let ((name (let loop ((i (- (string-length path) 1)))
+                    (cond ((< i 0) path)
+                          ((char=? (string-ref path i) #\/)
+                           (substring path (+ i 1) (string-length path)))
+                          (else (loop (- i 1)))))))
+        (dynamic-wind
+          (lambda () (dyn-binding-stack
+                      (cons (list (cons ldr-file-cell path) (cons ldr-spath-cell name))
+                            (dyn-binding-stack))))
+          thunk
+          (lambda () (dyn-binding-stack (cdr (dyn-binding-stack))))))))
+
 (define (load-jolt-file path)
   (let* ((src (ldr-read-source path)) (end (string-length src)))
     ;; parameterize (not a bare set!) so a require nested in this file's ns form
     ;; restores path when control returns to the rest of this file.
     (parameterize ((rdr-source-file path))   ; list forms read here carry :file = path
-      (let loop ((i 0))
-        (when (< i end)
-          (let-values (((form j) (rdr-read-form src i end)))
-            (when (> j i)
-              (unless (rdr-eof? form)
-                (when (getenv "JOLT_TRACE_LOAD")
-                  (display "  [load-form] " (current-error-port))
-                  (display (jolt-pr-str form) (current-error-port)) (newline (current-error-port)))
-                (jolt-compile-eval-form (if data-readers-active (ldr-apply-readers form) form)
-                                        (chez-current-ns)))
-              (loop j))))))))
+      (ldr-with-file-vars path
+        (lambda ()
+          (let loop ((i 0))
+            (when (< i end)
+              (let-values (((form j) (rdr-read-form src i end)))
+                (when (> j i)
+                  (unless (rdr-eof? form)
+                    (when (getenv "JOLT_TRACE_LOAD")
+                      (display "  [load-form] " (current-error-port))
+                      (display (jolt-pr-str form) (current-error-port)) (newline (current-error-port)))
+                    (jolt-compile-eval-form (if data-readers-active (ldr-apply-readers form) form)
+                                            (chez-current-ns)))
+                  (loop j))))))))))
 
 ;; load-namespace: load `name`'s source once. Marked loaded BEFORE eval so a
 ;; dependency cycle terminates (Clojure's behavior). The caller's current ns is

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -160,9 +160,22 @@
       (hashtable-keys ns-alias-table))
     m))
 
-;; ns-refers: the {sym -> var} referred into `desig` via refer/use.
+;; ns-refers: the {sym -> var} referred into `desig` via refer/use, plus the
+;; implicit refer-clojure every namespace gets — clojure.core's publics are
+;; visible everywhere, minus names the ns interns itself (an intern replaces
+;; the mapping in the JVM's namespace table).
 (define (jolt-ns-refers desig)
-  (let ((cns (ns-desig->name desig)) (m (jolt-hash-map)))
+  (let* ((cns (ns-desig->name desig))
+         (m (if (string=? cns "clojure.core")
+                (jolt-hash-map)
+                (pmap-fold (ns-vars-pmap-when "clojure.core"
+                                              (lambda (c) (not (var-private? c))))
+                           (lambda (k v acc)
+                             (let ((local (var-cell-lookup cns (symbol-t-name k))))
+                               (if (and local (var-cell-defined? local))
+                                   acc
+                                   (jolt-assoc acc k v))))
+                           (jolt-hash-map)))))
     (vector-for-each
       (lambda (k)
         (when (string=? (car k) cns)
@@ -202,6 +215,16 @@
         (loop (cdr ns)
               (jolt-assoc m (jolt-symbol #f (car ns)) (string-append "java.lang." (car ns)))))))
 (define (jolt-ns-imports . _) jolt-default-imports)
+
+;; ns-map: every mapping visible in the ns — the java.lang imports, the refers
+;; (including the implicit clojure.core publics), and the ns's own interns,
+;; later groups replacing earlier ones like the JVM's single mapping table.
+(define (jolt-ns-map desig)
+  (let* ((m (jolt-ns-imports desig))
+         (m (pmap-fold (jolt-ns-refers desig)
+                       (lambda (k v acc) (jolt-assoc acc k v)) m)))
+    (pmap-fold (jolt-ns-interns desig)
+               (lambda (k v acc) (jolt-assoc acc k v)) m)))
 
 ;; resolve: an unqualified symbol resolves in the current ns then clojure.core; a
 ;; qualified one in its own ns. Returns the var iff genuinely defined, else nil —
@@ -382,7 +405,7 @@
 (def-var! "clojure.core" "in-ns" jolt-in-ns)
 (def-var! "clojure.core" "all-ns" jolt-all-ns)
 (def-var! "clojure.core" "ns-publics" jolt-ns-publics)
-(def-var! "clojure.core" "ns-map" jolt-ns-interns)
+(def-var! "clojure.core" "ns-map" jolt-ns-map)
 (def-var! "clojure.core" "ns-interns" jolt-ns-interns)
 (def-var! "clojure.core" "ns-aliases" jolt-ns-aliases)
 (def-var! "clojure.core" "ns-refers" jolt-ns-refers)

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -216,6 +216,17 @@ else
   fails=$((fails + 1))
 fi
 
+# context-bound dynamic vars: *file*/*source-path* during a load,
+# *command-line-args*, *agent* inside an action, ns-map/ns-refers visibility.
+ctx_out="$(bin/joltc run test/chez/ctxvars-test.clj a1 a2 2>/dev/null)"
+if printf '%s' "$ctx_out" | grep -q 'CTXVARS OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: context vars"
+  printf '%s\n' "$ctx_out" | grep FAIL | head -5 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
 # move, mtime round-trip, which). The file self-checks and prints one marker.
 fs_out="$(bin/joltc run test/chez/fs-test.clj 2>/dev/null)"

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -49,6 +49,7 @@
 (defn- run-ns
   "Require ns-name and invoke its -main with the string app args."
   [ns-name app-args]
+  (push-thread-bindings {#'clojure.core/*command-line-args* (seq app-args)})
   (require (symbol ns-name))
   (if-let [mainv (ns-resolve (symbol ns-name) (symbol "-main"))]
     (apply (deref mainv) app-args)
@@ -72,7 +73,9 @@
   (apply-project! (deps/resolve-project (project-dir)))
   (cond
     (= "-m" (first more)) (run-ns (second more) (drop 2 more))
-    (seq more)            (do (load-file (first more)) nil)
+    (seq more)            (do (push-thread-bindings
+                                {#'clojure.core/*command-line-args* (seq (rest more))})
+                              (load-file (first more)) nil)
     :else (throw (ex-info "run needs -m NS or a FILE" {}))))
 
 ;; -M:alias…  — resolve with the aliases, run their :main-opts
@@ -151,6 +154,11 @@
   ;; code shows a tail-frame backtrace, no JOLT_TRACE needed (JOLT_TRACE=0 opts out).
   (jolt.host/enable-trace!)
   (println (str ";; jolt " (version) " repl — :repl/quit or ^D to exit"))
+  ;; *repl* reads true inside the session, and the result/exception history
+  ;; vars update per evaluation, like clojure.main's REPL.
+  (push-thread-bindings {#'clojure.core/*repl* true
+                         #'clojure.core/*1 nil #'clojure.core/*2 nil
+                         #'clojure.core/*3 nil #'clojure.core/*e nil})
   (loop []
     (let [form (repl-read-form)]
       (when form
@@ -159,8 +167,13 @@
         (if (#{:repl/quit :exit} (try (read-string form) (catch :default _ nil)))
           nil
           (do
-            (try (println (pr-str (load-string form)))
+            (try (let [v (load-string form)]
+                   (var-set #'clojure.core/*3 *2)
+                   (var-set #'clojure.core/*2 *1)
+                   (var-set #'clojure.core/*1 v)
+                   (println (pr-str v)))
                  (catch :default e
+                   (var-set #'clojure.core/*e e)
                    (println "error:" (or (ex-message e)
                                          (try ((resolve 'jolt.host/condition-message) e) (catch :default _ nil))
                                          (pr-str e)))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3656,4 +3656,15 @@
   {:suite "regex / redundant-escapes" :label "backslash-> is a literal >" :expected "\"a>b\"" :actual "(re-find #\"a\\>b\" \"a>b\")" :portability :common}
   {:suite "regex / redundant-escapes" :label "backslash-< is a literal <" :expected "\"<x>\"" :actual "(re-find #\"\\<x\\>\" \"<x>\")" :portability :common}
   {:suite "regex / redundant-escapes" :label "escaped backslash before > keeps both chars" :expected "\"a\\\\>\"" :actual "(re-find #\"a\\\\>\" \"a\\\\>\")" :portability :common}
+  {:suite "core / dynamic-vars" :label "*agent* is nil outside an action" :expected "nil" :actual "*agent*" :portability :common}
+  {:suite "core / dynamic-vars" :label "*agent* is the agent inside its action" :expected "true" :actual "(do (def dv-ag (agent 0)) (def dv-seen (atom nil)) (send dv-ag (fn [s] (reset! dv-seen (identical? *agent* dv-ag)) s)) (await dv-ag) (deref dv-seen))" :portability :common}
+  {:suite "core / dynamic-vars" :label "*repl* is false outside a REPL" :expected "false" :actual "*repl*" :portability :common}
+  {:suite "core / dynamic-vars" :label "*compile-path* default" :expected "\"classes\"" :actual "*compile-path*" :portability :common}
+  {:suite "core / dynamic-vars" :label "*allow-unresolved-vars* default" :expected "false" :actual "*allow-unresolved-vars*" :portability :common}
+  {:suite "core / dynamic-vars" :label "*verbose-defrecords* default" :expected "false" :actual "*verbose-defrecords*" :portability :common}
+  {:suite "core / dynamic-vars" :label "*use-context-classloader* default" :expected "true" :actual "*use-context-classloader*" :portability :common}
+  {:suite "core / dynamic-vars" :label "*suppress-read* default" :expected "nil" :actual "*suppress-read*" :portability :common}
+  {:suite "ns / ns-map" :label "ns-map of user resolves core fns" :expected "true" :actual "(var? (get (ns-map *ns*) 'inc))" :portability :common}
+  {:suite "ns / ns-map" :label "ns-refers of user includes the implicit refer-clojure" :expected "true" :actual "(var? (get (ns-refers 'user) 'map))" :portability :common}
+  {:suite "ns / ns-map" :label "an intern shadows the refer in ns-refers" :expected "false" :actual "(do (def nsr-shadow-inc 1) (contains? (ns-refers 'user) 'nsr-shadow-inc))" :portability :common}
 ]

--- a/test/chez/ctxvars-test.clj
+++ b/test/chez/ctxvars-test.clj
@@ -1,0 +1,25 @@
+;; Context-bound dynamic vars, run as a FILE with args (smoke.sh passes a1 a2):
+;; *file*/*source-path* bind during a load, *command-line-args* carries the app
+;; args, *agent* binds inside an agent action. Prints CTXVARS OK when all hold.
+(def failures (atom []))
+(defn chk [label ok] (when-not ok (swap! failures conj label)))
+
+(chk "*file* ends with ctxvars-test.clj"
+     (clojure.string/ends-with? (str *file*) "ctxvars-test.clj"))
+(chk "*source-path* is the bare name" (= *source-path* "ctxvars-test.clj"))
+(chk "*command-line-args*" (= *command-line-args* '("a1" "a2")))
+(chk "*repl* false outside a repl" (false? *repl*))
+(chk "*agent* nil outside an action" (nil? *agent*))
+
+(def ag (agent 0))
+(def seen (atom nil))
+(send ag (fn [s] (reset! seen (identical? *agent* ag)) s))
+(await ag)
+(chk "*agent* bound inside an action" (true? @seen))
+
+(chk "ns-map resolves core fns" (var? (get (ns-map *ns*) 'inc)))
+(chk "ns-refers includes implicit refer-clojure" (var? (get (ns-refers 'user) 'map)))
+
+(if (empty? @failures)
+  (println "CTXVARS OK")
+  (doseq [f @failures] (println "FAIL:" f)))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -636,4 +636,5 @@
   {:suite "instance? / bound-class" :expr "(do (def icv-k clojure.lang.Keyword) (instance? icv-k :k))" :expected "true"}
   {:suite "maps / hash-map order" :expr "(seq (hash-map :xmap 1 :! 2))" :expected "([:xmap 1] [:! 2])"}
   {:suite "maps / hash-map order" :expr "(do (def sq-log (atom [])) (defmacro sq-m3 [] `{:a ~(list 'swap! 'sq-log 'conj 1) :b ~(list 'swap! 'sq-log 'conj 2)}) (sq-m3) (deref sq-log))" :expected "[1 2]"}
+  {:suite "core / dynamic-vars" :expr "*source-path*" :expected "NO_SOURCE_FILE"}
 ]


### PR DESCRIPTION
Closes the `(ns-map *ns*)` earmuff-var gap against the JVM: the 11 missing core dynamic vars are defined with reference defaults, and the contextual ones behave for real —

- `*agent*` is bound to the agent inside its action
- `*repl*` reads true in a `joltc repl` session, and `*1`/`*2`/`*3`/`*e` track results and the last exception
- `*file*`/`*source-path*` bind to the path / bare file name during any load
- `*command-line-args*` carries app args for both `run FILE args…` and `-m ns args…`

`ns-map` now returns every visible mapping (imports + refers + interns with JVM shadowing) instead of aliasing `ns-interns`, and `ns-refers` materializes the implicit `refer-clojure`, so `(doseq [[sym v] (ns-map *ns*)] …)` behaves like the JVM in any namespace.

The rest of the ns-map diff was triaged against real library usage (grep of the conformance checkouts) into beads: refs/STM + `*loaded-libs*` (jolt-j4qk, tools.namespace/core.typed rely on it), agent API completion (jolt-jory), `tap>` (jolt-qmqp), misc portable fns (jolt-vp8l), core macros as vars (jolt-naa9), and a documented-N/A list of JVM implementation details (jolt-bd6o).

12 corpus rows, a ctxvars smoke fixture, no remint (all runtime). make test green, cts matches baseline.