### PR TITLE
ci: selfhost byte-fixpoint in the gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,30 +65,10 @@ jobs:
           clojure --version
 
       - name: Gate
-        # `make ci` runs the behavior gates (corpus/unit/smoke/buildsmoke/sci/
-        # certify). buildsmoke now links a real binary (the source-built Chez has
-        # the kernel dev files). The self-host byte-fixpoint (make selfhost) is a
-        # dev-machine check — it only holds on the Chez that minted the seed. See
-        # jolt-8479.
-        run: make ci
+        # `make test` = the self-host byte-fixpoint (the rebuilt seed must equal
+        # the checked-in seed byte-for-byte — holds cross-platform on the pinned
+        # source-built Chez) + the behavior gates (`make ci`: corpus/unit/smoke/
+        # buildsmoke/sci/certify). buildsmoke links a real binary (the source
+        # build ships the kernel dev files).
+        run: make test
 
-      # jolt-8479 probe: does the seed byte-fixpoint hold on a non-minting Chez?
-      # Rebuilds the seed and dumps the first divergences instead of a bare fail,
-      # so the probe names the drift (hashtable order vs gensym numbering).
-      - name: Selfhost probe (jolt-8479)
-        run: |
-          tmp=$(mktemp -d)
-          scheme --script host/chez/bootstrap.ss \
-            host/chez/seed/prelude.ss host/chez/seed/image.ss "$tmp/p.ss" "$tmp/i.ss" >/dev/null
-          st=0
-          for pair in "prelude host/chez/seed/prelude.ss $tmp/p.ss" "image host/chez/seed/image.ss $tmp/i.ss"; do
-            set -- $pair
-            if diff -q "$2" "$3" >/dev/null; then
-              echo "$1: byte-identical"
-            else
-              st=1
-              echo "=== $1 DIVERGED: $(diff "$2" "$3" | grep -c '^<') changed lines; first 40 diff lines ==="
-              diff "$2" "$3" | head -40
-            fi
-          done
-          exit $st

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,3 +71,24 @@ jobs:
         # dev-machine check — it only holds on the Chez that minted the seed. See
         # jolt-8479.
         run: make ci
+
+      # jolt-8479 probe: does the seed byte-fixpoint hold on a non-minting Chez?
+      # Rebuilds the seed and dumps the first divergences instead of a bare fail,
+      # so the probe names the drift (hashtable order vs gensym numbering).
+      - name: Selfhost probe (jolt-8479)
+        run: |
+          tmp=$(mktemp -d)
+          scheme --script host/chez/bootstrap.ss \
+            host/chez/seed/prelude.ss host/chez/seed/image.ss "$tmp/p.ss" "$tmp/i.ss" >/dev/null
+          st=0
+          for pair in "prelude host/chez/seed/prelude.ss $tmp/p.ss" "image host/chez/seed/image.ss $tmp/i.ss"; do
+            set -- $pair
+            if diff -q "$2" "$3" >/dev/null; then
+              echo "$1: byte-identical"
+            else
+              st=1
+              echo "=== $1 DIVERGED: $(diff "$2" "$3" | grep -c '^<') changed lines; first 40 diff lines ==="
+              diff "$2" "$3" | head -40
+            fi
+          done
+          exit $st


### PR DESCRIPTION
The selfhost gate (bootstrap.ss rebuild == checked-in seed, byte-for-byte) was dev-machine-only because a different Chez version used to emit byte-different output (jolt-8479). A probe run on this branch shows both prelude and image now rebuild byte-identical on CI's source-built Linux Chez — the drift sources are gone (sorted literal emission, emit consolidation, CI building Chez from source at the pinned version).

CI now runs make test (selfhost + ci) instead of make ci, so a seed source edited without a remint fails CI.