### PR TITLE
Add small nREPL completions support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 # build step. `make test` is the full gate. `make remint` rebuilds the seed after a
 # source change.
 
+CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
+
 .PHONY: test ci values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink numeric inline inline-body dcerefs shakesmoke remint joltc joltc-release joltc-debug joltcsmoke submodules
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
@@ -29,15 +31,15 @@ selfhost:
 
 # Value-model unit tests (nil/truthiness/collections on Chez).
 values:
-	@chez --script test/chez/values-test.ss
+	@$(CHEZ) --script test/chez/values-test.ss
 
 # Corpus conformance vs JVM-sourced expecteds (allowlist + floor).
 corpus:
-	@chez --script host/chez/run-corpus.ss
+	@$(CHEZ) --script host/chez/run-corpus.ss
 
 # Host-specific unit cases.
 unit:
-	@chez --script host/chez/run-unit.ss
+	@$(CHEZ) --script host/chez/run-unit.ss
 
 # Real-CLI smoke over bin/joltc.
 smoke:
@@ -62,9 +64,9 @@ staticnativesmoke:
 # machine. Built on a dev/CI host that HAS Chez + cc. release = optimize-level 3,
 # no inspector info, compressed; debug = optimize-level 0 + inspector + debug info.
 joltc-release:
-	@chez --script host/chez/build-joltc.ss release target/release/joltc
+	@$(CHEZ) --script host/chez/build-joltc.ss release target/release/joltc
 joltc-debug:
-	@chez --script host/chez/build-joltc.ss debug target/debug/joltc
+	@$(CHEZ) --script host/chez/build-joltc.ss debug target/debug/joltc
 # Re-mint the seed first so the embedded compiler image is current, then both builds.
 joltc: selfhost joltc-release joltc-debug
 	@echo "OK: target/release/joltc and target/debug/joltc built"
@@ -75,7 +77,7 @@ joltcsmoke:
 
 # SCI conformance: load borkdude/sci's source through joltc (floor-gated).
 sci:
-	@chez --script host/chez/run-sci.ss
+	@$(CHEZ) --script host/chez/run-sci.ss
 
 # clojure-test-suite conformance: run the vendored jank-lang/clojure-test-suite
 # per-namespace under joltc, gated on the per-namespace baseline
@@ -86,72 +88,72 @@ cts:
 # FFI: bind native functions (typed foreign-procedure), memory, and that a
 # :blocking call is collect-safe (a parked thread doesn't pin the collector).
 ffi:
-	@chez --script test/chez/ffi-binding-test.ss
+	@$(CHEZ) --script test/chez/ffi-binding-test.ss
 
 # Transients: mutable backing, snapshot on persistent!, and linear-time builds.
 transient:
-	@chez --script test/chez/transient-test.ss
+	@$(CHEZ) --script test/chez/transient-test.ss
 
 # Inference / success-type checking: drive jolt.passes.types directly and assert
 # diagnostic counts + collected calls/escapes (the optimization pass the other
 # gates don't exercise).
 infer:
-	@chez --script host/chez/run-infer.ss
+	@$(CHEZ) --script host/chez/run-infer.ss
 
 # Whole-program param-type fixpoint: record types flowing across fn boundaries
 # (a callee's param picks up its callers' ctor return types), the foundation the
 # bare-index field reads + protocol devirtualization build on.
 wp:
-	@chez --script host/chez/run-wp.ss
+	@$(CHEZ) --script host/chez/run-wp.ss
 
 # Protocol-call devirtualization: a monomorphic call resolves its impl by the
 # inferred record tag (find-protocol-method) instead of routing through the
 # protocol var; the result must match ordinary dispatch.
 devirt:
-	@chez --script host/chez/run-devirt.ss
+	@$(CHEZ) --script host/chez/run-devirt.ss
 
 # Native record field reads: a keyword lookup on a statically-known record reads
 # the field by its declared slot (jrec-field-at) instead of jolt-get; the value
 # must match, and a non-field key / default-arg form keeps the generic path.
 fieldread:
