### PR TITLE
Typed throws at operation sites; delete the exception message classifier

### DIFF
--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -147,7 +147,7 @@
 (define (pvec-pop p)
   (let ((cnt (pvec-cnt p)) (shift (pvec-shift p)))
     (cond
-      ((fx=? cnt 0) (error 'pop "can't pop empty vector"))
+      ((fx=? cnt 0) (jolt-throw (jolt-host-throwable "java.lang.IllegalStateException" "Can't pop empty vector")))
       ((fx=? cnt 1) empty-pvec)
       ((fx>? (fx- cnt (pv-tailoff cnt)) 1)
        (mk-pvec (fx- cnt 1) shift (pvec-root p) (vec-drop-last (pvec-tail p)) #f))
@@ -615,7 +615,7 @@
   (cond ((jolt-nil? coll) jolt-nil)                                 ; RT.pop(nil) is nil
         ((pvec? coll) (meta-carry coll (pvec-pop coll)))
         ((and (cseq? coll) (cseq-list? coll)) (meta-carry coll (jolt-rest coll)))
-        ((empty-list-t? coll) (error 'pop "can't pop empty list"))
+        ((empty-list-t? coll) (jolt-throw (jolt-host-throwable "java.lang.IllegalStateException" "Can't pop empty list")))
         (else (jolt-stack-throw coll))))
 
 ;; ============================================================================

--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -422,7 +422,9 @@
                 (pmap-assoc coll (pvec-nth-d x 0 jolt-nil) (pvec-nth-d x 1 jolt-nil)))
                (else (error 'conj "conj on a map expects a [k v] pair or a map"))))
         ((rec-coll-method coll "cons") => (lambda (m) (jolt-invoke m coll x)))
-        (else (error 'conj "unsupported collection"))))
+        (else (jolt-throw (jolt-host-throwable "java.lang.ClassCastException"
+                           (string-append "class " (guard (e (#t "?")) (jolt-class-name coll))
+                                          " cannot be cast to class clojure.lang.IPersistentCollection"))))))
 ;; (conj) -> []; (conj nil a b ...) builds a list (conj prepending -> (b a)).
 (define (jolt-conj . args)
   (if (null? args)
@@ -538,7 +540,9 @@
         ((pvec? coll) (pvec-assoc coll k v))
         ((jolt-nil? coll) (pmap-assoc empty-pmap k v))
         ((rec-coll-method coll "assoc") => (lambda (m) (jolt-invoke m coll k v)))
-        (else (error 'assoc "unsupported collection"))))
+        (else (jolt-throw (jolt-host-throwable "java.lang.ClassCastException"
+                           (string-append "class " (guard (e (#t "?")) (jolt-class-name coll))
+                                          " cannot be cast to class clojure.lang.Associative"))))))
 (define (jolt-assoc coll . kvs)
   (meta-carry coll
     (let loop ((coll coll) (kvs kvs))
@@ -550,11 +554,15 @@
 (define (jolt-dissoc coll . ks)
   (cond ((jolt-nil? coll) jolt-nil)
         ((pmap? coll) (meta-carry coll (fold-left pmap-dissoc coll ks)))
-        (else (error 'dissoc "unsupported collection"))))
+        (else (jolt-throw (jolt-host-throwable "java.lang.ClassCastException"
+                           (string-append "class " (guard (e (#t "?")) (jolt-class-name coll))
+                                          " cannot be cast to class clojure.lang.IPersistentMap"))))))
 (define jolt-dissoc2 (lambda (coll k)
   (cond ((jolt-nil? coll) jolt-nil)
         ((pmap? coll) (meta-carry coll (pmap-dissoc coll k)))
-        (else (error 'dissoc "unsupported collection")))))
+        (else (jolt-throw (jolt-host-throwable "java.lang.ClassCastException"
+                           (string-append "class " (guard (e (#t "?")) (jolt-class-name coll))
+                                          " cannot be cast to class clojure.lang.IPersistentMap")))))))
 
 (define (jolt-contains? coll k)
   (cond ((pmap? coll) (pmap-contains? coll k))

--- a/host/chez/host-table.ss
+++ b/host/chez/host-table.ss
@@ -107,6 +107,19 @@
 ;; sorted colls are collections (callable as fns via jolt-invoke, conj-able).
 (define %h-coll? jolt-coll?)
 (set! jolt-coll? (lambda (x) (or (htable-sorted? x) (%h-coll? x))))
+;; sorted colls invoke like their unordered counterparts: a sorted-map is
+;; IFn(get k [d]), a sorted-set is IFn(get k). Registered as invoke arms so
+;; jolt-invoke dispatches them before the final ClassCastException fallback.
+(register-invoke-arm! htable-sorted-map?
+  (lambda (f args)
+    (let ((n (length args)))
+      (jolt-check-arity-1or2 "clojure.lang.PersistentTreeMap" n)
+      (apply jolt-get f args))))
+(register-invoke-arm! htable-sorted-set?
+  (lambda (f args)
+    (let ((n (length args)))
+      (jolt-check-arity-1 "clojure.lang.PersistentTreeSet" n)
+      (apply jolt-get f args))))
 
 ;; public predicates: a sorted-map is map?, a sorted-set is set?, both coll?.
 ;; predicates.ss/records.ss def-var!'d a snapshot, so re-def-var! after set!.

--- a/host/chez/java/host-class.ss
+++ b/host/chez/java/host-class.ss
@@ -64,13 +64,13 @@
 ;; the class NAME of x (string), or nil for nil. (class x) wraps it in a Class
 ;; value (make-class-obj, host-static-classes.ss) so it renders like a JVM Class
 ;; while staying = its name string.
-;; a raw Chez condition Clojure raises a specific class for (records-interop.ss
-;; chez-condition-exc-class) reports that JVM class, so (class e) and a
-;; (thrown? ArityException …) test match — not the opaque :object fallback.
+;; a raw Chez condition: all operation sites now throw typed jolt throwables, so
+;; any raw condition that escapes is a runtime error — classify it as
+;; RuntimeException (not IllegalArgumentException, which was always a lie).
 (register-class-arm!
-  (lambda (x) (and (chez-condition-exc-class x) #t))
-  (lambda (x) (let ((p (assoc (chez-condition-exc-class x) class-token-alist)))
-                (if p (cdr p) "java.lang.IllegalArgumentException"))))
+  (lambda (x) (condition? x))
+  (lambda (x) (let ((p (assoc "RuntimeException" class-token-alist)))
+                (if p (cdr p) "java.lang.RuntimeException"))))
 ;; A fn def'd into a var reports a JVM-style class name "ns$munged-name" (the
 ;; forward CHAR_MAP), so clojure.spec.alpha's fn-sym (which splits on $ and
 ;; demunges) recovers the predicate's symbol. Anonymous / unregistered fns stay

--- a/host/chez/java/records-interop.ss
+++ b/host/chez/java/records-interop.ss
@@ -15,35 +15,15 @@
 (define (exception-isa? cls wanted)
   (jch-isa? (jch-fqn-of-simple cls) wanted))
 
-;; A raw Chez condition (an arity or non-seqable error Chez itself raised, not a
-;; jolt ex-info) carries no jolt exception class. Map the ones Clojure raises a
-;; specific class for, by message, so (class e) and (instance? C e) match the JVM.
-;; Returns a simple class name or #f.
-(define (ri-substring? needle hay)
-  (let ((nl (string-length needle)) (hl (string-length hay)))
-    (let loop ((i 0))
-      (cond ((> (+ i nl) hl) #f)
-            ((string=? needle (substring hay i (+ i nl))) #t)
-            (else (loop (+ i 1)))))))
+;; A raw Chez condition (an arity or non-seqable error Chez itself raised) carries
+;; no jolt exception class. All operation sites now throw typed jolt throwables
+;; (ArityException, IllegalArgumentException, ClassCastException, etc.) BEFORE
+;; Chez can raise a raw condition. Any raw condition that still escapes is a
+;; runtime error — classify it as RuntimeException.
+;; Returns #f (no special class — the generic condition->RuntimeException arm
+;; in host-class.ss applies).
 (define (chez-condition-exc-class v)
-  (and (condition? v) (message-condition? v)
-       (let ((m (condition-message v)))
-         (and (string? m)
-              (cond ((ri-substring? "incorrect number of arguments" m) "ArityException")
-                    ((ri-substring? "not seqable" m) "IllegalArgumentException")
-                    ;; Chez's numeric ops raise "~s is not a real number" on a bad
-                    ;; operand. The JVM throws NullPointerException for a nil operand
-                    ;; (null deref) and ClassCastException for a non-number (can't
-                    ;; cast to Number) — clojure.spec.alpha's conform-explain relies
-                    ;; on the distinction. The offending value rides in the irritants.
-                    ((or (ri-substring? "is not a real number" m)
-                         (ri-substring? "is not a number" m))
-                     (if (and (irritants-condition? v)
-                              (let loop ((xs (condition-irritants v)))
-                                (and (pair? xs) (or (jolt-nil? (car xs)) (loop (cdr xs))))))
-                         "NullPointerException"
-                         "ClassCastException"))
-                    (else #f))))))
+  #f)
 
 ;; instance-check: (type-sym val) — type/protocol membership. Host shims loaded
 ;; later (io, inst-time, natives-array, natives-queue, host-static-classes)

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -92,7 +92,9 @@
     ((pmap? x) (list->cseq (pmap-fold x (lambda (k v a) (cons (make-map-entry k v) a)) '())))
     ((pset? x) (list->cseq (pset-fold x cons '())))
     ((string? x) (str->seq x 0))
-    (else (error 'seq "not seqable" x))))
+    (else (jolt-throw (jolt-host-throwable "java.lang.IllegalArgumentException"
+                        (string-append "Don't know how to create ISeq from: "
+                                       (guard (e (#t "?")) (jolt-class-name x))))))))
 
 (define (jolt-sequential? x) (or (pvec? x) (cseq? x) (empty-list-t? x)))
 (define (seq->list s)                  ; force a finite seq to a Scheme list
@@ -471,19 +473,59 @@
           (((caar as) f) (cdar as))
           (else (loop (cdr as))))))
 
+;; --- arity pre-check: throw typed ArityException BEFORE applying a proc or
+;; invokable, so the site is classified structurally, not by matching Chez's
+;; error message text after the fact.
+(define (jolt-proc-arity-name f)
+  (let ((p (hashtable-ref proc-name-tbl f #f)))
+    (if p (string-append (car p) "/" (cdr p)) "fn")))
+(define (jolt-arity-error-name name nargs)
+  (jolt-throw (jolt-host-throwable "clojure.lang.ArityException"
+                (string-append "Wrong number of args ("
+                               (number->string nargs)
+                               ") passed to: " name))))
+(define (jolt-proc-arity-error f nargs)
+  (jolt-arity-error-name (jolt-proc-arity-name f) nargs))
+;; check one-arg-or-two: the common arity rule for keywords, symbols, maps.
+(define (jolt-check-arity-1or2 name nargs)
+  (unless (or (fx=? nargs 1) (fx=? nargs 2))
+    (jolt-arity-error-name name nargs)))
+;; check exactly-one-arg: vectors and sets on the JVM accept exactly 1 arg.
+(define (jolt-check-arity-1 name nargs)
+  (unless (fx=? nargs 1)
+    (jolt-arity-error-name name nargs)))
+
 (define (jolt-invoke f . args)
   (cond
-    ((procedure? f) (apply f args))
+    ((procedure? f) (let ((n (length args)))
+                      (unless (fxlogbit? n (procedure-arity-mask f))
+                        (jolt-proc-arity-error f n))
+                      (apply f args)))
     ((jolt-invoke-prefix-arm-for f) => (lambda (h) (h f args)))
-    ((keyword? f) (apply jolt-get (car args) f (cdr args)))   ; (:k m [d]) -> (get m :k [d])
-    ((jolt-symbol? f) (apply jolt-get (car args) f (cdr args)))   ; ('s m [d]) -> (get m 's [d])
-    ;; a VECTOR invokes as nth (a bad index throws, like IPersistentVector.invoke);
-    ;; maps and sets invoke as get.
-    ((pvec? f) (if (and (pair? args) (null? (cdr args)))
-                   (jolt-nth f (car args))
-                   (apply jolt-get f args)))
-    ((jolt-coll? f) (apply jolt-get f args))                  ; (coll k [d]) -> (get coll k [d])
-    ((jolt-transient? f) (apply jolt-get f args))             ; a transient vec/map/set is callable on the JVM
+    ((keyword? f) (let ((n (length args)))
+                    (jolt-check-arity-1or2 (if (keyword-t-ns f) 
+                                              (string-append ":" (keyword-t-ns f) "/" (keyword-t-name f))
+                                              (string-append ":" (keyword-t-name f)))
+                                           n)
+                    (apply jolt-get (car args) f (cdr args))))   ; (:k m [d]) -> (get m :k [d])
+    ((jolt-symbol? f) (let ((n (length args)))
+                        (jolt-check-arity-1or2 (symbol-t-name f) n)
+                        (apply jolt-get (car args) f (cdr args))))   ; ('s m [d]) -> (get m 's [d])
+    ;; a VECTOR invokes as nth, exactly one arg (a bad index throws, like
+    ;; IPersistentVector.invoke); 0 or 2+ args are an ArityException.
+    ((pvec? f) (let ((n (length args)))
+                 (jolt-check-arity-1 (jolt-class-name f) n)
+                 (jolt-nth f (car args))))
+    ;; a map invokes as get with 1 or 2 args; a set invokes as get with exactly 1.
+    ((pmap? f) (let ((n (length args)))
+                 (jolt-check-arity-1or2 (jolt-class-name f) n)
+                 (apply jolt-get f args)))
+    ((pset? f) (let ((n (length args)))
+                 (jolt-check-arity-1 (jolt-class-name f) n)
+                 (apply jolt-get f args)))
+    ((jolt-transient? f) (let ((n (length args)))
+                           (jolt-check-arity-1or2 (jolt-class-name f) n)
+                           (apply jolt-get f args)))             ; a transient vec/map/set is callable on the JVM
     ;; a record/reify implementing clojure.lang.IFn is callable: dispatch to its
     ;; inline `invoke` method with the value itself as the leading `this`.
     ((and (jrec? f) (find-method-any-protocol (jrec-tag f) "invoke"))
@@ -512,11 +554,13 @@
 ;; set callable) delegates to the full variadic jolt-invoke above, which after the
 ;; prefix-arm collapse is one lambda, one rest-list, no re-apply. The back end
 ;; picks jolt-invokeN by arg count (N<=4); apply/variadic cases keep jolt-invoke.
-(define (jolt-invoke0 f) (if (procedure? f) (f) (jolt-invoke f)))
-(define (jolt-invoke1 f a) (if (procedure? f) (f a) (jolt-invoke f a)))
-(define (jolt-invoke2 f a b) (if (procedure? f) (f a b) (jolt-invoke f a b)))
-(define (jolt-invoke3 f a b c) (if (procedure? f) (f a b c) (jolt-invoke f a b c)))
-(define (jolt-invoke4 f a b c d) (if (procedure? f) (f a b c d) (jolt-invoke f a b c d)))
+;; Each embeds an arity pre-check — one fxlogbit? test, predicted taken — so a
+;; wrong-arity call throws a typed ArityException BEFORE Chez raises a raw condition.
+(define (jolt-invoke0 f) (if (procedure? f) (if (fxlogbit? 0 (procedure-arity-mask f)) (f) (jolt-proc-arity-error f 0)) (jolt-invoke f)))
+(define (jolt-invoke1 f a) (if (procedure? f) (if (fxlogbit? 1 (procedure-arity-mask f)) (f a) (jolt-proc-arity-error f 1)) (jolt-invoke f a)))
+(define (jolt-invoke2 f a b) (if (procedure? f) (if (fxlogbit? 2 (procedure-arity-mask f)) (f a b) (jolt-proc-arity-error f 2)) (jolt-invoke f a b)))
+(define (jolt-invoke3 f a b c) (if (procedure? f) (if (fxlogbit? 3 (procedure-arity-mask f)) (f a b c) (jolt-proc-arity-error f 3)) (jolt-invoke f a b c)))
+(define (jolt-invoke4 f a b c d) (if (procedure? f) (if (fxlogbit? 4 (procedure-arity-mask f)) (f a b c d) (jolt-proc-arity-error f 4)) (jolt-invoke f a b c d)))
 
 ;; ============================================================================
 ;; chunked-seq accessors — the host side of the Clojure IChunkedSeq contract

--- a/host/chez/transients.ss
+++ b/host/chez/transients.ss
@@ -193,8 +193,12 @@
   ;; (disj nil ...) is nil on the JVM (disj is otherwise set-only).
   (if (jolt-nil? s)
       jolt-nil
-      (meta-carry s
-        (let loop ((s s) (xs xs)) (if (null? xs) s (loop (pset-disj s (car xs)) (cdr xs)))))))
+      (if (pset? s)
+          (meta-carry s
+            (let loop ((s s) (xs xs)) (if (null? xs) s (loop (pset-disj s (car xs)) (cdr xs)))))
+          (jolt-throw (jolt-host-throwable "java.lang.ClassCastException"
+                        (string-append "class " (guard (e (#t "?")) (jolt-class-name s))
+                                       " cannot be cast to class clojure.lang.IPersistentSet"))))))
 
 ;; --- see-through accessors ---------------------------------------------------
 (define (tvec-in-bounds? t i) (and (fixnum? i) (fx>=? i 0) (fx<? i (jolt-transient-n t))))


### PR DESCRIPTION
Raw Chez conditions were classified into JVM exception classes by
substring-matching the host error message (chez-condition-exc-class:
"incorrect number of arguments" -> ArityException, "is not a real number" ->
NPE-or-CCE guessed from the irritants). Fragile against Chez wording and
backwards: the operation site knows the operand.

Errors are now thrown typed at the site:

- seq: "Don't know how to create ISeq from: <class>" as
  IllegalArgumentException, message matching the JVM exactly.
- Collection ops on non-colls (conj/assoc/dissoc/disj) throw
  ClassCastException naming the target interface ("class java.lang.Long
  cannot be cast to class clojure.lang.IPersistentCollection"); conj on a
  non-coll previously reported an opaque :object class. pop of an empty
  vector is IllegalStateException "Can't pop empty vector".
- Numeric ops: the generic slow arm checks operands before the Chez
  primitive — nil operand -> NullPointerException, non-number ->
  ClassCastException. The fx/fl fast paths are untouched.
- Arity: jolt-invoke prechecks procedure-arity-mask and throws
  clojure.lang.ArityException with the JVM message ("Wrong number of args
  (1) passed to: user/f2", demunged name from the proc table). Measured
  free: fib/dispatch/mono-dispatch/collections A/B/A all within noise.
- The message classifier is deleted; a raw condition no site typed reports
  RuntimeException (previously it lied as IllegalArgumentException).

The corpus gate caught one integration bug during review: the new
not-invokable CCE fired before the sorted-map/sorted-set invoke arms, so
((sorted-map :a 1) :a) threw — fixed by registering invoke arms for the
sorted variants; the crash bucket is back to the 4 pre-existing
certify-harness quirks.

Known residual: statically-lowered keyword/collection invokes bypass
jolt-invoke, so a wrong-arity static keyword call reports RuntimeException
instead of ArityException (needs a backend lowering change; noted in the
bead).

14 new JVM-certified corpus rows. Full battery green (cts exact, certify
0 new / 0 stale); harnesses unchanged-or-better (fireworks 49/51, lasertag
45/58, expound alpha 233 pass).

Bead: jolt-vjwh.3 (conformance audit round 3).