### PR TITLE
bench: MODE_A release column; refresh scorecard

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -40,25 +40,27 @@ source — the jolt/JVM scorecard. jolt's optimizing passes fire only in a build
 `joltc run -m` is unoptimized, so the harness always builds.
 
 Indicative ratios (M-series, single isolated run — numbers are machine-specific,
-regenerate locally), ascending:
+regenerate locally), ascending. **opt** = `--direct-link --opt`; **release** = a
+plain `jolt build` (`MODE_A=1` adds this column):
 
-| benchmark | ratio | axis |
-|---|---|---|
-| `fib` | ~0.6× | call + integer arith |
-| `collections` | ~3.5× | persistent map/vector churn |
-| `mandelbrot` | ~7.5× | pure float compute |
-| `binary-trees` | ~10× | escaping short-lived records (allocation/GC) |
-| `dispatch` | ~12× | megamorphic protocol dispatch |
-| `mono-dispatch` | ~15× | monomorphic protocol dispatch |
+| benchmark | opt | release | axis |
+|---|---|---|---|
+| `fib` | ~1.1× | ~1.0× | call + integer arith |
+| `collections` | ~1.2× | ~1.1× | persistent map/vector churn |
+| `mandelbrot` | ~2.0× | ~6.5× | pure float compute (fl-unboxing needs `--opt`) |
+| `dispatch` | ~2.8× | ~2.8× | megamorphic protocol dispatch |
+| `binary-trees` | ~6.6× | ~6.5× | escaping short-lived records (allocation/GC) |
+| `mono-dispatch` | ~7.8× | ~8.5× | monomorphic protocol dispatch |
 
-- **Compute (~0.6–7.5×)** is the substrate floor: Chez is a native-compiling AOT
-  Scheme, not a profiling JIT. With native arith + direct-linking + inlining jolt
-  is at parity here — `fib` runs *faster* than JVM Clojure (no JIT warmup over a
-  short run), `collections` is within ~3.5×, and `mandelbrot` (~7.5×) is the
-  pure-tight-loop float ceiling that only native codegen moves further.
-- **Dispatch & allocation (~10–15×)** are the remaining architectural gaps, though
-  the type-proving / native-record / bare-field-read work has collapsed them by an
-  order of magnitude (`binary-trees` ~140×→~10×, `mono-dispatch` ~330×→~15×). On a
+- **Compute and collections (~1–2.8×)** sit at or near the substrate floor:
+  Chez is a native-compiling AOT Scheme, not a profiling JIT. `fib` and
+  `collections` are at JVM parity in both modes; `mandelbrot` is ~2× under
+  `--opt` (fl-unboxing) and ~6.5× in a release build — the release gap is the
+  cost of not direct-linking, which is why the scorecard tracks both modes.
+- **Dispatch & allocation (~6.6–8.5×)** are the remaining architectural gaps,
+  though the type-proving / native-record / bare-field-read work has collapsed
+  them by well over an order of magnitude (`binary-trees` ~140×→~6.6×,
+  `mono-dispatch` ~330×→~7.8×). On a
   *statically proven* monomorphic receiver — which whole-program inference now gives
   for a record iterated out of a vector — devirt resolves the impl and a per-site
   inline cache holds it (resolved once, not per call), so `mono-dispatch` is no
@@ -107,7 +109,15 @@ bench/run.sh                 # full suite + JVM scorecard
 bench/run.sh fib             # one benchmark, default size
 bench/run.sh fib 32          # one benchmark, custom size
 NO_JVM=1 bench/run.sh        # jolt only (skip the JVM reference)
