### PR TITLE
Docs: typed arithmetic model; deftype dispatch, Map views, Date deprecated surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Modes trade dynamism for speed: the default (release) build uses the proven code
 generator; `--opt` also runs the inference + inlining + scalar-replacement passes
 over the closed-world program; `--dev` is unoptimized.
 
+Numeric code unboxes to raw flonum/fixnum machine ops when types are proven —
+by whole-program inference (float literals, record fields, protocol returns:
+no annotations needed), by JVM-style `^double`/`^long` hints, or by
+`(double x)`/`(long x)` casts where inference can't see. See
+[docs/building-and-deps.md](docs/building-and-deps.md#typed-arithmetic-and-inference).
+
 Two opt-in closed-world flags cut dispatch cost and binary size:
 
 ```bash

--- a/docs/building-and-deps.md
+++ b/docs/building-and-deps.md
@@ -147,6 +147,32 @@ closed-world binaries, combine `--opt --direct-link --tree-shake` to drop dead c
 `--dev` produces a debug binary under `target/debug/` (const-fold + numeric annotate
 only), typically used during development for faster build times.
 
+### Typed arithmetic and inference
+
+Numeric code compiles to raw Chez flonum/fixnum operations (`fl*`, `fx+`) when
+the compiler can prove every operand's type. Three things prove types, in order
+of preference:
+
+1. **Inference.** Whole-program builds (`build`, or running a program with
+   `-m`) infer types with no annotations: float literals and their arithmetic,
+   `^double`/`^long` signatures across call sites, record fields whose every
+   constructor site passes a flonum, protocol-method returns, and reduce/HOF
+   accumulators all propagate. Most hot float code needs nothing else.
+2. **`^double` / `^long` hints** on fn params, returns, loop bindings, and
+   record fields. A hint is a contract enforced by coercion at the boundary:
+   a `^double` param converts its argument on entry, a `^long` param is a
+   fixnum promise — arithmetic on it raises on 61-bit overflow instead of
+   promoting to bignum. Use `^long` only where overflow is impossible.
+3. **`(double x)` / `(long x)` casts** where inference can't see — a value
+   from I/O, an untyped map, a dynamic call. The cast keeps its full Clojure
+   semantics (throws on non-numbers, `(long 1.5)` truncates) and types the
+   result like a hint. Portable: the same code speeds up on the JVM.
+
+Inference stays sound by widening: a conflicting, escaping, or unprovable type
+falls back to the generic (boxed, correct) path, never a wrong answer.
+Interactive modes (`repl`, `-e`, `nrepl-server`) skip whole-program passes so
+redefinition keeps working.
+
 ### deps.edn build options
 
 The `:jolt/build` map in `deps.edn` accepts these keys:

--- a/docs/host-interop.md
+++ b/docs/host-interop.md
@@ -110,6 +110,10 @@ aren't implemented; a few are accepted but no-ops (noted inline).
 
 - **`java.util.ArrayList`** — `add` `get` `set` `size` `isEmpty` `remove` `clear`
   `contains` `toArray` `iterator`.
+- **`java.util.Map` views on persistent maps** — a Jolt map answers the read-only
+  Map surface directly: `.keySet` `.values` `.entrySet` `.size` `.isEmpty`
+  `.containsKey` `.get`, so library code that walks a map through the Java
+  interface works unchanged.
 - **`java.util.HashMap`** / **`java.util.concurrent.ConcurrentHashMap`** — `put`
   `get` `getOrDefault` `containsKey` `containsValue` `size` `isEmpty` `remove`
   `clear` `putAll` `keySet` `values` `entrySet`; `clojure.core`'s `get` / `count` /
@@ -147,7 +151,10 @@ aren't implemented; a few are accepted but no-ops (noted inline).
 ### Time and date
 
 - **`java.util.Date`** — `(Date.)` / `(Date. ms)`; `getTime` `toInstant`
-  `toLocalDate(Time)` `before` `after` `equals` `toString` (RFC 3339).
+  `toLocalDate(Time)` `before` `after` `equals` `toString` (RFC 3339). The
+  deprecated calendar surface works too: `getYear` (1900-based) `getMonth`
+  (0-based) `getDate` `getDay` `getHours` `getMinutes` `getSeconds`, and the
+  multi-arg `(Date. year-1900 month0 date [hrs min [sec]])` constructor.
 - **`java.time`** — `Instant` (`now`, `ofEpochMilli`, `toEpochMilli`, `atZone`),
   `LocalDateTime`, `ZoneId`, `DateTimeFormatter` (`ofPattern`, `ISO_LOCAL_*`,
   localized styles), `FormatStyle`.
@@ -265,6 +272,15 @@ record's ancestry carries the record interfaces (`clojure.lang.IRecord`,
 an implemented interface — so `(ancestors MyRecord)`, `(isa? MyRecord
 clojure.lang.IPersistentMap)`, and hierarchy relationships `derive`d on a
 class's supers all answer like the JVM.
+
+A deftype *implementing* a `clojure.lang` collection interface drives the core
+functions through its methods, like the JVM: `Indexed` → `nth`, `Counted` →
+`count`, `ILookup` → `get`/keyword lookup, `Associative` → `assoc`, `ISeq`/
+`Seqable` → `seq`/`first`/`rest`, `IPersistentCollection` → `conj`, `Reversible`
+→ `rseq`, `Sorted` → `subseq`/`rsubseq`, `IDeref` → `deref`/`@`, `IFn` → the
+value is callable, `IReduceInit` → `reduce`. Methods can be arity-overloaded
+across interfaces (`seq [this]` and `seq [this ascending]`), and a marker
+protocol with no methods still answers `satisfies?`/`instance?`.
 
 Extending a *built-in* class instead (adding a method to core's `String` shim,
 say) means editing the relevant `host/chez/*.ss` file and running `make remint`


### PR DESCRIPTION
Documents the numeric performance model users actually have now: whole-program
inference (no annotations — float literals, ctor-joined record fields, protocol
returns, reduce accumulators), ^double/^long hints as boundary contracts (entry
coercion; ^long raises on fixnum overflow), and the (double x)/(long x) casts
from #340 as the portable escape hatch. New section in building-and-deps.md,
pointer from the README build section.

host-interop.md picks up three shipped-but-undocumented surfaces, each verified
against the compiler before writing: deftype clojure.lang-interface method
dispatch (Indexed/Counted/ILookup/Associative/ISeq/IFn/Sorted/IDeref/
IReduceInit, arity-overloaded methods, marker protocols), java.util.Map views
on persistent maps (.keySet/.entrySet/.containsKey/...), and java.util.Date's
deprecated calendar getters + multi-arg constructor.

Docs only. Closes jolt-biro, jolt-glwi.