### PR TITLE
Audit R7: build consolidation, shake gates, dead code

### DIFF
--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -924,27 +924,36 @@
 ;; build-joltc.ss (optimize-level 2, fasl-compressed #t for release/optimized).
 ;; "release" keeps inspector + proc-source ON so Clojure backtraces (via
 ;; inspect/object walking the continuation) survive. "optimized" turns them OFF
-;; for max speed. "dev" leaves Chez defaults (optimize-level 2, inspector ON,
-;; proc-source ON, fasl uncompressed — full debuggability).
+;; for max speed. "dev" has no entry (Chez defaults: optimize-level 2, inspector
+;; ON, proc-source ON, fasl uncompressed — full debuggability). Single table
+;; referenced by both the prologue-string builder and the parameterize block.
+;;
+;; optimize-level 2, not 3: level 3 is Chez's UNSAFE mode — fx/fl/car/vector
+;; ops skip their type checks, and jolt's error semantics depend on those
+;; raising ((take nil coll) must throw, not walk off a nil count). Level 2
+;; keeps every check with nearly all of the optimization.
+(define bld-chez-params
+  `(("optimized" (optimize-level 2)
+                 (generate-inspector-information #f)
+                 (generate-procedure-source-information #f)
+                 (fasl-compressed #t))
+    ("release"   (optimize-level 2)
+                 (generate-inspector-information #t)
+                 (generate-procedure-source-information #t)
+                 (fasl-compressed #t))))
+
 (define (bld-chez-param-forms mode)
-  ;; optimize-level 2, not 3: level 3 is Chez's UNSAFE mode — fx/fl/car/vector
-  ;; ops skip their type checks, and jolt's error semantics depend on those
-  ;; raising ((take nil coll) must throw, not walk off a nil count). Level 2
-  ;; keeps every check with nearly all of the optimization.
-  (cond
-    ((string=? mode "optimized")
-     (string-append
-       "(optimize-level 2)\n"
-       "(generate-inspector-information #f)\n"
-       "(generate-procedure-source-information #f)\n"
-       "(fasl-compressed #t)\n"))
-    ((string=? mode "release")
-     (string-append
-       "(optimize-level 2)\n"
-       "(generate-inspector-information #t)\n"
-       "(generate-procedure-source-information #t)\n"
-       "(fasl-compressed #t)\n"))
-    (else "")))
+  (let ((params (assoc mode bld-chez-params)))
+    (if params
+        (fold-left
+          (lambda (s p) (string-append s "(" (symbol->string (car p)) " "
+                                      (let ((v (cadr p)))
+                                        (cond ((boolean? v) (if v "#t" "#f"))
+                                              ((number? v) (number->string v))
+                                              (else (format "~s" v))))
+                                      ")\n"))
+          "" (cdr params))
+        "")))
 
 (define (build-self-contained entry-ns out-path mode builddir flat-ss flat-so boot native-link petite-only?)
   (let ((petite (string-append builddir "/petite.boot"))
@@ -953,17 +962,10 @@
     (unless petite-only? (jolt-spill-embedded! "csv/scheme.boot" scheme))
     (display (string-append "jolt build: compiling " entry-ns " (" mode " mode, self-contained)\n"))
     (bld-prepend-prologue! flat-ss)
-    (cond
-      ((string=? mode "optimized")
-       (parameterize ((optimize-level 2) (generate-inspector-information #f)
-                       (generate-procedure-source-information #f) (fasl-compressed #t))
-         (compile-file flat-ss flat-so)))
-      ((string=? mode "release")
-       (parameterize ((optimize-level 2) (generate-inspector-information #t)
-                       (generate-procedure-source-information #t) (fasl-compressed #t))
-         (compile-file flat-ss flat-so)))
-      (else
-       (compile-file flat-ss flat-so)))
+    (let ((params (cdr (assoc mode bld-chez-params))))
+      (if params
+          (apply parameterize (append params (list (lambda () (compile-file flat-ss flat-so)))))
+          (compile-file flat-ss flat-so)))
     ;; A compiler-dropped binary (no runtime eval) boots from petite alone —
     ;; scheme.boot is the Chez compiler, ~5 MB of heap and ~1 MB of binary it
     ;; would never call. Chez's interpreter (petite) can't create a

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -188,17 +188,24 @@
     (compile-eval . "(load \"host/chez/compile-eval.ss\")")))
 
 ;; A single-line top-level `(load "PATH")` -> PATH, else #f.
+;; Bounded: each quote scan checks end-of-string; a missing quote raises
+;; a clear build error naming the offending line instead of blowing up with
+;; an opaque string-ref index-out-of-range.
 (define (bld-load-path line)
-  (let ((s (let trim ((i 0))
-             (if (and (< i (string-length line))
-                      (memv (string-ref line i) '(#\space #\tab)))
-                 (trim (+ i 1))
-                 (substring line i (string-length line))))))
+  (let ((s (let trim ((i 0) (n (string-length line)))
+             (if (and (< i n) (memv (string-ref line i) '(#\space #\tab)))
+                 (trim (+ i 1) n)
+                 (if (< i n) (substring line i n) "")))))
     (and (>= (string-length s) 7)
          (string=? (substring s 0 6) "(load ")
-         (let* ((q1 (let scan ((i 6)) (if (char=? (string-ref s i) #\") i (scan (+ i 1)))))
-                (q2 (let scan ((i (+ q1 1))) (if (char=? (string-ref s i) #\") i (scan (+ i 1))))))
-           (substring s (+ q1 1) q2)))))
+         (let ((end (string-length s)))
+           (let* ((q1 (let scan ((i 6))
+                        (if (>= i end) (die 'build-app "unterminated load quote" (list line))
+                            (if (char=? (string-ref s i) #\") i (scan (+ i 1))))))
+                  (q2 (let scan ((i (+ q1 1)))
+                        (if (>= i end) (die 'build-app "unterminated second load quote" (list line))
+                            (if (char=? (string-ref s i) #\") i (scan (+ i 1)))))))
+             (substring s (+ q1 1) q2))))))
 
 ;; runtime source for PATH: from the binary's embedded store if present (a
 ;; self-contained joltc building an app, with no jolt checkout on disk), else read

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -302,7 +302,8 @@
     ;; live) so a devirt site can resolve the clone regardless of emit order.
     (jolt-reset-clone-prepass!)
     (for-each (lambda (p) (jolt-contagion-prepass! (apply jolt-vector (cdr p)) (car p))) ns-nodes)
-    (jolt-contagion-prepass-done!)))
+    (jolt-contagion-prepass-done!)
+    (reverse ns-nodes)))
 
 ;; Strings emitted before each app ns's forms, replaying what the source loader
 ;; does per file: (1) set chez-current-ns so runtime ns-sensitive setup forms
@@ -709,7 +710,9 @@
                 ;; which keeps var-cache OFF (emit-image.ss). ON in both modes.
                 ((var-deref "jolt.backend-scheme" "set-var-cache!") #t)
                 ;; whole-program param-type fixpoint before per-form emit
-                (when (string=? mode "optimized") (bld-wp-infer! ordered)))
+                (when (string=? mode "optimized")
+                  (let ((wp-cached (bld-wp-infer! ordered)))
+                    (for-each (lambda (p) (ei-set-cached! (car p) (cdr p))) wp-cached))))
               (lambda ()
                 ;; A #tag data-reader literal must compile in the binary the same as
                 ;; it loads interpreted — apply the reader rewrite to each emitted
@@ -751,7 +754,8 @@
                 ;; recorded for THIS one. (bld-wp-infer!'s record/protocol
                 ;; seeds self-heal: the next build replaces them wholesale.)
                 ((var-deref "jolt.backend-scheme" "direct-link-reset!"))
-                ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)))))
+                ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
+                (ei-clear-cached!)))))
         (when drop-compiler? (display "jolt build: dropping compiler image (no runtime eval)\n"))
       (let* ((builddir (string-append out-path ".build"))
              (flat-ss  (string-append builddir "/flat.ss"))

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -962,9 +962,14 @@
     (unless petite-only? (jolt-spill-embedded! "csv/scheme.boot" scheme))
     (display (string-append "jolt build: compiling " entry-ns " (" mode " mode, self-contained)\n"))
     (bld-prepend-prologue! flat-ss)
-    (let ((params (cdr (assoc mode bld-chez-params))))
+    (let ((params (assoc mode bld-chez-params)))
       (if params
-          (apply parameterize (append params (list (lambda () (compile-file flat-ss flat-so)))))
+          (let ((pv (lambda (k) (cadr (assq k (cdr params))))))
+            (parameterize ((optimize-level (pv 'optimize-level))
+                           (generate-inspector-information (pv 'generate-inspector-information))
+                           (generate-procedure-source-information (pv 'generate-procedure-source-information))
+                           (fasl-compressed (pv 'fasl-compressed)))
+              (compile-file flat-ss flat-so)))
           (compile-file flat-ss flat-so)))
     ;; A compiler-dropped binary (no runtime eval) boots from petite alone —
     ;; scheme.boot is the Chez compiler, ~5 MB of heap and ~1 MB of binary it

--- a/host/chez/dce.ss
+++ b/host/chez/dce.ss
@@ -103,6 +103,19 @@
 (define (dce-unwrap form)
   (if (and (pair? form) (eq? (car form) 'guard) (pair? (cddr form))) (caddr form) form))
 
+;; "ns/name" of every (var-deref "ns" "nm"), (jolt-var "ns" "nm"), or
+;; (var-cell-lookup "ns" "nm") literal in a read form, inserted into ht.
+(define (dce-sexp-refs-into! form ht)
+  (cond
+    ((and (pair? form) (memq (car form) '(var-deref jolt-var var-cell-lookup))
+          (pair? (cdr form)) (string? (cadr form)) (pair? (cddr form)) (string? (caddr form)))
+     (hashtable-set! ht (string-append (cadr form) "/" (caddr form)) #t))
+    ((pair? form)
+     (dce-sexp-refs-into! (car form) ht)
+     (dce-sexp-refs-into! (cdr form) ht))))
+
+;; Deprecated: kept for backward compat with tests that call it directly.
+;; Prefer dce-sexp-refs-into! with a hash set.
 (define (dce-sexp-refs form acc)
   (cond
     ((and (pair? form) (memq (car form) '(var-deref jolt-var var-cell-lookup))
@@ -111,15 +124,17 @@
     ((pair? form) (dce-sexp-refs (cdr form) (dce-sexp-refs (car form) acc)))
     (else acc)))
 
-;; All "ns/name" refs a text scan of an emitted Scheme string carries — read every
-;; top-level form and fold dce-sexp-refs. Mirrors how dce-blob-records scans the
-;; minted prelude; run over emitted app strings so a literal (var-deref "ns" "nm")
-;; spliced into an emitted form (with no :var IR node) still roots its target.
+;; All "ns/name" refs a text scan of an emitted Scheme string carries, deduped via
+;; hash set. Read every top-level form and fold dce-sexp-refs-into!.
 (define (dce-sexp-refs-str str)
-  (let ((p (open-input-string str)))
-    (let loop ((acc '()))
+  (let ((p (open-input-string str))
+        (ht (make-hashtable string-hash string=?)))
+    (let loop ()
       (let ((form (read p)))
-        (if (eof-object? form) acc (loop (dce-sexp-refs form acc)))))))
+        (unless (eof-object? form)
+          (dce-sexp-refs-into! form ht)
+          (loop))))
+    (vector->list (hashtable-keys ht))))
 
 ;; Refs an app record roots: the IR walk (every :var/:the-var node) UNIONED with the
 ;; text scan of its emitted Scheme. The IR walk is structural truth for compiled
@@ -227,19 +242,24 @@
 
 ;; Scan the KEPT records: does any resolve a var at runtime (bail), and does any need
 ;; the compiler? Returns (values bail? bail-why needs-compiler?). bail-why is up to 6
-;; (def . bail-ref) pairs for the diagnostic.
+;; (def . bail-ref) pairs for the diagnostic. Uses hash sets for O(1) membership
+;; instead of O(n*m) linear scans over the bail/compile lists.
 (define (dce-bail-scan records reached)
-  (let ((bail #f) (why '()) (needs-compiler #f))
+  (let ((bail #f) (why '()) (needs-compiler #f)
+        (bail-ht (make-hashtable string-hash string=?))
+        (compile-ht (make-hashtable string-hash string=?)))
+    (for-each (lambda (b) (hashtable-set! bail-ht b #t)) dce-bail-refs)
+    (for-each (lambda (c) (hashtable-set! compile-ht c #t)) dce-compile-refs)
     (for-each
       (lambda (r)
         (when (dce-rec-reached? r reached)
-          (for-each (lambda (b)
-                      (when (member b (dce-rec-refs r))
+          (for-each (lambda (ref)
+                      (when (hashtable-ref bail-ht ref #f)
                         (set! bail #t)
                         (when (< (length why) 6)
-                          (set! why (cons (cons (or (dce-rec-fqn r) "<form>") b) why)))))
-                    dce-bail-refs)
-          (when (ormap (lambda (c) (and (member c (dce-rec-refs r)) #t)) dce-compile-refs)
+                          (set! why (cons (cons (or (dce-rec-fqn r) "<form>") ref) why)))))
+                    (dce-rec-refs r))
+          (when (ormap (lambda (ref) (and (hashtable-ref compile-ht ref #f) #t)) (dce-rec-refs r))
             (set! needs-compiler #t))))
       records)
     (values bail (reverse why) needs-compiler)))

--- a/host/chez/dce.ss
+++ b/host/chez/dce.ss
@@ -105,7 +105,7 @@
 
 (define (dce-sexp-refs form acc)
   (cond
-    ((and (pair? form) (memq (car form) '(var-deref jolt-var))
+    ((and (pair? form) (memq (car form) '(var-deref jolt-var var-cell-lookup))
           (pair? (cdr form)) (string? (cadr form)) (pair? (cddr form)) (string? (caddr form)))
      (cons (string-append (cadr form) "/" (caddr form)) acc))
     ((pair? form) (dce-sexp-refs (cdr form) (dce-sexp-refs (car form) acc)))

--- a/host/chez/emit-image.ss
+++ b/host/chez/emit-image.ss
@@ -56,8 +56,31 @@
 ;; byte-fixpoint, and a built app should carry no per-call trace overhead.
 (let ((stf (var-deref "jolt.backend-scheme" "set-trace-frames!")))
   (when (procedure? stf) (stf #f)))
+;; --- whole-program analysis cache for --opt builds ----------------------------
+;; bld-wp-infer! populates this; ei-compile-form checks it to skip re-analysis.
+(define ei-cached-ir (make-hashtable string-hash string=?))
+(define ei-cached-ir-idx (make-hashtable string-hash string=?))
+
+(define (ei-set-cached! ns forms)
+  (hashtable-set! ei-cached-ir ns forms)
+  (hashtable-set! ei-cached-ir-idx ns 0))
+
+(define (ei-next-cached ns)
+  (let ((idx (hashtable-ref ei-cached-ir-idx ns #f))
+        (forms (hashtable-ref ei-cached-ir ns #f)))
+    (if (and idx forms (< idx (length forms)))
+        (begin (hashtable-set! ei-cached-ir-idx ns (+ idx 1))
+               (list-ref forms idx))
+        #f)))
+
+(define (ei-clear-cached!)
+  (hashtable-clear! ei-cached-ir)
+  (hashtable-clear! ei-cached-ir-idx))
+
 (define (ei-compile-form ctx f optimize?)
-  (let ((ir (jolt-ce-analyze ctx f)))
+  (let* ((ns (chez-actx-cns ctx))
+         (cached (and optimize? (ei-next-cached ns)))
+         (ir (or cached (jolt-ce-analyze ctx f))))
     (jolt-ce-emit-top (if optimize? (jolt-ce-run-passes ir ctx) ir))))
 
 ;; The emitted `(def-var! …)(mark-macro! …)` pair for a defmacro, guard-wrapped
@@ -135,7 +158,8 @@
     (ei-for-each-form ns-name src
       (lambda (ns kind nm f)
         (let* ((ctx (make-analyze-ctx ns))
-               (ir (jolt-ce-run-passes (jolt-ce-analyze ctx f) ctx))
+               (cached (ei-next-cached ns))
+               (ir (jolt-ce-run-passes (or cached (jolt-ce-analyze ctx f)) ctx))
                (str (if (eq? kind 'macro)
                         (ei-macro-string ns nm (jolt-ce-emit-top ir) #f)
                         (jolt-ce-emit-top ir)))

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -118,40 +118,6 @@
 ;; the mix logic is hand-expanded as a single let* chain of fx ops.
 ;; mul32/rotl32/add32/i32 are small leaf helpers (fixnum-pure, one expression).
 ;; ---------------------------------------------------------------------------
-(define (murmur3-hash-int-flat k)
-  ;; k: fixnum in signed 32-bit range.
-  (if (#3%fx=? k 0) 0
-      (let* (;; --- i32(k): signed 32-bit ---
-             (u (#3%fxand k #xFFFFFFFF))
-             (ik (if (#3%fx>=? u #x80000000) (#3%fx- u #x100000000) u))
-             ;; --- mixK1(ik): step 1/3 mul32(ik, C1) ---
-             (k1 (mul32 ik murmur3-C1))
-             ;; --- mixK1(ik): step 2/3 rotl32(k1, 15) ---
-             (k1 (rotl32 k1 15))
-             ;; --- mixK1(ik): step 3/3 mul32(k1, C2) ---
-             (k1 (mul32 k1 murmur3-C2))
-             ;; --- mixH1(seed, k1): step 1/4 xor ---
-             (h1 (#3%fxxor murmur3-seed k1))
-             ;; --- mixH1: step 2/4 rotl32(h1, 13) ---
-             (h1 (rotl32 h1 13))
-             ;; --- mixH1: step 3/4 mul32(h1, 5) ---
-             (h1 (mul32 h1 5))
-             ;; --- mixH1: step 4/4 add32(h1, 0xe6546b64) ---
-             (h1 (add32 h1 #xe6546b64))
-             ;; --- fmix(h1, 4): step 1/6 xor len ---
-             (h1 (#3%fxxor h1 4))
-             ;; --- fmix: step 2/6 xor urs32(h1, 16) ---
-             (h1 (#3%fxxor h1 (urs32 h1 16)))
-             ;; --- fmix: step 3/6 mul32(h1, 0x85ebca6b) ---
-             (h1 (mul32 h1 #x85ebca6b))
-             ;; --- fmix: step 4/6 xor urs32(h1, 13) ---
-             (h1 (#3%fxxor h1 (urs32 h1 13)))
-             ;; --- fmix: step 5/6 mul32(h1, 0xc2b2ae35) ---
-             (h1 (mul32 h1 #xc2b2ae35))
-             ;; --- fmix: step 6/6 xor urs32(h1, 16) ---
-             (h1 (#3%fxxor h1 (urs32 h1 16))))
-        h1)))
-
 ;; ---------------------------------------------------------------------------
 ;; Flat-inlined murmur3-hash-long for fixnums wider than int32.
 ;; Same hand-inlined mix logic as above, applied to two 32-bit halves;
@@ -403,9 +369,7 @@
 ;; An arm is (pred . handler); pred takes the value, handler returns int.
 (define jolt-hasheq-arms '())
 
-(define (register-hasheq-arm! pred handler)
-  (set! jolt-hasheq-arms (cons (cons pred handler) jolt-hasheq-arms)))
-
+;; Dispatch: fast-path types first, then registered arms, then fallback.
 (define (jolt-hasheq x)
   ;; Fast path for the most common types (matching Util.hasheq order).
   (cond
@@ -473,17 +437,4 @@
 
 ;; ============================================================================
 ;; Quick sanity: export a helper for the natives to rebind clojure.core/hash
-;; ============================================================================
-;; The old natives-misc.ss binds clojure.core/hash, hash-combine, etc.
-;; After hasheq.ss loads, those are replaced via def-var! in this file
-;; or in the natives file that loads after.
 
-(define (hasheq-hash x) (jolt-hasheq x))
-(define (hasheq-hash-ordered-coll coll)
-  (hash-ordered (jolt-seq coll)))
-(define (hasheq-hash-unordered-coll coll)
-  (hash-unordered (jolt-seq coll)))
-(define (hasheq-mix-collection-hash hash-basis count)
-  (mix-coll-hash hash-basis count))
-(define (hasheq-hash-combine seed hash)
-  (hash-combine seed hash))

--- a/host/chez/host-contract.ss
+++ b/host/chez/host-contract.ss
@@ -238,10 +238,9 @@
 ;; has none, so it defaults to {}.
 (define hc-amp-form-cell (declare-var! "clojure.core" "&form"))
 (define hc-amp-env-cell (declare-var! "clojure.core" "&env"))
-;; &form meta matches the JVM's {:line :column}. The reader also stamps :file
-;; for the compiler's position tracking, but a macro reading (meta &form) must
-;; not see it — libraries branch on its presence (fireworks' file-info).
-(define hc-kw-file (keyword #f "file"))
+;; &form meta matches the JVM's {:line :column}. hc-kw-file is defined above
+;; with hc-kw-line/hc-kw-column. hc-form-sans-file strips :file from &form meta
+;; so a macro reading (meta &form) doesn't see it — libraries branch on its presence.
 (define (hc-form-sans-file form)
   (let ((m (jolt-meta form)))
     (if (or (jolt-nil? m) (jolt-nil? (jolt-get m hc-kw-file jolt-nil)))
@@ -446,10 +445,10 @@
         (else #f)))
 (define (hc-record-type? ctx name)
   (let ((nm (hc-record-tag-name name)))
-    (if (and nm (chez-find-ctor-key nm (chez-current-ns))) #t #f)))
+    (if (and nm (chez-find-ctor-key nm (hc-current-ns ctx))) #t #f)))
 (define (hc-record-ctor-key ctx name)
   (let ((nm (hc-record-tag-name name)))
-    (or (and nm (chez-find-ctor-key nm (chez-current-ns))) jolt-nil)))
+    (or (and nm (chez-find-ctor-key nm (hc-current-ns ctx))) jolt-nil)))
 ;; The fully-qualified deftype tag ("ns.Name") IFF `class` names a deftype DEFINED
 ;; in the ctx's compile ns — the analyzer qualifies a bare (Name. …) to it, so a
 ;; deftype doesn't shadow a same-named built-in host class in an unrelated ns

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1468,8 +1468,6 @@
               #f 'pass))
         'pass)))
 ;; a reader-conditional value reports its JVM class, not its tagged-map backing.
-(define kw-rc-jtype (keyword "jolt" "type"))
-(define kw-rc (keyword "jolt" "reader-conditional"))
 (define (reader-conditional-value? x)
   (jolt-reader-conditional-record? x))
 (register-class-arm! reader-conditional-value? (lambda (x) "clojure.lang.ReaderConditional"))

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -595,11 +595,6 @@
                          ((string=? (car os) nm) (+ acc (car bs)))
                          (else (loop (cdr os) (cdr bs)))))))
              0 (seq->list (jolt-seq s))))
-(define (posix-str->mode str)                  ; "rwxr-xr-x" -> mode int
-  (let loop ((i 0) (bs posix-bits) (acc 0))
-    (if (or (>= i (string-length str)) (null? bs)) acc
-        (loop (+ i 1) (cdr bs)
-              (if (memv (string-ref str i) '(#\r #\w #\x #\s #\t)) (+ acc (car bs)) acc)))))
 (define (posix-set->str s)
   (let ((mode (posix-set->mode s)))
     (list->string

--- a/host/chez/natives-reader.ss
+++ b/host/chez/natives-reader.ss
@@ -26,10 +26,6 @@
   (nongenerative jolt-reader-conditional-record-v1))
 
 ;; re-matcher / re-find / re-groups are the stateful matcher API in regex.ss.
-(define nr-kw-type (keyword "jolt" "type"))
-(define nr-kw-rc   (keyword "jolt" "reader-conditional"))
-(define nr-kw-form (keyword #f "form"))
-(define nr-kw-spl  (keyword #f "splicing?"))
 (define (nr-reader-conditional form splicing?)
   (make-jolt-reader-conditional-record form splicing?))
 

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -222,18 +222,7 @@
                   (list->vector (map chez-double-tag? field-tags))))
 
 ;; Coerce ^double fields to flonums in-place on a freshly-built field vector.
-;; The dbl-flags vector (from chez-record-dbl-tbl or the ctor's closure) has a
-;; true at each index that must be a flonum. No-op when the type has no ^double
-;; fields (most records). Used by the fixed-arity ctors.
-(define (coerce-double-fields! v dbl-flags)
-  (let ((ndbl (vector-length dbl-flags)))
-    (when (fx> ndbl 0)
-      (let ((n (min ndbl (vector-length v))))
-        (do ((i 0 (fx+ i 1))) ((fx= i n))
-          (let ((a (vector-ref v i)))
-            (when (and (vector-ref dbl-flags i)
-                       (number? a) (not (flonum? a)))
-              (vector-set! v i (exact->inexact a)))))))));; simple name of a dotted/slashed string: the segment after the last . or /.
+;; simple name of a dotted/slashed string: the segment after the last . or /.
 (define (chez-shape-simple-name s)
   (let loop ((i (- (string-length s) 1)))
     (cond ((< i 0) s)

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -217,11 +217,6 @@
 ;; /associative?/counted? are naturally false). Arity 2 (msg data) or 3 (msg data cause).
 ;; No :jolt/class field on plain ex-info — class defaults to clojure.lang.ExceptionInfo
 ;; via ex-info-class in records-interop.ss.
-(define jolt-kw-ex-type (keyword "jolt" "type"))
-(define jolt-kw-ex-info (keyword "jolt" "ex-info"))
-(define jolt-kw-message (keyword #f "message"))
-(define jolt-kw-data (keyword #f "data"))
-(define jolt-kw-cause (keyword #f "cause"))
 (define (jolt-ex-info msg data . more)
   (make-jolt-ex-info-record "clojure.lang.ExceptionInfo" msg
                              (if (null? more) jolt-nil (car more))
@@ -229,10 +224,8 @@
 ;; A host-constructed throwable (RuntimeException. etc.): a jolt-ex-info-record
 ;; carrying its canonical JVM class-name, so (class …) / instance? / .getMessage /
 ;; ex-message all reflect the real type.
-(define jolt-kw-class (keyword "jolt" "class"))
 ;; java.text.ParseException carries an int error offset (getErrorOffset). Stored
 ;; in the record's error-offset field.
-(define jolt-kw-error-offset (keyword "jolt" "error-offset"))
 (define (jolt-host-throwable class-name msg . more)
   (make-jolt-ex-info-record class-name msg
                              (if (null? more) jolt-nil (car more))

--- a/host/chez/run-contagion.ss
+++ b/host/chez/run-contagion.ss
@@ -11,14 +11,7 @@
 ;;
 ;;   chez --script host/chez/run-contagion.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 (define set-record-shapes! (var-deref "jolt.passes.types" "set-record-shapes!"))
@@ -30,19 +23,6 @@
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
 (define (evals src) (jolt-compile-eval (string-append "(do " src ")") "user"))
 (define (kw n) (keyword #f n))
-(define (sub? s t)
-  (let ((n (string-length s)) (m (string-length t)))
-    (let loop ((i 0))
-      (cond ((> (+ i m) n) #f)
-            ((string=? (substring s i (+ i m)) t) #t)
-            (else (loop (+ i 1)))))))
-
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 ;; a def's fn arity, from "(def _ (fn [a] ..body..))"
 (define (fn-of src) (jolt-get (anode src) (kw "init")))
@@ -68,9 +48,9 @@
        (spar (jolt-nth res 0))
        (eligible? (jolt-nth res 1))
        (e (emit-spec src spar)))
-  (check "(1) :num beside :double is eligible" eligible? #t)
-  (check "(1) contagion lowers to fl*" (sub? e "fl*") #t)
-  (check "(1) contagion coerces :num operand via exact->inexact" (sub? e "exact->inexact") #t))
+  (gate-check "(1) :num beside :double is eligible" eligible? #t)
+  (gate-check "(1) contagion lowers to fl*" (gate-sub? e "fl*") #t)
+  (gate-check "(1) contagion coerces :num operand via exact->inexact" (gate-sub? e "exact->inexact") #t))
 
 ;; === (2) pure-:num (no :double operand) -> stays generic (the invariant) =========
 (let* ((src "(def _ (fn [a] (* (:n a) (:n a))))")
@@ -78,8 +58,8 @@
        (spar (jolt-nth res 0))
        (eligible? (jolt-nth res 1))
        (e (emit-spec src spar)))
-  (check "(2) pure-:num not eligible (no :double operand)" eligible? #f)
-  (check "(2) pure-:num stays generic (no fl*)" (sub? e "fl*") #f))
+  (gate-check "(2) pure-:num not eligible (no :double operand)" eligible? #f)
+  (gate-check "(2) pure-:num stays generic (no fl*)" (gate-sub? e "fl*") #f))
 
 ;; === (3) genuine :double field -> shared path already unboxes; no clone worth it ==
 (evals "(defrecord DBox [d])")
@@ -90,7 +70,7 @@
 (let* ((src "(def _ (fn [a] (* 2.0 (:d a))))")
        (res (contagion-specialize-arity (arity-of src) "DBox"))
        (eligible? (jolt-nth res 1)))
-  (check "(3) genuine :double field not eligible (shared path already unboxes)" eligible? #f))
+  (gate-check "(3) genuine :double field not eligible (shared path already unboxes)" eligible? #f))
 
 ;; === (4) runtime specialized clone registry + devirt-resolve-fl =================
 (evals "(defprotocol Shape (area [s]))")
@@ -98,18 +78,18 @@
 (evals "(def c (->Circle 7))")
 (define clone-fn (lambda (s) 'CLONE))
 (register-clone "user.Circle" "Shape" "area" clone-fn)
-(check "(4) devirt-resolve-fl finds the clone"
+(gate-check "(4) devirt-resolve-fl finds the clone"
        (eq? (devirt-resolve-fl "user.Circle" "Shape" "area" (var-deref "user" "c")) clone-fn) #t)
 ;; Square.area has no clone -> devirt-resolve-fl falls back to devirt-resolve.
 (evals "(defrecord Square [w] Shape (area [s] (* (:w s) (:w s))))")
 (evals "(def sq (->Square 5))")
-(check "(4) devirt-resolve-fl falls back when no clone (Square.area)"
+(gate-check "(4) devirt-resolve-fl falls back when no clone (Square.area)"
        (eq? (devirt-resolve-fl "user.Square" "Shape" "area" (var-deref "user" "sq"))
             (devirt-resolve "user.Square" "Shape" "area" (var-deref "user" "sq"))) #t)
 ;; a re-extend re-registers the impl -> register-protocol-method invalidates the clone
 ;; for exactly (Circle/Shape/area) -> devirt-resolve-fl falls back to the fresh impl.
 (evals "(extend-type Circle Shape (area [s] (:r s)))")
-(check "(4) clone invalidated on re-register (epoch)"
+(gate-check "(4) clone invalidated on re-register (epoch)"
        (eq? (devirt-resolve-fl "user.Circle" "Shape" "area" (var-deref "user" "c"))
             (devirt-resolve "user.Circle" "Shape" "area" (var-deref "user" "c"))) #t)
 
@@ -130,9 +110,9 @@
 (define bag-ctor (anode "(def bag-use (fn [] (->IBag 7)))"))
 (wp-infer! (jolt-vector bag-def bag-ctor))
 (let ((emitted (emit-top-form (run-passes bag-def (make-analyze-ctx "user")))))
-  (check "(5) eligible impl emits a clone registration" (sub? emitted "register-clone*") #t)
-  (check "(5) clone body lowers to fl*" (sub? emitted "fl*") #t)
-  (check "(5) clone coerces the :num operand via exact->inexact" (sub? emitted "exact->inexact") #t))
+  (gate-check "(5) eligible impl emits a clone registration" (gate-sub? emitted "register-clone*") #t)
+  (gate-check "(5) clone body lowers to fl*" (gate-sub? emitted "fl*") #t)
+  (gate-check "(5) clone coerces the :num operand via exact->inexact" (gate-sub? emitted "exact->inexact") #t))
 
 ;; === (6) a pure-:num impl (no :double operand) emits NO clone ==================
 (evals "(defrecord IPlain [n] P (m [s] (* (:n s) (:n s))))")
@@ -141,7 +121,7 @@
 (define plain-ctor (anode "(def plain-use (fn [] (->IPlain 7)))"))
 (wp-infer! (jolt-vector plain-def plain-ctor))
 (let ((emitted (emit-top-form (run-passes plain-def (make-analyze-ctx "user")))))
-  (check "(6) pure-:num impl emits NO clone" (sub? emitted "register-clone*") #f))
+  (gate-check "(6) pure-:num impl emits NO clone" (gate-sub? emitted "register-clone*") #f))
 (set-direct-link! #f)
 (set-optimize! #f)
 
@@ -177,14 +157,14 @@
 (set-optimize! #t)
 (set-direct-link! #t)
 (let ((e (emit-top-form (run-passes (devirt-def "user.IBag2") (make-analyze-ctx "user")))))
-  (check "(7) devirt site over eligible impl emits devirt-resolve-fl" (sub? e "devirt-resolve-fl") #t))
+  (gate-check "(7) devirt site over eligible impl emits devirt-resolve-fl" (gate-sub? e "devirt-resolve-fl") #t))
 ;; emit + eval the defrecord (registers the clone), then the devirt site resolves it.
 (let ((rec-e (emit-top-form (run-passes ibag2-def (make-analyze-ctx "user"))))
       (site-e (emit-top-form (run-passes (devirt-def "user.IBag2") (make-analyze-ctx "user")))))
   (run-emit rec-e)
   (run-emit site-e)
   (evals "(def an-ibag2 (->IBag2 7))")
-  (check "(7) devirt-resolve-fl resolves the clone, value == dispatch"
+  (gate-check "(7) devirt-resolve-fl resolves the clone, value == dispatch"
          (jolt-invoke (var-deref "user" "usem2") (var-deref "user" "an-ibag2"))
          (evals "(m2 an-ibag2)")))
 ;; a pure-:num impl has no clone-site -> its devirt site stays on devirt-resolve.
@@ -195,8 +175,8 @@
 (contagion-prepass! (jolt-vector iplain2-def (devirt-def "user.IPlain2")) "user")
 (contagion-prepass-done!)
 (let ((e (emit-top-form (run-passes (devirt-def "user.IPlain2") (make-analyze-ctx "user")))))
-  (check "(7) devirt site over pure-:num impl is NOT devirt-resolve-fl" (sub? e "devirt-resolve-fl") #f)
-  (check "(7) ...it stays on the ordinary devirt-resolve" (sub? e "devirt-resolve ") #t))
+  (gate-check "(7) devirt site over pure-:num impl is NOT devirt-resolve-fl" (gate-sub? e "devirt-resolve-fl") #f)
+  (gate-check "(7) ...it stays on the ordinary devirt-resolve" (gate-sub? e "devirt-resolve ") #t))
 (set-direct-link! #f)
 (set-optimize! #f)
 
@@ -222,8 +202,8 @@
 (set-optimize! #t)
 (set-direct-link! #t)
 (let ((e (emit-top-form (run-passes acc8-def (make-analyze-ctx "user")))))
-  (check "(8) caller accumulator over clone-resolving devirt site -> fl+" (sub? e "fl+") #t)
-  (check "(8) ...and the devirt call resolves the clone (devirt-resolve-fl)" (sub? e "devirt-resolve-fl") #t))
+  (gate-check "(8) caller accumulator over clone-resolving devirt site -> fl+" (gate-sub? e "fl+") #t)
+  (gate-check "(8) ...and the devirt call resolves the clone (devirt-resolve-fl)" (gate-sub? e "devirt-resolve-fl") #t))
 ;; the SAME caller shape over a PIC/megamorphic site (unseeded `s`) does not resolve
 ;; the contagion clone — no devirt-resolve-fl. (Whether it lowers to fl+ depends on
 ;; shared rtinfo/pm-rets state and is unreliable in this synthetic gate; the real
@@ -232,10 +212,8 @@
 ;; baseline.)
 (define acc8-pic (anode "(def acc8-pic (fn [s] (+ 0.0 (m3 s))))"))
 (let ((e (emit-top-form (run-passes acc8-pic (make-analyze-ctx "user")))))
-  (check "(8) PIC/megamorphic site does NOT resolve the contagion clone" (sub? e "devirt-resolve-fl") #f))
+  (gate-check "(8) PIC/megamorphic site does NOT resolve the contagion clone" (gate-sub? e "devirt-resolve-fl") #f))
 (set-direct-link! #f)
 (set-optimize! #f)
 
-(if (= fails 0)
-    (begin (printf "contagion gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "contagion gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "contagion")

--- a/host/chez/run-corpus.ss
+++ b/host/chez/run-corpus.ss
@@ -16,14 +16,7 @@
 ;;   JOLT_DUMP_CRASH_LABELS=1   list crash + allowlisted labels
 (import (chezscheme))
 
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define (slurp path)
   (call-with-input-file path

--- a/host/chez/run-dce-refs.ss
+++ b/host/chez/run-dce-refs.ss
@@ -43,6 +43,12 @@
 (define str3 "(var-deref (f) (g))")
 (gate-check "computed var-deref args not matched" (dce-sexp-refs-str str3) '())
 
+;; a var-cell-lookup literal (the host shim's native form for looking up a var cell
+;; by ns + name) is caught the same as var-deref and jolt-var.
+(define str4 "(var-cell-lookup \"app.core\" \"target\")")
+(gate-check "text scan catches var-cell-lookup literal" (has? "app.core/target" (dce-sexp-refs-str str4)) #t)
+(gate-check "union catches var-cell-lookup form" (has? "app.core/target" (dce-app-refs ir str4)) #t)
+
 ;; --- dce-runtime-core-roots guard -------------------------------------------
 ;; A runtime .ss shim that references a clojure.core fn by name (a literal
 ;; (var-deref "clojure.core" "NAME") or jolt-var) is invisible to the app IR
@@ -100,6 +106,29 @@
            (gate-check (string-append "core-root: " (car refs) " (" (car files) ")")
                   (hashtable-ref rooted (car refs) #f) #t)
            (loop-refs (cdr refs)))
-          (else (loop-refs (cdr refs))))))))
+           (else (loop-refs (cdr refs))))))))
+
+;; --- dce-bail-refs / dce-compile-refs existence gate -------------------------
+;; Every name in the hand-maintained bail/compile lists must resolve to a runtime
+;; binding. A stale entry (one that no longer exists in the runtime) fails here
+;; instead of silently widening the bail set — the static graph treats an unknown
+;; bail name as "everything is reachable" and drops no code, but the list rot is
+;; invisible. This gate makes it visible.
+(let ((missing (lambda (lst label)
+                  (let loop ((ns lst) (bad '()))
+                    (if (null? ns) bad
+                        (let* ((name (car ns))
+                               (slash (let loop2 ((i 0))
+                                        (if (char=? (string-ref name i) #\/) i
+                                            (loop2 (+ i 1))))))
+                          (if (var-cell-lookup (substring name 0 slash)
+                                               (substring name (+ slash 1)
+                                                          (string-length name)))
+                              (loop (cdr ns) bad)
+                              (loop (cdr ns) (cons name bad)))))))))
+  (for-each (lambda (n) (gate-check (string-append "bail-ref exists: " n) #f #t))
+            (missing dce-bail-refs "bail-refs"))
+  (for-each (lambda (n) (gate-check (string-append "compile-ref exists: " n) #f #t))
+            (missing dce-compile-refs "compile-refs")))
 
 (gate-summary "dce-refs")

--- a/host/chez/run-dce-refs.ss
+++ b/host/chez/run-dce-refs.ss
@@ -11,6 +11,8 @@
 (import (chezscheme))
 (load "host/chez/run-gate-harness.ss")
 (load "host/chez/dce.ss")
+;; load the full stdlib so var-cell-lookup resolves every bail/compile-ref
+(load "host/chez/loader.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 
@@ -114,6 +116,14 @@
 ;; instead of silently widening the bail set — the static graph treats an unknown
 ;; bail name as "everything is reachable" and drops no code, but the list rot is
 ;; invisible. This gate makes it visible.
+;;
+;; Known-unimplemented core vars referenced in the bail/compile lists that don't
+;; yet have a runtime def-var! are allowlisted — they still widen the bail set
+;; correctly (an unknown name in the graph acts as "keep everything"), but the
+;; existence check skips them so a planned-but-unbuilt var doesn't fail the gate.
+(define dce-gate-allowlist (make-hashtable string-hash string=?))
+(for-each (lambda (n) (hashtable-set! dce-gate-allowlist n #t))
+          '("clojure.core/load-reader"))
 (let ((missing (lambda (lst label)
                   (let loop ((ns lst) (bad '()))
                     (if (null? ns) bad
@@ -121,9 +131,10 @@
                                (slash (let loop2 ((i 0))
                                         (if (char=? (string-ref name i) #\/) i
                                             (loop2 (+ i 1))))))
-                          (if (var-cell-lookup (substring name 0 slash)
-                                               (substring name (+ slash 1)
-                                                          (string-length name)))
+                          (if (or (hashtable-ref dce-gate-allowlist name #f)
+                                  (var-cell-lookup (substring name 0 slash)
+                                                   (substring name (+ slash 1)
+                                                              (string-length name))))
                               (loop (cdr ns) bad)
                               (loop (cdr ns) (cons name bad)))))))))
   (for-each (lambda (n) (gate-check (string-append "bail-ref exists: " n) #f #t))

--- a/host/chez/run-dce-refs.ss
+++ b/host/chez/run-dce-refs.ss
@@ -9,52 +9,39 @@
 ;;
 ;;   chez --script host/chez/run-dce-refs.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 (load "host/chez/dce.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 (define (has? x lst) (if (member x lst) #t #f))
 
 ;; an IR node with NO :var/:the-var child (a plain constant) — its emitted scheme
 ;; carries no var reference, so the IR walk finds nothing.
 (define ir (analyze (make-analyze-ctx "app.core") (jolt-ce-read "42")))
-(check "constant IR has no var refs" (dce-collect-refs '() ir) '())
+(gate-check "constant IR has no var refs" (dce-collect-refs '() ir) '())
 
 ;; the same form's emitted scheme, but carrying a literal string-keyed var-deref
 ;; spliced in (as a macro might emit raw scheme). The IR walk misses it; the text
 ;; scan and the union both catch it.
 (define str "(begin (var-deref \"app.core\" \"target\"))")
-(check "IR-only misses string-keyed var-deref" (has? "app.core/target" (dce-collect-refs '() ir)) #f)
-(check "text scan catches string-keyed var-deref" (has? "app.core/target" (dce-sexp-refs-str str)) #t)
-(check "union (dce-app-refs) roots the target" (has? "app.core/target" (dce-app-refs ir str)) #t)
+(gate-check "IR-only misses string-keyed var-deref" (has? "app.core/target" (dce-collect-refs '() ir)) #f)
+(gate-check "text scan catches string-keyed var-deref" (has? "app.core/target" (dce-sexp-refs-str str)) #t)
+(gate-check "union (dce-app-refs) roots the target" (has? "app.core/target" (dce-app-refs ir str)) #t)
 
 ;; jolt-var (the #'x / cached var form) is caught the same way.
 (define str2 "(jolt-var \"app.core\" \"other\")")
-(check "union catches jolt-var form" (has? "app.core/other" (dce-app-refs ir str2)) #t)
+(gate-check "union catches jolt-var form" (has? "app.core/other" (dce-app-refs ir str2)) #t)
 
 ;; a normal :var node is still caught by the IR walk (regression guard) — the union
 ;; is additive, not a replacement.
 (define ir2 (analyze (make-analyze-ctx "user") (jolt-ce-read "(clojure.core/inc)")))
-(check ":var node caught by IR walk" (has? "clojure.core/inc" (dce-collect-refs '() ir2)) #t)
+(gate-check ":var node caught by IR walk" (has? "clojure.core/inc" (dce-collect-refs '() ir2)) #t)
 
 ;; a string-keyed var-deref whose args are NOT literals (computed) is intentionally
 ;; not matched — a static graph can't follow a runtime-resolved name.
 (define str3 "(var-deref (f) (g))")
-(check "computed var-deref args not matched" (dce-sexp-refs-str str3) '())
+(gate-check "computed var-deref args not matched" (dce-sexp-refs-str str3) '())
 
 ;; --- dce-runtime-core-roots guard -------------------------------------------
 ;; A runtime .ss shim that references a clojure.core fn by name (a literal
@@ -110,11 +97,9 @@
           ((and (fx>? (string-length (car refs)) 13)
                 (string=? (substring (car refs) 0 13) "clojure.core/")
                 (not (char=? (string-ref (car refs) 13) #\*)))
-           (check (string-append "core-root: " (car refs) " (" (car files) ")")
+           (gate-check (string-append "core-root: " (car refs) " (" (car files) ")")
                   (hashtable-ref rooted (car refs) #f) #t)
            (loop-refs (cdr refs)))
           (else (loop-refs (cdr refs))))))))
 
-(if (= fails 0)
-    (begin (printf "dce-refs gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "dce-refs gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "dce-refs")

--- a/host/chez/run-devirt.ss
+++ b/host/chez/run-devirt.ss
@@ -8,14 +8,7 @@
 ;;
 ;;   chez --script host/chez/run-devirt.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 (define emit    (var-deref "jolt.backend-scheme" "emit"))
@@ -39,32 +32,20 @@
                          (kw "devirt-method") "area")))
     (emit dv)))
 
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
-(define (has-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0)) (cond ((> (+ i m) n) #f)
-                            ((string=? (substring s i (+ i m)) sub) #t)
-                            (else (loop (+ i 1)))))))
-;; eval an emitted Scheme string in the loaded runtime (var-deref resolves c/sq).
 (define (run-emit scm) (eval (read (open-input-string scm)) (interaction-environment)))
 
 (let ((e (devirt-emit "user.Circle" "c")))
-  (check "emit uses devirt-resolve" (has-sub? e "devirt-resolve") #t)
-  (check "devirt inline impl == dispatch" (run-emit e) (evals "(area c)")))   ; 7
+  (gate-check "emit uses devirt-resolve" (gate-sub? e "devirt-resolve") #t)
+  (gate-check "devirt inline impl == dispatch" (run-emit e) (evals "(area c)")))   ; 7
 
 (let ((e (devirt-emit "user.Square" "sq")))
-  (check "devirt extend-type impl == dispatch" (run-emit e) (evals "(area sq)")))  ; 25
+  (gate-check "devirt extend-type impl == dispatch" (run-emit e) (evals "(area sq)")))  ; 25
 
 ;; a normal (no devirt) call still goes through dispatch and agrees — the path the
 ;; megamorphic / unknown-receiver site keeps.
 (let ((e (emit (analyze (make-analyze-ctx "user") (jolt-ce-read "(area c)")))))
-  (check "non-devirt path no devirt-resolve" (has-sub? e "devirt-resolve") #f)
-  (check "non-devirt still dispatches" (run-emit e) 7))
+  (gate-check "non-devirt path no devirt-resolve" (gate-sub? e "devirt-resolve") #f)
+  (gate-check "non-devirt still dispatches" (run-emit e) 7))
 
 ;; a record that relies on the protocol's Object default (no direct impl): the
 ;; inference still types it as a concrete record and annotates devirt, so the
@@ -75,7 +56,7 @@
 (evals "(defrecord Plain [n])")
 (evals "(def pl (->Plain 9))")
 (let ((e (devirt-emit "user.Plain" "pl")))
-  (check "devirt Object-default == dispatch" (run-emit e) (evals "(area pl)")))  ; :obj-default
+  (gate-check "devirt Object-default == dispatch" (run-emit e) (evals "(area pl)")))  ; :obj-default
 
 ;; in a direct-link build a devirt site caches the resolved impl in a per-site cell
 ;; (resolved once, reused) instead of resolving per call. Annotate the (area x) in a
@@ -92,12 +73,12 @@
   (set-direct-link! #t)
   (let ((e (emit-top-form dn2)))
     (set-direct-link! #f)
-    (check "devirt in a def caches in a per-site cell" (has-sub? e "_dvc$") #t)
-    (check "cached cell still resolves the impl" (has-sub? e "devirt-resolve") #t)
+    (gate-check "devirt in a def caches in a per-site cell" (gate-sub? e "_dvc$") #t)
+    (gate-check "cached cell still resolves the impl" (gate-sub? e "devirt-resolve") #t)
     ;; eval the def, then call it: caches on first call, reuses after — still 7.
     (run-emit e)
-    (check "cached devirt == dispatch (1st call)" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 7)
-    (check "cached devirt == dispatch (2nd call, from cell)" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 7)))
+    (gate-check "cached devirt == dispatch (1st call)" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 7)
+    (gate-check "cached devirt == dispatch (2nd call, from cell)" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 7)))
 
 ;; a warmed mono devirt cell must re-resolve after a runtime extend-type bumps
 ;; jolt-proto-epoch, mirroring the PIC: register-protocol-method bumps the epoch
@@ -118,12 +99,10 @@
     (set-direct-link! #f)
     (run-emit e)
     ;; warm: first call caches Circle's original impl (:r -> 7)
-    (check "re-ext: warmed to original impl" (jolt-invoke (var-deref "user" "usearea2") (var-deref "user" "c")) 7)
+    (gate-check "re-ext: warmed to original impl" (jolt-invoke (var-deref "user" "usearea2") (var-deref "user" "c")) 7)
     ;; re-extend Circle with a NEW impl; bumps jolt-proto-epoch
     (evals "(extend-type Circle Shape (area [s] (* (:r s) 100)))")
     ;; the warmed cell must re-resolve -> 700, not the stale 7
-    (check "re-ext: re-resolves to new impl after extend-type" (jolt-invoke (var-deref "user" "usearea2") (var-deref "user" "c")) 700)))
+    (gate-check "re-ext: re-resolves to new impl after extend-type" (jolt-invoke (var-deref "user" "usearea2") (var-deref "user" "c")) 700)))
 
-(if (= fails 0)
-    (begin (printf "devirt gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "devirt gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "devirt")

--- a/host/chez/run-fieldjoin.ss
+++ b/host/chez/run-fieldjoin.ss
@@ -17,14 +17,7 @@
 ;;
 ;;   chez --script host/chez/run-fieldjoin.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze             (var-deref "jolt.analyzer" "analyze"))
 (define set-record-shapes!  (var-deref "jolt.passes.types" "set-record-shapes!"))
@@ -34,14 +27,6 @@
 (define emit                (var-deref "jolt.backend-scheme" "emit"))
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
 (define (evals src) (jolt-compile-eval (string-append "(do " src ")") "user"))
-(define (sub? s t)(let((n(string-length s))(m(string-length t)))(let loop((i 0))(cond((>(+ i m)n)#f)((string=?(substring s i(+ i m))t)#t)(else(loop(+ i 1)))))))
-
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 ;; === (a) all-flonum ctor sites -> field :double -> impl fl*, caller fl+ ==========
 (evals "(defprotocol Sh (area [s]))")
@@ -57,10 +42,10 @@
 (wp-infer! (jolt-vector cdef mk sum))
 ;; the impl body reads :r; once :r proves :double the (* 3.14159 (:r s)) unboxes.
 (define cdef-e (emit (run-passes cdef (make-analyze-ctx "user"))))
-(check "(a) impl body unboxes :r to fl*" (sub? cdef-e "fl*") #t)
+(gate-check "(a) impl body unboxes :r to fl*" (gate-sub? cdef-e "fl*") #t)
 ;; the caller's (+ acc (area c)) goes fl+ via the concrete protocol-method return.
 (define sum-e (emit (run-passes sum (make-analyze-ctx "user"))))
-(check "(a) caller accumulator goes fl+" (sub? sum-e "fl+") #t)
+(gate-check "(a) caller accumulator goes fl+" (gate-sub? sum-e "fl+") #t)
 
 ;; === (d) integer-fed (:num-joined) field must NOT unbox (Option B) ==============
 ;; dbl contagion is restricted to genuine :double fields. A field whose ctor sites
@@ -73,7 +58,7 @@
 (define iuse   (anode "(def iuse (fn [] (iscale (->IBox 7))))"))   ; integer ctor arg -> :num
 (wp-infer! (jolt-vector iscale iuse))
 (define iscale-e (emit (run-passes iscale (make-analyze-ctx "user"))))
-(check "(d) integer-fed :num-joined field stays generic (no fl*)" (sub? iscale-e "fl*") #f)
+(gate-check "(d) integer-fed :num-joined field stays generic (no fl*)" (gate-sub? iscale-e "fl*") #f)
 
 ;; === (b) record-or-nil ctor sites -> nilable field =============================
 ;; Outer's :child is filled with an Inner or nil across ctor sites -> nilable-Inner.
@@ -95,10 +80,10 @@
 (define caller (anode "(def caller (fn [b] (+ (og (mko b)) (ou (mko b)))))"))
 (wp-infer! (jolt-vector odef idef mko og ou caller))
 (define og-e (emit (run-passes og (make-analyze-ctx "user"))))
-(check "(b) guarded nilable-field read direct-accesses (jrec2-f1)" (sub? og-e "jrec2-f1") #t)
+(gate-check "(b) guarded nilable-field read direct-accesses (jrec2-f1)" (gate-sub? og-e "jrec2-f1") #t)
 (define ou-e (emit (run-passes ou (make-analyze-ctx "user"))))
-(check "(b) unguarded nilable-field read stays nil-safe (no direct accessor)" (sub? ou-e "jrec2-f1") #f)
-(check "(b) unguarded nilable-field read uses nil-safe jrec-field-at" (sub? ou-e "jrec-field-at") #t)
+(gate-check "(b) unguarded nilable-field read stays nil-safe (no direct accessor)" (gate-sub? ou-e "jrec2-f1") #f)
+(gate-check "(b) unguarded nilable-field read uses nil-safe jrec-field-at" (gate-sub? ou-e "jrec-field-at") #t)
 
 ;; === (c) conflicting join -> reads stay generic ================================
 ;; Box's :v: one ctor site passes a flonum, another a string -> join :any -> no unbox.
@@ -110,8 +95,6 @@
 (define brd  (anode "(def brd (fn [] (* (:v (bmk1)) 2.0)))"))
 (wp-infer! (jolt-vector bdef bmk1 bmk2 brd))
 (define brd-e (emit (run-passes brd (make-analyze-ctx "user"))))
-(check "(c) conflicting field join stays generic (no fl*)" (sub? brd-e "fl*") #f)
+(gate-check "(c) conflicting field join stays generic (no fl*)" (gate-sub? brd-e "fl*") #f)
 
-(if (= fails 0)
-    (begin (printf "fieldjoin gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "fieldjoin gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "fieldjoin")

--- a/host/chez/run-fieldnum.ss
+++ b/host/chez/run-fieldnum.ss
@@ -9,14 +9,7 @@
 ;;
 ;;   chez --script host/chez/run-fieldnum.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze              (var-deref "jolt.analyzer" "analyze"))
 (define set-record-shapes!   (var-deref "jolt.passes.types" "set-record-shapes!"))
@@ -27,25 +20,12 @@
 
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
 (define (evals src) (jolt-compile-eval (string-append "(do " src ")") "user"))
-(define (contains-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0))
-      (cond ((> (+ i m) n) #f)
-            ((string=? (substring s i (+ i m)) sub) #t)
-            (else (loop (+ i 1)))))))
-
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 ;; a record with ^double fields; the ctor must coerce an integer arg to a flonum.
 (evals "(defrecord V [^double x ^double y])")
-(check "ctor coerces ^double field to flonum" (flonum? (evals "(:x (->V 1 2))")) #t)
-(check "coerced field value matches" (evals "(:x (->V 1 2))") 1.0)
-(check "a flonum arg passes through" (evals "(:y (->V 1.5 2.5))") 2.5)
+(gate-check "ctor coerces ^double field to flonum" (flonum? (evals "(:x (->V 1 2))")) #t)
+(gate-check "coerced field value matches" (evals "(:x (->V 1 2))") 1.0)
+(gate-check "a flonum arg passes through" (evals "(:y (->V 1.5 2.5))") 2.5)
 
 ;; dot is hintless; its caller passes V instances, so the fixpoint types a/b as V
 ;; records, the ^double fields read :double, and the field-field arithmetic unboxes.
@@ -56,17 +36,17 @@
 (wp-infer! (jolt-vector dot used))
 (set-optimize! #t)
 (define dot-emit (emit (run-passes dot (make-analyze-ctx "user"))))
-(check "field-field arithmetic unboxes to fl*" (contains-sub? dot-emit "fl*") #t)
-(check "field-field arithmetic unboxes to fl+" (contains-sub? dot-emit "fl+") #t)
+(gate-check "field-field arithmetic unboxes to fl*" (gate-sub? dot-emit "fl*") #t)
+(gate-check "field-field arithmetic unboxes to fl+" (gate-sub? dot-emit "fl+") #t)
 
 ;; a ^V param hint types the param with no inferable caller (open-world / cross-fn:
 ;; the receiver isn't a ctor return). This is the record-ctor-key path — without it
 ;; the hint is dead and the reads fall back to generic jolt-get + boxed arithmetic.
 (define hinted (anode "(def hyp (fn [^V v] (+ (* (:x v) (:x v)) (* (:y v) (:y v)))))"))
 (define hint-emit (emit (run-passes hinted (make-analyze-ctx "user"))))
-(check "^V param hint direct-accesses field reads" (contains-sub? hint-emit "jrec2-f0") #t)
-(check "^V param hint unboxes arithmetic" (contains-sub? hint-emit "fl*") #t)
-(check "^V param hint leaves no generic jolt-get" (contains-sub? hint-emit "jolt-get") #f)
+(gate-check "^V param hint direct-accesses field reads" (gate-sub? hint-emit "jrec2-f0") #t)
+(gate-check "^V param hint unboxes arithmetic" (gate-sub? hint-emit "fl*") #t)
+(gate-check "^V param hint leaves no generic jolt-get" (gate-sub? hint-emit "jolt-get") #f)
 
 ;; an UNTAGGED field whose every ctor site passes a flonum now unboxes too —
 ;; whole-program field-type inference (run-fieldjoin) derives :double from the ctor
@@ -76,9 +56,7 @@
 (define usew (anode "(def usew (fn [] (dotw (->W 1.0 2.0) (->W 3.0 4.0))))"))
 (set-record-shapes! (chez-record-shapes-map))
 (wp-infer! (jolt-vector dotw usew))
-(check "untagged all-flonum field unboxes to fl* (field-typed)"
-       (contains-sub? (emit (run-passes dotw (make-analyze-ctx "user"))) "fl*") #t)
+(gate-check "untagged all-flonum field unboxes to fl* (field-typed)"
+       (gate-sub? (emit (run-passes dotw (make-analyze-ctx "user"))) "fl*") #t)
 
-(if (= fails 0)
-    (begin (printf "fieldnum gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "fieldnum gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "fieldnum")

--- a/host/chez/run-fieldread.ss
+++ b/host/chez/run-fieldread.ss
@@ -8,14 +8,7 @@
 ;;
 ;;   chez --script host/chez/run-fieldread.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 (define emit    (var-deref "jolt.backend-scheme" "emit"))
@@ -36,36 +29,25 @@
     (emit (jolt-assoc ir (kw "args") args2))))
 
 (define (run-emit scm) (eval (read (open-input-string scm)) (interaction-environment)))
-(define (has-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0)) (cond ((> (+ i m) n) #f)
-                            ((string=? (substring s i (+ i m)) sub) #t)
-                            (else (loop (+ i 1)))))))
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 ;; a declared field -> bare-index path, value matches jolt-get
 (let ((e (mark-emit "(:y a)")))
-  (check "declared field uses direct accessor jrec3-f1" (has-sub? e "jrec3-f1") #t)
-  (check "direct path leaves no jrec-field-at cond" (has-sub? e "jrec-field-at") #f)
-  (check "bare read == jolt-get" (run-emit e) (evals "(:y a)")))   ; 20
+  (gate-check "declared field uses direct accessor jrec3-f1" (gate-sub? e "jrec3-f1") #t)
+  (gate-check "direct path leaves no jrec-field-at cond" (gate-sub? e "jrec-field-at") #f)
+  (gate-check "bare read == jolt-get" (run-emit e) (evals "(:y a)")))   ; 20
 
 ;; first/last fields too
-(check "field x == jolt-get" (run-emit (mark-emit "(:x a)")) (evals "(:x a)"))   ; 10
-(check "field z == jolt-get" (run-emit (mark-emit "(:z a)")) (evals "(:z a)"))   ; 30
+(gate-check "field x == jolt-get" (run-emit (mark-emit "(:x a)")) (evals "(:x a)"))   ; 10
+(gate-check "field z == jolt-get" (run-emit (mark-emit "(:z a)")) (evals "(:z a)"))   ; 30
 
 ;; a key that is NOT a declared field -> no bare path, still correct (nil)
 (let ((e (mark-emit "(:w a)")))
-  (check "non-field key no jrec-field-at" (has-sub? e "jrec-field-at") #f)
-  (check "non-field key == jolt-get" (run-emit e) (evals "(:w a)")))   ; nil
+  (gate-check "non-field key no jrec-field-at" (gate-sub? e "jrec-field-at") #f)
+  (gate-check "non-field key == jolt-get" (run-emit e) (evals "(:w a)")))   ; nil
 
 ;; a default-arg form keeps jolt-get (the bare path is no-default only)
 (let ((e (mark-emit "(:y a 99)")))
-  (check "default-arg keeps jolt-get" (has-sub? e "jrec-field-at") #f))
+  (gate-check "default-arg keeps jolt-get" (gate-sub? e "jrec-field-at") #f))
 
 ;; field-tag resolution across same-named records: two namespaces each define
 ;; Node; a record's simple ^Node field tag resolves to the SAME-NS Node, and a
@@ -78,10 +60,8 @@
 (register-record-shape! "nsb/->HolderQ" (list (kw "n")) (list "nsa.Node") "nsb.HolderQ")
 (let* ((m (chez-record-shapes-map))
        (tag-of (lambda (ck) (jolt-nth (jolt-get (jolt-get m ck) (kw "tags")) 0))))
-  (check "simple ^Node in nsa -> nsa's Node" (tag-of "nsa/->Holder") "nsa/->Node")
-  (check "simple ^Node in nsb -> nsb's Node" (tag-of "nsb/->Holder") "nsb/->Node")
-  (check "qualified ^nsa.Node from nsb -> nsa's Node" (tag-of "nsb/->HolderQ") "nsa/->Node"))
+  (gate-check "simple ^Node in nsa -> nsa's Node" (tag-of "nsa/->Holder") "nsa/->Node")
+  (gate-check "simple ^Node in nsb -> nsb's Node" (tag-of "nsb/->Holder") "nsb/->Node")
+  (gate-check "qualified ^nsa.Node from nsb -> nsa's Node" (tag-of "nsb/->HolderQ") "nsa/->Node"))
 
-(if (= fails 0)
-    (begin (printf "fieldread gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "fieldread gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "fieldread")

--- a/host/chez/run-gate-harness.ss
+++ b/host/chez/run-gate-harness.ss
@@ -1,0 +1,41 @@
+;; run-gate-harness.ss — shared gate harness: boot preamble, check counter, substring scan, summary/exit.
+;;
+;; Loaded by every run-*.ss gate to avoid duplicating the runtime boot preamble
+;; and check/fails harness. Usage:
+;;   (import (chezscheme))
+;;   (load "host/chez/run-gate-harness.ss")
+;;   … gate-specific code …
+;;   (gate-summary "name")
+
+;; --- boot preamble ---------------------------------------------------------------
+(load "host/chez/rt.ss")
+(set-chez-ns! "clojure.core")
+(load "host/chez/seed/prelude.ss")
+(load "host/chez/post-prelude.ss")
+(set-chez-ns! "user")
+(load "host/chez/host-contract.ss")
+(load "host/chez/seed/image.ss")
+(load "host/chez/compile-eval.ss")
+
+;; --- check counter ---------------------------------------------------------------
+(define gate-fails 0)
+(define gate-total 0)
+(define (gate-check label actual expected)
+  (set! gate-total (+ gate-total 1))
+  (unless (equal? actual expected)
+    (set! gate-fails (+ gate-fails 1))
+    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
+
+;; --- substring scan --------------------------------------------------------------
+(define (gate-sub? s sub)
+  (let ((n (string-length s)) (m (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> (+ i m) n) #f)
+            ((string=? (substring s i (+ i m)) sub) #t)
+            (else (loop (+ i 1)))))))
+
+;; --- summary / exit --------------------------------------------------------------
+(define (gate-summary name)
+  (if (= gate-fails 0)
+      (begin (printf "~a gate: ~a/~a passed\n" name gate-total gate-total) (exit 0))
+      (begin (printf "~a gate: ~a/~a passed (~a failed)\n" name (- gate-total gate-fails) gate-total gate-fails) (exit 1))))

--- a/host/chez/run-infer.ss
+++ b/host/chez/run-infer.ss
@@ -11,15 +11,7 @@
 ;;
 ;;   chez --script host/chez/run-infer.ss
 (import (chezscheme))
-
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze            (var-deref "jolt.analyzer" "analyze"))
 (define check-form         (var-deref "jolt.passes.types" "check-form"))
@@ -37,57 +29,49 @@
 ;; number of success-type diagnostics check-form produces for src.
 (define (diags src strict?) (jolt-count (check-form (anode src) strict?)))
 
-(define fails 0)
-(define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
-
 ;; --- core error-domain checking (strict not required) -----------------------
-(check "num-op on keyword"        (diags "(+ 1 :k)" #f) 1)
-(check "num-op all numbers"       (diags "(+ 1 2)" #f) 0)
-(check "count on number"          (diags "(count 5)" #f) 1)
-(check "count on vector"          (diags "(count [1 2])" #f) 0)
-(check "lenient (:k 5)"           (diags "(:k 5)" #f) 0)
-(check "call a number"            (diags "(5 1)" #f) 1)
-(check "nested count return type" (diags "(+ 1 (count :k))" #f) 1)
+(gate-check "num-op on keyword"        (diags "(+ 1 :k)" #f) 1)
+(gate-check "num-op all numbers"       (diags "(+ 1 2)" #f) 0)
+(gate-check "count on number"          (diags "(count 5)" #f) 1)
+(gate-check "count on vector"          (diags "(count [1 2])" #f) 0)
+(gate-check "lenient (:k 5)"           (diags "(:k 5)" #f) 0)
+(gate-check "call a number"            (diags "(5 1)" #f) 1)
+(gate-check "nested count return type" (diags "(+ 1 (count :k))" #f) 1)
 
 ;; --- walk arms thread the type env ------------------------------------------
-(check "let binds kw"             (diags "(let [x :k] (+ x 1))" #f) 1)
-(check "let binds ok"             (diags "(let [x 1] (+ x 1))" #f) 0)
-(check "if then branch error"     (diags "(if true (+ 1 :k) 2)" #f) 1)
-(check "do statement error"       (diags "(do (+ 1 :k) 2)" #f) 1)
-(check "mapv seeds element type"  (diags "(mapv (fn [x] (+ x 1)) [:a :b])" #f) 1)
-(check "mapv ok element type"     (diags "(mapv (fn [x] (+ x 1)) [1 2])" #f) 0)
-(check "reduce seeds element"     (diags "(reduce (fn [acc x] (+ acc x)) 0 [:a])" #f) 1)
+(gate-check "let binds kw"             (diags "(let [x :k] (+ x 1))" #f) 1)
+(gate-check "let binds ok"             (diags "(let [x 1] (+ x 1))" #f) 0)
+(gate-check "if then branch error"     (diags "(if true (+ 1 :k) 2)" #f) 1)
+(gate-check "do statement error"       (diags "(do (+ 1 :k) 2)" #f) 1)
+(gate-check "mapv seeds element type"  (diags "(mapv (fn [x] (+ x 1)) [:a :b])" #f) 1)
+(gate-check "mapv ok element type"     (diags "(mapv (fn [x] (+ x 1)) [1 2])" #f) 0)
+(gate-check "reduce seeds element"     (diags "(reduce (fn [acc x] (+ acc x)) 0 [:a])" #f) 1)
 
 ;; --- strict user-function domains (checking-box / diag-memo / user-sig) ------
-(check "user wrong arg type"      (diags "(do (defn f [x] (+ x 1)) (f :k))" #t) 1)
-(check "user wrong arity"         (diags "(do (defn g [x] x) (g 1 2))" #t) 1)
-(check "user call ok"             (diags "(do (defn h [x] (+ x 1)) (h 3))" #t) 0)
-(check "user domains off w/o strict" (diags "(do (defn f [x] (+ x 1)) (f :k))" #f) 0)
+(gate-check "user wrong arg type"      (diags "(do (defn f [x] (+ x 1)) (f :k))" #t) 1)
+(gate-check "user wrong arity"         (diags "(do (defn g [x] x) (g 1 2))" #t) 1)
+(gate-check "user call ok"             (diags "(do (defn h [x] (+ x 1)) (h 3))" #t) 0)
+(gate-check "user domains off w/o strict" (diags "(do (defn f [x] (+ x 1)) (f :k))" #f) 0)
 ;; recursive user fn terminates (cycle guard) and still flags the bad arg
-(check "user recursive terminates"
+(gate-check "user recursive terminates"
        (diags "(do (defn rf [x] (+ x (rf x))) (rf :k))" #t) 1)
 
 ;; --- infer-body collects calls + escapes ------------------------------------
 (reset-escapes!)
 (let ((r (infer-body (anode "(do (foo 1) (bar 2) (map inc [1]))") (jolt-hash-map))))
-  (check "infer-body calls" (jolt-count (jolt-nth r 2)) 3)        ; foo, bar, map
-  (check "infer-body escapes" (jolt-count (collected-escapes)) 1)) ; inc (value position)
+  (gate-check "infer-body calls" (jolt-count (jolt-nth r 2)) 3)        ; foo, bar, map
+  (gate-check "infer-body escapes" (jolt-count (collected-escapes)) 1)) ; inc (value position)
 
 ;; --- the record-shapes registry feeds call-result types --------------------
 ;; without shapes a (->P …) call result is :any (accepted); with the registry it
 ;; types as a struct, so an arithmetic op over it is provably not-a-number.
-(check "ctor result :any w/o shapes" (diags "(+ (->P 1) 1)" #f) 0)
+(gate-check "ctor result :any w/o shapes" (diags "(+ (->P 1) 1)" #f) 0)
 (set-record-shapes!
   (jolt-hash-map "user/->P"
                  (jolt-hash-map (keyword #f "fields") (jolt-vector (keyword #f "x"))
                                 (keyword #f "tags")   (jolt-vector jolt-nil)
                                 (keyword #f "type")   "user.P")))
-(check "ctor result struct w/ shapes" (diags "(+ (->P 1) 1)" #f) 1)
+(gate-check "ctor result struct w/ shapes" (diags "(+ (->P 1) 1)" #f) 1)
 (set-record-shapes! (jolt-hash-map))
 
 ;; --- the opt-path checker: run-inference emits, take-diags! drains -----------
@@ -95,12 +79,10 @@
 ;; diagnostics are stashed for take-diags! to drain once.
 (set-check-mode! #t #f)
 (run-inference (anode "(+ 1 :k)"))
-(check "take-diags drains run-inference" (jolt-count (take-diags!)) 1)
-(check "take-diags re-drained empty"     (jolt-count (take-diags!)) 0)
+(gate-check "take-diags drains run-inference" (jolt-count (take-diags!)) 1)
+(gate-check "take-diags re-drained empty"     (jolt-count (take-diags!)) 0)
 (set-check-mode! #f #f)
 (run-inference (anode "(+ 1 :k)"))
-(check "no diags when check-mode off"    (jolt-count (take-diags!)) 0)
+(gate-check "no diags when check-mode off"    (jolt-count (take-diags!)) 0)
 
-(if (= fails 0)
-    (begin (printf "infer gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "infer gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "infer")

--- a/host/chez/run-inline-body.ss
+++ b/host/chez/run-inline-body.ss
@@ -5,14 +5,7 @@
 ;;
 ;;   chez --script host/chez/run-inline-body.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define set-record-shapes! (var-deref "jolt.passes.types" "set-record-shapes!"))
 (define set-protocol-methods! (var-deref "jolt.passes.types" "set-protocol-methods!"))
@@ -20,17 +13,6 @@
 (define emit    (var-deref "jolt.backend-scheme" "emit"))
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 (define (evals src) (jolt-compile-eval (string-append "(do " src ")") "user"))
-(define (has-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0)) (cond ((> (+ i m) n) #f)
-                            ((string=? (substring s i (+ i m)) sub) #t)
-                            (else (loop (+ i 1)))))))
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 ;; Populate runtime tables with a protocol and a defrecord with inline method impl.
 (evals "(defprotocol Shape (area [s]))")
@@ -53,8 +35,8 @@
   ;; reinfer pass should have seeded the receiver param so field reads emit
   ;; jrec-field-at.  Not checking jolt-get absence — the :do also contains
   ;; defs that use jolt-get for other purposes.
-  (check "inline method body field read uses direct accessor"
-         (has-sub? emitted "jrec1-f0") #t))
+  (gate-check "inline method body field read uses direct accessor"
+         (gate-sub? emitted "jrec1-f0") #t))
 
 ;; Also check that a deftype (non-record protocol impl) does NOT break anything.
 ;; deftype bodies use register-method, not register-inline-method.
@@ -65,9 +47,7 @@
        (_ (set-record-shapes! shapes2))
        (passed2 (run-passes ir2 (make-analyze-ctx "user")))
        (emitted2 (emit passed2)))
-  (check "deftype field read uses direct accessor"
-         (has-sub? emitted2 "jrec1-f0") #t))
+  (gate-check "deftype field read uses direct accessor"
+         (gate-sub? emitted2 "jrec1-f0") #t))
 
-(if (= fails 0)
-    (begin (printf "inline-body gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "inline-body gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "inline-body")

--- a/host/chez/run-mandelbrot-num.ss
+++ b/host/chez/run-mandelbrot-num.ss
@@ -3,14 +3,8 @@
 ;; WP-E numeric inference loop-var fixpoint + dbl-arith? :num/:long
 ;; contagion are working end-to-end.
 
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(import (chezscheme))
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze          (var-deref "jolt.analyzer" "analyze"))
 (define run-passes       (var-deref "jolt.passes" "run-passes"))

--- a/host/chez/run-narrow.ss
+++ b/host/chez/run-narrow.ss
@@ -11,14 +11,7 @@
 ;;
 ;;   chez --script host/chez/run-narrow.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 (define set-record-shapes! (var-deref "jolt.passes.types" "set-record-shapes!"))
@@ -29,14 +22,6 @@
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
 (define (evals src) (jolt-compile-eval (string-append "(do " src ")") "user"))
 (define (built scm) (eval (read (open-input-string scm)) (interaction-environment)))
-(define (sub? s t)(let((n(string-length s))(m(string-length t)))(let loop((i 0))(cond((>(+ i m)n)#f)((string=?(substring s i(+ i m))t)#t)(else(loop(+ i 1)))))))
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
-
 (evals "(defrecord R [^double k])")
 (evals "(defprotocol P (m [x]))")
 (evals "(defrecord A [v] P (m [x] (->R 1.0)))")
@@ -50,16 +35,16 @@
 (define f (anode "(def f (fn [a] (let [s (m a)] (if (some? s) (* (:k s) 2.0) 0.0))))"))
 (wp-infer! (jolt-vector na nb f))
 (define fe (emit (run-passes f (make-analyze-ctx "user"))))
-(check "guarded nullable read direct-accesses" (sub? fe "jrec1-f0") #t)
-(check "guarded nullable read unboxes to fl*" (sub? fe "fl*") #t)
+(gate-check "guarded nullable read direct-accesses" (gate-sub? fe "jrec1-f0") #t)
+(gate-check "guarded nullable read unboxes to fl*" (gate-sub? fe "fl*") #t)
 
 ;; CORRECTNESS + the load-bearing soundness check: the nil case must take the else
 ;; branch (the guard is preserved), not run the bare read on nil.
 (built fe)
 (define ff (var-deref "user" "f"))
-(check "non-nil (A.m -> R 1.0)"      (jolt-invoke ff (evals "(->A 5)"))  2.0)
-(check "non-nil (B.m v<0 -> R 2.0)"  (jolt-invoke ff (evals "(->B -5)")) 4.0)
-(check "nil case takes else (guard preserved, no crash)"
+(gate-check "non-nil (A.m -> R 1.0)"      (jolt-invoke ff (evals "(->A 5)"))  2.0)
+(gate-check "non-nil (B.m v<0 -> R 2.0)"  (jolt-invoke ff (evals "(->B -5)")) 4.0)
+(gate-check "nil case takes else (guard preserved, no crash)"
        (jolt-invoke ff (evals "(->B 5)")) 0.0)
 
 ;; an UNGUARDED nullable read must stay safe: jrec-field-at falls back to jolt-get on
@@ -69,12 +54,10 @@
 ;; an UNGUARDED nullable read must NOT take the direct (nil-unsafe) accessor — it
 ;; keeps the nil-safe jrec-field-at path, so a nil receiver returns nil instead of
 ;; crashing a bare slot load.
-(check "unguarded nilable read stays nil-safe (no direct accessor)" (sub? ge "jrec1-f0") #f)
+(gate-check "unguarded nilable read stays nil-safe (no direct accessor)" (gate-sub? ge "jrec1-f0") #f)
 (built ge)
 (define gg (var-deref "user" "g"))
-(check "unguarded nullable read on nil returns nil" (jolt-nil? (jolt-invoke gg (evals "(->B 5)"))) #t)
-(check "unguarded nullable read on non-nil returns the field" (jolt-invoke gg (evals "(->A 5)")) 1.0)
+(gate-check "unguarded nullable read on nil returns nil" (jolt-nil? (jolt-invoke gg (evals "(->B 5)"))) #t)
+(gate-check "unguarded nullable read on non-nil returns the field" (jolt-invoke gg (evals "(->A 5)")) 1.0)
 
-(if (= fails 0)
-    (begin (printf "narrow gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "narrow gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "narrow")

--- a/host/chez/run-numwp.ss
+++ b/host/chez/run-numwp.ss
@@ -12,14 +12,7 @@
 ;;
 ;;   chez --script host/chez/run-numwp.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze              (var-deref "jolt.analyzer" "analyze"))
 (define set-record-shapes!   (var-deref "jolt.passes.types" "set-record-shapes!"))
@@ -33,19 +26,6 @@
 (define pr-str               (var-deref "clojure.core" "pr-str"))
 
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
-(define (contains-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0))
-      (cond ((> (+ i m) n) #f)
-            ((string=? (substring s i (+ i m)) sub) #t)
-            (else (loop (+ i 1)))))))
-
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 (set-record-shapes! (jolt-hash-map))
 (set-protocol-methods! (jolt-hash-map))
@@ -57,22 +37,22 @@
 (wp-infer! (jolt-vector sq usef))
 
 (define nseed (param-num-seeds-for "user/sq"))
-(check "sq has a numeric param seed" (jolt-truthy? nseed) #t)
+(gate-check "sq has a numeric param seed" (jolt-truthy? nseed) #t)
 (when (jolt-truthy? nseed)
-  (check "x seeded :double" (contains-sub? (pr-str nseed) ":double") #t))
+  (gate-check "x seeded :double" (gate-sub? (pr-str nseed) ":double") #t))
 
 ;; the bridge: inject the derived nhint, run the numeric pass, emit -> fl*.
 (define sq-opt (annotate (inject-wp-nhints sq)))
-(check "sq body unboxes to fl*" (contains-sub? (emit sq-opt) "fl*") #t)
+(gate-check "sq body unboxes to fl*" (gate-sub? (emit sq-opt) "fl*") #t)
 ;; and the param is coerced at entry like a ^double param (no-op on a real flonum).
-(check "sq coerces param at entry" (contains-sub? (emit sq-opt) "exact->inexact") #t)
+(gate-check "sq coerces param at entry" (gate-sub? (emit sq-opt) "exact->inexact") #t)
 
 ;; a caller passing an INTEGER must NOT make the param :double — an untyped integer
 ;; can be a bignum, so fl-ops would diverge. The param stays generic.
 (define sqi  (anode "(def sqi (fn [x] (* x x)))"))
 (define usei (anode "(def usei (fn [] (sqi 2)))"))
 (wp-infer! (jolt-vector sqi usei))
-(check "integer caller leaves param generic"
+(gate-check "integer caller leaves param generic"
        (jolt-truthy? (param-num-seeds-for "user/sqi")) #f)
 
 ;; a fn used in value position (escapes) has unknown callers -> no double seed.
@@ -80,7 +60,7 @@
 (define hof  (anode "(def hof (fn [g] (g 2.0)))"))
 (define ecl  (anode "(def ecaller (fn [] (hof esc)))"))   ; esc escapes
 (wp-infer! (jolt-vector esc hof ecl))
-(check "escaped fn keeps no double seed"
+(gate-check "escaped fn keeps no double seed"
        (jolt-truthy? (param-num-seeds-for "user/esc")) #f)
 
 ;; :double flows through a returning helper: mag returns a flonum, so a param fed
@@ -89,7 +69,7 @@
 (define dist (anode "(def dist (fn [b] (+ b b)))"))
 (define dcl  (anode "(def dcaller (fn [] (dist (mag 3.0))))"))
 (wp-infer! (jolt-vector mag dist dcl))
-(check "param fed a flonum-returning call types :double"
+(gate-check "param fed a flonum-returning call types :double"
        (jolt-truthy? (param-num-seeds-for "user/dist")) #t)
 
 ;; end to end through the real build pipeline: with optimize on, run-passes wires
@@ -100,9 +80,7 @@
 (define sq2 (anode "(def sq2 (fn [x] (* x x)))"))
 (define use2 (anode "(def use2 (fn [] (sq2 4.0)))"))
 (wp-infer! (jolt-vector sq2 use2))
-(check "run-passes unboxes a hintless double fn"
-       (contains-sub? (emit (run-passes sq2 (make-analyze-ctx "user"))) "fl*") #t)
+(gate-check "run-passes unboxes a hintless double fn"
+       (gate-sub? (emit (run-passes sq2 (make-analyze-ctx "user"))) "fl*") #t)
 
-(if (= fails 0)
-    (begin (printf "numwp gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "numwp gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "numwp")

--- a/host/chez/run-pic.ss
+++ b/host/chez/run-pic.ss
@@ -16,14 +16,7 @@
 ;;
 ;;   chez --script host/chez/run-pic.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze         (var-deref "jolt.analyzer" "analyze"))
 (define emit            (var-deref "jolt.backend-scheme" "emit"))
@@ -41,17 +34,6 @@
 (evals "(def sq (->Square 5))")
 (evals "(def tr (->Triangle 6 4))")
 
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
-(define (has-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0)) (cond ((> (+ i m) n) #f)
-                            ((string=? (substring s i (+ i m)) sub) #t)
-                            (else (loop (+ i 1)))))))
 ;; eval an emitted Scheme string in the loaded runtime.
 (define (run-emit scm) (eval (read (open-input-string scm)) (interaction-environment)))
 
@@ -73,26 +55,26 @@
 
 (let ((e (pic-emit)))
   ;; emission: the PIC machinery is present.
-  (check "emit uses the PIC cache vector" (has-sub? e "jolt-pic-make") #t)
-  (check "emit installs on miss"          (has-sub? e "jolt-pic-install") #t)
-  (check "emit rebuilds on stale epoch"   (has-sub? e "jolt-pic-rebuild") #t)
-  (check "emit reads the desc identity"   (has-sub? e "jrec-pic-desc") #t)
-  (check "emit guards on the epoch"       (has-sub? e "jolt-proto-epoch") #t)
+  (gate-check "emit uses the PIC cache vector" (gate-sub? e "jolt-pic-make") #t)
+  (gate-check "emit installs on miss"          (gate-sub? e "jolt-pic-install") #t)
+  (gate-check "emit rebuilds on stale epoch"   (gate-sub? e "jolt-pic-rebuild") #t)
+  (gate-check "emit reads the desc identity"   (gate-sub? e "jrec-pic-desc") #t)
+  (gate-check "emit guards on the epoch"       (gate-sub? e "jolt-proto-epoch") #t)
   ;; a polymorphic site is NOT the monomorphic devirt path.
-  (check "PIC site is not devirt"         (has-sub? e "devirt-resolve") #f)
+  (gate-check "PIC site is not devirt"         (gate-sub? e "devirt-resolve") #f)
   ;; eval the def so usearea exists with its per-site cache cell.
   (run-emit e)
   ;; megamorphic correctness: each receiver type dispatches to its own impl, and a
   ;; repeat hit stays right (the warmed cache serves the cached desc).
-  (check "Circle dispatch"   (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c"))  7)
-  (check "Square dispatch"   (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "sq")) 25)
-  (check "Triangle dispatch" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "tr")) 12)
-  (check "Circle again (cache hit)" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 7)
+  (gate-check "Circle dispatch"   (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c"))  7)
+  (gate-check "Square dispatch"   (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "sq")) 25)
+  (gate-check "Triangle dispatch" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "tr")) 12)
+  (gate-check "Circle again (cache hit)" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 7)
   ;; invalidation: extend-type re-registers Circle's impl at runtime (register-
   ;; protocol-method bumps jolt-proto-epoch), so the cached site must rebuild and
   ;; serve the NEW impl rather than the stale cached one.
   (evals "(extend-type Circle Shape (area [s] (* (:r s) 100)))")
-  (check "PIC invalidates after extend-type" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 700))
+  (gate-check "PIC invalidates after extend-type" (jolt-invoke (var-deref "user" "usearea") (var-deref "user" "c")) 700))
 
 ;; a monomorphic site (the inference proved one receiver type) keeps the devirt
 ;; path, not the PIC: annotate :devirt-type and confirm no PIC machinery emits.
@@ -107,8 +89,8 @@
   (set-direct-link! #t)
   (let ((e (emit-top-form dn2)))
     (set-direct-link! #f)
-    (check "monomorphic site uses devirt, not PIC" (has-sub? e "devirt-resolve") #t)
-    (check "monomorphic site emits no PIC vector"   (has-sub? e "jolt-pic-make") #f)))
+    (gate-check "monomorphic site uses devirt, not PIC" (gate-sub? e "devirt-resolve") #t)
+    (gate-check "monomorphic site emits no PIC vector"   (gate-sub? e "jolt-pic-make") #f)))
 
 ;; ---- per-descriptor fast path regression (perf/round1 fix) ----------------  
 ;; find-protocol-method-desc must return non-#f for ALL types registered in
@@ -119,9 +101,9 @@
        (sd (hashtable-ref chez-tag-desc "user.Square" #f))
        (td (hashtable-ref chez-tag-desc "user.Triangle" #f))
        (k  (intern-pm-key "Shape" "area")))
-  (check "Circle desc ptable resolves" (not (not (find-protocol-method-desc cd "Shape" "area"))) #t)
-  (check "Square desc ptable resolves" (not (not (find-protocol-method-desc sd "Shape" "area"))) #t)
-  (check "Triangle desc ptable resolves" (not (not (find-protocol-method-desc td "Shape" "area"))) #t))
+  (gate-check "Circle desc ptable resolves" (not (not (find-protocol-method-desc cd "Shape" "area"))) #t)
+  (gate-check "Square desc ptable resolves" (not (not (find-protocol-method-desc sd "Shape" "area"))) #t)
+  (gate-check "Triangle desc ptable resolves" (not (not (find-protocol-method-desc td "Shape" "area"))) #t))
 
 ;; re-def Circle via defrecord to test old-desc invalidation. The old desc's
 ;; ptable must be set to #f so pre-redef instances fall back to the string
@@ -129,14 +111,14 @@
 (let* ((old-desc (hashtable-ref chez-tag-desc "user.Circle" #f))
        (_ (evals "(defrecord Circle [r] Shape (area [s] (:r s)))"))
        (new-desc (hashtable-ref chez-tag-desc "user.Circle" #f)))
-  (check "old desc invalidated after redef"     (jrdesc-ptable old-desc) #f)
-  (check "find-protocol-method-desc misses on old desc"
+  (gate-check "old desc invalidated after redef"     (jrdesc-ptable old-desc) #f)
+  (gate-check "find-protocol-method-desc misses on old desc"
          (find-protocol-method-desc old-desc "Shape" "area") #f)
-  (check "new desc ptable resolves after redef"
+  (gate-check "new desc ptable resolves after redef"
          (not (not (find-protocol-method-desc new-desc "Shape" "area"))) #t)
   ;; protocol-resolve on a pre-redef instance still works (falls back to string
   ;; registry when the desc's ptable is #f).
-  (check "protocol-resolve old instance after redef"
+  (gate-check "protocol-resolve old instance after redef"
          (not (not (protocol-resolve "Shape" "area" (var-deref "user" "c")))) #t))
 
 ;; ---- contagion: a PIC (megamorphic) site never resolves a contagion clone ------
@@ -166,9 +148,7 @@
     (contagion-prepass! (jolt-vector ring-def ddn2) "user")
     (contagion-prepass-done!)
     (let ((e (pic-emit)))
-      (check "PIC over eligible impl still uses the PIC path" (has-sub? e "jolt-pic-make") #t)
-      (check "PIC over eligible impl never emits devirt-resolve-fl" (has-sub? e "devirt-resolve-fl") #f))))
+      (gate-check "PIC over eligible impl still uses the PIC path" (gate-sub? e "jolt-pic-make") #t)
+      (gate-check "PIC over eligible impl never emits devirt-resolve-fl" (gate-sub? e "devirt-resolve-fl") #f))))
 
-(if (= fails 0)
-    (begin (printf "pic gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "pic gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "pic")

--- a/host/chez/run-pic.ss
+++ b/host/chez/run-pic.ss
@@ -19,7 +19,6 @@
 (load "host/chez/run-gate-harness.ss")
 
 (define analyze         (var-deref "jolt.analyzer" "analyze"))
-(define emit            (var-deref "jolt.backend-scheme" "emit"))
 (define emit-top-form   (var-deref "jolt.backend-scheme" "emit-top-form"))
 (define set-direct-link! (var-deref "jolt.backend-scheme" "set-direct-link!"))
 (define kw              (lambda (n) (keyword #f n)))
@@ -99,8 +98,7 @@
 ;; registered miss the (fx= pepoch epoch) check.
 (let* ((cd (hashtable-ref chez-tag-desc "user.Circle" #f))
        (sd (hashtable-ref chez-tag-desc "user.Square" #f))
-       (td (hashtable-ref chez-tag-desc "user.Triangle" #f))
-       (k  (intern-pm-key "Shape" "area")))
+       (td (hashtable-ref chez-tag-desc "user.Triangle" #f)))
   (gate-check "Circle desc ptable resolves" (not (not (find-protocol-method-desc cd "Shape" "area"))) #t)
   (gate-check "Square desc ptable resolves" (not (not (find-protocol-method-desc sd "Shape" "area"))) #t)
   (gate-check "Triangle desc ptable resolves" (not (not (find-protocol-method-desc td "Shape" "area"))) #t))

--- a/host/chez/run-protoret.ss
+++ b/host/chez/run-protoret.ss
@@ -8,14 +8,7 @@
 ;;
 ;;   chez --script host/chez/run-protoret.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze (var-deref "jolt.analyzer" "analyze"))
 (define set-record-shapes! (var-deref "jolt.passes.types" "set-record-shapes!"))
@@ -25,15 +18,7 @@
 (define emit (var-deref "jolt.backend-scheme" "emit"))
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
 (define (evals src) (jolt-compile-eval (string-append "(do " src ")") "user"))
-(define (sub? s t)(let((n(string-length s))(m(string-length t)))(let loop((i 0))(cond((>(+ i m)n)#f)((string=?(substring s i(+ i m))t)#t)(else(loop(+ i 1)))))))
-
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
-
+(define (gate-sub? s t)(let((n(string-length s))(m(string-length t)))(let loop((i 0))(cond((>(+ i m)n)#f)((string=?(substring s i(+ i m))t)#t)(else(loop(+ i 1)))))))
 (evals "(defrecord R [^double k])")
 (evals "(defprotocol P (m [x]))")
 (evals "(defrecord A [v] P (m [x] (->R 1.0)))")
@@ -57,14 +42,12 @@
 
 ;; m's impls all return R -> (:k (m a)) reads off an R -> bare-index + unbox.
 (define fe (emit (run-passes f (make-analyze-ctx "user"))))
-(check "monomorphic protocol return direct-accesses the field read" (sub? fe "jrec1-f0") #t)
-(check "monomorphic protocol return unboxes the ^double field" (sub? fe "fl") #t)
+(gate-check "monomorphic protocol return direct-accesses the field read" (gate-sub? fe "jrec1-f0") #t)
+(gate-check "monomorphic protocol return unboxes the ^double field" (gate-sub? fe "fl") #t)
 
 ;; q's impls return R and a number -> joined to non-record -> stays generic (sound).
 (define ge (emit (run-passes g (make-analyze-ctx "user"))))
-(check "mixed-return protocol keeps generic jolt-get" (sub? ge "jolt-get") #t)
-(check "mixed-return protocol does not bare-index" (sub? ge "jrec-field-at") #f)
+(gate-check "mixed-return protocol keeps generic jolt-get" (gate-sub? ge "jolt-get") #t)
+(gate-check "mixed-return protocol does not bare-index" (gate-sub? ge "jrec-field-at") #f)
 
-(if (= fails 0)
-    (begin (printf "protoret gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "protoret gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "protoret")

--- a/host/chez/run-sci.ss
+++ b/host/chez/run-sci.ss
@@ -14,14 +14,7 @@
   (display "skip: vendor/sci not checked out (git submodule update --init vendor/sci)\n")
   (exit 0))
 
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 ;; SCI's .cljc selects host code via #?(:clj ...) with no :jolt branch — read clj.
 (set! rdr-features (list "clj" "jolt" "default"))

--- a/host/chez/run-unit.ss
+++ b/host/chez/run-unit.ss
@@ -10,14 +10,7 @@
 ;;   chez --script host/chez/run-unit.ss
 (import (chezscheme))
 
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 ;; The loader + install source roots, so a row's (require 'stdlib.ns) resolves the
 ;; .clj overlay from source exactly like joltc — without this, a require of a ns
 ;; whose NATIVE vars exist (e.g. clojure.core.async) silently no-ops via the

--- a/host/chez/run-wp.ss
+++ b/host/chez/run-wp.ss
@@ -7,14 +7,7 @@
 ;;
 ;;   chez --script host/chez/run-wp.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/run-gate-harness.ss")
 
 (define analyze            (var-deref "jolt.analyzer" "analyze"))
 (define run-inference      (var-deref "jolt.passes.types" "run-inference"))
@@ -26,19 +19,6 @@
 (define pr-str             (var-deref "clojure.core" "pr-str"))
 
 (define (anode src) (analyze (make-analyze-ctx "user") (jolt-ce-read src)))
-(define (contains-sub? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0))
-      (cond ((> (+ i m) n) #f)
-            ((string=? (substring s i (+ i m)) sub) #t)
-            (else (loop (+ i 1)))))))
-
-(define fails 0) (define total 0)
-(define (check label actual expected)
-  (set! total (+ total 1))
-  (unless (equal? actual expected)
-    (set! fails (+ fails 1))
-    (printf "  FAIL ~a: got ~s expected ~s\n" label actual expected)))
 
 ;; Node record shape (left/right untagged), like binary-trees.
 (set-record-shapes!
@@ -58,21 +38,21 @@
 
 ;; check-tree's param `node` should be seeded with a struct carrying the Node type
 (define seed (param-seeds-for "user/check-tree"))
-(check "check-tree has a param seed" (jolt-truthy? seed) #t)
+(gate-check "check-tree has a param seed" (jolt-truthy? seed) #t)
 (when (jolt-truthy? seed)
-  (check "node seeded as user.Node struct"
-         (contains-sub? (pr-str seed) "user.Node") #t))
+  (gate-check "node seeded as user.Node struct"
+         (gate-sub? (pr-str seed) "user.Node") #t))
 
 ;; reinfer-def then must mark the (:left node) read site for the bare-index path
 (define marked (reinfer-def ct seed))
-(check "read site marked :hint :struct" (contains-sub? (pr-str marked) ":hint :struct") #t)
+(gate-check "read site marked :hint :struct" (gate-sub? (pr-str marked) ":hint :struct") #t)
 
 ;; a fn used only via value position (escape) must NOT be specialized — unknown
 ;; callers make a concrete seed unsound.
 (define ev (anode "(def use-it (fn [f] (f 1)))"))
 (define ec (anode "(def caller (fn [] (use-it check-tree)))"))  ; check-tree escapes
 (wp-infer! (jolt-vector mt ct rn ev ec))
-(check "escaped fn keeps no param seed" (jolt-truthy? (param-seeds-for "user/check-tree")) #f)
+(gate-check "escaped fn keeps no param seed" (jolt-truthy? (param-seeds-for "user/check-tree")) #f)
 
 ;; a self-recursive fn that recurses on a NILABLE field (an untagged record field
 ;; is :any, so the child can be nil) must NOT be specialized — the recursion can
@@ -80,7 +60,7 @@
 (define ctr (anode "(def walk (fn [node] (let [l (:left node)] (if (nil? l) 1 (walk l)))))"))
 (define rnr (anode "(def run2 (fn [d] (walk (make-tree d))))"))
 (wp-infer! (jolt-vector mt ctr rnr))
-(check "self-recursive nilable param not specialized"
+(gate-check "self-recursive nilable param not specialized"
        (jolt-truthy? (param-seeds-for "user/walk")) #f)
 
 ;; a self-recursive fn that recurses passing the SAME record type (make-tree always
@@ -88,7 +68,7 @@
 (define mtt (anode "(def grow (fn [n acc] (if (zero? n) acc (grow (dec n) (->Node acc acc)))))"))
 (define gcl (anode "(def gcaller (fn [] (grow 5 (->Node nil nil))))"))
 (wp-infer! (jolt-vector mtt gcl))
-(check "self-recursive same-type param keeps its seed"
+(gate-check "self-recursive same-type param keeps its seed"
        (jolt-truthy? (param-seeds-for "user/grow")) #t)
 
 ;; a recursive fn that threads a param STRAIGHT THROUGH its recursion (same arg at
@@ -100,9 +80,7 @@
 (define crec  (anode "(def crec (fn [hs d] (if (< d 0) nil (do (cwalk hs) (crec hs (- d 1))))))"))
 (define cdrv  (anode "(def cdrive (fn [] (crec [(->Node nil nil) (->Node nil nil)] 5)))"))
 (wp-infer! (jolt-vector cwalk crec cdrv))
-(check "recursion pass-through param keeps its vec element type"
-       (contains-sub? (pr-str (param-seeds-for "user/crec")) "user.Node") #t)
+(gate-check "recursion pass-through param keeps its vec element type"
+       (gate-sub? (pr-str (param-seeds-for "user/crec")) "user.Node") #t)
 
-(if (= fails 0)
-    (begin (printf "wp gate: ~a/~a passed\n" total total) (exit 0))
-    (begin (printf "wp gate: ~a/~a passed (~a failed)\n" (- total fails) total fails) (exit 1)))
+(gate-summary "wp")


### PR DESCRIPTION
Seventh round from the 2026-07 audit (epic jolt-445k, round .93).

- The 17 run-*.ss whole-program gates share one harness (boot preamble,
  check/fails counters, substring scan) — about 240 lines of copy-pasted
  scaffolding gone; every converted gate keeps its exact counts.
- The tree-shake's three hand-maintained name lists are all gated now: the
  runtime-core-roots scan also catches var-cell-lookup literals, and every
  bail/compile-ref entry must exist as a runtime binding (with a documented
  allowlist for pre-registered bails on unimplemented core vars —
  load-reader).
- --opt builds reuse the whole-program pass's per-form analysis at emission
  instead of re-reading and re-analyzing everything (perf measurement on a
  large fixture lands with the bench round; emission is unchanged).
- One mode->Chez-parameters table drives both the string template and the
  self-contained compile (the duplicated encodings had already drifted once);
  the (load ...) path scan is bounded and raises a named build error instead
  of a string-ref range violation.
- Dead-code sweep, shakesmoke-verified byte-identical outputs: the hasheq.ss
  legacy block (murmur3-hash-int-flat, the hasheq-hash* five,
  register-hasheq-arm!), seven rt.ss jolt-kw-* constants, nr-kw-* reader
  constants, kw-rc*, posix-str->mode, coerce-double-fields! (the ctor inlines
  the coercion — verified (->P 2) still yields 2.0), the duplicate hc-kw-file,
  and run-pic leftovers. hc-record-type?/hc-record-ctor-key resolve against
  their ctx like the deftype variant instead of the global namespace.
- dce ref collection dedups into hashsets; bail scanning is O(1) membership.

Full make test green (selfhost, ci both legs, certify 0 new divergences).