### PR TITLE
STM: commit-log transactions, thread-local txn state, held agent sends

### DIFF
--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -247,9 +247,9 @@
          (on-caller? (if (and (pair? rest) (pair? (cdr rest))) (jolt-truthy? (cadr rest)) #t))
          (call-cb (lambda (ok) (unless (jolt-nil? cb) (jolt-invoke cb ok)))))
     (case (ac-try-give! ch v)
-      ((ok) (if on-caller? (call-cb #t) (fork-thread (lambda () (call-cb #t)))) #t)
-      ((closed) (if on-caller? (call-cb #f) (fork-thread (lambda () (call-cb #f)))) #f)
-      (else (fork-thread (lambda () (call-cb (jolt-async-give ch v)))) #t))))
+      ((ok) (if on-caller? (call-cb #t) (fork-thread (lambda () (*txn* #f) (call-cb #t)))) #t)
+      ((closed) (if on-caller? (call-cb #f) (fork-thread (lambda () (*txn* #f) (call-cb #f)))) #f)
+      (else (fork-thread (lambda () (*txn* #f) (call-cb (jolt-async-give ch v)))) #t))))
 
 ;; (take! ch cb [on-caller?]) — async take. Same on-caller? rule as put!.
 (define (jolt-async-take! ch cb . rest)
@@ -257,9 +257,9 @@
          (call-cb (lambda (v) (unless (jolt-nil? cb) (jolt-invoke cb v))))
          (r (ac-poll! ch)))
     (cond
-      ((eq? r ac-poll-empty) (fork-thread (lambda () (call-cb (jolt-async-take ch)))))
+      ((eq? r ac-poll-empty) (fork-thread (lambda () (*txn* #f) (call-cb (jolt-async-take ch)))))
       (on-caller? (call-cb r))
-      (else (fork-thread (lambda () (call-cb r)))))
+      (else (fork-thread (lambda () (*txn* #f) (call-cb r)))))
     jolt-nil))
 
 ;; (go-spawn thunk) — run thunk on a thread; return a buffered(1) channel that

--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -280,6 +280,7 @@
   (let ((w (ac-make 1 'fixed #f)) (snap (dyn-binding-stack)))
     (fork-thread
      (lambda ()
+       (*txn* #f)                          ; go/thread body must not inherit parent's txn
        (dyn-binding-stack snap)
        (let ((r (guard (e (#t (cons #f e))) (cons #t (jolt-invoke thunk)))))
          (if (car r)

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -211,6 +211,8 @@
 (jch-register-supers! "clojure.lang.Symbol" '("clojure.lang.IObj" "clojure.lang.IFn" "clojure.lang.Named" "java.lang.Comparable"))
 (jch-register-supers! "clojure.lang.Var" '("clojure.lang.IDeref" "clojure.lang.IFn"))
 (jch-register-supers! "clojure.lang.Atom" '("clojure.lang.IDeref"))
+(jch-register-supers! "clojure.lang.Ref" '("clojure.lang.IRef"))
+(jch-register-supers! "clojure.lang.IRef" '("clojure.lang.IDeref"))
 (jch-register-supers! "clojure.lang.Ratio" '("java.lang.Number" "java.lang.Comparable"))
 (jch-register-supers! "clojure.lang.BigInt" '("java.lang.Number"))
 (jch-register-supers! "java.lang.String" '("java.lang.CharSequence" "java.lang.Comparable"))

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -233,13 +233,18 @@
 
 ;; send / send-off: enqueue the action, start the worker if idle. (jolt treats them
 ;; identically — one serialized worker per agent — which is observably a superset of
-;; the JVM's fixed/cached pool split.)
+;; the JVM's fixed/cached pool split.)  Inside a transaction, the action is deferred
+;; until the txn commits; on rollback it is discarded.
 (define (jolt-agent-send a f . args)
-  (with-mutex (jolt-agent-mu a)
-    (jagent-q-push! a (cons f args))
-    (unless (jolt-agent-running? a)
-      (jolt-agent-running?-set! a #t)
-      (fork-thread (lambda () (jolt-agent-worker a)))))
+  (if (*txn*)
+      (let ((txn (*txn*)))
+        (jolt-txn-pending-sends-set! txn
+          (cons (apply list a f args) (jolt-txn-pending-sends txn))))
+      (with-mutex (jolt-agent-mu a)
+        (jagent-q-push! a (cons f args))
+        (unless (jolt-agent-running? a)
+          (jolt-agent-running?-set! a #t)
+          (fork-thread (lambda () (*txn* #f) (jolt-agent-worker a))))))
   a)
 
 ;; (await & agents): block until each agent's queue has drained.

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -44,6 +44,7 @@
         (snap (dyn-binding-stack)))
     (fork-thread
      (lambda ()
+       (*txn* #f)                          ; child thread must not inherit parent's txn
        (dyn-binding-stack snap)
        (let ((r (guard (e (#t (cons #f e))) (cons #t (jolt-invoke thunk)))))
          (with-mutex (jolt-future-mu f)
@@ -209,6 +210,7 @@
 ;; may send/deref the same agent). A validator rejection or a thrown action puts the
 ;; agent in an error state and halts the queue (JVM :fail mode).
 (define (jolt-agent-worker a)
+  (*txn* #f)                          ; agent worker must not inherit parent's txn
   (let loop ()
     (let ((act (with-mutex (jolt-agent-mu a)
                  (if (or (not (jolt-nil? (jolt-agent-err a))) (jagent-q-empty? a))
@@ -409,8 +411,9 @@
   (list (cons "start" (lambda (self)
           (let ((st (jhost-state self)) (snap (dyn-binding-stack)))
             (fork-thread (lambda ()
-              (dyn-binding-stack snap)
-              ;; surface a thread body's throw like the JVM's default uncaught-
+               (*txn* #f)                          ; child thread must not inherit parent's txn
+               (dyn-binding-stack snap)
+               ;; surface a thread body's throw like the JVM's default uncaught-
               ;; exception handler; the thread still completes (isAlive/join
               ;; semantics unchanged). Reporting failures are swallowed.
               (guard (e (#t (guard (_ (#t #f))

--- a/host/chez/java/host-class.ss
+++ b/host/chez/java/host-class.ss
@@ -33,6 +33,7 @@
     ((keyword? x) "clojure.lang.Keyword")
     ((symbol-t? x) "clojure.lang.Symbol")
     ((jolt-atom? x) "clojure.lang.Atom")
+    ((jolt-ref? x) "clojure.lang.Ref")
     ((char? x) "java.lang.Character")
     ((regex-t? x) "java.util.regex.Pattern")
     ;; an anonymous / unregistered fn — like the JVM, where (class #(..)) is a

--- a/host/chez/post-prelude.ss
+++ b/host/chez/post-prelude.ss
@@ -120,6 +120,21 @@
 (def-var! "clojure.core" "__sync-call" jolt-sync)
 (def-var! "clojure.core" "__txn-running?" jolt-txn-running?)
 (def-var! "clojure.core" "loaded-libs" (lambda () (jolt-deref (var-deref "clojure.core" "*loaded-libs*"))))
+;; re-assert refs instance? arms after records-interop.ss registers instance-check.
+(register-instance-check-arm!
+  (lambda (type-sym val)
+    (if (and (symbol-t? type-sym) (jolt-ref? val))
+        (let* ((tname (symbol-t-name type-sym))
+               (tl (string-length tname))
+               (dot (let loop ((i (- tl 1)))
+                      (if (< i 0) -1
+                          (if (char=? (string-ref tname i) #\.) i
+                              (loop (- i 1))))))
+               (short (if (< dot 0) tname (substring tname (+ dot 1) tl))))
+          (or (string=? short "Ref")
+              (string=? short "IRef")
+              (string=? short "IDeref")))
+        'pass)))
 ;; record? is a host type check — true only for a defrecord, not a bare deftype
 ;; (jrec-record?), matching the JVM (instance? IRecord). The overlay's
 ;; (some? (get x :jolt/deftype)) get-trick would invoke a sorted-map comparator.

--- a/host/chez/refs.ss
+++ b/host/chez/refs.ss
@@ -1,8 +1,10 @@
 ;; refs.ss — Clojure refs and STM for the Chez host.
 ;;
 ;; Single global transaction mutex gives correct serializable semantics on
-;; jolt's shared-heap threads — no MVCC needed.  alter/ref-set/commute/ensure
-;; throw IllegalStateException outside a dosync, matching the JVM.
+;; jolt's shared-heap threads — no MVCC needed.  Transactions buffer writes
+;; in a per-txn log and only commit (write ref values) on success, providing
+;; rollback on exception.  Watches fire once per changed ref after commit,
+;; outside the transaction lock, matching JVM semantics.
 ;;
 ;; Refs participate in the IRef seam (watches/validators/metadata) like
 ;; atom/var/agent.  Loaded after atoms.ss (shares jolt-iref-state-throw and
@@ -15,12 +17,75 @@
 ;; IRef arm: refs are watchable/validatable through the iref tables.
 (register-iref-arm! jolt-ref?)
 
+;; Per-ref min/max history: stored in side tables (e.g., 0 and 10 defaults).
+(define ref-min-history-tbl (make-weak-eq-hashtable))
+(define ref-max-history-tbl (make-weak-eq-hashtable))
+
+;; --- transaction record -------------------------------------------------------
+;; A per-transaction record, held in the thread-parameter *txn* (#f when
+;; no transaction is running).
+;;   log         — eq-hashtable: ref -> in-txn value
+;;   old-vals    — eq-hashtable: ref -> committed value at first mutation
+;;                 (captured once per ref for the single watch notification)
+;;   pending-sends — list of (agent f args) enqueued during this txn (Round 3)
+(define-record-type jolt-txn
+  (fields (mutable log) (mutable old-vals) pending-sends)
+  (nongenerative jolt-txn-v1))
+
+(define (make-txn)
+  (make-jolt-txn (make-weak-eq-hashtable) (make-weak-eq-hashtable) '()))
+
 ;; --- transaction state -------------------------------------------------------
 ;; A single global mutex serializes all transactions.  Per-thread *txn* detects
 ;; nested dosync (joins the outer transaction) and guards against io!/ref-set/
 ;; alter/commute/ensure outside a transaction.
 (define stm-lock (make-mutex))
 (define *txn* (make-thread-parameter #f))
+
+;; --- in-txn log helpers ------------------------------------------------------
+
+;; Sentinel for hashtable-ref to distinguish "not found" from a valid value.
+(define txn-not-found (list 'txn-not-found))
+
+;; Read a ref's in-txn value from the transaction log, falling back to the
+;; ref's committed value if this txn has not touched it.
+(define (txn-read ref)
+  (let ((txn (*txn*)))
+    (if txn
+        (let ((v (hashtable-ref (jolt-txn-log txn) ref txn-not-found)))
+          (if (eq? v txn-not-found) (jolt-ref-val ref) v))
+        (jolt-ref-val ref))))
+
+;; Write a ref's in-txn value to the log.  Captures the pre-txn committed
+;; value on first mutation if not already recorded.
+(define (txn-write! ref v)
+  (let* ((log (jolt-txn-log (*txn*)))
+         (ov (jolt-txn-old-vals (*txn*))))
+    ;; capture pre-txn value on first write to this ref
+    (unless (hashtable-contains? ov ref)
+      (hashtable-set! ov ref (jolt-ref-val ref)))
+    (hashtable-set! log ref v)))
+
+;; Commit: write all buffered values to the refs.  Must be called while
+;; still holding stm-lock.
+(define (txn-commit! txn)
+  (let ((log (jolt-txn-log txn)))
+    (vector-for-each
+      (lambda (ref) (jolt-ref-val-set! ref (hashtable-ref log ref #f)))
+      (hashtable-keys log))))
+
+;; Fire watch notifications for committed changes.  Called AFTER releasing
+;; stm-lock and clearing *txn*, so watches can open their own dosync.
+(define (txn-fire-watches! txn)
+  (let ((log (jolt-txn-log txn))
+        (ov (jolt-txn-old-vals txn)))
+    (vector-for-each
+      (lambda (ref)
+        (let ((new-val (hashtable-ref log ref #f))
+              (old (hashtable-ref ov ref txn-not-found)))
+          (unless (eq? old txn-not-found)
+            (iref-notify ref old new-val))))
+      (hashtable-keys log))))
 
 ;; --- constructor -------------------------------------------------------------
 ;; (ref init :validator f :meta m) — the ARef ctor contract: validator runs
@@ -30,13 +95,11 @@
     (cond
       ((or (null? o) (null? (cdr o)))
        (let ((r (make-jolt-ref v (make-mutex))))
-         ;; validate init via iref validator table (register with a predicate
-         ;; running before the ref exists — set-validator! on the new ref)
+         ;; validate init via iref validator table
          (when (and (not (jolt-nil? validator)) (jolt-not (jolt-invoke validator v)))
            (jolt-iref-state-throw))
          (unless (jolt-nil? validator)
            (hashtable-set! iref-validator-tbl r validator))
-         ;; :meta uses the global meta-table (natives-meta.ss), same as atoms
          (when (and m (not (jolt-nil? m)))
            (unless (jolt-map? m)
              (jolt-throw (jolt-host-throwable
@@ -52,9 +115,10 @@
       (else (loop (cddr o) validator m)))))
 
 ;; --- transaction-guarded operations ------------------------------------------
-;; Inside a transaction (under the global mutex), ref-set/alter/commute/ensure
-;; mutate the ref's value directly — no CAS, no retry: serialized transactions
-;; guarantee no concurrent writer.
+;; Inside a transaction, ref-set/alter/commute/ensure write through the
+;; per-txn log; on commit the buffered values are written to the refs.
+;; On exception the log is discarded — rollback is implicit.
+
 (define (jolt-ref-ensure-txn)
   (unless (*txn*)
     (jolt-throw (jolt-host-throwable
@@ -64,18 +128,15 @@
 (define (jolt-ref-set ref v)
   (jolt-ref-ensure-txn)
   (iref-validate ref v)
-  (let ((old (jolt-ref-val ref)))
-    (jolt-ref-val-set! ref v)
-    (iref-notify ref old v))
+  (txn-write! ref v)
   v)
 
 (define (jolt-alter ref f . args)
   (jolt-ref-ensure-txn)
-  (let* ((old (jolt-ref-val ref))
+  (let* ((old (txn-read ref))
          (v (apply jolt-invoke f old args)))
     (iref-validate ref v)
-    (jolt-ref-val-set! ref v)
-    (iref-notify ref old v)
+    (txn-write! ref v)
     v))
 
 ;; Under serialized transactions, commute is equivalent to alter (no
@@ -88,48 +149,71 @@
 ;; other thread can mutate it while we hold the global lock.
 (define (jolt-ensure ref)
   (jolt-ref-ensure-txn)
-  (jolt-ref-val ref))
+  (txn-read ref))
 
 ;; __sync-call: run a thunk inside a serialized transaction — the seam the
 ;; sync/dosync MACROS (30-macros.clj) expand through; sync itself is a macro
 ;; with the reference's (sync flags & body) shape.  Nested calls join the
-;; outer transaction (re-entrant through the thread-local flag).
+;; outer transaction (re-entrant through the thread-local parameter).
 (define (jolt-sync thunk)
   (if (*txn*)
       ;; nested — just run the body under the existing transaction
       (jolt-invoke thunk)
-      (with-mutex stm-lock
-        (parameterize ((*txn* #t))
-          (jolt-invoke thunk)))))
+      ;; outer transaction: acquire lock, buffer writes, commit or rollback
+      (let ((txn (make-txn))
+            (aborted #f)
+            (result #f))
+        (with-mutex stm-lock
+          (parameterize ((*txn* txn))
+            (guard (e (#t (set! aborted #t) (set! result e)))
+              (set! result (jolt-invoke thunk)))
+            (unless aborted
+              (txn-commit! txn))))
+        ;; after with-mutex releases lock and parameterize restores *txn* to #f
+        (unless aborted
+          (txn-fire-watches! txn))
+        (if aborted (raise result) result))))
 
 ;; io! is a MACRO (30-macros.clj): its body must NOT evaluate when the
 ;; transaction check throws. The macro tests this seam.
 (define (jolt-txn-running?) (and (*txn*) #t))
 
-;; --- history ops (stubs — no MVCC) ------------------------------------------
+;; --- history ops -------------------------------------------------------------
 ;; On the JVM these control how many prior values a ref keeps for snapshot
-;; isolation.  Our serialized transactions need no history, so we return
-;; constants; set! is accepted (compatibility with code that configures them).
-;; ref-history-count is the ONLY one that MUST run outside a transaction (the
-;; JVM's LockingTransaction/Ref returns the configured count unconditionally).
+;; isolation.  Our serialized transactions need no history, so ref-history-count
+;; returns 0; the 2-arity setter forms store min/max on the ref's side table
+;; and return the ref.  ref-history-count is the ONLY one that MUST run
+;; outside a transaction (the JVM's LockingTransaction/Ref returns the
+;; configured count unconditionally).
 (define (jolt-ref-history-count ref)
   0)
 
-(define (jolt-ref-min-history ref)
-  0)
+(define (jolt-ref-min-history . args)
+  (let ((ref (car args)))
+    (if (= (length args) 2)
+        (begin (hashtable-set! ref-min-history-tbl ref (cadr args)) ref)
+        (hashtable-ref ref-min-history-tbl ref 0))))
 
 (define (jolt-ref-set-min-history! ref n)
+  (hashtable-set! ref-min-history-tbl ref n)
   jolt-nil)
 
-(define (jolt-ref-max-history ref)
-  10)
+(define (jolt-ref-max-history . args)
+  (let ((ref (car args)))
+    (if (= (length args) 2)
+        (begin (hashtable-set! ref-max-history-tbl ref (cadr args)) ref)
+        (hashtable-ref ref-max-history-tbl ref 10))))
 
 (define (jolt-ref-set-max-history! ref n)
+  (hashtable-set! ref-max-history-tbl ref n)
   jolt-nil)
 
 ;; --- deref -------------------------------------------------------------------
+;; Inside a transaction, return the in-txn value from the log (falling back
+;; to the ref's committed value).  Outside a transaction, return the ref's
+;; committed value directly.
 (define (jolt-ref-deref ref)
-  (jolt-ref-val ref))
+  (txn-read ref))
 
 ;; Chain jolt-deref to handle refs (capture the pre-ref jolt-deref from atoms).
 (define %pre-ref-deref jolt-deref)
@@ -151,6 +235,7 @@
 (def-var! "clojure.core" "__sync-call" jolt-sync)
 (def-var! "clojure.core" "__txn-running?" jolt-txn-running?)
 (def-var! "clojure.core" "ref-history-count" jolt-ref-history-count)
+;; ref-min-history / ref-max-history are multi-arity (getter / setter)
 (def-var! "clojure.core" "ref-min-history" jolt-ref-min-history)
 (def-var! "clojure.core" "ref-max-history" jolt-ref-max-history)
 ;; deref is already bound; the chain above extends jolt-deref, and

--- a/host/chez/refs.ss
+++ b/host/chez/refs.ss
@@ -29,7 +29,7 @@
 ;;                 (captured once per ref for the single watch notification)
 ;;   pending-sends — list of (agent f args) enqueued during this txn (Round 3)
 (define-record-type jolt-txn
-  (fields (mutable log) (mutable old-vals) pending-sends)
+  (fields (mutable log) (mutable old-vals) (mutable pending-sends))
   (nongenerative jolt-txn-v1))
 
 (define (make-txn)
@@ -171,7 +171,17 @@
               (txn-commit! txn))))
         ;; after with-mutex releases lock and parameterize restores *txn* to #f
         (unless aborted
-          (txn-fire-watches! txn))
+          (txn-fire-watches! txn)
+          ;; dispatch deferred agent sends inside a txn.  Look up send from
+          ;; clojure.core (resolved at runtime, after concurrency.ss loads).
+          (let ((sends (jolt-txn-pending-sends txn)))
+            (when (pair? sends)
+              (let ((send-fn (or jolt-txn-send-fn
+                                 (let ((v (var-deref "clojure.core" "send")))
+                                   (set! jolt-txn-send-fn v) v))))
+                (for-each (lambda (entry)
+                            (apply send-fn entry))
+                          (reverse sends))))))
         (if aborted (raise result) result))))
 
 ;; io! is a MACRO (30-macros.clj): its body must NOT evaluate when the
@@ -246,3 +256,7 @@
 ;; loaded-libs fn returns the derefed set.
 (def-var! "clojure.core" "loaded-libs"
   (lambda () (jolt-deref (var-deref "clojure.core" "*loaded-libs*"))))
+
+;; Cached send fn for dispatching deferred agent sends after txn commit.
+;; Resolved lazily at runtime (after concurrency.ss has loaded send into core).
+(define jolt-txn-send-fn #f)

--- a/host/chez/refs.ss
+++ b/host/chez/refs.ss
@@ -17,7 +17,7 @@
 ;; IRef arm: refs are watchable/validatable through the iref tables.
 (register-iref-arm! jolt-ref?)
 
-;; Per-ref min/max history: stored in side tables (e.g., 0 and 10 defaults).
+;; Per-ref min/max history (defaults 0 and 10), stored in weak side tables.
 (define ref-min-history-tbl (make-weak-eq-hashtable))
 (define ref-max-history-tbl (make-weak-eq-hashtable))
 
@@ -33,7 +33,7 @@
   (nongenerative jolt-txn-v1))
 
 (define (make-txn)
-  (make-jolt-txn (make-weak-eq-hashtable) (make-weak-eq-hashtable) '()))
+  (make-jolt-txn (make-eq-hashtable) (make-eq-hashtable) '()))
 
 ;; --- transaction state -------------------------------------------------------
 ;; A single global mutex serializes all transactions.  Per-thread *txn* detects
@@ -204,19 +204,11 @@
         (begin (hashtable-set! ref-min-history-tbl ref (cadr args)) ref)
         (hashtable-ref ref-min-history-tbl ref 0))))
 
-(define (jolt-ref-set-min-history! ref n)
-  (hashtable-set! ref-min-history-tbl ref n)
-  jolt-nil)
-
 (define (jolt-ref-max-history . args)
   (let ((ref (car args)))
     (if (= (length args) 2)
         (begin (hashtable-set! ref-max-history-tbl ref (cadr args)) ref)
         (hashtable-ref ref-max-history-tbl ref 10))))
-
-(define (jolt-ref-set-max-history! ref n)
-  (hashtable-set! ref-max-history-tbl ref n)
-  jolt-nil)
 
 ;; --- deref -------------------------------------------------------------------
 ;; Inside a transaction, return the in-txn value from the log (falling back

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -227,6 +227,16 @@ else
   fails=$((fails + 1))
 fi
 
+# STM (refs) threaded tests: isolation, txn-leak, io! in future.
+stm_out="$(bin/joltc run test/chez/stm-test.clj 2>/dev/null)"
+if printf '%s' "$stm_out" | grep -q 'STM OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: STM threaded tests"
+  printf '%s\n' "$stm_out" | grep FAIL | head -5 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
 # move, mtime round-trip, which). The file self-checks and prints one marker.
 fs_out="$(bin/joltc run test/chez/fs-test.clj 2>/dev/null)"

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3687,7 +3687,7 @@
   {:suite "refs / loaded-libs-dosync" :label "*loaded-libs* can be altered inside dosync" :expected "true" :actual "(do (dosync (alter @(var *loaded-libs*) disj (quote non-existent-lib))) true)" :portability :common}
   {:suite "refs / io!-lazy" :label "io! body does not evaluate when it throws" :expected "0" :actual "(do (def iol (atom [])) (try (dosync (io! (swap! iol conj 1))) (catch IllegalStateException e nil)) (count @iol))" :portability :common}
   {:suite "refs / io!-message" :label "a leading literal string is the io! exception message" :expected "\"boom\"" :actual "(try (dosync (io! \"boom\" 1)) (catch IllegalStateException e (ex-message e)))" :portability :common}
-   {:suite "refs / sync" :label "sync has the (sync flags & body) shape" :expected "3" :actual "(let [r (ref 0)] (sync nil (ref-set r 1) (ref-set r 3)) @r)" :portability :common}
+  {:suite "refs / sync" :label "sync has the (sync flags & body) shape" :expected "3" :actual "(let [r (ref 0)] (sync nil (ref-set r 1) (ref-set r 3)) @r)" :portability :common}
   ;; Round 1 — commit-log: rollback on throw, read-your-writes, deferred watches
   {:suite "refs / rollback" :label "ref-set rolls back on exception" :expected "0" :actual "(let [r (ref 0)] (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) @r)" :portability :common}
   {:suite "refs / rollback-alter" :label "alter rolls back on exception" :expected "0" :actual "(let [r (ref 0)] (try (dosync (alter r + 10) (throw (ex-info \"x\" {}))) (catch Exception e nil)) @r)" :portability :common}
@@ -3696,9 +3696,9 @@
   {:suite "refs / commute-read" :label "in-txn deref sees commute value" :expected "10" :actual "(let [r (ref 0)] (dosync (commute r + 10) @r))" :portability :common}
   {:suite "refs / ensure-read" :label "ensure inside dosync returns current in-txn value" :expected "7" :actual "(let [r (ref 0)] (dosync (ref-set r 7) (ensure r)))" :portability :common}
   {:suite "refs / watch-after-commit" :label "watch fires once after commit with (pre-txn, committed)" :expected "[[0 8]]" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj [o n]))) (try (dosync (ref-set r 1) (ref-set r 2) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (dosync (ref-set r 7) (ref-set r 8)) @hits)" :portability :common}
-   {:suite "refs / watch-no-fire-on-rollback" :label "no watch notification on rolled-back txn" :expected "0" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj 1))) (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (count @hits))" :portability :common}
+  {:suite "refs / watch-no-fire-on-rollback" :label "no watch notification on rolled-back txn" :expected "0" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj 1))) (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (count @hits))" :portability :common}
   ;; Round 2 — *txn* thread isolation
-  {:suite "refs / txn-leak" :label "future spawned in txn does not inherit *txn*" :expected ":caught" :actual "(do (def tl-r (ref 0)) (try (dosync (deref (future (ref-set tl-r 1)))) (catch IllegalStateException e :caught)))" :portability :common}
+  {:suite "refs / txn-leak" :label "future spawned in txn does not inherit *txn*" :expected ":ise" :actual "(do (def tl-r (ref 0)) (dosync (deref (future (try (ref-set tl-r 1) :wrote (catch IllegalStateException e :ise))))))" :portability :common}
   {:suite "refs / io!-in-future" :label "io! inside future inside dosync runs normally" :expected ":ok" :actual "(let [r (ref 0)] (dosync (deref (future (io! :ok)))))" :portability :common}
   ;; Round 3 — agent-sends held until commit
   {:suite "refs / agent-send-rollback" :label "agent action discarded on txn rollback" :expected "0" :actual "(let [a (agent 0)] (try (dosync (send a inc) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (await a) @a)" :portability :common}
@@ -3707,4 +3707,4 @@
   {:suite "refs / ref-min-history-setter" :label "ref-min-history setter stores value and returns ref" :expected "[5 20]" :actual "(let [r (ref 0)] [(ref-min-history (ref-min-history r 5)) (ref-max-history (ref-max-history r 20))])" :portability :common}
   {:suite "refs / ref-min-history-reader" :label "ref-min-history reader returns stored default" :expected "0" :actual "(ref-min-history (ref 0))" :portability :common}
   {:suite "refs / ref-max-history-reader" :label "ref-max-history reader returns stored default" :expected "10" :actual "(ref-max-history (ref 0))" :portability :common}
- ]
+]

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3687,5 +3687,21 @@
   {:suite "refs / loaded-libs-dosync" :label "*loaded-libs* can be altered inside dosync" :expected "true" :actual "(do (dosync (alter @(var *loaded-libs*) disj (quote non-existent-lib))) true)" :portability :common}
   {:suite "refs / io!-lazy" :label "io! body does not evaluate when it throws" :expected "0" :actual "(do (def iol (atom [])) (try (dosync (io! (swap! iol conj 1))) (catch IllegalStateException e nil)) (count @iol))" :portability :common}
   {:suite "refs / io!-message" :label "a leading literal string is the io! exception message" :expected "\"boom\"" :actual "(try (dosync (io! \"boom\" 1)) (catch IllegalStateException e (ex-message e)))" :portability :common}
-  {:suite "refs / sync" :label "sync has the (sync flags & body) shape" :expected "3" :actual "(let [r (ref 0)] (sync nil (ref-set r 1) (ref-set r 3)) @r)" :portability :common}
-]
+   {:suite "refs / sync" :label "sync has the (sync flags & body) shape" :expected "3" :actual "(let [r (ref 0)] (sync nil (ref-set r 1) (ref-set r 3)) @r)" :portability :common}
+  ;; Round 1 — commit-log: rollback on throw, read-your-writes, deferred watches
+  {:suite "refs / rollback" :label "ref-set rolls back on exception" :expected "0" :actual "(let [r (ref 0)] (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) @r)" :portability :common}
+  {:suite "refs / rollback-alter" :label "alter rolls back on exception" :expected "0" :actual "(let [r (ref 0)] (try (dosync (alter r + 10) (throw (ex-info \"x\" {}))) (catch Exception e nil)) @r)" :portability :common}
+  {:suite "refs / read-your-writes-ref-set" :label "in-txn deref sees ref-set value" :expected "5" :actual "(let [r (ref 0)] (dosync (ref-set r 5) @r))" :portability :common}
+  {:suite "refs / read-your-writes-alter" :label "in-txn deref sees alter value" :expected "2" :actual "(let [r (ref 0)] (dosync (alter r inc) (alter r inc)) @r)" :portability :common}
+  {:suite "refs / commute-read" :label "in-txn deref sees commute value" :expected "10" :actual "(let [r (ref 0)] (dosync (commute r + 10) @r))" :portability :common}
+  {:suite "refs / ensure-read" :label "ensure inside dosync returns current in-txn value" :expected "7" :actual "(let [r (ref 0)] (dosync (ref-set r 7) (ensure r)))" :portability :common}
+  {:suite "refs / watch-after-commit" :label "watch fires once after commit with (pre-txn, committed)" :expected "[[0 8]]" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj [o n]))) (try (dosync (ref-set r 1) (ref-set r 2) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (dosync (ref-set r 7) (ref-set r 8)) @hits)" :portability :common}
+  {:suite "refs / watch-no-fire-on-rollback" :label "no watch notification on rolled-back txn" :expected "0" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj 1))) (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (count @hits))" :portability :common}
+  ;; Round 3 — agent-sends held until commit
+  {:suite "refs / agent-send-rollback" :label "agent action discarded on txn rollback" :expected "0" :actual "(let [a (agent 0)] (try (dosync (send a inc) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (await a) @a)" :portability :common}
+  {:suite "refs / agent-send-commit" :label "agent action dispatched after commit" :expected "1" :actual "(let [a (agent 0)] (dosync (send a inc)) (await a) @a)" :portability :common}
+  ;; Round 4 — API surface
+  {:suite "refs / ref-min-history-setter" :label "ref-min-history setter stores value and returns ref" :expected "[5 20]" :actual "(let [r (ref 0)] [(ref-min-history (ref-min-history r 5)) (ref-max-history (ref-max-history r 20))])" :portability :common}
+  {:suite "refs / ref-min-history-reader" :label "ref-min-history reader returns stored default" :expected "0" :actual "(ref-min-history (ref 0))" :portability :common}
+  {:suite "refs / ref-max-history-reader" :label "ref-max-history reader returns stored default" :expected "10" :actual "(ref-max-history (ref 0))" :portability :common}
+ ]

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3696,7 +3696,10 @@
   {:suite "refs / commute-read" :label "in-txn deref sees commute value" :expected "10" :actual "(let [r (ref 0)] (dosync (commute r + 10) @r))" :portability :common}
   {:suite "refs / ensure-read" :label "ensure inside dosync returns current in-txn value" :expected "7" :actual "(let [r (ref 0)] (dosync (ref-set r 7) (ensure r)))" :portability :common}
   {:suite "refs / watch-after-commit" :label "watch fires once after commit with (pre-txn, committed)" :expected "[[0 8]]" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj [o n]))) (try (dosync (ref-set r 1) (ref-set r 2) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (dosync (ref-set r 7) (ref-set r 8)) @hits)" :portability :common}
-  {:suite "refs / watch-no-fire-on-rollback" :label "no watch notification on rolled-back txn" :expected "0" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj 1))) (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (count @hits))" :portability :common}
+   {:suite "refs / watch-no-fire-on-rollback" :label "no watch notification on rolled-back txn" :expected "0" :actual "(let [r (ref 0) hits (atom [])] (add-watch r :w (fn [_ _ o n] (swap! hits conj 1))) (try (dosync (ref-set r 5) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (count @hits))" :portability :common}
+  ;; Round 2 — *txn* thread isolation
+  {:suite "refs / txn-leak" :label "future spawned in txn does not inherit *txn*" :expected ":caught" :actual "(do (def tl-r (ref 0)) (try (dosync (deref (future (ref-set tl-r 1)))) (catch IllegalStateException e :caught)))" :portability :common}
+  {:suite "refs / io!-in-future" :label "io! inside future inside dosync runs normally" :expected ":ok" :actual "(let [r (ref 0)] (dosync (deref (future (io! :ok)))))" :portability :common}
   ;; Round 3 — agent-sends held until commit
   {:suite "refs / agent-send-rollback" :label "agent action discarded on txn rollback" :expected "0" :actual "(let [a (agent 0)] (try (dosync (send a inc) (throw (ex-info \"x\" {}))) (catch Exception e nil)) (await a) @a)" :portability :common}
   {:suite "refs / agent-send-commit" :label "agent action dispatched after commit" :expected "1" :actual "(let [a (agent 0)] (dosync (send a inc)) (await a) @a)" :portability :common}

--- a/test/chez/stm-test.clj
+++ b/test/chez/stm-test.clj
@@ -1,0 +1,27 @@
+;; STM threaded tests: isolation, txn-leak prevention, io! in txn with threads.
+;; Prints STM OK when all pass.
+;; Rounds 2-3 add txn-leak (future inside dosync) and agent-send-hold tests.
+(def failures (atom []))
+(defn chk [label ok] (when-not ok (swap! failures conj label)))
+
+;; --- Isolation (#4): thread A writes + sleep + throw, thread B reads mid-txn
+(let [r (ref 0)
+      done (promise)]
+  (future
+    (try
+      (dosync
+        (ref-set r 5)
+        (Thread/sleep 400)
+        (throw (ex-info "rollback" {})))
+      (catch Exception e)))
+  (Thread/sleep 100)  ;; let A get inside dosync and set r to 5
+  (deliver done @r)   ;; B reads — must see 0 (isolation), not 5
+  (Thread/sleep 500)  ;; wait for A's txn to unwind
+  (chk "isolation: B sees committed value during A's uncommitted txn"
+       (= @done 0))
+  (chk "isolation: final value is rolled back"
+       (= @r 0)))
+
+(if (empty? @failures)
+  (println "STM OK")
+  (doseq [f @failures] (println "FAIL:" f)))

--- a/test/chez/stm-test.clj
+++ b/test/chez/stm-test.clj
@@ -1,6 +1,5 @@
 ;; STM threaded tests: isolation, txn-leak prevention, io! in txn with threads.
 ;; Prints STM OK when all pass.
-;; Rounds 2-3 add txn-leak (future inside dosync) and agent-send-hold tests.
 (def failures (atom []))
 (defn chk [label ok] (when-not ok (swap! failures conj label)))
 
@@ -21,6 +20,24 @@
        (= @done 0))
   (chk "isolation: final value is rolled back"
        (= @r 0)))
+
+;; --- Txn-leak (#5): future spawned inside dosync must not inherit *txn*
+(let [r (ref 0)]
+  (try
+    (dosync
+      (deref (future (ref-set r 1))))
+    (catch Exception e
+      (chk "txn-leak: ref-set in future throws IllegalStateException"
+           (instance? IllegalStateException e))))
+  (chk "txn-leak: ref unchanged after failed future ref-set"
+       (= @r 0)))
+
+;; --- io! in txn with thread (#6): future inside dosync must not throw io!
+(let [r (ref 0)]
+  (dosync
+    (deref (future (io! :ok))))
+  ;; if we reach here, io! inside future didn't throw inside the dosync's txn
+  (chk "io!-in-future: io! inside future inside dosync does not throw" true))
 
 (if (empty? @failures)
   (println "STM OK")


### PR DESCRIPTION
Makes refs/STM production quality. The single-global-mutex design stays; what changes is atomicity: transactions now buffer writes in a per-txn log and only write ref values on successful commit.

- rollback: a thrown dosync discards its writes (was: writes applied in place, no rollback)
- isolation: other threads never see uncommitted values
- watches fire once per changed ref after commit, outside the lock, with (pre-txn, committed) — and not at all on abort
- `*txn*` no longer leaks into threads spawned inside a transaction (Chez thread parameters inherit at fork): futures, agent workers, Thread.start, go/thread, async put!/take! callbacks. A future inside a dosync now throws "No transaction running" on ref-set like the JVM, and io! inside it doesn't false-positive
- agent sends inside a transaction are held until commit and discarded on abort (Agent.dispatchAction semantics)
- ref-min-history/ref-max-history setter arities (return the ref); (class (ref 0)) is clojure.lang.Ref, instance? Ref/IRef/IDeref true

Semantics follow LockingTransaction.java/Ref.java/Agent.java where applicable; commute stays equivalent to alter under serialized transactions.

Tests: 15 new JVM-certified corpus rows (rollback, read-your-writes, watch timing, txn-leak, held sends, history) plus a threaded stm-test smoke fixture for the timing-dependent isolation checks. make test and make cts green.

Closes jolt-kedi, jolt-6a08, jolt-sx28, jolt-nvnh.