-	@chez --script host/chez/run-fieldread.ss
+	@$(CHEZ) --script host/chez/run-fieldread.ss
 
 # Inline method body field-read gate: when the optimize pipeline re-infers
 # defrecord/deftype inline method bodies with the receiver typed, field reads
 # must emit jrec-field-at (bare index) instead of jolt-get.
 inline-body:
-	@chez --script host/chez/run-inline-body.ss
+	@$(CHEZ) --script host/chez/run-inline-body.ss
 
 # DCE reference collection (dce.ss): an app form's refs must union an IR walk
 # (:var/:the-var nodes) with a text scan of the emitted Scheme, so a macro-spliced
 # (var-deref "ns" "nm") with no :var node still roots its target. Pins both halves.
 dcerefs:
-	@chez --script host/chez/run-dce-refs.ss
+	@$(CHEZ) --script host/chez/run-dce-refs.ss
 
 # Hintless whole-program double inference: a fn whose every call site passes a
 # flonum has its param typed :double by the closed-world fixpoint and unboxed to
 # fl-ops with no ^double hint; an integer caller leaves it generic, an escaped fn
 # keeps :any.
 numwp:
-	@chez --script host/chez/run-numwp.ss
+	@$(CHEZ) --script host/chez/run-numwp.ss
 
 # Mandelbrot count-point hot loop: whole-program fixpoint must seed cr/ci as
 # :double from caller type, and the numeric pass must emit fl-ops with zero
 # jolt-n* generic arith in the double arithmetic path.
 mandelbrot-num:
-	@chez --script host/chez/run-mandelbrot-num.ss
+	@$(CHEZ) --script host/chez/run-mandelbrot-num.ss
 
 # Double record fields: a ^double-tagged field reads back as a flonum (coerced at
 # construction and set!), so hintless arithmetic over those fields unboxes to fl-ops;
 # an untagged field stays generic.
 fieldnum:
-	@chez --script host/chez/run-fieldnum.ss
+	@$(CHEZ) --script host/chez/run-fieldnum.ss
 
 # Protocol-method return inference: a method whose impls all return the same record
 # type has a monomorphic return, so a (method recv ..) call types as that record and
 # a field read off the result bare-indexes; a disagreeing impl keeps the generic path.
 protoret:
-	@chez --script host/chez/run-protoret.ss
+	@$(CHEZ) --script host/chez/run-protoret.ss
 
 # Protocol-dispatch polymorphic inline cache: a protocol call the inference tags
 # :proto/:method but can't prove monomorphic emits a per-site cache keyed on the
@@ -159,30 +161,30 @@ protoret:
 # emission, megamorphic correctness across record types, and that an extend-type at
 # runtime invalidates the cache (the epoch bump) so the new impl is served.
 pic:
-	@chez --script host/chez/run-pic.ss
+	@$(CHEZ) --script host/chez/run-pic.ss
 
 # Nilable record types + flow-sensitive narrowing: a record-or-nil types as a nilable
 # record (some?/nil? don't fold, so a runtime guard stays); inside (if (some? x) ..)
 # the then-branch narrows x to non-nil, so its field reads bare-index and unbox.
 narrow:
-	@chez --script host/chez/run-narrow.ss
+	@$(CHEZ) --script host/chez/run-narrow.ss
 
 # Direct-linking emission: a closed-world build binds top-level app defs to jv$
 # Scheme bindings and routes app->app calls/refs to them, skipping var-deref +
 # jolt-invoke; ^:dynamic/^:redef and nested defs opt out.
 directlink:
-	@chez --script test/chez/directlink-test.ss
+	@$(CHEZ) --script test/chez/directlink-test.ss
 
 # Hint-directed fast arithmetic: ^double/^long param hints (and float literals)
 # lower arithmetic to Chez fl*/fx* ops; un-hinted integer code stays generic.
 numeric:
