### PR TITLE
Cut built-binary memory: fd-region boot loading + petite-only boot for shaken apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built binaries use roughly a third less memory. The launcher registers the
   appended boot image as a region of the executable (read through a file
   descriptor at startup) instead of holding a resident copy — 7–14 MB less
-  depending on the app. Tree-shaken binaries with no runtime eval now boot from
-  `petite.boot` alone, dropping the bundled Chez compiler: another ~5 MB of
-  memory and ~1 MB of binary size. A hello world goes from ~34 MB to ~22 MB
-  resident; default (REPL-capable) builds keep the compiler and still save the
-  boot copy. Windows keeps the previous loading path for now.
+  depending on the app, on every platform. Tree-shaken binaries with no runtime
+  eval now boot from `petite.boot` alone, dropping the bundled Chez compiler:
+  another ~5 MB of memory and ~1 MB of binary size (macOS/Linux). A hello world
+  goes from ~34 MB to ~22 MB resident; default (REPL-capable) builds keep the
+  compiler and still save the boot copy.
 
 ## [0.3.1] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Built binaries use roughly a third less memory. The launcher registers the
+  appended boot image as a region of the executable (read through a file
+  descriptor at startup) instead of holding a resident copy — 7–14 MB less
+  depending on the app. Tree-shaken binaries with no runtime eval now boot from
+  `petite.boot` alone, dropping the bundled Chez compiler: another ~5 MB of
+  memory and ~1 MB of binary size. A hello world goes from ~34 MB to ~22 MB
+  resident; default (REPL-capable) builds keep the compiler and still save the
+  boot copy. Windows keeps the previous loading path for now.
+
 ## [0.3.1] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-15
+
 ### Changed
 
 - Built binaries use roughly a third less memory. The launcher registers the

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -237,8 +237,24 @@ if ! JOLT_PWD="$fsapp" bin/joltc build -m fsapp.main -o "$fsout" >/dev/null 2>&1
   echo "  FAIL: jolt build of a jolt.fs / babashka.fs app exited non-zero"; exit 1
 fi
 got_fs="$(cd / && "$fsout" 2>&1 | tail -1)"
-if [ "$got_fs" != "FS-APP a/b true true" ]; then
-  echo "  FAIL: built binary missing vendored babashka.fs — want 'FS-APP a/b true true', got \`$got_fs\`"; exit 1
+if [ "$got_fs" != "FS-APP a/b true true rw-------" ]; then
+  echo "  FAIL: built binary missing vendored babashka.fs — want 'FS-APP a/b true true rw-------', got \`$got_fs\`"; exit 1
 fi
 
-echo "build smoke: passed (release + optimized + direct-link + tree-shake + compiler+core shake + data-reader + no-main + optional-native + deps-opt + cljc-cond + vendored-fs)"
+# The same fs app tree-shaken: a compiler-dropped binary boots from petite alone
+# (no scheme.boot), so its libc calls through jolt-foreign-proc-safe (stat &co
+# under jolt.fs) must resolve as compiled foreign-procedures — an eval'd form
+# would silently return #f under the interpreter and the output would change.
+fsshake="$(dirname "$out")/fs-app-shake-bin"
+if ! JOLT_PWD="$fsapp" bin/joltc build -m fsapp.main -o "$fsshake" --tree-shake >/dev/null 2>&1; then
+  echo "  FAIL: jolt build --tree-shake of the jolt.fs app exited non-zero"; exit 1
+fi
+if grep -q 'scheme.boot' "$fsshake.build/compile.ss" 2>/dev/null; then
+  echo "  FAIL: tree-shaken fs app still bundles scheme.boot (petite-only boot expected)"; exit 1
+fi
+got_fss="$(cd / && "$fsshake" 2>&1 | tail -1)"
+if [ "$got_fss" != "FS-APP a/b true true rw-------" ]; then
+  echo "  FAIL: petite-only fs binary output mismatch — want 'FS-APP a/b true true rw-------', got \`$got_fss\`"; exit 1
+fi
+
+echo "build smoke: passed (release + optimized + direct-link + tree-shake + compiler+core shake + data-reader + no-main + optional-native + deps-opt + cljc-cond + vendored-fs + petite-only-fs)"

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -751,12 +751,17 @@
           (library?
            (build-shared entry-ns out-path mode builddir flat-ss flat-so boot boot-h
                          (bld-native-link-flags natives)))
