### PR TITLE
test: gates run the built binary (4x faster); fix launcher -e fork and O3 unsafe mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,5 +70,7 @@ jobs:
         # source-built Chez) + the behavior gates (`make ci`: corpus/unit/smoke/
         # buildsmoke/sci/certify). buildsmoke links a real binary (the source
         # build ships the kernel dev files).
-        run: make test
+        # -j overlaps the independent gates (ci is a plain dependency list);
+        # -Oline keeps per-recipe output contiguous for failure reading.
+        run: make -j"$(nproc)" -Oline test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release and optimized builds compile at Chez optimize-level 2, not 3 — level
+  3 is unsafe mode (fx/fl/car operations skip their type checks) and jolt's
+  error semantics depend on those raising: an optimized binary returned
+  `(take nil coll)` instead of throwing and looped forever on a nil-count
+  `repeat`. Costs ~8-13% on dispatch/allocation benchmarks, nothing on
+  numeric ones.
+- The standalone `joltc` binary's `-e` matches the script driver: trailing
+  args bind `*command-line-args*`, the first `--` ends option parsing, and an
+  uncaught throw reports its source location. Both entry points now share one
+  dispatch (`cli-core.ss`), guarded against re-diverging by the load-manifest
+  check.
+
+### Changed
+
+- The smoke and clojure-test-suite gates run against a freshly built joltc
+  binary (10x faster boot than script mode): `make test` drops from ~12 to
+  ~3 minutes (`make -j` parallelizes the rest), and the gates now exercise
+  the shipped artifact — which is how both fixes above were found.
+
 ## [0.2.2] - 2026-07-10
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke submodules
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke submodules
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -42,8 +42,15 @@ unit:
 	@$(CHEZ) --script host/chez/run-unit.ss
 
 # Real-CLI smoke over bin/joltc.
-smoke:
-	@sh host/chez/smoke.sh
+# smoke and cts spawn a joltc process per case; a prebuilt binary boots ~10x
+# faster than script mode (0.14s vs 1.5s), so both build one first (12s,
+# always rebuilt so it can't go stale against edited sources). JOLT_BIN=bin/joltc
+# forces script mode.
+testbin:
+	@$(CHEZ) --script host/chez/build-joltc.ss release target/release/joltc
+
+smoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/joltc}" sh host/chez/smoke.sh
 
 # `jolt build` produces a working standalone binary.
 buildsmoke:
@@ -82,8 +89,8 @@ sci:
 # clojure-test-suite conformance: run the vendored jank-lang/clojure-test-suite
 # per-namespace under joltc, gated on the per-namespace baseline
 # (test/chez/cts-known-failures.txt).
-cts:
-	@bash host/chez/cts.sh
+cts: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/joltc}" bash host/chez/cts.sh
 
 # FFI: bind native functions (typed foreign-procedure), memory, and that a
 # :blocking call is collect-safe (a parked thread doesn't pin the collector).

--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -148,17 +148,10 @@
     ;; JOLT_TRACE at RUNTIME (the env is unset at heap-build), before any app ns
     ;; compiles, so a `-M:run` traces the app's own code.
     (jolt-trace-init-from-env!)
