### PR TITLE
Defect round: unbound-var sentinel, dot list-member corpus rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reading a declared-but-unset var returns the `Var$Unbound` sentinel from
+  every surface — a plain read, `@#'x`, and `var-get` all yield the same
+  object (printing as `#object[clojure.lang.Var$Unbound …]`) instead of two
+  of the three throwing; `bound?` still reports false.
+- The self-host byte-fixpoint runs in CI: the seed rebuild is byte-identical
+  on the pinned source-built Chez, so a seed source edited without a remint
+  fails the gate on every platform.
 - A tree-shaken binary crashed at startup when the project registered data
   readers (`data_readers.clj`): the emitted launcher re-scanned the source roots
   and eagerly reloaded each reader namespace through `jolt-compile-eval-form`,

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -287,7 +287,8 @@
 ;; later resolve returns nil.
 (define (jolt-ns-unmap ns-desig sym)
   (let ((c (var-cell-lookup (ns-desig->name ns-desig) (symbol-t-name sym))))
-    (when c (var-cell-defined?-set! c #f) (var-cell-root-set! c jolt-unbound)))
+    (when c (var-cell-defined?-set! c #f)
+           (var-cell-root-set! c (make-jolt-var-unbound (var-cell-ns c) (var-cell-name c)))))
   jolt-nil)
 
 ;; --- ns runtime fns ---------------------------------------------------------
@@ -471,7 +472,7 @@
   (lambda (ns name)
     (let ((c (var-cell-lookup ns name)))
       (if (and c (var-cell-defined? c)
-               (not (eq? (var-cell-root c) jolt-unbound)))
+               (not (jolt-var-unbound? (var-cell-root c))))
           c jolt-nil))))
 
 ;; --- printer patches: a namespace renders as its name (str / pr-str / -e) ----

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -231,10 +231,11 @@
 ;; A var is a mutable cell keyed by "ns/name". A `:def` sets the root; a `:var`
 ;; reference reads it at use time (late binding), so a forward/mutually-recursive
 ;; reference resolves to whatever the cell holds when the call actually runs.
-;; declare / (def name) with no init reserves a cell holding this placeholder
-;; until the real def overwrites it (a forward reference resolves to the cell, and
-;; correct code never reads it before the binding def runs).
-(define jolt-unbound (string->symbol "#<jolt-unbound>"))
+;; declare / (def name) with no init, and a forward var-deref on a not-yet-defined
+;; name, reserve a cell whose root is a per-cell unbound sentinel. Per-cell (not a
+;; single global) so it names its var like the JVM's Var$Unbound, and every read
+;; surface (a plain read, var-get, deref/@) returns the SAME object.
+(define-record-type jolt-var-unbound (fields ns name) (nongenerative jolt-var-unbound-v1))
 ;; `defined?` distinguishes a genuinely interned var (def / declare / a native-op
 ;; cell) from a cell lazily materialised by a forward `var-deref` / `(var x)` on a
 ;; not-yet-defined name — `resolve` returns the cell iff defined?.
@@ -244,7 +245,7 @@
 (define (jolt-var ns name)
   (let ((k (string-append ns "/" name)))
     (or (hashtable-ref var-table k #f)
-        (let ((c (make-var-cell ns name jolt-nil #f)))
+        (let ((c (make-var-cell ns name (make-jolt-var-unbound ns name) #f)))
           (hashtable-set! var-table k c)
           c))))
 ;; non-creating lookup (resolve / find-var / ns-unmap): #f when absent, so a
@@ -298,7 +299,7 @@
 (define (declare-var! ns name)
   (let ((k (string-append ns "/" name)))
     (or (hashtable-ref var-table k #f)
-        (let ((c (make-var-cell ns name jolt-unbound #t)))  ; declared => interned/resolvable
+        (let ((c (make-var-cell ns name (make-jolt-var-unbound ns name) #t)))  ; declared => interned/resolvable
           (hashtable-set! var-table k c)
           c))))
 

--- a/host/chez/vars.ss
+++ b/host/chez/vars.ss
@@ -14,11 +14,12 @@
 
 (define (jolt-var-pred? x) (var-cell? x))
 
-;; the var's current root; unbound is an error (Clojure throws on an unbound var).
+;; the var's current root. Lenient on an unbound root: returns the sentinel, so
+;; var-get / @ on an unbound var match a plain read (JVM Var$Unbound parity —
+;; nothing throws).
 (define (jolt-var-get v)
   (if (var-cell? v)
-      (let ((r (var-cell-root v)))
-        (if (eq? r jolt-unbound) (error #f "Unbound var" v) r))
+      (var-cell-root v)
       (error #f "var-get: not a var" v)))
 
 ;; deref of a var -> its root.
@@ -44,8 +45,18 @@
 (register-pr-arm! var-cell? var->str)
 (register-str-render! var-cell? var->str)
 
+;; an unbound var's sentinel names its var: str -> "Unbound: #'ns/name",
+;; pr-str -> #object[clojure.lang.Var$Unbound 0 "Unbound: #'ns/name"].
+(define (unbound-marker-str u)
+  (string-append "Unbound: #'" (jolt-var-unbound-ns u) "/" (jolt-var-unbound-name u)))
+(define (unbound-marker-pr u)
+  (string-append "#object[clojure.lang.Var$Unbound 0 \"" (unbound-marker-str u) "\"]"))
+(register-pr-str-arm! jolt-var-unbound? unbound-marker-str)
+(register-str-render! jolt-var-unbound? unbound-marker-str)
+(register-pr-readable-arm! jolt-var-unbound? unbound-marker-pr)
+
 ;; bound? — native (the overlay's (get v :root) is nil on a var-cell record).
-(define (jolt-var-bound-one? v) (and (var-cell? v) (not (eq? (var-cell-root v) jolt-unbound))))
+(define (jolt-var-bound-one? v) (and (var-cell? v) (not (jolt-var-unbound? (var-cell-root v)))))
 (define (jolt-bound? . vars) (if (for-all jolt-var-bound-one? vars) #t #f))
 
 (def-var! "clojure.core" "var?" jolt-var-pred?)

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3483,6 +3483,9 @@
   {:suite "vars / privacy" :label "defn- marks the var :private" :expected "true" :actual "(do (defn- p [] 1) (true? (:private (meta (var p)))))" :portability :common}
   {:suite "vars / privacy" :label "ns-publics drops private vars; ns-interns keeps them" :expected "[true false true]" :actual "(do (defn pub [] 1) (defn- priv [] 2) [(contains? (ns-publics (quote user)) (quote pub)) (contains? (ns-publics (quote user)) (quote priv)) (contains? (ns-interns (quote user)) (quote priv))])" :portability :common}
   {:suite "host interop / dot form" :label "(. target (method args)) list-member sugar" :expected "\"HELLO\"" :actual "(. \"hello\" (toUpperCase))" :portability :jvm}
+  {:suite "conformance / host interop dot form" :label "list-member 0-arg (. target (method)) equals bare form" :expected "5" :actual "(. \"hello\" (length))" :portability :common}
+  {:suite "conformance / host interop dot form" :label "list-member with args (. target (method args))" :expected "\"el\"" :actual "(. \"hello\" (substring 1 3))" :portability :common}
+  {:suite "conformance / host interop dot form" :label "list-member desugars identically to the bare form" :expected "true" :actual "(= (. \"hello\" (substring 1 3)) (. \"hello\" substring 1 3))" :portability :common}
   {:suite "predicates / identical?" :label "reference identity, not value equality" :expected "[true false false]" :actual "[(identical? :a :a) (identical? (quote x) (quote x)) (identical? [1] [1])]" :portability :common}
   {:suite "host interop / hashCode" :label "Java String and Symbol hashCode" :expected "[120 -1634134448]" :actual "[(.hashCode \"x\") (.hashCode (quote foo/bar))]" :portability :jvm}
   {:suite "structmaps" :label "defstruct / struct-map / struct" :expected "[{:a 1 :b 2} {:a 1 :b 2} {:a 1 :b nil}]" :actual "(do (defstruct sx :a :b) [(struct-map sx :a 1 :b 2) (struct sx 1 2) (struct-map sx :a 1)])" :portability :common}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3486,6 +3486,7 @@
   {:suite "conformance / host interop dot form" :label "list-member 0-arg (. target (method)) equals bare form" :expected "5" :actual "(. \"hello\" (length))" :portability :common}
   {:suite "conformance / host interop dot form" :label "list-member with args (. target (method args))" :expected "\"el\"" :actual "(. \"hello\" (substring 1 3))" :portability :common}
   {:suite "conformance / host interop dot form" :label "list-member desugars identically to the bare form" :expected "true" :actual "(= (. \"hello\" (substring 1 3)) (. \"hello\" substring 1 3))" :portability :common}
+  {:suite "regex / nested quantifier capture" :label "(a+)* group 1 captures the greedy whole like Java" :expected "[\"aaaa\" \"aaaa\"]" :actual "(re-matches #\"(a+)*\" \"aaaa\")" :portability :common}
   {:suite "predicates / identical?" :label "reference identity, not value equality" :expected "[true false false]" :actual "[(identical? :a :a) (identical? (quote x) (quote x)) (identical? [1] [1])]" :portability :common}
   {:suite "host interop / hashCode" :label "Java String and Symbol hashCode" :expected "[120 -1634134448]" :actual "[(.hashCode \"x\") (.hashCode (quote foo/bar))]" :portability :jvm}
   {:suite "structmaps" :label "defstruct / struct-map / struct" :expected "[{:a 1 :b 2} {:a 1 :b 2} {:a 1 :b nil}]" :actual "(do (defstruct sx :a :b) [(struct-map sx :a 1 :b 2) (struct sx 1 2) (struct-map sx :a 1)])" :portability :common}

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -641,4 +641,14 @@
   {:suite "core / PrintWriter-on" :expr "(let [sb (atom nil)] (let [w (PrintWriter-on (fn [s] (reset! sb s)) nil)] (.write w \"a\") (.write w \"b\") (.flush w)) @sb)" :expected "ab"}
   {:suite "core / print-simple" :expr "(with-out-str (print-simple {:a 1} *out*))" :expected "{:a 1}"}
   {:suite "core / StackTraceElement->vec" :expr "(vec (map StackTraceElement->vec (.getStackTrace (Thread/currentThread))))" :expected "[]"}
+  ;; an unbound var reads as a per-cell sentinel naming its var (JVM Var$Unbound
+  ;; parity) on every read surface: a plain compiled read, var-get, and deref/@.
+  {:suite "vars / unbound" :expr "(do (declare uv-a) (pr-str uv-a))" :expected "#object[clojure.lang.Var$Unbound 0 \"Unbound: #'user/uv-a\"]"}
+  {:suite "vars / unbound" :expr "(do (declare uv-b) (pr-str (var-get (var uv-b))))" :expected "#object[clojure.lang.Var$Unbound 0 \"Unbound: #'user/uv-b\"]"}
+  {:suite "vars / unbound" :expr "(do (declare uv-c) (pr-str (deref (var uv-c))))" :expected "#object[clojure.lang.Var$Unbound 0 \"Unbound: #'user/uv-c\"]"}
+  {:suite "vars / unbound" :expr "(do (declare uv-d) (bound? (var uv-d)))" :expected "false"}
+  {:suite "vars / unbound" :expr "(do (declare uv-e) (identical? uv-e (var-get (var uv-e))))" :expected "true"}
+  {:suite "vars / unbound" :expr "(do (declare uv-f) (str uv-f))" :expected "Unbound: #'user/uv-f"}
+  {:suite "vars / unbound" :expr "(pr-str uv-late-undef-xyz)" :expected "#object[clojure.lang.Var$Unbound 0 \"Unbound: #'user/uv-late-undef-xyz\"]"}
+  {:suite "vars / unbound" :expr "(do (declare uv-g) (binding [uv-g 42] (deref (var uv-g))))" :expected "42"}
 ]


### PR DESCRIPTION
First round of the post-audit defect queue.

**unbound vars** (a260df1): reading a declared-but-unset var behaved three different ways — the compiled read returned a sentinel, @#'x and var-get threw "Unbound var", and an auto-vivified late-bind cell read nil. All three now return the same per-cell Var$Unbound sentinel like the JVM, printing as #object[clojure.lang.Var$Unbound 0 "Unbound: #'user/xx"]; bound? still reports false. Unit rows cover the three surfaces.

**dot list-member form** (67440c3): (. target (method args)) turned out to already work — the desugaring landed with the core.logic fixes. Corpus rows now pin it ((. "hello" (length)), (. "hello" (substring 1 3)), list/bare equivalence) so it can't regress silently. One permissiveness gap flagged for later: (. x (:keyword)) is accepted where the JVM throws (jolt-2fqo, P4).

Gates: make test green (0 new divergences), make cts exact baseline (6077). Branch carries the merge from main picking up the CI selfhost gate.