-	@chez --script test/chez/numeric-test.ss
+	@$(CHEZ) --script test/chez/numeric-test.ss
 
 # IR inlining: a small single-arity defn is spliced at call sites (under optimize
 # + direct-link, closed-world guarantee), with ^double/^long entry/return
 # coercions carried through via :coerce nodes.
 inline:
-	@chez --script test/chez/inline-test.ss
+	@$(CHEZ) --script test/chez/inline-test.ss
 
 # Tree-shake soundness: build example apps (incl. deps.edn git-lib apps) default vs
 # --tree-shake and require identical output. Slow (two builds per app); not in the

--- a/host/chez/build-lib-smoke.sh
+++ b/host/chez/build-lib-smoke.sh
@@ -9,7 +9,7 @@ cd "$root"
 # (libkernel.a + scheme.h) and a C compiler. Skip cleanly where absent.
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v scheme || command -v petite || true)"
+  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -11,7 +11,7 @@ cd "$root"
 # csv dir we validate so the build uses exactly it.
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v scheme || command -v petite || true)"
+  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/joltc-selfbuild-smoke.sh
+++ b/host/chez/joltc-selfbuild-smoke.sh
@@ -11,7 +11,7 @@ cd "$root"
 # ships neither, so skip there (CI included).
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v scheme || command -v petite || true)"
+  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do
@@ -29,7 +29,7 @@ export JOLT_CHEZ_CSV="$csv"
 # is identical to release, only Chez compile settings differ).
 joltc="$root/target/debug/joltc"
 echo "joltc self-build smoke: building $joltc"
-if ! chez --script host/chez/build-joltc.ss debug "$joltc" >/dev/null 2>&1; then
+if ! "$chez_bin" --script host/chez/build-joltc.ss debug "$joltc" >/dev/null 2>&1; then
   echo "  FAIL: build-joltc.ss exited non-zero"
   exit 1
 fi

--- a/host/chez/remint.sh
+++ b/host/chez/remint.sh
@@ -6,6 +6,7 @@
 set -e
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
+CHEZ="${CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme)}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -14,7 +15,7 @@ cp host/chez/seed/image.ss   "$tmp/cur-i.ss"
 i=0
 while [ "$i" -lt 8 ]; do
   i=$((i + 1))
-  chez --script host/chez/bootstrap.ss \
+  "$CHEZ" --script host/chez/bootstrap.ss \
     "$tmp/cur-p.ss" "$tmp/cur-i.ss" "$tmp/new-p.ss" "$tmp/new-i.ss" >/dev/null
   if diff -q "$tmp/cur-p.ss" "$tmp/new-p.ss" >/dev/null \
      && diff -q "$tmp/cur-i.ss" "$tmp/new-i.ss" >/dev/null; then

--- a/host/chez/selfcheck.sh
+++ b/host/chez/selfcheck.sh
@@ -5,9 +5,10 @@
 set -e
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
+CHEZ="${CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme)}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-chez --script host/chez/bootstrap.ss \
+"$CHEZ" --script host/chez/bootstrap.ss \
   host/chez/seed/prelude.ss host/chez/seed/image.ss "$tmp/p.ss" "$tmp/i.ss" >/dev/null
 if diff -q host/chez/seed/prelude.ss "$tmp/p.ss" >/dev/null \
    && diff -q host/chez/seed/image.ss "$tmp/i.ss" >/dev/null; then

--- a/host/chez/static-native-smoke.sh
+++ b/host/chez/static-native-smoke.sh
@@ -10,7 +10,7 @@ cd "$root"
 # kernel dev files, same as build-smoke. Skip otherwise (CI on a distro package).
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v scheme || command -v petite || true)"
+  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/tree-shake-smoke.sh
+++ b/host/chez/tree-shake-smoke.sh
@@ -15,7 +15,7 @@ if [ ! -d "$examples" ]; then echo "shake smoke: skipped (examples repo not foun
 
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v scheme || command -v petite || true)"
+  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do [ -f "${d}libkernel.a" ] && csv="${d%/}" && break; done

