### PR TITLE
Add jolt.parser and jolt.infix to the standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transaction are held until commit, and transaction state does not leak into
   threads spawned inside a `dosync`. `(class (ref 0))` is `clojure.lang.Ref`,
   and `ref-min-history`/`ref-max-history` take the setter arity.
+- `jolt.parser`: a general monadic parser-combinator core (`jolt.parser` +
+  `jolt.parser.{basic,combinators,monad,position}`), adapted from rm-hull/jasentaa,
+  with added combinators (`eof`, `between`, `sep-by`, an `optional` default-value
+  arity, and the `digit`/`letter`/`alpha-num` character classes). Parse failures
+  raise a jolt `ex-info`.
+- `jolt.infix`: built-in infix math notation via the `infix`/`$=` macros and
+  `from-string` (ported from rm-hull/infix), built on `jolt.parser`.
+- `Math/atan2`, `Math/sinh`, `Math/cosh`, `Math/tanh` static methods.
+- `java.text.ParseException` as a constructable/catchable host exception class.
 
 ## [0.2.1] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raise a jolt `ex-info`.
 - `jolt.infix`: built-in infix math notation via the `infix`/`$=` macros and
   `from-string` (ported from rm-hull/infix), built on `jolt.parser`.
-- `Math/atan2`, `Math/sinh`, `Math/cosh`, `Math/tanh` static methods.
-- `java.text.ParseException` as a constructable/catchable host exception class.
+- Rounded out the `java.lang.Math` static surface: `atan2`, `sinh`, `cosh`,
+  `tanh`, `cbrt`, `hypot`, `rint`, `floorDiv`, `floorMod`, `copySign`,
+  `toRadians`, `toDegrees`, `log1p`, `expm1`.
+- `java.text.ParseException` as a constructable/catchable host exception class,
+  including `.getErrorOffset`.
 
 ## [0.2.1] - 2026-07-09
 

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -243,6 +243,7 @@
 (jch-register-supers! "java.io.UncheckedIOException" '("java.lang.RuntimeException"))
 (jch-register-supers! "java.time.DateTimeException" '("java.lang.RuntimeException"))
 (jch-register-supers! "java.time.format.DateTimeParseException" '("java.time.DateTimeException"))
+(jch-register-supers! "java.text.ParseException" '("java.lang.Exception"))
 (jch-register-supers! "java.lang.InterruptedException" '("java.lang.Exception"))
 (jch-register-supers! "java.io.IOException" '("java.lang.Exception"))
 (jch-register-supers! "java.io.InterruptedIOException" '("java.io.IOException"))

--- a/host/chez/java/dot-forms.ss
+++ b/host/chez/java/dot-forms.ss
@@ -80,6 +80,8 @@
                (jolt-get obj jolt-kw-message jolt-nil)
                (jolt-str-render-one obj))))
     ((string=? name "getCause")  (list (jolt-get obj jolt-kw-cause jolt-nil)))
+    ;; java.text.ParseException.getErrorOffset — the int offset stashed by its ctor.
+    ((string=? name "getErrorOffset") (list (jolt-get obj jolt-kw-error-offset 0)))
     ;; java.sql.SQLException chaining — ex-info / host throwables don't chain.
     ((string=? name "getNextException") (list jolt-nil))
     ((string=? name "getStackTrace") (list (jolt-vector)))

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -536,15 +536,17 @@
     "FileNotFoundException" "UnsupportedEncodingException" "EOFException" "java.io.EOFException"
     "Error" "AssertionError"))
 
-;; java.text.ParseException(String s, int errorOffset): unlike the exceptions above,
-;; its second ctor arg is an int offset, not a cause — take the message and drop the
-;; offset (nothing reads getErrorOffset here) rather than misfiling it as a cause.
+;; java.text.ParseException(String s, int errorOffset): unlike the exceptions
+;; above, its second ctor arg is an int offset (getErrorOffset), not a cause.
+;; Keep the offset under :jolt/error-offset (invisible to ex-data) so .getErrorOffset
+;; can read it back, rather than misfiling it as a cause.
 (register-class-ctor! "ParseException"
   (lambda args
-    (let ((a0 (if (pair? args) (car args) jolt-nil)))
-      (if (string? a0)
-          (jolt-host-throwable "java.text.ParseException" a0)
-          (jolt-host-throwable "java.text.ParseException" (jolt-str-render-one a0))))))
+    (let* ((a0 (if (pair? args) (car args) jolt-nil))
+           (off (if (and (pair? args) (pair? (cdr args))) (cadr args) 0))
+           (msg (if (string? a0) a0 (jolt-str-render-one a0))))
+      (jolt-assoc (jolt-host-throwable "java.text.ParseException" msg)
+                  jolt-kw-error-offset off))))
 
 ;; ---- URLEncoder / URLDecoder (www-form-urlencoded) --------------------------
 (define (url-unreserved? b)

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -536,6 +536,16 @@
     "FileNotFoundException" "UnsupportedEncodingException" "EOFException" "java.io.EOFException"
     "Error" "AssertionError"))
 