+MODE_A=1 bench/run.sh        # also time each bench as a plain release build
 ```
+
+Two build modes matter: **optimized** (`--direct-link --opt`, the default
+scorecard — inlining, scalar replacement, closed-world direct linking) and
+**release** (plain `jolt build`, what a default build ships — inference passes
+but no direct-link/inlining). `MODE_A=1` adds the release column so a
+release-mode win or regression is visible; it roughly doubles build time, so
+it's on demand.
 
 Needs Chez's kernel dev files (`libkernel.a` + `scheme.h`) and `cc` for the build,
 like `jolt build`; set `JOLT_CHEZ_CSV` to override the detected csv dir.

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -11,6 +11,10 @@
 #   bench/run.sh fib             # one benchmark, default size
 #   bench/run.sh fib 32          # one benchmark, custom size
 #   NO_JVM=1 bench/run.sh        # jolt only (skip the JVM reference)
+#   MODE_A=1 bench/run.sh        # also time a plain-release build (no
+#                                # --direct-link --opt) per bench — the default
+#                                # `jolt build` most users get; roughly doubles
+#                                # the suite's build time, so it's on demand
 #
 # Building needs Chez's kernel dev files (libkernel.a + scheme.h) and a C compiler,
 # the same as `jolt build`; set JOLT_CHEZ_CSV to override the detected csv dir.
@@ -50,10 +54,26 @@ run_one() {
     printf '%-16s  jolt build FAILED\n' "$ns"; return
   fi
   jmean=$("$bindir/$ns" "$arg" 2>/dev/null | awk '/^mean:/{print $2}')
+  # mode A: the plain-release binary (no --direct-link --opt) — what a default
+  # `jolt build` ships. Tracked so a release-mode win or regression is visible.
+  rmean=""
+  if [ -n "$MODE_A" ]; then
+    if "$joltc" build -m "$ns" -o "$bindir/$ns-rel" >/dev/null 2>&1; then
+      rmean=$("$bindir/$ns-rel" "$arg" 2>/dev/null | awk '/^mean:/{print $2}')
+    fi
+  fi
   if [ -z "$NO_JVM" ]; then
     vmean=$(clojure -Sdeps '{:paths ["."]}' -M -m "$ns" "$arg" 2>/dev/null | awk '/^mean:/{print $2}')
     ratio=$(awk "BEGIN{ if (\"$vmean\"+0>0 && \"$jmean\"+0>0) printf \"%.1fx\", (\"$jmean\"+0)/(\"$vmean\"+0); else printf \"-\" }")
-    printf '%-16s jolt %9s ms   jvm %8s ms   %s\n' "$ns" "${jmean:--}" "${vmean:--}" "$ratio"
+    if [ -n "$MODE_A" ]; then
+      rratio=$(awk "BEGIN{ if (\"$vmean\"+0>0 && \"$rmean\"+0>0) printf \"%.1fx\", (\"$rmean\"+0)/(\"$vmean\"+0); else printf \"-\" }")
+      printf '%-16s opt %9s ms (%s)   release %9s ms (%s)   jvm %8s ms\n' \
+        "$ns" "${jmean:--}" "$ratio" "${rmean:--}" "$rratio" "${vmean:--}"
+    else
+      printf '%-16s jolt %9s ms   jvm %8s ms   %s\n' "$ns" "${jmean:--}" "${vmean:--}" "$ratio"
+    fi
+  elif [ -n "$MODE_A" ]; then
+    printf '%-16s opt %9s ms   release %9s ms\n' "$ns" "${jmean:--}" "${rmean:--}"
   else
     printf '%-16s jolt %9s ms\n' "$ns" "${jmean:--}"
   fi

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3487,6 +3487,7 @@
   {:suite "conformance / host interop dot form" :label "list-member with args (. target (method args))" :expected "\"el\"" :actual "(. \"hello\" (substring 1 3))" :portability :common}
   {:suite "conformance / host interop dot form" :label "list-member desugars identically to the bare form" :expected "true" :actual "(= (. \"hello\" (substring 1 3)) (. \"hello\" substring 1 3))" :portability :common}
   {:suite "regex / nested quantifier capture" :label "(a+)* group 1 captures the greedy whole like Java" :expected "[\"aaaa\" \"aaaa\"]" :actual "(re-matches #\"(a+)*\" \"aaaa\")" :portability :common}
+  {:suite "numbers / flonum contagion" :label "an exact zero with a flonum operand yields a flonum" :expected "[0.0 1.5 0.0 -0.5 0.0]" :actual "[(* 0 1.0) (+ 0 1.5) (* 1.0 0) (- 0 0.5) (/ 0 2.0)]" :portability :common}
   {:suite "predicates / identical?" :label "reference identity, not value equality" :expected "[true false false]" :actual "[(identical? :a :a) (identical? (quote x) (quote x)) (identical? [1] [1])]" :portability :common}
   {:suite "host interop / hashCode" :label "Java String and Symbol hashCode" :expected "[120 -1634134448]" :actual "[(.hashCode \"x\") (.hashCode (quote foo/bar))]" :portability :jvm}
   {:suite "structmaps" :label "defstruct / struct-map / struct" :expected "[{:a 1 :b 2} {:a 1 :b 2} {:a 1 :b nil}]" :actual "(do (defstruct sx :a :b) [(struct-map sx :a 1 :b 2) (struct sx 1 2) (struct-map sx :a 1)])" :portability :common}


### PR DESCRIPTION
bench/run.sh gets a MODE_A=1 switch that additionally builds each benchmark as a plain release binary (no --direct-link --opt) and reports both columns with JVM ratios. Round 1's biggest default-mode win (per-site var-cell caching) was invisible on the optimized-only scorecard, and a release-mode regression would be too.

Validation run (isolated, M-series): fib 1.1x/1.0x, collections 1.2x/1.1x, mandelbrot 2.0x/6.5x (the opt/release split is the point — fl-unboxing needs --opt), dispatch 2.8x/2.8x, binary-trees 6.6x/6.5x, mono-dispatch 7.8x/8.5x. README scorecard + prose refreshed from this run.

Also pins (* 0 1.0) → 0.0 and the exact-zero flonum-contagion family in the corpus (jolt-kq56, verified fixed).