--- a/jolt-core/jolt/nrepl.clj
+++ b/jolt-core/jolt/nrepl.clj
@@ -203,6 +203,46 @@
   "Register op name(s) so `describe` advertises them. Call at middleware load."
   [& ops] (swap! extra-ops into (map name ops)))
 
+(defn completions
+  "Return nREPL completion entries for `prefix` in request namespace `ns-str`.
+  This intentionally stays small: vars from ns-map/ns-publics plus alias and
+  namespace-name candidates."
+  [prefix ns-str]
+  (let [prefix (or prefix "")
+        ns-str (if (str/blank? ns-str) (str (ns-name *ns*)) ns-str)
+        ns (or (find-ns (symbol ns-str)) (the-ns 'user))
+        entry (fn ([candidate] {"candidate" candidate})
+                ([candidate type] {"candidate" candidate "type" type}))
+        var-entry (fn [candidate v]
+                    (if-let [n (:ns (meta v))]
+                      {"candidate" candidate "ns" (str n)}
+                      {"candidate" candidate}))
+        keep (fn [s p] (str/starts-with? (str s) p))]
+    (if-let [slash (str/index-of prefix "/")]
+      (let [ns-prefix (subs prefix 0 slash)
+            sym-prefix (subs prefix (inc slash))
+            target (or (get (ns-aliases ns) (symbol ns-prefix))
+                       (find-ns (symbol ns-prefix)))]
+        (if target
+          (vec (for [[sym v] (ns-publics target)
+                     :let [sym-name (str sym)]
+                     :when (keep sym-name sym-prefix)]
+                 (var-entry (str ns-prefix "/" sym-name) v)))
+          []))
+      (vec (concat
+             (for [[sym v] (ns-map ns)
+                   :let [candidate (str sym)]
+                   :when (keep candidate prefix)]
+               (var-entry candidate v))
+             (for [[alias _] (ns-aliases ns)
+                   :let [candidate (str alias "/")]
+                   :when (keep candidate prefix)]
+               (entry candidate "namespace"))
+             (for [n (all-ns)
+                   :let [candidate (str (ns-name n) "/")]
+                   :when (keep candidate prefix)]
+               (entry candidate "namespace")))))))
+
 ;; --- built-in handler ------------------------------------------------------
 (defn- built-in-handler [request]
   (let [op (get request "op")]
@@ -211,9 +251,15 @@
       (= op "close")    (respond request {"status" ["session-closed" "done"]})
       (= op "describe") (respond request {"status" ["done"]
                                           "versions" {"jolt-nrepl" {"major" 0 "minor" 1}}
-                                          "ops" (zipmap (into #{"clone" "close" "describe" "eval" "load-file"}
+                                          "ops" (zipmap (into #{"clone" "close" "describe" "eval" "load-file"
+                                                                "completions" "complete"}
                                                               @extra-ops)
                                                         (repeat {}))})
+      (or (= op "completions") (= op "complete"))
+      (respond request {"completions" (completions (or (get request "prefix")
+                                                       (get request "symbol"))
+                                                   (get request "ns"))
+                        "status" ["done"]})
       (or (= op "eval") (= op "load-file"))
       (let [code (wire-> (if (= op "load-file") (get request "file") (get request "code")))
             {:keys [value out ns err]} (evaluate code (get request "ns"))]


### PR DESCRIPTION
Description:

This adds a small built-in nREPL completions implementation for Jolt.

Changes:

- Advertise completions and complete in nREPL describe.
- Handle op=completions and op=complete.
- Return nREPL-style completion entries with candidate, plus optional ns / type.
- Complete visible vars from ns-map.
- Complete qualified vars through aliases or namespace names via ns-publics.
- Complete aliases and namespace names as slash-suffixed candidates.
- Keep the implementation intentionally small and dependency-free inside jolt.nrepl.

Also included:

- Makefile and shell gate support for systems where Chez is installed as chezscheme instead of chez.
- The resolver now checks chez, then chezscheme.