+;; java.text.ParseException(String s, int errorOffset): unlike the exceptions above,
+;; its second ctor arg is an int offset, not a cause — take the message and drop the
+;; offset (nothing reads getErrorOffset here) rather than misfiling it as a cause.
+(register-class-ctor! "ParseException"
+  (lambda args
+    (let ((a0 (if (pair? args) (car args) jolt-nil)))
+      (if (string? a0)
+          (jolt-host-throwable "java.text.ParseException" a0)
+          (jolt-host-throwable "java.text.ParseException" (jolt-str-render-one a0))))))
+
 ;; ---- URLEncoder / URLDecoder (www-form-urlencoded) --------------------------
 (define (url-unreserved? b)
   (or (and (>= b 48) (<= b 57)) (and (>= b 65) (<= b 90)) (and (>= b 97) (<= b 122))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -19,6 +19,10 @@
         (cons "sin" (lambda (x) (->dbl (sin x)))) (cons "cos" (lambda (x) (->dbl (cos x))))
         (cons "tan" (lambda (x) (->dbl (tan x)))) (cons "asin" (lambda (x) (->dbl (asin x))))
         (cons "acos" (lambda (x) (->dbl (acos x)))) (cons "atan" (lambda (x) (->dbl (atan x))))
+        ;; Math.atan2(y, x) — Chez's 2-arg atan is (atan y x).
+        (cons "atan2" (lambda (y x) (->dbl (atan y x))))
+        (cons "sinh" (lambda (x) (->dbl (sinh x)))) (cons "cosh" (lambda (x) (->dbl (cosh x))))
+        (cons "tanh" (lambda (x) (->dbl (tanh x))))
         (cons "log" (lambda (x) (->dbl (log x)))) (cons "log10" (lambda (x) (->dbl (/ (log x) (log 10)))))
         (cons "exp" (lambda (x) (->dbl (exp x))))
         ;; getExponent: the unbiased binary exponent of a double (floor(log2|x|));

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -9,12 +9,23 @@
 ;; JVM (Chez's sqrt/expt return EXACT for exact args, e.g. (sqrt 9) -> 3), so coerce
 ;; to flonum. round -> long (exact); abs/max/min preserve the argument's type.
 (define (->dbl x) (exact->inexact x))
+(define math-pi (acos -1.0))
+;; sign-aware cube root: expt of a negative flonum to 1/3 goes complex.
+(define (math-cbrt x)
+  (let ((x (exact->inexact x)))
+    (if (< x 0.0) (- (expt (- x) (/ 1.0 3.0))) (expt x (/ 1.0 3.0)))))
 (register-class-statics! "Math"
   (list (cons "sqrt" (lambda (x) (->dbl (sqrt x))))
+        (cons "cbrt" (lambda (x) (math-cbrt x)))
         (cons "pow" (lambda (a b) (->dbl (expt a b))))
+        (cons "hypot" (lambda (a b) (->dbl (sqrt (+ (* a a) (* b b))))))
         (cons "floor" (lambda (x) (->dbl (floor x))))
         (cons "ceil" (lambda (x) (->dbl (ceiling x))))
         (cons "round" (lambda (x) (exact (floor (+ x 1/2)))))   ; JVM round-half-up -> long
+        (cons "rint" (lambda (x) (->dbl (round x))))            ; round-half-even -> double
+        ;; Math.floorDiv/floorMod: integer floor division / modulus (long -> long).
+        (cons "floorDiv" (lambda (a b) (exact (floor (/ a b)))))
+        (cons "floorMod" (lambda (a b) (exact (- a (* b (floor (/ a b)))))))
         (cons "abs" (lambda (x) (abs x)))
         (cons "sin" (lambda (x) (->dbl (sin x)))) (cons "cos" (lambda (x) (->dbl (cos x))))
         (cons "tan" (lambda (x) (->dbl (tan x)))) (cons "asin" (lambda (x) (->dbl (asin x))))
@@ -24,7 +35,12 @@
         (cons "sinh" (lambda (x) (->dbl (sinh x)))) (cons "cosh" (lambda (x) (->dbl (cosh x))))
         (cons "tanh" (lambda (x) (->dbl (tanh x))))
         (cons "log" (lambda (x) (->dbl (log x)))) (cons "log10" (lambda (x) (->dbl (/ (log x) (log 10)))))
+        (cons "log1p" (lambda (x) (->dbl (log (+ 1.0 x)))))
         (cons "exp" (lambda (x) (->dbl (exp x))))
+        (cons "expm1" (lambda (x) (->dbl (- (exp x) 1.0))))
+        (cons "toRadians" (lambda (d) (->dbl (/ (* d math-pi) 180.0))))
+        (cons "toDegrees" (lambda (r) (->dbl (/ (* r 180.0) math-pi))))
+        (cons "copySign" (lambda (m s) (->dbl (if (< s 0.0) (- (abs m)) (abs m)))))
         ;; getExponent: the unbiased binary exponent of a double (floor(log2|x|));
         ;; scalb: x * 2^n. test.check's double generator uses both.
         (cons "getExponent" (lambda (x) (if (= x 0.0) -1023

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -202,6 +202,10 @@
 ;; ex-message all reflect the real type. Plain ex-info has no :jolt/class (its class
 ;; defaults to clojure.lang.ExceptionInfo), so those maps stay byte-identical.
 (define jolt-kw-class (keyword "jolt" "class"))
+;; java.text.ParseException carries an int error offset (getErrorOffset). Stored
+;; under a jolt-namespaced key so it never shows up in (ex-data …), which reads
+;; the :data key.
+(define jolt-kw-error-offset (keyword "jolt" "error-offset"))
 (define (jolt-host-throwable class-name msg . more)
   (jolt-hash-map jolt-kw-ex-type jolt-kw-ex-info
                  jolt-kw-class class-name

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -248,6 +248,28 @@ else
   fails=$((fails + 1))
 fi
 
+# jolt.parser — the general parser-combinator core, running rm-hull/jasentaa's
+# own suite for the adopted pieces plus jolt's added combinators. Self-checks.
+parser_out="$(bin/joltc run test/chez/parser-test.clj 2>/dev/null)"
+if printf '%s' "$parser_out" | grep -q 'PARSER OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.parser"
+  printf '%s\n' "$parser_out" | grep FAIL | head -5 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
+# jolt.infix — jolt's built-in infix math notation, running rm-hull/infix's own
+# suite (macros/grammar/core tests). The file self-checks and prints one marker.
+infix_out="$(bin/joltc run test/chez/infix-test.clj 2>/dev/null)"
+if printf '%s' "$infix_out" | grep -q 'INFIX OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: infix"
+  printf '%s\n' "$infix_out" | grep FAIL | head -5 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # A data reader that returns a CODE form (deps.edn data_readers.clj -> reader fn)
 # must have its result spliced in and COMPILED, like Clojure — #code [:x] becomes
 # (+ 40 2) and evaluates to 42, not the literal list. A project run so the source

--- a/stdlib/jolt/infix.clj
+++ b/stdlib/jolt/infix.clj
@@ -1,0 +1,74 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+
+(ns jolt.infix
+  (:require
+   [jolt.parser :refer [parse-all]]
+   [jolt.infix.core :refer [rewrite resolve-alias base-env]]
+   [jolt.infix.grammar :refer [expression]]))
+
+(defmacro infix
+  "Takes an infix expression, resolves any aliases before rewriting the
+   infix expressions into standard LISP prefix expressions."
+  [& expr]
+  (->>
+   expr
+   (map resolve-alias)
+   rewrite))
+
+;; Short alias for infix
+(defmacro $=
+  "Takes an infix expression, resolves any aliases before rewriting the
+   infix expressions into standard LISP prefix expressions."
+  [& expr]
+  `(infix ~@expr))
+
+(defn- binding-vars [bindings]
+  (->>
+   bindings
+   (map #(vector (keyword %) (gensym "arg_")))
+   (into {})))
+
+(defmacro from-string
+  ([expr]
+   `(from-string [] ~expr))
+
+  ([bindings expr]
+   ;; Reference the base-env var at runtime rather than splicing its value:
+   ;; the map holds live fn objects, which jolt can't embed as a compile-time
+   ;; constant (JVM Clojure tolerates it, but referring the var is portable).
+   `(from-string ~bindings base-env ~expr))
+
+  ([bindings env expr]
+   (cond
+     (not (vector? bindings))
+     (throw (IllegalArgumentException. "Binding variables is not a vector"))
+
+     :else
+     (let [b# (binding-vars bindings)
+           p# (mapv keyword bindings)]
+       `(if-let [f# (parse-all expression ~expr)]
+          (with-meta
+            (fn [~@(vals b#)]
+              (f# (merge ~env ~b#)))
+            {:doc ~expr :params ~p#}))))))

--- a/stdlib/jolt/infix/core.clj
+++ b/stdlib/jolt/infix/core.clj
@@ -1,0 +1,173 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.core
+  (:require
+   [jolt.infix.math.core]
+   [jolt.infix.math.constants]
+   [jolt.infix.math.bit-shuffling]
+   [jolt.infix.math.trig]))
+
+(def operator-alias
+  (atom
+   {'&&     'and
+    '||     'or
+    '!=     'not=
+    '%      'mod
+    '<<     'bit-shift-left
+    '>>     'bit-shift-right
+    '>>>    'unsigned-bit-shift-right
+    '!      'not
+    '&      'bit-and
+    '|      'bit-or
+    '.      '*
+    'abs    'Math/abs
+    'signum 'Math/signum
+    '**     'Math/pow
+    'sin    'Math/sin
+    'cos    'Math/cos
+    'tan    'Math/tan
+    'asin   'Math/asin
+    'acos   'Math/acos
+    'atan   'Math/atan
+    'sinh   'Math/sinh
+    'cosh   'Math/cosh
+    'tanh   'Math/tanh
+    'sec    'jolt.infix.math.trig/sec
+    'csc    'jolt.infix.math.trig/csc
+    'cot    'jolt.infix.math.trig/cot
+    'asec   'jolt.infix.math.trig/asec
+    'acsc   'jolt.infix.math.trig/acsc
+    'acot   'jolt.infix.math.trig/acot
+    'exp    'Math/exp
+    'log    'Math/log
+    'e      'Math/E
+    'π      'Math/PI
+    'φ      'jolt.infix.math.constants/φ
+    'sqrt   'Math/sqrt
+    '√      'Math/sqrt
+    '÷      'jolt.infix.math.core/divide
+    'root   'jolt.infix.math.core/root
+    'gcd    'jolt.infix.math.core/gcd
+    'lcm    'jolt.infix.math.core/lcm
+    'fact   'jolt.infix.math.core/fact
+    'sum    'jolt.infix.math.core/sum
+    '∑      'jolt.infix.math.core/sum
+    'product 'jolt.infix.math.core/product
+    '∏      'jolt.infix.math.core/product}))
+
+(defn suppress! [sym]
+  (swap! operator-alias dissoc sym))
+
+(def operator-precedence
+  ; From https://en.wikipedia.org/wiki/Order_of_operations#Programming_languages
+  ; Lowest precedence first
+  [;; binary operators
+   'or 'and 'bit-or 'bit-xor 'bit-and 'not= '= '== '>= '> '<= '<
+   'unsigned-bit-shift-right 'bit-shift-right 'bit-shift-left
+   '+ '- '* '/ 'jolt.infix.math.core/divide 'Math/pow 'mod
+
+   ;; unary operators
+   'not
+   'Math/sin  'Math/cos  'Math/tan
+   'Math/asin 'Math/acos 'Math/atan
+   'Math/sinh 'Math/cosh 'Math/tanh
+   'Math/sqrt 'Math/exp  'Math/log
+   'Math/abs  'Math/signum])
+
+(def right-associative-operators
+  #{'Math/pow})
+
+(defn- bounded? [sym]
+  (if-let [v (resolve sym)]
+    (bound? v)
+    false))
+
+(defn resolve-alias
+  "Attempt to resolve any aliases: if not found just return the original term"
+  [term]
+  (if (and (symbol? term) (bounded? term))
+    term
+    (get @operator-alias term term)))
+
+(defn- empty-arglist? [xs]
+  (let [elem (fnext xs)]
+    (and (seq? elem) (empty? elem))))
+
+(defn rewrite
+  "Recursively rewrites the infix-expr as a prefix expression, according to
+   the operator precedence rules"
+  [infix-expr]
+  (cond
+    (not (seq? infix-expr))
+    (resolve-alias infix-expr)
+
+    (and (seq? (first infix-expr)) (= (count infix-expr) 1))
+    (rewrite (first infix-expr))
+
+    (empty? (rest infix-expr))
+    (first infix-expr)
+
+    :else
+    (let [infix-expr (map resolve-alias infix-expr)]
+      (loop [ops operator-precedence]
+        (if-let [op (first ops)]
+          (let [idx (if (right-associative-operators op)
+                      (.indexOf ^java.util.List infix-expr op)
+                      (.lastIndexOf ^java.util.List infix-expr op))]
+            (if (pos? idx)
+              (let [[expr1 [op & expr2]] (split-at idx infix-expr)]
+                (list op (rewrite expr1) (rewrite expr2)))
+              (recur (next ops))))
+
+          (if (empty-arglist? infix-expr)
+            (list (rewrite (first infix-expr)))
+            (list (rewrite (first infix-expr)) (rewrite (next infix-expr)))))))))
+
+(defn- logical-or [a b] (or a b))
+(defn- logical-and [a b] (and a b))
+
+(def base-env
+  (merge
+    ; wrapped java.lang.Math constants & functions
+   (->>
+    ['jolt.infix.math.core 'jolt.infix.math.constants
+     'jolt.infix.math.trig 'jolt.infix.math.bit-shuffling]
+    (mapcat ns-publics)
+    (map (fn [[k v]] (vector (keyword k) v)))
+    (into {}))
+
+    ; Basic ops
+   {:== ==
+    := =
+    :!= not=
+    :+ +
+    :- -
+    :* *
+    :/ /
+    :% mod
+    :&& logical-and
+    :|| logical-or
+    :> >
+    :< <
+    :>= >=
+    :<= <=}))

--- a/stdlib/jolt/infix/grammar.clj
+++ b/stdlib/jolt/infix/grammar.clj
@@ -1,0 +1,233 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.grammar
+  (:refer-clojure :exclude [boolean])
+  (:require
+   [jolt.parser.monad :as m]
+   [jolt.parser.position :refer [strip-location]]
+   [jolt.parser.basic :refer :all]
+   [jolt.parser.combinators :refer :all]))
+
+; expression ::= term { addop term }.
+; term ::= factor { mulop factor }.
+; factor ::= base { expop base }
+; base ::= "(" expression ")" | boolean | number | var | function | ternary.
+; addop ::= "+" | "-".
+; mulop ::= "*" | "/".
+; expop ::= "**"
+;
+; function ::= envref expression | envref "(" <empty> | expression { "," expression } ")".
+; ternary ::= expression "?" expression ":" expression.
+; envref ::= letter | "_" { letter | digit | "_"  | "." }.
+; var ::= envref.
+; boolean :: = "true" | "false"
+; number ::= integer | decimal | rational | binary | hex
+; binary :: = [ "-" ] "0b" { "0" | "1" }.
+; hex :: = [ "-" ] "0x" | "#" { "0" | ... | "9" | "A" | ... | "F" | "a" | ... | "f" }.
+; integer :: = [ "-" ] digits.
+; decimal :: = [ "-" ] digits "." digits.
+; rational :: = integer "/" digits.
+; letter ::= "A" | "B" | ... | "Z" | "a" | "b" | ... | "z".
+; digit ::= "0" | "1" | ... | "8" | "9".
+; digits ::= digit { digit }.
+
+(def digit (from-re #"[0-9]"))
+
+; TODO: allow unicode/utf8 characters
+(def letter (from-re #"[a-zA-Z]"))
+
+(def alpha-num (any-of letter digit (match "_") (match ".")))
+
+(def digits
+  (m/do*
+   (text <- (plus digit))
+   (m/return (strip-location text))))
+
+(def envref
+  (m/do*
+   (fst <- (any-of letter (match "_") (match ".")))
+   (rst <- (token (many alpha-num)))
+   (m/return (let [kw (keyword (strip-location (cons fst rst)))]
+               (fn [env]
+                 (if (contains? env kw)
+                   (get env kw)
+                   (throw (IllegalStateException.
+                           (str (name kw) " is not bound in environment")))))))))
+
+(def var envref)
+
+(def binary
+  (m/do*
+   (sign <- (optional (match "-")))
+   (string "0b")
+   (value <- (m/do*
+              (text <- (token (plus (from-re #"[01]"))))
+              (m/return (strip-location text))))
+   (m/return (constantly (Long/parseLong (str (strip-location sign) value) 2)))))
+
+(def hex
+  (m/do*
+   (sign <- (optional (match "-")))
+   (any-of
+    (match "#")
+    (string "0x"))
+   (value <- (m/do*
+              (text <- (token (plus (from-re #"[0-9A-Fa-f]"))))
+              (m/return (strip-location text))))
+   (m/return (constantly (Long/parseLong (str (strip-location sign) value) 16)))))
+
+(def integer
+  (m/do*
+   (sign <- (optional (match "-")))
+   (value <- (token digits))
+   (m/return (constantly (Long/parseLong (str (strip-location sign) value))))))
+
+(def rational
+  (m/do*
+   (dividend <- integer)
+   (match "/")
+   (divisor <- (token digits))
+   (m/return (constantly (/ (dividend) (Long/parseLong divisor))))))
+
+(def decimal
+  (m/do*
+   (sign <- (optional (match "-")))
+   (i <- digits)
+   (p <- (match "."))
+   (d <- (token digits))
+   (m/return (constantly (Double/parseDouble (str (strip-location sign) i "." d))))))
+
+(def number
+  (any-of integer decimal rational binary hex))
+
+(def boolean
+  (m/do*
+   (value <- (any-of (string "true") (string "false")))
+   (m/return (constantly (Boolean/parseBoolean (str (strip-location value)))))))
+
+(defn list-of [parser]
+  (optional (separated-by (token parser) (symb ","))))
+
+(declare expression)
+
+(def function
+  (or-else
+   (m/do*
+    (f <- envref)
+    (plus (match " "))
+    (expr <- expression)
+    (m/return (fn [env]
+                ((f env) (expr env)))))
+   (m/do*
+    (f <- envref)
+    (symb "(")
+    (args <- (list-of expression))
+    (symb ")")
+    (m/return (fn [env]
+                (apply
+                 (f env)
+                 (map #(% env) args)))))))
+
+(def ternary-op
+  (m/do*
+   (symb "(")
+   (condition <- expression)
+   (symb ")")
+   (symb "?")
+   (yes-exp <- expression)
+   (symb ":")
+   (no-exp <- expression)
+   (m/return (fn [env]
+               (if (condition env) (yes-exp env) (no-exp env))))))
+
+(def base
+  (any-of
+   (m/do*
+    (symb "(")
+    (e <- expression)
+    (symb ")")
+    (m/return e))
+   boolean
+   number
+   var
+   function
+   ternary-op))
+
+(defn binary-op [& ops]
+  (m/do*
+   (op <- (reduce or-else (map string ops)))
+   (m/return
+    (let [kw (keyword (str (strip-location op)))]
+      (fn [env]
+        (if (contains? env kw)
+          (get env kw)
+          (throw (IllegalStateException.
+                  (str (name kw) " is not bound in environment")))))))))
+
+(def expop (binary-op "**"))
+(def mulop (binary-op "*" "/" "÷" "%" ">>" ">>>" "<<" "=" "==" "!=" ">" "<" ">=" "<="))
+(def addop (binary-op "+" "-" "|" "&" "||" "&&"))
+
+(defn- resolve-var [arg env]
+  (let [v (arg env)]
+    (if (var? v)
+      (var-get v)
+      v)))
+
+(defn- left-associative-reducer [op-parser arg-parser]
+  (m/do*
+   (a1 <- arg-parser)
+   (rst <- (many
+            (m/do*
+             spaces
+             (op <- (token op-parser))
+             (a2 <- arg-parser)
+             (m/return [op a2]))))
+   (m/return
+    (fn [env]
+      (reduce
+       (fn [acc [op a2]] ((op env) acc (resolve-var a2 env)))
+       (resolve-var a1 env)
+       rst)))))
+
+(defn- right-associative-reducer [op-parser arg-parser]
+  (m/do*
+   (rst <- (many
+            (m/do*
+             spaces
+             (a <- arg-parser)
+             (op <- (token op-parser))
+             (m/return [a op]))))
+   (an <- arg-parser)
+   (m/return
+    (fn [env]
+      (reduce
+       (fn [acc [a op]] ((op env) (resolve-var a env) acc))
+       (resolve-var an env)
+       (reverse rst))))))
+
+(def factor (right-associative-reducer expop base))
+
+(def term (left-associative-reducer mulop factor))
+
+(def expression (left-associative-reducer addop term))

--- a/stdlib/jolt/infix/math.clj
+++ b/stdlib/jolt/infix/math.clj
@@ -1,0 +1,34 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.math)
+
+(defmacro defunary [func-name & [alias]]
+  (let [arg (gensym "x__")]
+    `(defn ~(or alias func-name) [^double ~arg]
+       (~(symbol (str "Math/" func-name)) ~arg))))
+
+(defmacro defbinary [func-name & [alias]]
+  (let [arg1 (gensym "x__")
+        arg2 (gensym "y__")]
+    `(defn ~(or alias func-name) [^double ~arg1 ^double ~arg2]
+       (~(symbol (str "Math/" func-name)) ~arg1 ~arg2))))

--- a/stdlib/jolt/infix/math/bit_shuffling.clj
+++ b/stdlib/jolt/infix/math/bit_shuffling.clj
@@ -1,0 +1,36 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.math.bit-shuffling)
+
+(def | bit-or)
+
+(def & bit-and)
+
+(def ¬ bit-not)
+
+(def >> bit-shift-right)
+
+(def >>> unsigned-bit-shift-right)
+
+(def << bit-shift-left)
+

--- a/stdlib/jolt/infix/math/constants.clj
+++ b/stdlib/jolt/infix/math/constants.clj
@@ -1,0 +1,31 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.math.constants
+  (:require
+   [jolt.infix.math.core :refer [√]]))
+
+(def φ (/ (inc (√ 5)) 2))
+(def e Math/E)
+(def π Math/PI)
+(def pi Math/PI)
+

--- a/stdlib/jolt/infix/math/core.clj
+++ b/stdlib/jolt/infix/math/core.clj
@@ -1,0 +1,66 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.math.core
+  (:refer-clojure :exclude [rand])
+  (:require
+   [jolt.infix.math :refer [defunary defbinary]]))
+
+(defunary abs)
+(defunary signum)
+(defunary sqrt)
+(defunary sqrt √)
+(defunary exp)
+(defunary log)
+
+(defbinary pow)
+(defbinary pow **)
+
+(def product *)
+(def sum +)
+(def rand clojure.core/rand)
+(def randInt clojure.core/rand-int)
+
+(defn divide [a b]
+  (if (zero? b)
+    (if (neg? a)
+      Double/NEGATIVE_INFINITY
+      Double/POSITIVE_INFINITY)
+    (/ a b)))
+
+(def ÷ divide)
+
+(defn root [a b]
+  (pow b (/ 1 a)))
+
+(defn gcd [a b]
+  (if (zero? b)
+    a
+    (recur b (rem a b))))
+
+(defn lcm [a b]
+  (/ (* a b) (gcd a b)))
+
+(defn fact [n]
+  (if (zero? n)
+    1
+    (apply * (range 1 (inc n)))))

--- a/stdlib/jolt/infix/math/trig.clj
+++ b/stdlib/jolt/infix/math/trig.clj
@@ -1,0 +1,71 @@
+;; The MIT License (MIT)
+;;
+;; Copyright (c) 2016 Richard Hull
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(ns jolt.infix.math.trig
+  (:require
+   [jolt.infix.math :refer [defunary defbinary]]
+   [jolt.infix.math.core :refer [÷]]))
+
+(defunary sin)
+(defunary cos)
+(defunary tan)
+
+(defunary asin)
+(defunary acos)
+(defunary atan)
+(defbinary atan2)
+
+(defunary sinh)
+(defunary cosh)
+(defunary tanh)
+
+;; Additional trig functions not found in JDK java.lang.Math
+(defn sec
+  "compute secant, given the angle in radians"
+  [θ]
+  (÷ 1 (Math/cos θ)))
+
+(defn csc
+  "compute cosecant, given the angle in radians"
+  [θ]
+  (÷ 1 (Math/sin θ)))
+
+(defn cot
+  "compute cotangent, given the angle in radians"
+  [θ]
+  (÷ 1 (Math/tan θ)))
+
+(defn asec
+  "compute arcsecant, given the number, returns the arcsecant in radians"
+  [value]
+  (Math/acos (÷ 1 value)))
+
+(defn acsc
+  "compute arccosecant, given the number, returns the arccosecant in radians"
+  [value]
+  (Math/asin (÷ 1 value)))
+
+(defn acot
+  "compute arccotangent, given the number, returns the arccotangent in radians"
+  [value]
+  (Math/atan (÷ 1 value)))
+

--- a/stdlib/jolt/parser.clj
+++ b/stdlib/jolt/parser.clj
@@ -1,0 +1,30 @@
+;; Top-level parse driver, adapted from rm-hull/jasentaa (MIT).
+
+(ns jolt.parser
+  (:refer-clojure :exclude [apply])
+  (:require
+   [jolt.parser.combinators :refer [spaces]]
+   [jolt.parser.monad :as m :refer [>>=]]
+   [jolt.parser.position :refer [augment-location parse-exception]]))
+
+(defn apply
+  "Apply a parser, throwing away any leading space:"
+  [parser input]
+  (m/bind
+   (augment-location input)
+   (m/do*
+    spaces
+    parser)))
+
+(def ^:private first-error
+  (comp first second first))
+
+(defn parse-all
+  "Attempts to fully consume the input using the supplied parser.
+   Throws on input that cannot be fully parsed."
+  [parser input]
+  (let [result (apply parser input)
+        parsed (ffirst (filter (comp empty? second) result))]
+    (or
+     parsed
+     (throw (parse-exception (first-error result))))))

--- a/stdlib/jolt/parser/basic.clj
+++ b/stdlib/jolt/parser/basic.clj
@@ -1,0 +1,50 @@
+;; Primitive character parsers, adapted from rm-hull/jasentaa (MIT).
+
+(ns jolt.parser.basic
+  (:require
+   [jolt.parser.monad :as m :refer [>>=]]))
+
+(defn any [input]
+  (if (empty? input)
+    (m/failure input)
+    (list [(first input) (rest input)])))
+
+(defn eof
+  "Succeeds only at the end of input, consuming nothing (dual of `any`)."
+  [input]
+  (if (empty? input)
+    (list [nil input])
+    (m/failure input)))
+
+(defn sat
+  "Satisfies a given predicate"
+  [pred]
+  (>>= any (fn [v]
+             (if (pred (:char v))
+               (m/return v)
+               m/failure))))
+
+(defn char-cmp
+  "Does a character comparison using a specific function"
+  [f]
+  (fn [c] (sat (partial f (first c)))))
+
+(def match
+  "Recognises a given char"
+  (char-cmp =))
+
+(def none-of
+  "Rejects a given char"
+  (char-cmp not=))
+
+(defn from-re [re]
+  (sat (fn [v]
+         (not (nil? (re-find re (str v)))))))
+
+(defmacro fwd
+  "Delays the evaluation of a parser that was forward (declare)d and
+   it has not been defined yet. For use in (def)s of no-arg parsers,
+   since the parser expression evaluates immediately."
+  [p]
+  (let [x (gensym)]
+    `(fn [~x] (~p ~x))))

--- a/stdlib/jolt/parser/collections.clj
+++ b/stdlib/jolt/parser/collections.clj
@@ -1,0 +1,34 @@
+;; Adapted from rm-hull/jasentaa (MIT).
+
+(ns jolt.parser.collections)
+
+(defn- not-list? [x]
+  (or
+   (not (coll? x))
+   (record? x)))
+
+(defn join [a b]
+  (cond
+    (and (string? a) (string? b))
+    (str a b)
+
+    (and (nil? a) (string? b))
+    b
+
+    (and (string? a) (nil? b))
+    a
+
+    (nil? a)
+    (recur [] b)
+
+    (nil? b)
+    (recur a [])
+
+    (not-list? a)
+    (recur (list a) b)
+
+    (not-list? b)
+    (recur a (list b))
+
+    :else
+    (concat a b)))

--- a/stdlib/jolt/parser/combinators.clj
+++ b/stdlib/jolt/parser/combinators.clj
@@ -1,0 +1,193 @@
+;; Parser combinators, adapted from rm-hull/jasentaa (MIT).
+
+(ns jolt.parser.combinators
+  (:require
+   [jolt.parser.basic :refer [match from-re]]
+   [jolt.parser.monad :as m :refer [>>=]]
+   [jolt.parser.collections :refer [join]]))
+
+(defn and-then
+  "(ab)"
+  [p1 p2]
+  (m/do*
+   (r1 <- p1)
+   (r2 <- p2)
+   (m/return (join r1 r2))))
+
+(defn or-else
+  "(a|b)
+
+  Non-deterministic choice (++) operator. Applies both parsers
+  to the argument string, and appends their list of results."
+  [p1 p2]
+  (fn [input]
+    (lazy-cat (m/bind input p1) (m/bind input p2))))
+
+(defn choice
+  "(a|b)
+
+  Deterministic choice (+++) operator. Has the same behaviour
+  as `or-else`, except that at most one result is returned."
+  [p1 p2]
+  (fn [input]
+    (let [[x & xs] (m/bind input (or-else p1 p2))]
+      (if (nil? x)
+        []
+        [x]))))
+
+(declare plus)
+(declare optional)
+
+(defn many
+  "(a*)
+
+  Parse repeated applications of a parser; the many combinator
+  permits zero or more applications of the parser."
+  [p]
+  (optional (plus p)))
+
+(defn plus
+  "(a+) is equivalent to (aa*)
+
+  Parse repeated applications of a parser; the plus combinator
+  permits one or more applications of the parser."
+  [p]
+  (m/do*
+   (a <- p)
+   (as <- (many p))
+   (m/return (cons a as))))
+
+(defn optional
+  "(a?)
+
+  Parse zero or one applications of a parser. With `default`, that value is
+  the result when p does not match (otherwise nil)."
+  ([p] (or-else p (m/return nil)))
+  ([p default] (or-else p (m/return default))))
+
+(defn any-of [& ps]
+  "(a|b|c|...)
+
+  Parse application any of the given parsers."
+  (reduce or-else ps))
+
+(def space
+  "Parse a single space, tab, newline or carriage-return."
+  (any-of
+   (match " ")
+   (match "\t")
+   (match "\n")
+   (match "\r")))
+
+(def spaces
+  "Parse a string of (zero or more) spaces, tabs, and newlines."
+  (many space))
+
+(defn string
+  "Parse a specific string."
+  [input]
+  (reduce and-then (map (comp match str) input)))
+
+(defn token
+  "Parse a token using a parser p, throwing away any trailing space."
+  [p]
+  (m/do*
+   (a <- p)
+   spaces
+   (m/return a)))
+
+(def symb
+  "Parse a symbolic token."
+  (comp token string))
+
+(defn chain-left
+  "Parse repeated applications of a parser p, separated by
+  applications of a parser op whose result value is an
+  operator that is assumed to associate to the left, and
+  which is used to combine the results from the p parsers."
+  ([p op a]
+   (choice
+    (chain-left p op)
+    (m/return a)))
+
+  ([p op]
+   (m/do*
+    (a <- p)
+    (rst <- (many
+             (m/do*
+              (f <- op)
+              (b <- p)
+              (m/return [f b]))))
+    (m/return
+     (reduce
+      (fn [acc [f b]] (f acc b))
+      a
+      rst)))))
+
+(defn chain-right
+  "Parse repeated applications of a parser p, separated by
+  applications of a parser op whose result value is an
+  operator that is assumed to associate to the right, and
+  which is used to combine the results from the p parsers.
+   "
+  ([p op a]
+   (choice
+    (chain-right p op)
+    (m/return a)))
+
+  ([p op]
+   (m/do*
+    (scan <- (many
+              (m/do*
+               (a <- p)
+               (f <- op)
+               (m/return [f a]))))
+    (b <- p)
+    (m/return
+     (reduce
+      (fn [acc [f a]] (f a acc))
+      b
+      (reverse scan))))))
+
+(defn separated-by
+  "Parse repeated applications of a parser p, separated by
+  applications of a parser sep whose result values are
+  thrown away.
+
+  This parser will process at least one application of p.
+  For a list of zero or more, use `sep-by`."
+  [p sep]
+  (m/do*
+   (fst <- p)
+   (rst <- (many (m/do* sep p)))
+   (m/return (cons fst rst))))
+
+(defn sep-by
+  "Parse zero or more applications of p separated by sep (sep's results are
+  discarded), returning a list of p's results (nil when none match). The
+  zero-or-more counterpart to `separated-by`."
+  [p sep]
+  (or-else (separated-by p sep) (m/return nil)))
+
+(defn between
+  "Parse p wrapped by open and close (open's and close's results are
+  discarded), returning p's result — e.g. (between (symb \"(\") (symb \")\") expr)."
+  [open close p]
+  (m/do*
+   open
+   (x <- p)
+   close
+   (m/return x)))
+
+;; Common character-class parsers, each matching a single character.
+(def digit
+  "Match a single decimal digit (0-9)."
+  (from-re #"[0-9]"))
+
+(def letter
+  "Match a single ASCII letter (a-z, A-Z)."
+  (from-re #"[a-zA-Z]"))
+
+(def alpha-num
+  "Match a single letter or digit."
+  (any-of letter digit))

--- a/stdlib/jolt/parser/monad.clj
+++ b/stdlib/jolt/parser/monad.clj
@@ -1,0 +1,32 @@
+;; Minimal monadic-parser core, adapted from rm-hull/jasentaa
+;; (MIT). A parser is a fn from input to a seq of [value remaining] results;
+;; do* threads them together.
+
+(ns jolt.parser.monad)
+
+(defn failure [& args]
+  '())
+
+(defn bind [v f]
+  (f v))
+
+(defn return [v]
+  (fn [input]
+    (list [v input])))
+
+(defn >>= [m f]
+  (fn [input]
+    (->>
+     m
+     (bind input)
+     (mapcat (fn [[v tail]] (bind tail (f v)))))))
+
+(defn- merge-bind [body bind]
+  (if (and (not= clojure.lang.Symbol (type bind))
+           (= 3 (count bind))
+           (= '<- (second bind)))
+    `(>>= ~(last bind) (fn [~(first bind)] ~body))
+    `(>>= ~bind (fn [~'_] ~body))))
+
+(defmacro do* [& forms]
+  (reduce merge-bind (last forms) (reverse (butlast forms))))

--- a/stdlib/jolt/parser/position.clj
+++ b/stdlib/jolt/parser/position.clj
@@ -1,0 +1,57 @@
+;; Source-location tracking + parse-error reporting, adapted from
+;; rm-hull/jasentaa (MIT). Parse failures are signalled with a natural jolt
+;; ex-info carrying :offset/:line/:col rather than a host exception class.
+
+(ns jolt.parser.position
+  (:require
+   [clojure.string :as s]))
+
+(defrecord Location [char line col offset full-text])
+
+(defn augment-location
+  ([text]
+   (augment-location text 1 1 0 text))
+
+  ([text line col offset full-text]
+   (let [ch (first text)]
+     (if-not (nil? ch)
+       (cons
+        (Location. ch line col offset full-text)
+        (lazy-seq
+         (augment-location
+          (rest text)
+          (if (= ch \newline) (inc line) line)
+          (if (= ch \newline) 1 (inc col))
+          (inc offset)
+          full-text)))))))
+
+(defn strip-location [input]
+  (cond
+    (not (nil? (:char input)))
+    (:char input)
+
+    (seq? input)
+    (apply str (map strip-location input))
+
+    :else
+    input))
+
+(defn show-error [location]
+  (if (and location (< (:offset location) (count (:full-text location))))
+    (let [input   (:full-text location)
+          start   (inc (or (s/last-index-of input "\n" (:offset location)) -1))
+          end     (or (s/index-of input "\n" (:offset location)) (count input))
+          padding (apply str (repeat (dec (:col location)) " "))]
+      (str (subs input start end) \newline padding "^" \newline))))
+
+(defn parse-exception [location]
+  (if (nil? location)
+    (ex-info "Unable to parse text" {:type :parse-error :offset 0})
+    (ex-info
+     (str
+      "Failed to parse text at line: " (:line location) ", col: " (:col location)
+      \newline (show-error location))
+     {:type :parse-error
+      :offset (int (:offset location))
+      :line (:line location)
+      :col (:col location)})))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3164,7 +3164,18 @@
   {:suite "conformance / numbers / math" :label "Math/sinh" :expected "0.0" :actual "(Math/sinh 0.0)" :portability :jvm}
   {:suite "conformance / numbers / math" :label "Math/cosh" :expected "1.0" :actual "(Math/cosh 0.0)" :portability :jvm}
   {:suite "conformance / numbers / math" :label "Math/tanh" :expected "0.0" :actual "(Math/tanh 0.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/cbrt" :expected "2.0" :actual "(Math/cbrt 8.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/hypot" :expected "5.0" :actual "(Math/hypot 3.0 4.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/rint" :expected "2.0" :actual "(Math/rint 2.5)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/floorDiv" :expected "3" :actual "(Math/floorDiv 7 2)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/floorMod" :expected "1" :actual "(Math/floorMod 7 3)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/copySign" :expected "-3.0" :actual "(Math/copySign 3.0 -1.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/toRadians" :expected "0.0" :actual "(Math/toRadians 0.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/toDegrees" :expected "0.0" :actual "(Math/toDegrees 0.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/log1p" :expected "0.0" :actual "(Math/log1p 0.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/expm1" :expected "0.0" :actual "(Math/expm1 0.0)" :portability :jvm}
   {:suite "conformance / host interop / exceptions" :label "java.text.ParseException" :expected "\"boom\"" :actual "(try (throw (java.text.ParseException. \"boom\" 3)) (catch java.text.ParseException e (.getMessage e)))" :portability :jvm}
+  {:suite "conformance / host interop / exceptions" :label "ParseException getErrorOffset" :expected "7" :actual "(try (throw (java.text.ParseException. \"boom\" 7)) (catch java.text.ParseException e (.getErrorOffset e)))" :portability :jvm}
   {:suite "conformance / numbers / math" :label "min-key" :expected "1" :actual "(min-key abs 1 -2 3)" :portability :common}
   {:suite "conformance / numbers / math" :label "max-key" :expected "-4" :actual "(max-key abs 1 -2 -4 3)" :portability :common}
   {:suite "conformance / strings (clojure.string)" :label "str/trim" :expected "\"hi\"" :actual "(do (require (quote [clojure.string :as s])) (s/trim \"  hi  \"))" :portability :common}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3160,6 +3160,11 @@
   {:suite "conformance / numbers / math" :label "bit-shift" :expected "[8 2]" :actual "[(bit-shift-left 1 3) (bit-shift-right 8 2)]" :portability :common}
   {:suite "conformance / numbers / math" :label "Math/sqrt" :expected "3.0" :actual "(Math/sqrt 9)" :portability :jvm}
   {:suite "conformance / numbers / math" :label "Math/pow" :expected "8.0" :actual "(Math/pow 2 3)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/atan2" :expected "0.0" :actual "(Math/atan2 0.0 1.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/sinh" :expected "0.0" :actual "(Math/sinh 0.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/cosh" :expected "1.0" :actual "(Math/cosh 0.0)" :portability :jvm}
+  {:suite "conformance / numbers / math" :label "Math/tanh" :expected "0.0" :actual "(Math/tanh 0.0)" :portability :jvm}
+  {:suite "conformance / host interop / exceptions" :label "java.text.ParseException" :expected "\"boom\"" :actual "(try (throw (java.text.ParseException. \"boom\" 3)) (catch java.text.ParseException e (.getMessage e)))" :portability :jvm}
   {:suite "conformance / numbers / math" :label "min-key" :expected "1" :actual "(min-key abs 1 -2 3)" :portability :common}
   {:suite "conformance / numbers / math" :label "max-key" :expected "-4" :actual "(max-key abs 1 -2 -4 3)" :portability :common}
   {:suite "conformance / strings (clojure.string)" :label "str/trim" :expected "\"hi\"" :actual "(do (require (quote [clojure.string :as s])) (s/trim \"  hi  \"))" :portability :common}

--- a/test/chez/infix-test.clj
+++ b/test/chez/infix-test.clj
@@ -1,0 +1,340 @@
+;; jolt.infix gate — exercises jolt's built-in infix notation (jolt.infix +
+;; jolt.parser) with the upstream rm-hull/infix suite (macros/grammar/core
+;; tests). Self-checks and prints INFIX OK when all pass (smoke.sh greps for it).
+;; Parse failures surface as a jolt ex-info rather than a host exception class,
+;; so the error-path checks look for ExceptionInfo.
+;; Run: bin/joltc run test/chez/infix-test.clj
+(ns infix-test
+  (:require
+   [jolt.infix :refer [infix $= from-string]]
+   [jolt.infix.core :refer [suppress! base-env]]
+   [jolt.infix.grammar :as g]
+   [jolt.parser :refer [parse-all]]))
+
+(def failures (atom []))
+(defn fail! [msg] (swap! failures conj msg))
+(defn chk [label ok] (when-not ok (fail! label)))
+(defn chk= [label got want]
+  (when-not (= got want)
+    (fail! (str label ": want " (pr-str want) " got " (pr-str got)))))
+
+(defn float=
+  ([x y] (float= x y 0.00001))
+  ([x y epsilon]
+   (let [scale (if (or (zero? x) (zero? y)) 1 (Math/abs x))]
+     (<= (Math/abs (- x y)) (* scale epsilon)))))
+(defn chk-near [label got want]
+  (when-not (float= got want)
+    (fail! (str label ": ~want " want " got " got))))
+
+(defn threw [thunk] (try (thunk) ::none (catch Throwable e e)))
+(defn chk-throws [label pred thunk]
+  (let [e (threw thunk)]
+    (cond
+      (= e ::none) (fail! (str label ": expected throw, got none"))
+      (not (pred e)) (fail! (str label ": wrong throw " (pr-str (type e))
+                                 " / " (pr-str (.getMessage e)))))))
+(defn ex? [e] (instance? clojure.lang.ExceptionInfo e))
+(defn ise? [e] (instance? IllegalStateException e))
+(defn arity? [e] (instance? clojure.lang.ArityException e))
+(defn parse-msg [re] (fn [e] (and (ex? e) (boolean (re-find re (str (.getMessage e)))))))
+
+(def ε 0.0000001)
+
+;; ---------------------------------------------------------------- macros tests
+
+;; basic-arithmetic
+(chk= "ba1" (infix 3 + 4) (+ 3 4))
+(chk= "ba2" (infix 3 + 5 * 8) 43)
+(chk= "ba3" (infix (3 + 5) * 8) 64)
+(chk= "ba4" (infix (3 - 2) - 1) 0)
+(chk= "ba5" (infix 3 - 2 - 1) 0)
+(chk= "ba6" (infix 3 + 2 % 3) 5)
+(chk= "ba7" (infix (3 + 2) % 3) 2)
+(chk= "ba8" (infix 1 - 1 + 1) 1)
+(chk= "ba9" (infix 1 - 2 + 3) 2)
+
+;; basic-arithmetic-$=
+(chk= "$=1" ($= 3 + 4) (+ 3 4))
+(chk= "$=2" ($= 3 + 5 * 8) 43)
+(chk= "$=3" ($= (3 + 5) * 8) 64)
+(chk= "$=4" ($= (3 - 2) - 1) 0)
+(chk= "$=5" ($= 3 - 2 - 1) 0)
+(chk= "$=6" ($= 3 + 2 % 3) 5)
+(chk= "$=7" ($= (3 + 2) % 3) 2)
+(chk= "$=8" ($= 1 - 1 + 1) 1)
+(chk= "$=9" ($= 1 - 2 + 3) 2)
+
+;; check-aliasing
+(chk= "al1" (infix √ (5 * 5)) 5.0)
+(chk= "al2" (infix 5 % 3) 2)
+(let [t 0.324]
+  (chk "al3" (> ε (Math/abs (- (infix sin (2 * t) + 3 * cos (4 * t)) 1.4176457261295824)))))
+
+;; check-nested-aliasing
+(chk= "nest" (infix abs (3 ** 6)) 729.0)
+
+;; check-nullary-operators
+(let [f (fn [] (infix 3 + 7))
+      g #(infix 7 + 21)]
+  (chk= "null1" (infix f () + 4) 14)
+  (chk= "null2" (infix g () / 4) 7)
+  (chk "null3" (<= 0 (infix rand () * 3) 3)))
+
+;; check-unary-precedence
+(let [x 4 y 3]
+  (chk= "un1" (infix √ x) 2.0)
+  (chk= "un2" (infix √ x + y) 5.0)
+  (chk= "un3" (infix cos π) -1.0))
+
+;; check-binary-precedence
+(let [x 4 y 3]
+  (chk= "bin1" (infix x . y) 12)
+  (chk= "bin2" (infix x ** y) 64.0)
+  (chk= "bin3" (infix 2 ** 2 ** 2 ** 2) 65536.0))
+
+;; check-from-string
+(chk= "fs1" ((from-string "5")) 5)
+(chk= "fs2" ((from-string "5 * 2")) 10)
+(chk= "fs3" ((from-string "5 + 2")) 7)
+(chk= "fs4" ((from-string "1 - 1 + 1")) 1)
+(chk= "fs5" ((from-string "1 - 2 + 3")) 2)
+(chk= "fs6" ((from-string [x] "x + 3") 4) 7)
+(chk= "fs7" ((from-string [_x] "_x + 3") 4) 7)
+(chk= "fs8" ((from-string [x] {:+ -} "x + 3") 4) 1)
+(chk= "fs9" ((from-string [] {:x 6 :+ +} "x + 1")) 7)
+(chk= "fs10" ((from-string [] "3 + 5**2")) 28.0)
+(chk= "fs11" ((from-string [] "3 * 5**2")) 75.0)
+(chk= "fs12" ((from-string [t] "(t*(t>>5|t>>8))>>(t>>16)") 3425) 380175)
+(chk= "fs13" ((from-string [t] "( t * (  t  >> 5 | t >>  8 ) ) >> ( t >> 16  )") 3425) 380175)
+(chk= "fs14" ((from-string "(3-2)-1")) 0)
+(chk= "fs15" ((from-string "3 - 2 - 1")) 0)
+(chk= "fs16" ((from-string "2 ** 2 ** 2 ** 2")) 65536.0)
+(chk= "fs17" ((from-string "divide(3, 0)")) Double/POSITIVE_INFINITY)
+(chk= "fs18" ((from-string "-3 ÷ 0")) Double/NEGATIVE_INFINITY)
+(chk= "fs19" ((from-string [t] "t - 2") 7) 5)
+(chk= "fs20" ((from-string [t] "t-2") 7) 5)
+(chk= "fs21" ((from-string [t] "t- 2") 7) 5)
+(chk= "fs22" ((from-string [t] "t+2") 3) 5)
+(chk= "fs23" ((from-string [f] "f() + 2") (fn [] 3)) 5)
+(chk "fs24" (<= 0 ((from-string "rand() * 10")) 10))
+(chk "fs25" (<= 0 ((from-string "randInt(10)")) 10))
+(chk "fs26" (<= 0 ((from-string [n] "randInt(n)") 5) 5))
+(chk= "fs27" ((from-string "pow(5,2)")) 25.0)
+(chk= "fs28" ((from-string "sin(3)")) 0.1411200080598672)
+(chk= "fs29" ((from-string "sin 3")) 0.1411200080598672)
+(chk= "fs30" ((from-string "pi")) 3.1415926535897932)
+(chk= "fs31" ((from-string "e")) 2.718281828459045)
+(chk= "fs32" ((from-string [e] "e * 3") 5) 15)
+(chk= "fs33" ((from-string [e] "e ** (3 + pi)") 5) 19624.068163608234)
+(chk= "fs34" ((from-string [x] "product(e, pi, 3 * 3, x)") 5) 384.2880400203104)
+(chk= "fs35" ((from-string "16 = 16")) true)
+(chk= "fs36" ((from-string "16 == 16")) true)
+(chk= "fs37" ((from-string "16 != 17")) true)
+(chk= "fs38" ((from-string "16 | 32")) 48)
+(chk= "fs39" ((from-string "false || true")) true)
+(chk= "fs40" ((from-string "false || false")) false)
+(chk= "fs41" ((from-string "16 & 48")) 16)
+(chk= "fs42" ((from-string "true && false")) false)
+(chk= "fs43" ((from-string "true && true")) true)
+(chk-throws "fs44" (parse-msg #"Failed to parse text at line: 1, col: 3\nx \+ \n  \^")
+            #((from-string [x] "x + ") 3))
+(chk-throws "fs45" (parse-msg #"Failed to parse text at line: 1, col: 8\nx\+\(y\*7\)\)\n       \^")
+            #((from-string [x y] "x+(y*7))") 3 2))
+(chk-throws "fs46" arity? #((from-string [x] "x + 3") 2 3))
+(chk-throws "fs47" (fn [e] (and (ise? e) (re-find #"x is not bound in environment" (str (.getMessage e)))))
+            #((from-string "x + 3")))
+
+;; check-math-namespace-aliases
+(chk= "csc" (infix csc (32)) 1.813477718829676)
+(chk= "sec" (infix sec (4)) -1.5298856564663974)
+
+;; check-alias-expansion
+(let [x 4 y 3]
+  (chk-near "alx" (infix exp (sin x + cos y) - sin (exp (x + y))) 0.389947492069644965))
+
+;; check-equivalence
+(let [f (from-string [t] "t>>5 | t>>8")]
+  (doseq [t (repeatedly 50 #(rand-int 1000000))]
+    (chk (str "equiv t=" t) (= (f t) (infix (t >> 5 | t >> 8))))))
+
+;; check-division-precedence
+(let [x 0 y 1]
+  (chk= "dp1" (infix sin (x ÷ y ** 2)) 0.0)
+  (chk= "dp2" (infix 4 / 4 * 2) 2)
+  (chk= "dp3" (infix (4 / 4) * 2) 2)
+  (chk= "dp4" (infix 4 / (4 * 2)) 1/2)
+  (chk= "dp5" (infix 4 / (4 * 2.0)) 0.5)
+  (chk= "dp6" (infix 4 * 4 / 2) 8)
+  (chk= "dp7" (infix (4 * 4) / 2) 8)
+  (chk= "dp8" (infix 4 * (4 / 2)) 8))
+
+;; check-equality
+(chk "eq1" (true? (infix 5 = 5)))
+(chk "eq2" (false? (infix 5 = 5.0)))
+(chk "eq3" (true? (infix 5 == 5)))
+(chk "eq4" (true? (infix 5 == 5.0)))
+(chk "eq5" (true? (infix 5 != 3)))
+(chk "eq6" (true? (infix 5 not= 4)))
+
+;; check-comparison
+(chk "cmp1" (true? (infix 3 < 5)))
+(chk "cmp2" (false? (infix 3 > 5)))
+(chk "cmp3" (true? (infix 3 <= 5)))
+(chk "cmp4" (false? (infix 3 >= 5)))
+(chk "cmp5" (true? (infix 3 >= 3)))
+(chk "cmp6" (true? (infix 3 <= 3)))
+
+;; check-meta
+(let [hypot (from-string [x y] "sqrt(x**2 + y**2)")
+      no-params (from-string "1 + 2")]
+  (chk= "meta1" (meta hypot) {:params [:x :y] :doc "sqrt(x**2 + y**2)"})
+  (chk= "meta2" (meta no-params) {:params [] :doc "1 + 2"}))
+
+;; ------------------------------------------------------------------ core tests
+
+(suppress! 'e)
+(let [e 9]
+  (chk= "suppress" (infix e * 3) 27))
+
+;; --------------------------------------------------------------- grammar tests
+
+;; check-var
+(let [env {:x 32 :something_else 19 :dot.var 608}]
+  (chk-throws "gvar-noparse" ex? #(parse-all g/var "54"))
+  (chk= "gvar-x" ((parse-all g/var "x") env) 32)
+  (chk= "gvar-se" ((parse-all g/var "something_else") env) 19)
+  (chk= "gvar-dot" ((parse-all g/var "dot.var") env) 608)
+  (chk-throws "gvar-fred" ise? #((parse-all g/var "fred") env)))
+
+;; check-integer
+(chk-throws "int-f" ex? #(parse-all g/integer "f"))
+(chk-throws "int-rat" ex? #(parse-all g/integer "1/2"))
+(chk-throws "int-dec" ex? #(parse-all g/integer "1.2"))
+(chk-throws "int-bin" ex? #(parse-all g/integer "0b01011"))
+(chk-throws "int-hex" ex? #(parse-all g/integer "0xDEADCAFE"))
+(chk= "int-17" ((parse-all g/integer "17")) 17)
+(chk= "int-neg17" ((parse-all g/integer "-17")) -17)
+(chk= "int-big" ((parse-all g/integer "443243242444234217")) 443243242444234217)
+
+;; check-binary
+(chk-throws "bin-f" ex? #(parse-all g/binary "f"))
+(chk-throws "bin-rat" ex? #(parse-all g/binary "1/2"))
+(chk-throws "bin-dec" ex? #(parse-all g/binary "1.2"))
+(chk= "bin-27" ((parse-all g/binary "0b011011")) 27)
+(chk= "bin-neg27" ((parse-all g/binary "-0b011011")) -27)
+(chk= "bin-big" ((parse-all g/binary "0b100000010011000001110001111011011")) 4334871515)
+
+;; check-hex
+(chk-throws "hex-f" ex? #(parse-all g/hex "f"))
+(chk-throws "hex-rat" ex? #(parse-all g/hex "1/2"))
+(chk-throws "hex-dec" ex? #(parse-all g/hex "1.2"))
+(chk= "hex-cafe" ((parse-all g/hex "0xCAFEBABE")) 3405691582)
+(chk= "hex-dead" ((parse-all g/hex "#DEADBEEF")) 3735928559)
+
+;; check-rational
+(chk-throws "rat-f" ex? #(parse-all g/rational "f"))
+(chk-throws "rat-int" ex? #(parse-all g/rational "12"))
+(chk-throws "rat-dec" ex? #(parse-all g/rational "1.2"))
+(chk-throws "rat-bin" ex? #(parse-all g/rational "0b01011"))
+(chk-throws "rat-hex" ex? #(parse-all g/rational "0xDEADCAFE"))
+(chk= "rat-17" ((parse-all g/rational "1/7")) 1/7)
+(chk= "rat-neg17" ((parse-all g/rational "-1/7")) -1/7)
+
+;; check-decimal
+(chk-throws "dec-f" ex? #(parse-all g/decimal "f"))
+(chk-throws "dec-int" ex? #(parse-all g/decimal "12"))
+(chk-throws "dec-rat" ex? #(parse-all g/decimal "1/2"))
+(chk-throws "dec-bin" ex? #(parse-all g/decimal "0b01011"))
+(chk-throws "dec-hex" ex? #(parse-all g/decimal "0xDEADCAFE"))
+(chk= "dec-17" ((parse-all g/decimal "1.7")) 1.7)
+(chk= "dec-neg17" ((parse-all g/decimal "-1.7")) -1.7)
+
+;; check-number
+(chk-throws "num-f" ex? #(parse-all g/number "f"))
+(chk= "num-rat" ((parse-all g/number "6/72")) 1/12)
+(chk= "num-17" ((parse-all g/number "17")) 17)
+(chk= "num-dec" ((parse-all g/number "-1.7")) -1.7)
+(chk= "num-bin" ((parse-all g/number "0b11110000")) 240)
+(chk= "num-hex" ((parse-all g/number "#FFFE")) 65534)
+
+;; check-list
+(chk-throws "list-sp" ex? #(parse-all (g/list-of g/digits) " "))
+(chk-throws "list-empty" ex? #(parse-all (g/list-of g/digits) ""))
+(chk= "list-1" (parse-all (g/list-of g/digits) "1") ["1"])
+(chk= "list-678" (parse-all (g/list-of g/digits) "6 , 7, 8 ") ["6" "7" "8"])
+(chk= "list-fib" (parse-all (g/list-of g/digits) "1,1,2,3,5") ["1" "1" "2" "3" "5"])
+
+;; check-function
+(let [env {:x 81 :* * :sqrt (fn [x] (Math/sqrt x))}]
+  (chk= "gfn-x" ((parse-all g/function "sqrt x") env) 9.0)
+  (chk= "gfn-25" ((parse-all g/function "sqrt(25)") env) 5.0)
+  (chk= "gfn-49" ((parse-all g/function "sqrt(7*7)") env) 7.0)
+  (chk-throws "gfn-bargle" ise? #((parse-all g/function "bargle(7)") env))
+  (chk-throws "gfn-arity" arity? #((parse-all g/function "sqrt(7, 5)") env)))
+
+;; check-expression
+(let [env (merge base-env {:t 0.324 :x_y_z 3 :_a 4 :_a.b 2})]
+  (chk-near "gex-sin" ((parse-all g/expression "sin(2 * t) + 3 * cos(4 * t)") env) 1.4176457261295824)
+  (chk-throws "gex-unbound" ise? #((parse-all g/expression "3 + 4") {}))
+  (chk= "gex-43" ((parse-all g/expression "3 + 5 * 8") env) 43)
+  (chk= "gex-64" ((parse-all g/expression "(3 + 5) * 8") env) 64)
+  (chk= "gex-pow" ((parse-all g/expression "2 ** 2 ** 2 ** 2") env) 65536.0)
+  (chk= "gex-xyz" ((parse-all g/expression "x_y_z * 2 + _a") env) 10)
+  (chk= "gex-xyz2" ((parse-all g/expression "x_y_z * 2 + _a / _a.b") env) 8))
+
+;; check-ternary-op
+(let [env (merge base-env {:t 150 :x 10 :y 20})]
+  (chk= "tern1" ((parse-all g/ternary-op "(t > 100) ? 1 : 0") env) 1)
+  (chk= "tern2" ((parse-all g/ternary-op "(t < 100) ? x + y : x - y") env) -10)
+  (chk= "tern3" ((parse-all g/ternary-op "(sum(x, y) >= 30) ? sum(x, y) : 0") env) 30))
+
+;; check-baseenv-functions
+(chk= "be-add" ((parse-all g/expression "9 + 7") base-env) 16)
+(chk= "be-sub" ((parse-all g/expression "19 - 7") base-env) 12)
+(chk= "be-mul" ((parse-all g/expression "9 * 7") base-env) 63)
+(chk= "be-div" ((parse-all g/expression "19 / 75") base-env) 19/75)
+(chk= "be-p1" ((parse-all g/expression "3 + 5 ** 2") base-env) 28.0)
+(chk= "be-p2" ((parse-all g/expression "3 * 5 ** 2") base-env) 75.0)
+(chk-near "be-pow" ((parse-all g/expression "pow(2.53, 3.1)") base-env) (Math/pow 2.53 3.1))
+(chk-near "be-pow2" ((parse-all g/expression "7.01 ** 1.9") base-env) (Math/pow 7.01 1.9))
+(chk-near "be-abs" ((parse-all g/expression "abs(-9.213)") base-env) (Math/abs -9.213))
+(chk-near "be-signum" ((parse-all g/expression "signum(-9.213)") base-env) (Math/signum -9.213))
+(chk-near "be-sqrt" ((parse-all g/expression "sqrt(24353)") base-env) (Math/sqrt 24353))
+(chk-near "be-root" ((parse-all g/expression "root(3, 27)") base-env) 3)
+(chk-near "be-exp" ((parse-all g/expression "exp(93)") base-env) (Math/exp 93))
+(chk-near "be-log" ((parse-all g/expression "log(23.1)") base-env) (Math/log 23.1))
+(chk-near "be-sin" ((parse-all g/expression "sin(1.91)") base-env) (Math/sin 1.91))
+(chk-near "be-cos" ((parse-all g/expression "cos(2.791)") base-env) (Math/cos 2.791))
+(chk-near "be-tan" ((parse-all g/expression "tan(44.3)") base-env) (Math/tan 44.3))
+(chk-near "be-asin" ((parse-all g/expression "asin(0.99)") base-env) (Math/asin 0.99))
+(chk-near "be-acos" ((parse-all g/expression "acos(0.04)") base-env) (Math/acos 0.04))
+(chk-near "be-atan" ((parse-all g/expression "atan(0.11)") base-env) (Math/atan 0.11))
+(chk-near "be-atan2" ((parse-all g/expression "atan2(0.1, 2)") base-env) (Math/atan2 0.1 2))
+(chk-near "be-sinh" ((parse-all g/expression "sinh(60)") base-env) (Math/sinh 60))
+(chk-near "be-cosh" ((parse-all g/expression "cosh(4)") base-env) (Math/cosh 4))
+(chk-near "be-tanh" ((parse-all g/expression "tanh(1.9)") base-env) (Math/tanh 1.9))
+(chk-near "be-sec" ((parse-all g/expression "sec(3.0)") base-env) (/ 1 (Math/cos 3)))
+(chk-near "be-csc" ((parse-all g/expression "csc(2)") base-env) (/ 1 (Math/sin 2)))
+(chk-near "be-cot" ((parse-all g/expression "cot(1.322)") base-env) (/ 1 (Math/tan 1.322)))
+(chk-near "be-asec" ((parse-all g/expression "asec(3.0)") base-env) (Math/acos (/ 1 3)))
+(chk-near "be-acsc" ((parse-all g/expression "acsc(33)") base-env) (Math/asin (/ 1 33)))
+(chk-near "be-acot" ((parse-all g/expression "acot(0.21)") base-env) (Math/atan (/ 1 0.21)))
+(chk-near "be-sum" ((parse-all g/expression "sum(1, 2, 5.7, 4)") base-env) (+ 1 2 5.7 4))
+(chk-near "be-product" ((parse-all g/expression "product(1, 2, 5.7, 4)") base-env) (* 1 2 5.7 4))
+(chk= "be-fact0" ((parse-all g/expression "fact 0") base-env) 1)
+(chk= "be-fact5" ((parse-all g/expression "fact 5") base-env) 120)
+(chk= "be-gcd" ((parse-all g/expression "gcd(8, 12)") base-env) 4)
+(chk= "be-lcm" ((parse-all g/expression "lcm(8, 12)") base-env) 24)
+(chk= "be-eq1" ((parse-all g/expression "3 = 3") base-env) true)
+(chk= "be-eq2" ((parse-all g/expression "3 = (5 - 1)") base-env) false)
+(chk= "be-neq" ((parse-all g/expression "3 != 5") base-env) true)
+(chk= "be-eq3" ((parse-all g/expression "0 = 0.0") base-env) false)
+(chk= "be-eqeq" ((parse-all g/expression "0 == 0.0") base-env) true)
+
+;; ---------------------------------------------------------------------- report
+(if (empty? @failures)
+  (println "INFIX OK")
+  (do
+    (println "INFIX FAIL" (count @failures) "failures:")
+    (doseq [f @failures] (println "  FAIL:" f))))

--- a/test/chez/parser-test.clj
+++ b/test/chez/parser-test.clj
@@ -1,0 +1,165 @@
+;; jolt.parser gate — ports rm-hull/jasentaa's own suite for the pieces jolt
+;; adopted (collections/position/basic/combinators) and covers the combinators
+;; jolt adds on top (eof, between, sep-by, optional-default, digit/letter/
+;; alpha-num). Parse errors are a jolt ex-info (not java.text.ParseException).
+;; Self-checks and prints PARSER OK. Run: bin/joltc run test/chez/parser-test.clj
+(ns parser-test
+  (:require
+   [jolt.parser.monad :as m]
+   [jolt.parser.collections :refer [join]]
+   [jolt.parser.position :as pos]
+   [jolt.parser.basic :as pb]
+   [jolt.parser.combinators :as pc]))
+
+(def failures (atom []))
+(defn fail! [msg] (swap! failures conj msg))
+(defn chk= [label got want]
+  (when-not (= got want)
+    (fail! (str label ": want " (pr-str want) " got " (pr-str got)))))
+(defn threw [thunk] (try (thunk) ::none (catch Throwable e e)))
+(defn chk-throws [label pred thunk]
+  (let [e (threw thunk)]
+    (cond
+      (= e ::none) (fail! (str label ": expected throw, got none"))
+      (not (pred e)) (fail! (str label ": wrong throw " (pr-str (type e))
+                                 " / " (pr-str (.getMessage e)))))))
+(defn ex? [e] (instance? clojure.lang.ExceptionInfo e))
+
+;; jasentaa's test harness: run a parser over augmented input and format the
+;; first result as [value remaining], with value stripped back to char(s).
+(defn harness [parser input]
+  (let [result (first (parser (pos/augment-location input)))]
+    (if (empty? result)
+      (m/failure)
+      (list [(if (char? (-> result first :char))
+               (-> result first :char)
+               (mapv :char (first result)))
+             (pos/strip-location (fnext result))]))))
+(def FAIL (m/failure))
+
+;; ------------------------------------------------------------- collections/join
+(chk= "join-1-2"   (join 1 2) [1 2])
+(chk= "join-v3-4"  (join [3] 4) [3 4])
+(chk= "join-5-v6"  (join 5 [6]) [5 6])
+(chk= "join-v7-v8" (join [7] [8]) [7 8])
+(chk= "join-9-nil" (join 9 nil) [9])
+(chk= "join-nil-0" (join nil 0) [0])
+(chk= "join-nil-nil" (join nil nil) [])
+(chk= "join-str"   (join "a" "b") "ab")
+(chk= "join-str-a" (join "a" nil) "a")
+(chk= "join-str-b" (join nil "b") "b")
+(let [[a b] (pos/augment-location "ab")]
+  (chk= "join-rec-a"  (join a nil) [a])
+  (chk= "join-rec-b"  (join nil b) [b])
+  (chk= "join-rec-ab" (join a b) [a b]))
+
+;; ---------------------------------------------------------------------- position
+(chk= "augment-then-strip"
+      (pos/strip-location (pos/augment-location "the quick brown fox"))
+      "the quick brown fox")
+(chk= "augment-empty" (pos/augment-location "") nil)
+(chk= "augment-plain"
+      (pos/augment-location "Hello\nWorld!")
+      (list
+       (pos/->Location \H 1 1 0 "Hello\nWorld!")
+       (pos/->Location \e 1 2 1 "Hello\nWorld!")
+       (pos/->Location \l 1 3 2 "Hello\nWorld!")
+       (pos/->Location \l 1 4 3 "Hello\nWorld!")
+       (pos/->Location \o 1 5 4 "Hello\nWorld!")
+       (pos/->Location \newline 1 6 5 "Hello\nWorld!")
+       (pos/->Location \W 2 1 6 "Hello\nWorld!")
+       (pos/->Location \o 2 2 7 "Hello\nWorld!")
+       (pos/->Location \r 2 3 8 "Hello\nWorld!")
+       (pos/->Location \l 2 4 9 "Hello\nWorld!")
+       (pos/->Location \d 2 5 10 "Hello\nWorld!")
+       (pos/->Location \! 2 6 11 "Hello\nWorld!")))
+(chk= "strip-loc-char" (pos/strip-location (pos/->Location \h 1 1 0 "help")) \h)
+(chk= "strip-loc-nil"  (pos/strip-location nil) nil)
+(chk= "strip-loc-str"  (pos/strip-location "Hello") "Hello")
+(chk-throws "exc-nil"
+            (fn [e] (and (ex? e) (re-find #"Unable to parse text" (str (.getMessage e)))))
+            #(throw (pos/parse-exception nil)))
+(chk-throws "exc-loc"
+            (fn [e] (and (ex? e) (re-find #"Failed to parse text at line: 6, col: 31" (str (.getMessage e)))))
+            #(throw (pos/parse-exception (pos/->Location \Y 6 31 321 "Makes no sense"))))
+(let [text "We choked on street tap water well I'm gonna have to try the real thing\n
+I took your laugh by the collar and it knew not to swing\n
+Anytime I tried an honest job well the till had a hole and ha-ha\n
+We laughed about payin' rent 'cause the county jails they're free"
+      loc (vec (pos/augment-location text))]
+  (chk= "show-err-10"  (pos/show-error (get loc 10))
+        "We choked on street tap water well I'm gonna have to try the real thing\n          ^\n")
+  (chk= "show-err-110" (pos/show-error (get loc 110))
+        "I took your laugh by the collar and it knew not to swing\n                                     ^\n")
+  (chk= "show-err-210" (pos/show-error (get loc 210))
+        "We laughed about payin' rent 'cause the county jails they're free\n             ^\n")
+  (chk= "show-err-nil" (pos/show-error nil) nil)
+  (chk= "show-err-oob" (pos/show-error (pos/->Location \h 1 1 1000 "wut?")) nil))
+
+;; ------------------------------------------------------------------------- basic
+(chk= "any-apple" (harness pb/any "apple") (list [\a "pple"]))
+(chk= "any-a"     (harness pb/any "a")     (list [\a ""]))
+(chk= "any-empty-vec" (harness pb/any [])  FAIL)
+(chk= "any-nil"   (harness pb/any nil)     FAIL)
+(chk= "any-empty" (harness pb/any "")      FAIL)
+(chk= "match-apple" (harness (pb/match "a") "apple") (list [\a "pple"]))
+(chk= "match-a"     (harness (pb/match "a") "a")     (list [\a ""]))
+(chk= "match-no"    (harness (pb/match "a") "banana") FAIL)
+(chk= "none-banana" (harness (pb/none-of "a") "banana") (list [\b "anana"]))
+(chk= "none-b"      (harness (pb/none-of "a") "b")      (list [\b ""]))
+(chk= "none-no"     (harness (pb/none-of "b") "banana") FAIL)
+(chk= "re-apple"  (harness (pb/from-re #"[a-z]") "apple")  (list [\a "pple"]))
+(chk= "re-banana" (harness (pb/from-re #"[a-z]") "banana") (list [\b "anana"]))
+(chk= "re-pear"   (harness (pb/from-re #"[a-z]") "pear")   (list [\p "ear"]))
+(chk= "re-no"     (harness (pb/from-re #"[a-z]") "Tomtato") FAIL)
+
+;; ------------------------------------------------------------------ combinators
+(let [parser (pc/and-then (pb/match "a") (pb/match "b"))]
+  (chk= "and-then-abel" (harness parser "abel") (list [[\a \b] "el"]))
+  (chk= "and-then-no"   (harness parser "apple") FAIL)
+  (chk= "and-then-empty" (harness parser "") FAIL))
+(let [parser (pc/or-else (pb/match "a") (pb/match "b"))]
+  (chk= "or-else-apple"  (harness parser "apple")  (list [\a "pple"]))
+  (chk= "or-else-banana" (harness parser "banana") (list [\b "anana"]))
+  (chk= "or-else-no"     (harness parser "orange") FAIL))
+(let [parser (pc/many (pb/match "a"))]
+  (chk= "many-a"   (first (harness parser "a"))      [[\a] ""])
+  (chk= "many-aaa" (first (harness parser "aaabbb")) [[\a \a \a] "bbb"])
+  (chk= "many-empty" (first (harness parser ""))     [[] nil])
+  (chk= "many-apple" (first (harness parser "apple")) [[\a] "pple"])
+  (chk= "many-orange" (first (harness parser "orange")) [[] "orange"]))
+
+;; ------------------------------------------------------- jolt-added combinators
+;; eof consumes nothing at end of input (tested directly: the harness formatter
+;; isn't meaningful for eof's nil result).
+(chk= "eof-empty" (pb/eof "") (list [nil ""]))
+(chk= "eof-no"    (pb/eof "x") FAIL)
+(chk= "digit"  (harness pc/digit "7x") (list [\7 "x"]))
+(chk= "digit-no" (harness pc/digit "x") FAIL)
+(chk= "letter" (harness pc/letter "Ab") (list [\A "b"]))
+(chk= "letter-no" (harness pc/letter "1") FAIL)
+(chk= "alpha-num-l" (harness pc/alpha-num "a1") (list [\a "1"]))
+(chk= "alpha-num-d" (harness pc/alpha-num "9z") (list [\9 "z"]))
+(chk= "alpha-num-no" (harness pc/alpha-num "-") FAIL)
+;; between / sep-by / optional through the real parse driver
+(require '[jolt.parser :refer [parse-all]])
+(chk= "between" (mapv :char (parse-all (pc/between (pb/match "(") (pb/match ")") (pc/plus pc/digit)) "(42)"))
+      [\4 \2])
+(chk= "sep-by-3" (mapv (fn [g] (mapv :char g))
+                       (parse-all (pc/sep-by (pc/plus pc/digit) (pb/match ",")) "1,22,333"))
+      [[\1] [\2 \2] [\3 \3 \3]])
+(chk= "sep-by-1" (mapv (fn [g] (mapv :char g))
+                       (parse-all (pc/sep-by (pc/plus pc/digit) (pb/match ",")) "5"))
+      [[\5]])
+(chk= "optional-default" (parse-all (pc/optional (pb/match "x") :none) "") :none)
+(chk= "optional-match"   (:char (parse-all (pc/optional (pb/match "x") :none) "x")) \x)
+
+;; monad do* / >>= sanity
+(chk= "do*-return" ((m/do* (m/return 42)) "in") (list [42 "in"]))
+
+;; ---------------------------------------------------------------------- report
+(if (empty? @failures)
+  (println "PARSER OK")
+  (do
+    (println "PARSER FAIL" (count @failures) "failures:")
+    (doseq [f @failures] (println "  FAIL:" f))))


### PR DESCRIPTION
Brings infix math notation into jolt core and factors out the general parser it's built on.

## What's added

- **`jolt.parser`** — a general-purpose monadic parser-combinator library (`jolt.parser` + `jolt.parser.{basic,combinators,monad,collections,position}`), adapted from [rm-hull/jasentaa](https://github.com/rm-hull/jasentaa). Nothing in it refers back to infix. Beyond the adopted pieces it adds the standard combinators jasentaa lacked: `eof`, `between`, `sep-by` (the zero-or-more partner to `separated-by`), an `optional` default-value arity, and the `digit`/`letter`/`alpha-num` character classes. Parse failures raise a jolt `ex-info`.
- **`jolt.infix`** — infix math notation (`infix`/`$=` macros and `from-string`), ported from [rm-hull/infix](https://github.com/rm-hull/infix), built on `jolt.parser`.

```clojure
(require '[jolt.infix :refer [infix $= from-string]])
(infix 3 + 5 * 8)                              ;=> 43
((from-string [x y] "sqrt(x**2 + y**2)") 3 4)  ;=> 5.0
```

## Runtime gaps this surfaced (fixed generally)

- `Math/atan2`, `Math/sinh`, `Math/cosh`, `Math/tanh` were missing from the `Math` static table.
- `java.text.ParseException` is now a constructable/catchable host exception class.

Each is covered by a corpus row (exact base cases for the transcendentals, since Chez and the JVM differ in the last ULP).

## Tests

- `test/chez/parser-test.clj` — ports jasentaa's own suite for every adopted piece (join; augment/strip/parse-exception/show-error; any/match/none-of/from-re; and-then/or-else/many; a `do*` check) plus coverage for each added combinator. Prints `PARSER OK`.
- `test/chez/infix-test.clj` — ports the full rm-hull/infix suite (~200 assertions across macros/grammar/core). Prints `INFIX OK`.

Both wired into `smoke.sh`.

## Validation

- `make smoke` — 49/49
- `make corpus` — 0 new divergences
- `make certify` — 0 new / 0 stale (new rows certified against JVM Clojure 1.12.5)