-    (guard (v (#t (jolt-report-throwable v (current-error-port)) (exit 1)))
-      (cond
-        ((and (= (length args) 2) (string=? (car args) \"-e\"))
-         (let ((result (jolt-final-str
-                         (jolt-compile-eval (string-append \"(do \" (cadr args) \")\") \"user\"))))
-           (unless (string=? result \"\") (display result) (newline))))
-        (else
-         (when (and (pair? args) (string=? (car args) \"build\"))
-           (jolt-materialize-bundles!))
-         (load-namespace \"jolt.main\")
-         (apply jolt-invoke (var-deref \"jolt.main\" \"-main\") args))))
+    ;; shared dispatch (cli-core.ss, inlined via the runtime manifest): the -e
+    ;; arm, end-of-options, and uncaught reporting are the same code the script
+    ;; driver runs — the launcher once carried a stale fork of the -e arm.
+    (jolt-cli-run args (lambda () (jolt-materialize-bundles!)))
     (exit 0)))
 "))
 
@@ -199,7 +192,9 @@
     (put-string p
       (string-append
         "(import (chezscheme))\n"
-        "(optimize-level " (if jb-release? "3" "0") ")\n"
+        ;; level 2 not 3: 3 is unsafe mode (no fx/car type checks) and jolt error
+        ;; paths rely on those raising — see bld-chez-param-forms.
+        "(optimize-level " (if jb-release? "2" "0") ")\n"
         "(generate-inspector-information " (jb-bool (not jb-release?)) ")\n"
         "(generate-procedure-source-information " (jb-bool (not jb-release?)) ")\n"
         "(debug-on-exception " (jb-bool (not jb-release?)) ")\n"

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -176,6 +176,7 @@
     "(load \"host/chez/host-contract.ss\")"
     'image
     'compile-eval
+    "(load \"host/chez/cli-core.ss\")"
     "(load \"host/chez/png.ss\")"
     "(load \"host/chez/loader.ss\")"
     "(load \"host/chez/java/ffi.ss\")"
@@ -798,22 +799,26 @@
       (close-port out))))
 
 ;; Per-mode Chez compile parameters for app binaries. Mirrors the pattern in
-;; build-joltc.ss (optimize-level 3, fasl-compressed #t for release/optimized).
+;; build-joltc.ss (optimize-level 2, fasl-compressed #t for release/optimized).
 ;; "release" keeps inspector + proc-source ON so Clojure backtraces (via
 ;; inspect/object walking the continuation) survive. "optimized" turns them OFF
 ;; for max speed. "dev" leaves Chez defaults (optimize-level 2, inspector ON,
 ;; proc-source ON, fasl uncompressed — full debuggability).
 (define (bld-chez-param-forms mode)
+  ;; optimize-level 2, not 3: level 3 is Chez's UNSAFE mode — fx/fl/car/vector
+  ;; ops skip their type checks, and jolt's error semantics depend on those
+  ;; raising ((take nil coll) must throw, not walk off a nil count). Level 2
+  ;; keeps every check with nearly all of the optimization.
   (cond
     ((string=? mode "optimized")
      (string-append
-       "(optimize-level 3)\n"
+       "(optimize-level 2)\n"
        "(generate-inspector-information #f)\n"
        "(generate-procedure-source-information #f)\n"
        "(fasl-compressed #t)\n"))
     ((string=? mode "release")
      (string-append
-       "(optimize-level 3)\n"
+       "(optimize-level 2)\n"
        "(generate-inspector-information #t)\n"
        "(generate-procedure-source-information #t)\n"
        "(fasl-compressed #t)\n"))
@@ -828,11 +833,11 @@
     (bld-prepend-prologue! flat-ss)
     (cond
       ((string=? mode "optimized")
-       (parameterize ((optimize-level 3) (generate-inspector-information #f)
+       (parameterize ((optimize-level 2) (generate-inspector-information #f)
                        (generate-procedure-source-information #f) (fasl-compressed #t))
          (compile-file flat-ss flat-so)))
       ((string=? mode "release")
-       (parameterize ((optimize-level 3) (generate-inspector-information #t)
+       (parameterize ((optimize-level 2) (generate-inspector-information #t)
                        (generate-procedure-source-information #t) (fasl-compressed #t))
          (compile-file flat-ss flat-so)))
       (else

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -1,0 +1,60 @@
+;; Shared CLI dispatch for the two joltc entry points: the script-mode driver
+;; (cli.ss under `chez --script`) and the standalone binary's launcher
+;; (build-joltc.ss scheme-start). Both call jolt-cli-run so the -e handling,
+;; end-of-options rule, and uncaught-throw reporting cannot drift apart — the
+;; binary once carried a stale copy of the -e arm.
+
+;; Render an uncaught jolt throw (any value, not just a Chez condition) to stderr
+;; and exit non-zero, instead of Chez's opaque "non-condition value" dump. The
+;; message/ex-data/cause + a mapped Clojure backtrace come from the shared
+;; renderer (source-registry.ss); this adds the top-level source location.
+(define (jolt-report-uncaught raw)
+  (let ((v (jolt-unwrap-throw raw))
+        (port (current-error-port)))
+    (jolt-render-throwable v port)
+    ;; The top-level form that was evaluating when this propagated (file:line:col).
+    (let ((loc (jolt-current-source-string)))
+      (when loc (display "  at " port) (display loc port) (newline port)))
+    (let ((bt (jolt-backtrace-string v)))
+      (when bt (display "  trace:\n" port) (display bt port)))
+    (exit 1)))
+
+;; POSIX end-of-options: drop the first standalone "--" in an argv list; any
+;; later "--" stays literal program data. Returns a Scheme list.
+(define (drop-end-of-options args)
+  (let loop ((in args) (acc '()))
+    (cond
+      ((null? in) (reverse acc))
+      ((string=? (car in) "--") (append (reverse acc) (cdr in)))
+      (else (loop (cdr in) (cons (car in) acc))))))
+
+;; Dispatch a joltc argv. prepare-build! runs before jolt.main dispatches a
+;; `build` — the script driver loads the build driver from the repo, the
+;; standalone binary materializes its bundled boots/stub (build.ss itself is
+;; already inlined there).
+(define (jolt-cli-run cli-args prepare-build!)
+  (guard (v (#t (jolt-report-uncaught v)))
+    (cond
+      ;; -e EXPR [args…] — evaluate one expression and print it (blank for nil).
+      ;; Wrapped in (do …) so a multi-form string evaluates every form and returns
+      ;; the last. The argv after EXPR are *command-line-args* (nil when empty),
+      ;; with the first standalone "--" consumed as POSIX end-of-options.
+      ((and (pair? cli-args) (string=? (car cli-args) "-e")
+            (pair? (cdr cli-args)))
+       (let* ((expr (cadr cli-args))
+              (app-args (drop-end-of-options (cddr cli-args)))
+              (cla (if (null? app-args) jolt-nil (list->cseq app-args))))
+         (jolt-push-thread-bindings
+           (jolt-hash-map (jolt-var "clojure.core" "*command-line-args*") cla))
+         (let ((result (jolt-final-str
+                         (jolt-compile-eval (string-append "(do " expr ")") "user"))))
+           (jolt-pop-thread-bindings)
+           (unless (string=? result "")
+             (display result) (newline)))))
+      ;; otherwise dispatch the argv through jolt.main/-main
+      (else
+       (when (and (pair? cli-args) (string=? (car cli-args) "build"))
+         (prepare-build!))
+       (load-namespace "jolt.main")
+       (let ((mainv (var-deref "jolt.main" "-main")))
+         (apply jolt-invoke mainv cli-args))))))

--- a/host/chez/cli.ss
+++ b/host/chez/cli.ss
@@ -39,6 +39,7 @@
 (load "host/chez/host-contract.ss")
 (load "host/chez/seed/image.ss")
 (load "host/chez/compile-eval.ss")
+(load "host/chez/cli-core.ss")
 (load "host/chez/png.ss")          ; jolt.png — a baked namespace before the snapshot
 (load "host/chez/loader.ss")
 ;; jolt.ffi host primitives (memory / library loading) load AFTER the loader's
@@ -51,58 +52,15 @@
 ;; A project's resolved deps roots are prepended to these by jolt.main.
 (set-source-roots! (list "jolt-core" "stdlib"))
 
-;; Render an uncaught jolt throw (any value, not just a Chez condition) to stderr
-;; and exit non-zero, instead of Chez's opaque "non-condition value" dump. The
-;; message/ex-data/cause + a mapped Clojure backtrace come from the shared
-;; renderer (source-registry.ss); the cli adds the top-level source location.
-(define (jolt-report-uncaught raw)
-  (let ((v (jolt-unwrap-throw raw))
-        (port (current-error-port)))
-    (jolt-render-throwable v port)
-    ;; The top-level form that was evaluating when this propagated (file:line:col).
-    (let ((loc (jolt-current-source-string)))
-      (when loc (display "  at " port) (display loc port) (newline port)))
-    (let ((bt (jolt-backtrace-string v)))
-      (when bt (display "  trace:\n" port) (display bt port)))
-    (exit 1)))
+;; jolt-report-uncaught / drop-end-of-options / the -e arm live in cli-core.ss,
+;; shared with the standalone binary's launcher (build-joltc.ss).
 
 ;; JOLT_TRACE opt-in, at runtime (before any app ns compiles) so the app is traced.
 (jolt-trace-init-from-env!)
 
-;; POSIX end-of-options: drop the first standalone "--" in an argv list; any
-;; later "--" stays literal program data. Returns a Scheme list.
-(define (drop-end-of-options args)
-  (let loop ((in args) (acc '()))
-    (cond
-      ((null? in) (reverse acc))
-      ((string=? (car in) "--") (append (reverse acc) (cdr in)))
-      (else (loop (cdr in) (cons (car in) acc))))))
 
-(guard (v (#t (jolt-report-uncaught v)))
-  (cond
-    ;; -e EXPR [args…] — evaluate one expression and print it (blank for nil).
-    ;; Wrapped in (do …) so a multi-form string evaluates every form and returns
-    ;; the last. The argv after EXPR are *command-line-args* (nil when empty),
-    ;; with the first standalone "--" consumed as POSIX end-of-options.
-    ((and (pair? cli-args) (string=? (car cli-args) "-e")
-          (pair? (cdr cli-args)))
-     (let* ((expr (cadr cli-args))
-            (app-args (drop-end-of-options (cddr cli-args)))
-            (cla (if (null? app-args) jolt-nil (list->cseq app-args))))
-       (jolt-push-thread-bindings
-         (jolt-hash-map (jolt-var "clojure.core" "*command-line-args*") cla))
-       (let ((result (jolt-final-str
-                       (jolt-compile-eval (string-append "(do " expr ")") "user"))))
-         (jolt-pop-thread-bindings)
-         (unless (string=? result "")
-           (display result) (newline)))))
-    ;; otherwise dispatch the argv through jolt.main/-main
-    (else
-     ;; `build` AOT-compiles an app to a standalone binary — load the build
-     ;; driver (the cross-compiler emitter) on demand so a normal run never pays
-     ;; for it. It defines jolt.host/build-binary, which jolt.main's build cmd calls.
-     (when (and (pair? cli-args) (string=? (car cli-args) "build"))
-       (load "host/chez/build.ss"))
-     (load-namespace "jolt.main")
-     (let ((mainv (var-deref "jolt.main" "-main")))
-       (apply jolt-invoke mainv cli-args)))))
+(jolt-cli-run cli-args
+  ;; `build` AOT-compiles an app to a standalone binary — load the build driver
+  ;; (the cross-compiler emitter) on demand so a normal run never pays for it.
+  ;; It defines jolt.host/build-binary, which jolt.main's build cmd calls.
+  (lambda () (load "host/chez/build.ss")))

--- a/host/chez/cts.sh
+++ b/host/chez/cts.sh
@@ -19,8 +19,13 @@ cd "$root"
 suite="vendor/clojure-test-suite/test"
 baseline="test/chez/cts-known-failures.txt"
 app="$root/test/chez/cts-app"
-jobs="${JOLT_CTS_JOBS:-4}"
+# one process per namespace; default the worker count to the CPU count
+cpus="$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)"
+jobs="${JOLT_CTS_JOBS:-$cpus}"
 tmo="${JOLT_CTS_TIMEOUT:-120}"
+# JOLT_BIN overrides the joltc under test (make test points it at the freshly
+# built target/release/joltc — 10x faster boot than script mode)
+joltc="${JOLT_BIN:-$root/bin/joltc}"
 
 if [ ! -d "$suite/clojure" ]; then
   echo "cts: skipped (git submodule update --init vendor/clojure-test-suite)"
@@ -43,7 +48,7 @@ awk -v j="$jobs" '{print > ("'"$work"'/chunk." (NR % j))}' "$work/nses"
 run_chunk() {
   chunk="$1"; out="$2"
   while IFS= read -r ns; do
-    res=$(JOLT_PWD="$app" perl -e "alarm $tmo; exec @ARGV" -- "$root/bin/joltc" -M:cts "$ns" 2>&1 </dev/null)
+    res=$(JOLT_PWD="$app" perl -e "alarm $tmo; exec @ARGV" -- "$joltc" -M:cts "$ns" 2>&1 </dev/null)
     rc=$?
     line=$(echo "$res" | grep '^CTS-RESULT' | head -1)
     if [ -n "$line" ]; then

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
-# CLI smoke: exercise the real bin/joltc process end to end — core eval, runtime
+# CLI smoke: exercise the real joltc process end to end — core eval, runtime
 # eval/load-string, runtime defmacro, futures, and the numeric tower. The in-process
 # corpus/unit gates cover semantics in depth; this confirms the CLI entry itself.
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
 
+# JOLT_BIN overrides the joltc under test (make test points it at the freshly
+# built target/release/joltc — 10x faster boot than script mode; the explicit
+# script-mode case below keeps the source-load path covered).
+joltc="${JOLT_BIN:-bin/joltc}"
+
 fails=0
 check() {
-  got="$(bin/joltc -e "$1" 2>/dev/null | tail -1)"
+  got="$($joltc -e "$1" 2>/dev/null | tail -1)"
   if [ "$got" = "$2" ]; then
     pass=$((pass + 1))
   else
@@ -20,7 +25,7 @@ pass=0
 
 # An uncaught error reports the source location of the top-level form (stderr).
 check_loc() {
-  err="$(bin/joltc -e "$1" 2>&1 >/dev/null)"
+  err="$($joltc -e "$1" 2>&1 >/dev/null)"
   if printf '%s' "$err" | grep -q "$2"; then
     pass=$((pass + 1))
   else
@@ -34,7 +39,7 @@ check_loc() {
 # survive TCO (the non-tail spine), even though the eval path registers no source
 # map — "print what is available". Asserts a substring appears under "  trace:".
 check_trace() {
-  err="$(bin/joltc -e "$1" 2>&1 >/dev/null)"
+  err="$($joltc -e "$1" 2>&1 >/dev/null)"
   if printf '%s' "$err" | grep -q '  trace:' && printf '%s' "$err" | grep -q "$2"; then
     pass=$((pass + 1))
   else
@@ -48,7 +53,7 @@ check_trace() {
 # ERE) must match the "  trace:" block. Used to assert TCO-elided frames are
 # recovered and non-tail caller context survives a tail loop.
 check_trace_on() {
-  err="$(JOLT_TRACE=1 bin/joltc -e "$1" 2>&1 >/dev/null)"
+  err="$(JOLT_TRACE=1 $joltc -e "$1" 2>&1 >/dev/null)"
   ok=1
   printf '%s' "$err" | grep -q '  trace:' || ok=0
   shift
@@ -117,7 +122,7 @@ check_trace_on '(defn g [n] (+ :x n)) (defn ^long f [n] (g n)) (f 3)' 'f' 'g'
 # (h2/u2), not frames from an earlier, already-returned form (h1/u1).
 check_trace_on '(defn h1 [x] (inc x)) (defn u1 [] (inc (h1 5))) (u1) (defn h2 [x] (+ :x x)) (defn u2 [] (inc (h2 5))) (u2)' \
   'h2' 'u2'
-err_stale="$(JOLT_TRACE=1 bin/joltc -e '(defn h1 [x] (inc x)) (defn u1 [] (inc (h1 5))) (u1) (defn h2 [x] (+ :x x)) (defn u2 [] (inc (h2 5))) (u2)' 2>&1 >/dev/null)"
+err_stale="$(JOLT_TRACE=1 $joltc -e '(defn h1 [x] (inc x)) (defn u1 [] (inc (h1 5))) (u1) (defn h2 [x] (+ :x x)) (defn u2 [] (inc (h2 5))) (u2)' 2>&1 >/dev/null)"
 if printf '%s' "$err_stale" | grep -q 'h1'; then
   echo "  FAIL (trace-on): stale frame h1 from an earlier form leaked into the trace"
   fails=$((fails + 1))
@@ -130,7 +135,7 @@ tr_proj="$(mktemp -d)"
 mkdir -p "$tr_proj/src/tp"
 printf '{:paths ["src"] :aliases {:run {:main-opts ["-m" "tp.core"]}}}\n' > "$tr_proj/deps.edn"
 printf '(ns tp.core)\n(defn deep [x] (+ x 1))\n(defn mid [x] (inc (deep x)))\n(defn -main [& _] (mid :nan))\n' > "$tr_proj/src/tp/core.clj"
-tr_out="$(JOLT_TRACE=1 JOLT_PWD="$tr_proj" bin/joltc -M:run 2>&1)"
+tr_out="$(JOLT_TRACE=1 JOLT_PWD="$tr_proj" $joltc -M:run 2>&1)"
 if printf '%s' "$tr_out" | grep -Eq 'tp\.core/deep \(.*/tp/core\.clj:2\)'; then
   pass=$((pass + 1))
 else
@@ -148,47 +153,47 @@ cla_check() {
   if [ "$out" = "$2" ]; then pass=$((pass + 1))
   else echo "  FAIL: $1"; echo "    want \`$2\` got \`$out\`"; fails=$((fails + 1)); fi
 }
-cla_check "bin/joltc -e '(println *command-line-args*)' one two three" '(one two three)'
-cla_check "bin/joltc -e '(println *command-line-args*)' -- one two"      '(one two)'
-cla_check "bin/joltc -e '(println *command-line-args*)' -- -e"           '(-e)'
-cla_check "bin/joltc -e '(println *command-line-args*)' a -- b -- c"     '(a b -- c)'
-cla_check "bin/joltc -e '(println *command-line-args*)'"                 'nil'
+cla_check "$joltc -e '(println *command-line-args*)' one two three" '(one two three)'
+cla_check "$joltc -e '(println *command-line-args*)' -- one two"      '(one two)'
+cla_check "$joltc -e '(println *command-line-args*)' -- -e"           '(-e)'
+cla_check "$joltc -e '(println *command-line-args*)' a -- b -- c"     '(a b -- c)'
+cla_check "$joltc -e '(println *command-line-args*)'"                 'nil'
 # run FILE -- ... : the "--" is consumed, "-e" stays a program arg.
 rc_dir="$(mktemp -d)"; rc="$rc_dir/rc.clj"; printf '(prn *command-line-args*)\n' > "$rc"
-cla_check "bin/joltc run \"$rc\" -- -e x" '("-e" "x")'
+cla_check "$joltc run \"$rc\" -- -e x" '("-e" "x")'
 rm -rf "$rc_dir"
 # -m NS -- ... : same end-of-options rule for a namespace -main.
 mp="$(mktemp -d)"; mkdir -p "$mp/src"
 printf '{:paths ["src"]}\n' > "$mp/deps.edn"
 printf '(ns mcmd) (defn -main [& a] (prn *command-line-args*))\n' > "$mp/src/mcmd.clj"
-cla_check "JOLT_PWD=\"$mp\" bin/joltc -m mcmd -- a b" '("a" "b")'
+cla_check "JOLT_PWD=\"$mp\" $joltc -m mcmd -- a b" '("a" "b")'
 rm -rf "$mp"
 
 # help prints usage (bare `help` and --help/-h are synonyms) and lists the
 # nREPL server as a bare command.
-help_out="$(bin/joltc help 2>/dev/null)"
+help_out="$($joltc help 2>/dev/null)"
 if printf '%s' "$help_out" | grep -q 'nrepl-server'; then
   pass=$((pass + 1))
 else
   echo "  FAIL: help should list nrepl-server"
   fails=$((fails + 1))
 fi
-if [ "$(bin/joltc --help 2>/dev/null)" = "$help_out" ]; then
+if [ "$($joltc --help 2>/dev/null)" = "$help_out" ]; then
   pass=$((pass + 1))
 else
   echo "  FAIL: --help should print the same usage as help"
   fails=$((fails + 1))
 fi
 # version / --version are synonyms and name the version.
-if bin/joltc version 2>/dev/null | grep -q '^jolt ' \
-   && [ "$(bin/joltc version 2>/dev/null)" = "$(bin/joltc --version 2>/dev/null)" ]; then
+if $joltc version 2>/dev/null | grep -q '^jolt ' \
+   && [ "$($joltc version 2>/dev/null)" = "$($joltc --version 2>/dev/null)" ]; then
   pass=$((pass + 1))
 else
   echo "  FAIL: version / --version"
   fails=$((fails + 1))
 fi
 # bare joltc starts a REPL (bb/clj parity): piped stdin evaluates and exits.
-repl_out="$(printf '(+ 1 2)\n' | bin/joltc 2>/dev/null)"
+repl_out="$(printf '(+ 1 2)\n' | $joltc 2>/dev/null)"
 if printf '%s' "$repl_out" | grep -q '3'; then
   pass=$((pass + 1))
 else
@@ -199,7 +204,7 @@ fi
 # clojure.test extension points (assert-expr / do-report / report) need separate
 # top-level forms — assert-expr must register before `is` expands — so this is a
 # multi-form `joltc run`, not an -e one-liner. The file self-checks its tallies.
-ct_out="$(bin/joltc run test/chez/clojure-test.clj 2>/dev/null)"
+ct_out="$($joltc run test/chez/clojure-test.clj 2>/dev/null)"
 if printf '%s' "$ct_out" | grep -q 'CLOJURE-TEST OK'; then
   pass=$((pass + 1))
 else
@@ -210,7 +215,7 @@ fi
 
 # A throwing go/thread body reports to stderr (the JVM's uncaught-exception
 # handler behavior) while the channel still just closes: <!! stays nil.
-thr_out="$(bin/joltc -e "(do (require '[clojure.core.async :as a]) (pr (a/<!! (a/thread (/ 1 0)))))" 2>/tmp/jolt-smoke-thr-err)"
+thr_out="$($joltc -e "(do (require '[clojure.core.async :as a]) (pr (a/<!! (a/thread (/ 1 0)))))" 2>/tmp/jolt-smoke-thr-err)"
 if [ "$thr_out" = "nil" ] && grep -q "Exception in go/thread body" /tmp/jolt-smoke-thr-err; then
   pass=$((pass + 1))
 else
@@ -219,7 +224,7 @@ else
   fails=$((fails + 1))
 fi
 # Same for a raw Thread body.
-bin/joltc -e '(do (.start (Thread. (fn [] (throw (ex-info "boom" {}))))) (Thread/sleep 200))' 2>/tmp/jolt-smoke-thr2-err >/dev/null
+$joltc -e '(do (.start (Thread. (fn [] (throw (ex-info "boom" {}))))) (Thread/sleep 200))' 2>/tmp/jolt-smoke-thr2-err >/dev/null
 if grep -q "Exception in Thread body" /tmp/jolt-smoke-thr2-err; then
   pass=$((pass + 1))
 else
@@ -231,7 +236,7 @@ fi
 rp="$(mktemp -d)/rproj"; mkdir -p "$rp/src"
 printf '{:paths ["src"]}\n' > "$rp/deps.edn"
 printf '(ns app)\n(def broken "unterminated\n' > "$rp/src/app.clj"
-rerr="$(JOLT_PWD="$rp" bin/joltc run -m app 2>&1)"
+rerr="$(JOLT_PWD="$rp" $joltc run -m app 2>&1)"
 if printf '%s' "$rerr" | grep -q 'src/app.clj:'; then
   pass=$((pass + 1))
 else
@@ -244,7 +249,7 @@ fi
 # without :git/sha names the coordinate.
 bp="$(mktemp -d)/badproj"; mkdir -p "$bp/src"
 printf '{:paths ["src" :oops\n' > "$bp/deps.edn"
-berr="$(JOLT_PWD="$bp" bin/joltc run -m app 2>&1)"
+berr="$(JOLT_PWD="$bp" $joltc run -m app 2>&1)"
 if printf '%s' "$berr" | grep -q 'deps.edn'; then
   pass=$((pass + 1))
 else
@@ -254,7 +259,7 @@ fi
 gp="$(mktemp -d)/gitproj"; mkdir -p "$gp/src"
 printf '{:paths ["src"] :deps {some/dep {:git/url "https://example.com/x.git"}}}\n' > "$gp/deps.edn"
 printf '(ns app)\n(defn -main [& _] (println :ok))\n' > "$gp/src/app.clj"
-gerr="$(JOLT_PWD="$gp" bin/joltc run -m app 2>&1)"
+gerr="$(JOLT_PWD="$gp" $joltc run -m app 2>&1)"
 if printf '%s' "$gerr" | grep -q 'needs :git/sha'; then
   pass=$((pass + 1))
 else
@@ -265,7 +270,7 @@ fi
 
 # context-bound dynamic vars: *file*/*source-path* during a load,
 # *command-line-args*, *agent* inside an action, ns-map/ns-refers visibility.
-ctx_out="$(bin/joltc run test/chez/ctxvars-test.clj a1 a2 2>/dev/null)"
+ctx_out="$($joltc run test/chez/ctxvars-test.clj a1 a2 2>/dev/null)"
 if printf '%s' "$ctx_out" | grep -q 'CTXVARS OK'; then
   pass=$((pass + 1))
 else
@@ -275,7 +280,7 @@ else
 fi
 
 # STM (refs) threaded tests: isolation, txn-leak, io! in future.
-stm_out="$(bin/joltc run test/chez/stm-test.clj 2>/dev/null)"
+stm_out="$($joltc run test/chez/stm-test.clj 2>/dev/null)"
 if printf '%s' "$stm_out" | grep -q 'STM OK'; then
   pass=$((pass + 1))
 else
@@ -285,7 +290,7 @@ else
 fi
 
 # tap system + agent API: async delivery, error modes, held nested sends.
-ta_out="$(bin/joltc run test/chez/tap-agents-test.clj 2>/dev/null)"
+ta_out="$($joltc run test/chez/tap-agents-test.clj 2>/dev/null)"
 if printf '%s' "$ta_out" | grep -q 'TAP-AGENTS OK'; then
   pass=$((pass + 1))
 else
@@ -296,7 +301,7 @@ fi
 
 # jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
 # move, mtime round-trip, which). The file self-checks and prints one marker.
-fs_out="$(bin/joltc run test/chez/fs-test.clj 2>/dev/null)"
+fs_out="$($joltc run test/chez/fs-test.clj 2>/dev/null)"
 if printf '%s' "$fs_out" | grep -q 'FS-TEST OK'; then
   pass=$((pass + 1))
 else
@@ -307,7 +312,7 @@ fi
 
 # jolt.parser — the general parser-combinator core, running rm-hull/jasentaa's
 # own suite for the adopted pieces plus jolt's added combinators. Self-checks.
-parser_out="$(bin/joltc run test/chez/parser-test.clj 2>/dev/null)"
+parser_out="$($joltc run test/chez/parser-test.clj 2>/dev/null)"
 if printf '%s' "$parser_out" | grep -q 'PARSER OK'; then
   pass=$((pass + 1))
 else
@@ -318,7 +323,7 @@ fi
 
 # jolt.infix — jolt's built-in infix math notation, running rm-hull/infix's own
 # suite (macros/grammar/core tests). The file self-checks and prints one marker.
-infix_out="$(bin/joltc run test/chez/infix-test.clj 2>/dev/null)"
+infix_out="$($joltc run test/chez/infix-test.clj 2>/dev/null)"
 if printf '%s' "$infix_out" | grep -q 'INFIX OK'; then
   pass=$((pass + 1))
 else
@@ -331,7 +336,7 @@ fi
 # must have its result spliced in and COMPILED, like Clojure — #code [:x] becomes
 # (+ 40 2) and evaluates to 42, not the literal list. A project run so the source
 # root's data_readers.clj is picked up.
-dr_out="$(JOLT_PWD="$root/test/chez/datareader-app" bin/joltc run -m drtest.main 2>/dev/null | tail -1)"
+dr_out="$(JOLT_PWD="$root/test/chez/datareader-app" $joltc run -m drtest.main 2>/dev/null | tail -1)"
 if [ "$dr_out" = "42" ]; then
   pass=$((pass + 1))
 else
@@ -342,7 +347,7 @@ fi
 # A required namespace's own :as aliases must not leak into the requirer: fix.main
 # aliases clojure.string as ss and requires fix.lib (which aliases clojure.set as
 # ss); (ss/upper-case "hi") in main must stay clojure.string -> "HI #{1 2}".
-al_out="$(JOLT_PWD="$root/test/chez/alias-leak-app" bin/joltc run -m fix.main 2>/dev/null | tail -1)"
+al_out="$(JOLT_PWD="$root/test/chez/alias-leak-app" $joltc run -m fix.main 2>/dev/null | tail -1)"
 if [ "$al_out" = "HI #{1 2}" ]; then
   pass=$((pass + 1))
 else
@@ -354,7 +359,7 @@ fi
 # whose var resolves surfaces a throw (not silently degraded), the LIST-libspec
 # superset (use '(ns :only [x])), and the prefix-list form ((require '(pfx [c :as s]))).
 # The fixture writes its own scratch ns files under a temp dir and requires them.
-loader_out="$(bin/joltc run test/chez/loader-test.clj 2>/dev/null)"
+loader_out="$($joltc run test/chez/loader-test.clj 2>/dev/null)"
 if printf '%s' "$loader_out" | grep -q 'LOADER OK'; then
   pass=$((pass + 1))
 else
@@ -366,7 +371,7 @@ fi
 # Unit-checks the REPL read-until-complete predicate over balanced/unbalanced,
 # string, comment and regex-literal inputs. A multi-form `joltc run` so jolt.main
 # is loaded and its private var resolves; the file self-checks and prints a sentinel.
-rr_out="$(bin/joltc run test/chez/repl-reader-test.clj 2>/dev/null)"
+rr_out="$($joltc run test/chez/repl-reader-test.clj 2>/dev/null)"
 if printf '%s' "$rr_out" | grep -q 'REPL-READER OK'; then
   pass=$((pass + 1))
 else
@@ -378,7 +383,7 @@ fi
 # REPL must exit on :repl/quit / :exit — a reliable exit that works in any
 # terminal, unlike ^D (which some terminals/editors don't deliver as EOF).
 # Pipe: an evaluable form, the quit keyword, then a sentinel that must NOT run.
-repl_out="$(printf '(+ 1000 23)\n:repl/quit\n(* 999 9)\n' | bin/joltc repl 2>/dev/null)"
+repl_out="$(printf '(+ 1000 23)\n:repl/quit\n(* 999 9)\n' | $joltc repl 2>/dev/null)"
 if printf '%s' "$repl_out" | grep -q '1023' && ! printf '%s' "$repl_out" | grep -q '8991'; then
   pass=$((pass + 1))
 else
@@ -387,7 +392,7 @@ else
   fails=$((fails + 1))
 fi
 
-repl_out="$(printf '(- 2024 1)\n:exit\n(* 999 9)\n' | bin/joltc repl 2>/dev/null)"
+repl_out="$(printf '(- 2024 1)\n:exit\n(* 999 9)\n' | $joltc repl 2>/dev/null)"
 if printf '%s' "$repl_out" | grep -q '2023' && ! printf '%s' "$repl_out" | grep -q '8991'; then
   pass=$((pass + 1))
 else
@@ -398,7 +403,7 @@ fi
 
 # A form split across lines is accumulated and evaluated once complete, with a
 # secondary continuation prompt before each continued line.
-repl_out="$(printf '(+ 1\n2)\n:exit\n' | bin/joltc repl 2>/dev/null)"
+repl_out="$(printf '(+ 1\n2)\n:exit\n' | $joltc repl 2>/dev/null)"
 if printf '%s' "$repl_out" | grep -q '3' && ! printf '%s' "$repl_out" | grep -q 'error'; then
   pass=$((pass + 1))
 else
@@ -409,7 +414,7 @@ fi
 
 # A single-line regex literal is complete on its own — the #" opens a regex whose
 # body (delimiters, quotes and all) must not be miscounted as unbalanced parens.
-repl_out="$(printf '(re-find #"(a)(b)" "ab")\n:exit\n' | bin/joltc repl 2>/dev/null)"
+repl_out="$(printf '(re-find #"(a)(b)" "ab")\n:exit\n' | $joltc repl 2>/dev/null)"
 if printf '%s' "$repl_out" | grep -q 'ab' && ! printf '%s' "$repl_out" | grep -q 'error'; then
   pass=$((pass + 1))
 else
@@ -421,7 +426,7 @@ fi
 # REPL-driven development traces by default: an error in an evaluated form shows a
 # tail-frame backtrace with no JOLT_TRACE set. rb tail-calls ra tail-calls +, all
 # TCO-elided from the continuation — only the history recovers them.
-repl_err="$(printf '(defn ra [x] (+ x 1))\n(defn rb [x] (ra x))\n(rb :nan)\n:exit\n' | bin/joltc repl 2>&1)"
+repl_err="$(printf '(defn ra [x] (+ x 1))\n(defn rb [x] (ra x))\n(rb :nan)\n:exit\n' | $joltc repl 2>&1)"
 if printf '%s' "$repl_err" | grep -q '  trace:' && printf '%s' "$repl_err" | grep -q 'rb'; then
   pass=$((pass + 1))
 else
@@ -430,12 +435,21 @@ else
   fails=$((fails + 1))
 fi
 # JOLT_TRACE=0 opts out — no trace in the REPL.
-repl_off="$(printf '(defn ra [x] (+ x 1))\n(defn rb [x] (ra x))\n(rb :nan)\n:exit\n' | JOLT_TRACE=0 bin/joltc repl 2>&1)"
+repl_off="$(printf '(defn ra [x] (+ x 1))\n(defn rb [x] (ra x))\n(rb :nan)\n:exit\n' | JOLT_TRACE=0 $joltc repl 2>&1)"
 if printf '%s' "$repl_off" | grep -q '  trace:'; then
   echo "  FAIL: JOLT_TRACE=0 should suppress the REPL trace"
   fails=$((fails + 1))
 else
   pass=$((pass + 1))
+fi
+
+# script-mode boot: bin/joltc (chez --script over the seed source) must still
+# work even when the rest of the smoke runs against a prebuilt JOLT_BIN.
+if [ "$(bin/joltc -e '(+ 20 22)' 2>/dev/null | tail -1)" = "42" ]; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: script-mode bin/joltc boot"
+  fails=$((fails + 1))
 fi
 
 echo "cli smoke: $pass passed, $fails failed"


### PR DESCRIPTION
Test-speed pass that turned into a bug hunt.

**Speed**: smoke and cts spawn a joltc per case; the prebuilt binary boots 10x faster (0.14s vs 1.5s) than script mode, so both gates build target/release/joltc once (12s) and run against it (JOLT_BIN; bin/joltc stays the default, one script-mode smoke case keeps that path covered). cts workers default to CPU count. CI runs make -j. Numbers: smoke 105s→27s, cts 135s→29s, full make test ~12min→173s (-j8). corpus stays untouched — 3729 JVM-certified rows in 4s is the spec, not the cost.

**Bug 1 — binary -e fork**: the standalone launcher replicated cli.ss's dispatch and fossilized pre-#328: `joltc -e EXPR args…` was 'unknown command or task: -e', no --, no error locations, in every shipped binary. Both entry points now share cli-core.ss, inlined via the runtime manifest so manifest-check forbids re-divergence.

**Bug 2 — optimize-level 3 is unsafe mode**: release/optimized builds compiled at O3, where Chez's fx/fl/car ops skip type checks — and jolt's error semantics depend on those raising. Shipped binaries returned `(take nil coll)` instead of throwing and hung on nil-count `repeat` (caught the moment cts ran against the binary). Now O2: every check kept, ~13% mono-dispatch / ~8% binary-trees / 0% numerics; jolt-si8x tracks recovering O3 for inference-proven regions.

Both bugs ship in v0.2.2 → a v0.2.3 follows this merge.

Gates: full make test green incl. cts at the exact baseline against the O2 binary, joltcsmoke (self-build), manifestcheck, buildsmoke/shakesmoke.