+          ;; petite-only is POSIX-only: on Windows jolt-foreign-proc-safe still
+          ;; evals its foreign-procedure forms (fasl relocations abort the boot
+          ;; there), and eval needs the compiler boot resident.
           ((jolt-embedded-bytes "stub/launcher")
            (build-self-contained entry-ns out-path mode builddir flat-ss flat-so boot
-                                 (bld-native-link-flags natives)))
+                                 (bld-native-link-flags natives)
+                                 (and drop-compiler? (not bld-nt?))))
           (else
            (build-with-cc entry-ns out-path mode builddir flat-ss flat-so boot boot-h main-c
-                          (bld-native-link-flags natives))))))))))
+                          (bld-native-link-flags natives)
+                          (and drop-compiler? (not bld-nt?)))))))))))
 
 ;; --- self-contained link (in-process compile + append the boot to the stub) ---
 ;; compile-file runs against the DEFAULT interaction environment, so the boot's
@@ -837,11 +842,11 @@
        "(fasl-compressed #t)\n"))
     (else "")))
 
-(define (build-self-contained entry-ns out-path mode builddir flat-ss flat-so boot native-link)
+(define (build-self-contained entry-ns out-path mode builddir flat-ss flat-so boot native-link petite-only?)
   (let ((petite (string-append builddir "/petite.boot"))
         (scheme (string-append builddir "/scheme.boot")))
     (jolt-spill-embedded! "csv/petite.boot" petite)
-    (jolt-spill-embedded! "csv/scheme.boot" scheme)
+    (unless petite-only? (jolt-spill-embedded! "csv/scheme.boot" scheme))
     (display (string-append "jolt build: compiling " entry-ns " (" mode " mode, self-contained)\n"))
     (bld-prepend-prologue! flat-ss)
     (cond
@@ -855,7 +860,14 @@
          (compile-file flat-ss flat-so)))
       (else
        (compile-file flat-ss flat-so)))
-    (make-boot-file boot '() petite scheme flat-so)
+    ;; A compiler-dropped binary (no runtime eval) boots from petite alone —
+    ;; scheme.boot is the Chez compiler, ~5 MB of heap and ~1 MB of binary it
+    ;; would never call. Chez's interpreter (petite) can't create a
+    ;; foreign-procedure at runtime, but every defcfn in the image was
+    ;; AOT-compiled, so the FFI is unaffected.
+    (if petite-only?
+        (make-boot-file boot '() petite flat-so)
+        (make-boot-file boot '() petite scheme flat-so))
     ;; The stub is the native launcher the boot is appended to. With no :static
     ;; natives it's the prebuilt one bundled in joltc (no cc needed); with :static
     ;; natives it's re-linked here from the bundled kernel + launcher source so the
@@ -892,7 +904,7 @@
       native-link " " (bld-link-libs)))))
 
 ;; --- legacy cc link (dev bin/joltc): fresh Chez compile + xxd + cc ------------
-(define (build-with-cc entry-ns out-path mode builddir flat-ss flat-so boot boot-h main-c native-link)
+(define (build-with-cc entry-ns out-path mode builddir flat-ss flat-so boot boot-h main-c native-link petite-only?)
   (display (string-append "jolt build: compiling " entry-ns " (" mode " mode)\n"))
   (let ((cs (string-append builddir "/compile.ss")))
     (let ((p (open-output-file cs 'replace)))
@@ -901,9 +913,13 @@
           "(import (chezscheme))\n"
           (bld-chez-param-forms mode)
           "(compile-file " (ei-str-lit flat-ss) " " (ei-str-lit flat-so) ")\n"
+          ;; petite-only boot when the compiler image was dropped (see
+          ;; build-self-contained).
           "(make-boot-file " (ei-str-lit boot) " '()\n  "
           (ei-str-lit (string-append bld-csv-dir "/petite.boot")) "\n  "
-          (ei-str-lit (string-append bld-csv-dir "/scheme.boot")) "\n  "
+          (if petite-only?
+              ""
+              (string-append (ei-str-lit (string-append bld-csv-dir "/scheme.boot")) "\n  "))
           (ei-str-lit flat-so) ")\n"))
       (close-port p))
     (bld-system (string-append bld-chez " --script '" cs "'")))

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -12,16 +12,33 @@
 
 (load "host/chez/values.ss")
 (load "host/chez/hasheq.ss")
-;; Resolve a libc entry point at RUN time. A literal (foreign-procedure "name" …)
-;; in COMPILED code becomes a fasl relocation resolved when the boot loads — on a
-;; platform lacking the symbol (chmod/sigaddset on Windows) that kills the boot
-;; before any guard can run. eval defers the lookup to evaluation time, where the
-;; guard works; returns #f when the entry doesn't exist.
-(define (jolt-foreign-proc-safe name args res)
-  (guard (e (#t #f))
-    (load-shared-object #f)
-    (and (foreign-entry? name)
-         (eval `(foreign-procedure ,name ,args ,res)))))
+;; Resolve a libc entry point at RUN time; #f when the entry doesn't exist
+;; (chmod/sigaddset on Windows). A macro so the platforms can differ:
+;;
+;; - POSIX: a compiled (foreign-procedure …) guarded at creation time. The
+;;   foreign entry resolves when the closure is created (this define running),
+;;   not when the fasl loads, so a missing symbol raises here and the guard
+;;   returns #f. Compiled creation is what lets these run under a petite-only
+;;   boot (a compiler-dropped binary): Chez's interpreter cannot build a
+;;   foreign-procedure, so an eval'd form would silently yield #f there.
+;;
+;; - Windows: eval the form instead. A foreign reference in compiled fasl is a
+;;   load-time relocation there and a missing symbol aborts the boot (exit 3)
+;;   before any guard runs; eval keeps the form out of the fasl entirely.
+;;   Windows builds always carry the compiler boot, so eval compiles.
+(define-syntax jolt-foreign-proc-safe
+  (lambda (x)
+    (syntax-case x (quote)
+      ((_ name (quote args) (quote res))
+       (if (memq (machine-type) '(a6nt ta6nt i3nt ti3nt))
+           #'(guard (e (#t #f))
+               (load-shared-object #f)
+               (and (foreign-entry? name)
+                    (eval `(foreign-procedure ,name ,'args ,'res))))
+           #'(guard (e (#t #f))
+               (load-shared-object #f)
+               (and (foreign-entry? name)
+                    (foreign-procedure name args res))))))))
 
 (load "host/chez/collections.ss")
 (load "host/chez/seq.ss")

--- a/host/chez/stub/launcher.c
+++ b/host/chez/stub/launcher.c
@@ -7,7 +7,10 @@
  *
  * (see host/chez/java/io.ss jolt-append-payload!). At startup the stub locates
  * its own executable, reads the trailing 16-byte frame to find the boot, and
- * hands the boot to the Chez kernel — no external boot file, no Chez install.
+ * registers the boot as a region of the executable itself: the Chez kernel
+ * reads it through the fd during Sbuild_heap and closes it when done. No
+ * external boot file, no Chez install, and no resident copy — a malloc'd
+ * payload here stayed dirty for the life of the process (7-14 MB per app).
  *
  * Built once at joltc-build time against the Chez kernel (libkernel.a + scheme.h)
  * by host/chez/build-joltc.ss; the resulting binary is embedded into joltc and
@@ -27,12 +30,17 @@ static int self_path(char *buf, uint32_t size) {
   /* _NSGetExecutablePath fills buf and reports the needed size on overflow. */
   return _NSGetExecutablePath(buf, &size);
 }
+static int open_self(const char *path) { return open(path, O_RDONLY); }
 #elif defined(_WIN32)
 #include <windows.h>
+#include <io.h>
+#include <fcntl.h>
 static int self_path(char *buf, uint32_t size) {
   DWORD n = GetModuleFileNameA(NULL, buf, size);
   return (n == 0 || n >= size) ? -1 : 0;
 }
+/* A CRT fd in binary mode — the kernel reads the region with CRT reads. */
+static int open_self(const char *path) { return _open(path, _O_RDONLY | _O_BINARY); }
 #else
 #include <unistd.h>
 #include <fcntl.h>
@@ -42,6 +50,7 @@ static int self_path(char *buf, uint32_t size) {
   buf[n] = '\0';
   return 0;
 }
+static int open_self(const char *path) { return open(path, O_RDONLY); }
 #endif
 
 #define JOLT_MAGIC "JOLTBOOT"
@@ -88,45 +97,19 @@ int main(int argc, char *argv[]) {
     fclose(f);
     return 1;
   }
-
-#if defined(_WIN32)
-  /* Windows: read the payload into memory. (The fd-region path below is POSIX;
-   * a CRT-fd equivalent is untested against the Chez kernel's Windows I/O, so
-   * the copying path stays until it's verified there.) */
-  void *boot = malloc((size_t)boot_len);
-  if (!boot) { fclose(f); return 1; }
-  if (fseek(f, boot_off, SEEK_SET) != 0 ||
-      fread(boot, 1, (size_t)boot_len, f) != (size_t)boot_len) {
-    free(boot);
-    fclose(f);
-    return 1;
-  }
   fclose(f);
 
-  Sscheme_init(0);
-  Sregister_boot_file_bytes("jolt", boot, (iptr)boot_len);
-  Sbuild_heap(0, 0);
-  int status = Sscheme_start(argc, (const char **)argv);
-  Sscheme_deinit();
-  free(boot);
-  return status;
-#else
-  /* Register the boot as a region of the executable itself: the kernel reads it
-   * through the fd during Sbuild_heap and closes it when done. No resident copy —
-   * a malloc'd payload here stayed dirty for the life of the process (7-14 MB
-   * depending on the app). */
-  fclose(f);
-  int fd = open(path, O_RDONLY);
+  int fd = open_self(path);
   if (fd < 0) {
     fprintf(stderr, "jolt: cannot reopen self for boot\n");
     return 1;
   }
 
   Sscheme_init(0);
+  /* final arg: close the fd when the boot is consumed */
   Sregister_boot_file_fd_region("jolt", fd, (iptr)boot_off, (iptr)boot_len, 1);
   Sbuild_heap(0, 0);
   int status = Sscheme_start(argc, (const char **)argv);
   Sscheme_deinit();
   return status;
-#endif
 }

--- a/host/chez/stub/launcher.c
+++ b/host/chez/stub/launcher.c
@@ -22,6 +22,7 @@
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
+#include <fcntl.h>
 static int self_path(char *buf, uint32_t size) {
   /* _NSGetExecutablePath fills buf and reports the needed size on overflow. */
   return _NSGetExecutablePath(buf, &size);
@@ -34,6 +35,7 @@ static int self_path(char *buf, uint32_t size) {
 }
 #else
 #include <unistd.h>
+#include <fcntl.h>
 static int self_path(char *buf, uint32_t size) {
   ssize_t n = readlink("/proc/self/exe", buf, (size_t)size - 1);
   if (n < 0) return -1;
@@ -87,8 +89,10 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  /* The kernel keeps the boot bytes for the life of the process (demand-loaded),
-   * so this buffer is freed only after Sscheme_deinit. */
+#if defined(_WIN32)
+  /* Windows: read the payload into memory. (The fd-region path below is POSIX;
+   * a CRT-fd equivalent is untested against the Chez kernel's Windows I/O, so
+   * the copying path stays until it's verified there.) */
   void *boot = malloc((size_t)boot_len);
   if (!boot) { fclose(f); return 1; }
   if (fseek(f, boot_off, SEEK_SET) != 0 ||
@@ -106,4 +110,23 @@ int main(int argc, char *argv[]) {
   Sscheme_deinit();
   free(boot);
   return status;
+#else
+  /* Register the boot as a region of the executable itself: the kernel reads it
+   * through the fd during Sbuild_heap and closes it when done. No resident copy —
+   * a malloc'd payload here stayed dirty for the life of the process (7-14 MB
+   * depending on the app). */
+  fclose(f);
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr, "jolt: cannot reopen self for boot\n");
+    return 1;
+  }
+
+  Sscheme_init(0);
+  Sregister_boot_file_fd_region("jolt", fd, (iptr)boot_off, (iptr)boot_len, 1);
+  Sbuild_heap(0, 0);
+  int status = Sscheme_start(argc, (const char **)argv);
+  Sscheme_deinit();
+  return status;
+#endif
 }

--- a/test/chez/fs-app/src/fsapp/main.clj
+++ b/test/chez/fs-app/src/fsapp/main.clj
@@ -1,9 +1,17 @@
 ;; Smoke fixture: a built binary must have the vendored babashka.fs (via jolt.fs)
 ;; available — including functions defined after babashka.fs's cljs-only reader
 ;; conditionals (directory?/cwd/which), which the emission must not truncate.
+;; The perms round-trip goes through chmod/stat resolved by jolt-foreign-proc-safe,
+;; so the tree-shaken (petite-only) build proves compiled foreign-procedures
+;; resolve without the compiler boot.
 (ns fsapp.main (:require [jolt.fs :as fs]))
 (defn -main [& _]
-  (println "FS-APP"
-           (str (fs/path "a" "b"))
-           (fs/directory? (fs/cwd))
-           (some? (fs/which "sh"))))
+  (let [tmp (str (fs/create-temp-file))]
+    (fs/set-posix-file-permissions tmp "rw-------")
+    (let [perms (fs/posix->str (fs/posix-file-permissions tmp))]
+      (fs/delete tmp)
+      (println "FS-APP"
+               (str (fs/path "a" "b"))
+               (fs/directory? (fs/cwd))
+               (some? (fs/which "sh"))
+               perms))))


### PR DESCRIPTION
Investigated why binaries idle heavy (hello world ~34 MB, nREPL app ~56 MB). Two root causes, measured with footprint(1):

**The launcher malloc'd the whole boot payload.** `stub/launcher.c` read the appended boot (7–14 MB) into a malloc'd buffer held for the life of the process. It now registers the payload as a region of the executable (`Sregister_boot_file_fd_region`), so the kernel reads it through the fd during heap build and nothing stays resident. This covers all platforms — the Windows path (CRT fd, `_O_BINARY`) passed the full release-matrix smoke (joltc.exe boots, evals, builds an app, the app runs, dynamic require works: [dry run](https://github.com/jolt-lang/jolt/actions/runs/29418360913)).

**Tree-shaken binaries bundled the Chez compiler they can never call.** Compiler-dropped builds (no runtime eval) now boot from `petite.boot` alone: −5 MB heap, −1 MB binary. This rides the existing `drop-compiler?` flag, so default/release builds keep `scheme.boot` and the REPL/eval works exactly as before — only optimized closed-world builds shed it. The enabler: `jolt-foreign-proc-safe` eval'd its `foreign-procedure` forms (petite's interpreter can't build one); it's now a macro that compiles them on POSIX and keeps eval on Windows machine types, where a compiled foreign reference is a load-time fasl relocation that aborts the boot — petite-only stays POSIX-gated for that reason.

Numbers (macOS/arm64): hello world **34 → 22 MB** resident (binary 8.3 → 7.2 MB), nREPL example **56 → 45 MB**, tree-shaken example apps 14.2 → 10.9 MB on disk. Idle Chez itself is ~22 MB, so a shaken app now runs at the substrate floor.

Dead ends measured and skipped: `Scompact_heap` (no effect), startup full-collect (makes it worse, +9 MB), inspector-info is a further ~9 MB but stays on in release for stack traces.

build-smoke gains a tree-shaken `jolt.fs` fixture: chmod/stat through `jolt-foreign-proc-safe` must round-trip under the petite-only boot, and the build must not bundle `scheme.boot`. `make test`, buildsmoke, shakesmoke (byte-identical output), joltcsmoke, and the full release matrix (macos/linux/windows) all green.