### PR TITLE
java.time: 1-arg .until returns a Period

### DIFF
--- a/host/chez/java/java-time.ss
+++ b/host/chez/java/java-time.ss
@@ -1218,7 +1218,9 @@
                                                         (temporal-plus-period t a -1)))
                                 (else (error #f "minus: bad amount"))))
                    ((t n u) (temporal-plus-unit t (- (jt->exact n)) (arg-unit-name u)))))
-   (cons "until" (lambda (t o u) (unit-between (arg-unit-name u) t o)))
+   (cons "until" (case-lambda
+                   ((t o) (per-between t o))                                ; (.until start end) -> Period
+                   ((t o u) (unit-between (arg-unit-name u) t o))))
    (cons "get" (lambda (t f) (temporal-get-field t (arg-field-name f))))
    (cons "getLong" (lambda (t f) (temporal-get-field t (arg-field-name f))))
    (cons "with" (case-lambda

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3358,6 +3358,7 @@
   {:suite "interop / java.time" :label "Instant getNano of negative nano" :expected "999999999" :actual "(.getNano (.plusNanos (java.time.Instant/ofEpochSecond 0) -1))" :portability :jvm}
   {:suite "interop / java.time" :label "Instant toEpochMilli floors sub-milli" :expected "1000" :actual "(.toEpochMilli (.plusNanos (java.time.Instant/ofEpochSecond 1) 999999))" :portability :jvm}
   {:suite "interop / java.time" :label "Instant truncatedTo SECONDS drops nanos" :expected "\"1970-01-01T00:00:05Z\"" :actual "(str (.truncatedTo (.plusNanos (java.time.Instant/ofEpochSecond 5) 123) java.time.temporal.ChronoUnit/SECONDS))" :portability :jvm}
+  {:suite "interop / java.time" :label "LocalDate until without unit yields a Period" :expected "\"P6M10D\"" :actual "(str (.until (java.time.LocalDate/of 2026 1 1) (java.time.LocalDate/of 2026 7 11)))" :portability :jvm}
   {:suite "interop / java.io File" :label "getName" :expected "\"c.txt\"" :actual "(.getName (java.io.File. \"/a/b/c.txt\"))" :portability :jvm}
   {:suite "interop / java.io File" :label "getParent" :expected "\"/a/b\"" :actual "(.getParent (java.io.File. \"/a/b/c.txt\"))" :portability :jvm}
   {:suite "interop / java.io File" :label "getPath keeps relative path" :expected "\"rel/x\"" :actual "(.getPath (java.io.File. \"rel/x\"))" :portability :jvm}


### PR DESCRIPTION
The shared temporal method table only had the 3-arg (.until start end unit) form; JVM LocalDate.until(end) returns the Period between the dates. Wires the 2-arg arm to the existing per-between. Corpus row pins P6M10D vs the JVM. Found while probing jolt-0ug7 — the rest of that bead's surface (Duration/Period arithmetic, ChronoUnit.between, DayOfWeek/Month/ChronoField enums, TemporalAdjusters, with/get/range) verified already working, accumulated via the tick and cljc.java-time suites.