### PR TITLE
records: field-tag resolution prefers same-ns then qualified match

### DIFF
--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -147,12 +147,27 @@
 ;; resolve a field's declared type tag to what jolt.passes.types wants: "num"
 ;; passes through; a record name (simple "Vec3" or qualified "ns.Vec3") resolves
 ;; to its ctor-key (so the field reads back as that record); anything else -> nil.
-(define (chez-resolve-field-tag tag by-name)
+;; Resolution order: the tag as written (a qualified "ns.Vec3" hits its exact
+;; entry), then the owner namespace's record of that simple name (two namespaces
+;; can each define a Node — a simple ^Node means the local one), then any record
+;; with that simple name (imported/cross-ns).
+(define (chez-resolve-field-tag tag by-name owner-ns)
   (cond ((or (not tag) (jolt-nil-t? tag)) jolt-nil)
         ((string=? tag "num") "num")
         ((string=? tag "double") "double")   ; a ^double field reads back as a flonum
-        (else (let ((ck (hashtable-ref by-name (chez-shape-simple-name tag) #f)))
+        (else (let* ((simple (chez-shape-simple-name tag))
+                     (qualified? (not (string=? simple tag)))
+                     (ck (or (and qualified? (hashtable-ref by-name tag #f))
+                             (hashtable-ref by-name (string-append owner-ns "." simple) #f)
+                             (hashtable-ref by-name simple #f))))
                 (if ck ck jolt-nil)))))
+
+;; namespace part of a ctor-key "ns/->Name" (up to the /).
+(define (chez-ctor-key-ns k)
+  (let loop ((i 0))
+    (cond ((>= i (string-length k)) k)
+          ((char=? (string-ref k i) #\/) (substring k 0 i))
+          (else (loop (+ i 1))))))
 
 ;; materialize chez-record-shapes-tbl into "ns/->Name" -> {:fields :tags :type},
 ;; the shape record-type-from-entry consumes.
@@ -160,15 +175,21 @@
   (let ((by-name (make-hashtable string-hash string=?))
         (kw-fields (keyword #f "fields")) (kw-tags (keyword #f "tags")) (kw-type (keyword #f "type"))
         (out (jolt-hash-map)))
-    ;; index simple record name (from the type tag "ns.Name") -> ctor-key for
-    ;; nested-field-tag resolution.
+    ;; index the full type tag "ns.Name" AND the simple record name -> ctor-key
+    ;; for nested-field-tag resolution (qualified entries are unambiguous; the
+    ;; simple entry is the cross-ns fallback and may be overwritten on collision).
     (let-values (((ks vs) (hashtable-entries chez-record-shapes-tbl)))
       (vector-for-each
-        (lambda (k v) (hashtable-set! by-name (chez-shape-simple-name (vector-ref v 2)) k)) ks vs)
+        (lambda (k v)
+          (let ((type-tag (vector-ref v 2)))
+            (hashtable-set! by-name type-tag k)
+            (hashtable-set! by-name (chez-shape-simple-name type-tag) k)))
+        ks vs)
       (vector-for-each
         (lambda (k v)
           (let* ((fields (vector-ref v 0)) (tags (vector-ref v 1)) (type-tag (vector-ref v 2))
-                 (rtags (map (lambda (t) (chez-resolve-field-tag t by-name)) tags)))
+                 (owner-ns (chez-ctor-key-ns k))
+                 (rtags (map (lambda (t) (chez-resolve-field-tag t by-name owner-ns)) tags)))
             (set! out (jolt-assoc out k
                                   (jolt-hash-map kw-fields (apply jolt-vector fields)
                                                  kw-tags   (apply jolt-vector rtags)

--- a/host/chez/run-fieldread.ss
+++ b/host/chez/run-fieldread.ss
@@ -67,6 +67,21 @@
 (let ((e (mark-emit "(:y a 99)")))
   (check "default-arg keeps jolt-get" (has-sub? e "jrec-field-at") #f))
 
+;; field-tag resolution across same-named records: two namespaces each define
+;; Node; a record's simple ^Node field tag resolves to the SAME-NS Node, and a
+;; qualified ^nsa.Node tag resolves to exactly that namespace's Node from
+;; anywhere — never last-writer-wins on the simple name.
+(register-record-shape! "nsa/->Node" (list (kw "x")) (list jolt-nil) "nsa.Node")
+(register-record-shape! "nsb/->Node" (list (kw "x")) (list jolt-nil) "nsb.Node")
+(register-record-shape! "nsa/->Holder"  (list (kw "n")) (list "Node")     "nsa.Holder")
+(register-record-shape! "nsb/->Holder"  (list (kw "n")) (list "Node")     "nsb.Holder")
+(register-record-shape! "nsb/->HolderQ" (list (kw "n")) (list "nsa.Node") "nsb.HolderQ")
+(let* ((m (chez-record-shapes-map))
+       (tag-of (lambda (ck) (jolt-nth (jolt-get (jolt-get m ck) (kw "tags")) 0))))
+  (check "simple ^Node in nsa -> nsa's Node" (tag-of "nsa/->Holder") "nsa/->Node")
+  (check "simple ^Node in nsb -> nsb's Node" (tag-of "nsb/->Holder") "nsb/->Node")
+  (check "qualified ^nsa.Node from nsb -> nsa's Node" (tag-of "nsb/->HolderQ") "nsa/->Node"))
+
 (if (= fails 0)
     (begin (printf "fieldread gate: ~a/~a passed\n" total total) (exit 0))
     (begin (printf "fieldread gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))


### PR DESCRIPTION
The record shape map indexed types by simple name only, so two namespaces each defining a Node collided last-writer-wins — a ^Node field tag could resolve to the wrong record's ctor-key and mistype nested-field inference. The index now also carries the qualified type tag; resolution tries the tag as written (a qualified ^nsa.Node hits its exact entry), then the owner namespace's record of that simple name, then the cross-ns simple fallback. Runtime only, no remint. The fieldread gate pins all three cases (went red on the collision before the fix).

Gates: make test, cts exact baseline, fieldread 11/11, fieldnum, wp, numwp.