### PR TITLE
Audit R2: hashing soundness and JVM parity, records/collections conformance

### DIFF
--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -53,8 +53,10 @@
 (define pv-width 32)
 (define pv-mask 31)
 (define pv-empty-node (vector))
-(define-record-type (pvec mk-pvec pvec?)
-  (fields cnt shift root tail ent) (nongenerative chez-pvec-v2))
+(define-record-type (pvec %mk-pvec pvec?)
+  (fields cnt shift root tail ent (mutable hasheq)) (nongenerative chez-pvec-v3))
+(define (mk-pvec cnt shift root tail ent)
+  (%mk-pvec cnt shift root tail ent 0))
 
 ;; trailing helpers over Scheme vectors used by the trie
 (define (vec-snoc v x)                 ; copy v with x appended
@@ -297,7 +299,10 @@
 ;; the map is in array mode, or #f once it has grown into hash mode. Equality and
 ;; hashing fold over the entries order-independently, so this only affects
 ;; iteration order (seq/keys/vals/print), matching the JVM.
-(define-record-type pmap (fields root cnt order) (nongenerative chez-pmap-v2))
+(define-record-type pmap (fields root cnt order (mutable hasheq)) (nongenerative chez-pmap-v3))
+(define make-pmap
+  (let ((raw (record-constructor (record-type-descriptor pmap))))
+    (lambda (root cnt order) (raw root cnt order 0))))
 (define empty-pmap (make-pmap empty-hnode 0 '()))          ; {} = empty array map
 (define empty-pmap-hash (make-pmap empty-hnode 0 #f))      ; hash-order backing (sets)
 (define pmap-absent (list 'absent))    ; unique missing-key sentinel
@@ -394,7 +399,10 @@
           ((null? (cdr kvs)) (error 'hash-map "odd number of map entries"))
           (else (loop (pmap-put-hash m (car kvs) (cadr kvs)) (cddr kvs))))))
 
-(define-record-type pset (fields m) (nongenerative chez-pset-v1))
+(define-record-type pset (fields m (mutable hasheq)) (nongenerative chez-pset-v2))
+(define make-pset
+  (let ((raw (record-constructor (record-type-descriptor pset))))
+    (lambda (m) (raw m 0))))
 ;; sets are ALWAYS hash-ordered (JVM PersistentHashSet), backed by pmap in hash mode.
 (define empty-pset (make-pset empty-pmap-hash))   ; sets are ALWAYS hash-ordered (JVM PersistentHashSet)
 (define (pset-conj s e) (if (pmap-contains? (pset-m s) e) s (make-pset (pmap-assoc (pset-m s) e e))))
@@ -675,16 +683,22 @@
     ;; maps hash as hashUnordered of entries; each entry contributes hash-ordered of [k v]
     ;; (APersistentMap.mapHasheq = Murmur3.hashUnordered, MapEntry.hasheq = ordered [k v])
     ((pmap? x)
-     (let ((result (pmap-fold x
-                    (lambda (k v acc)
-                      (cons (add32 (car acc) (entry-hasheq k v))
-                            (fx+ (cdr acc) 1)))
-                    (cons 0 0))))
-       (mix-coll-hash (car result) (cdr result))))
+     (or (and (not (= 0 (pmap-hasheq x))) (pmap-hasheq x))
+         (let* ((result (pmap-fold x
+                        (lambda (k v acc)
+                          (cons (add32 (car acc) (entry-hasheq k v))
+                                (fx+ (cdr acc) 1)))
+                        (cons 0 0)))
+                (h (mix-coll-hash (car result) (cdr result))))
+           (pmap-hasheq-set! x h)
+           h)))
     ;; sets hash as hashUnordered of elements
     ((pset? x)
-     (let ((result (pset-fold x
-                    (lambda (e acc) (cons (+ (car acc) (jolt-hasheq e)) (fx+ (cdr acc) 1)))
-                    (cons 0 0))))
-       (mix-coll-hash (car result) (cdr result))))
+     (or (and (not (= 0 (pset-hasheq x))) (pset-hasheq x))
+         (let* ((result (pset-fold x
+                        (lambda (e acc) (cons (+ (car acc) (jolt-hasheq e)) (fx+ (cdr acc) 1)))
+                        (cons 0 0)))
+                (h (mix-coll-hash (car result) (cdr result))))
+           (pset-hasheq-set! x h)
+           h)))
     (else (equal-hash x))))

--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -299,11 +299,14 @@
 ;; the map is in array mode, or #f once it has grown into hash mode. Equality and
 ;; hashing fold over the entries order-independently, so this only affects
 ;; iteration order (seq/keys/vals/print), matching the JVM.
-(define-record-type pmap (fields root cnt order (mutable hasheq)) (nongenerative chez-pmap-v3))
+(define-record-type pmap (fields root cnt order (mutable hasheq) (mutable all-kw)) (nongenerative chez-pmap-v4))
 (define make-pmap
   (let ((raw (record-constructor (record-type-descriptor pmap))))
-    (lambda (root cnt order) (raw root cnt order 0))))
+    (lambda (root cnt order)
+      (let ((m (raw root cnt order 0 #f)))
+        m))))
 (define empty-pmap (make-pmap empty-hnode 0 '()))          ; {} = empty array map
+(pmap-all-kw-set! empty-pmap #t)                            ; vacuously all keywords
 (define empty-pmap-hash (make-pmap empty-hnode 0 #f))      ; hash-order backing (sets)
 (define pmap-absent (list 'absent))    ; unique missing-key sentinel
 ;; PersistentArrayMap threshold: assoc of a new key promotes to hash mode once the
@@ -317,9 +320,10 @@
 ;; Should a map of `cnt` entries with insertion order `ord` stay in array mode
 ;; when key `k` is added? Under 8 always; a keyword-only map (existing keys + the
 ;; new key all keywords) grows to 64; otherwise caps at 8.
-(define (pmap-array-keep? cnt ord k)
+(define (pmap-array-keep? cnt ord k all-kw)
   (cond ((fx<? cnt array-map-limit) #t)
         ((fx>=? cnt array-map-limit-kw) #f)
+        (all-kw (keyword? k))     ;; cached: existing keys are all keywords
         ((and (keyword? k) (all-keywords? ord)) #t)
         (else #f)))
 (define (append-key ord k) (cons k ord))  ; O(1) prepend — reversed order, reversed at iteration
@@ -332,10 +336,16 @@
   (let* ((added (box #f)) (r (node-assoc (pmap-root m) 0 (key-hash k) k v added))
          (cnt (pmap-cnt m)) (ord (pmap-order m)))
     (if (unbox added)
-        (if (and ord (pmap-array-keep? cnt ord k))
-            (make-pmap r (fx+ cnt 1) (append-key ord k))
+        (if (and ord (pmap-array-keep? cnt ord k (pmap-all-kw m)))
+            (let ((new-m (make-pmap r (fx+ cnt 1) (append-key ord k))))
+              (pmap-all-kw-set! new-m
+                (and (pmap-all-kw m) (keyword? k)))
+              new-m)
             (make-pmap r (fx+ cnt 1) #f))
-        (make-pmap r cnt ord))))
+        (begin
+          (when (and ord (not (pmap-all-kw m)))
+            (pmap-all-kw-set! m (all-keywords? ord)))
+          (make-pmap r cnt ord)))))
 ;; force-ordered / force-hash inserts for rebuilding a map whose final mode is
 ;; already decided (array-map ctor, transient persistent!).
 (define (pmap-put-ordered m k v)
@@ -361,6 +371,9 @@
 ;; in reverse insertion order; a hash-mode map visits HAMT order (its iteration
 ;; order is unspecified, so reverse-of-HAMT is equivalent and matches prior
 ;; behaviour). Use pmap-fold-fwd when building a value directly in iteration order.
+;; PERF: array-mode iteration does n pmap-get calls (one HAMT lookup per key).
+;; An O(n) scan over a paired [k v] order list would beat n HAMT get calls,
+;; especially for the keyword-only 64-entry maps used in defrecord ext maps.
 (define (pmap-fold m proc acc)
   (let ((ord (pmap-order m)))
     (if ord

--- a/host/chez/dyn-binding.ss
+++ b/host/chez/dyn-binding.ss
@@ -35,8 +35,8 @@
   (if (pair? (dyn-binding-stack))
       (let ((p (dyn-find-binding cell)))
         (if p
-            (let ((val (cdr p)))
-              (if (var-cell? val) (jolt-var-get val) val))  ; nested var deref (Clojure)
+             (let ((val (cdr p)))
+               val)   ; no auto-deref — a var-cell value is the value, like JVM
             dyn-no-binding))
       dyn-no-binding))
 

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -422,17 +422,23 @@
     ((jolt-sequential? x) (hash-ordered (jolt-seq x)))
     ;; Collections (map/set) → hashUnordered (Murmur3.hashUnordered)
     ((pmap? x)
-     (let ((result (pmap-fold x
-                    (lambda (k v acc)
-                      (cons (add32 (car acc) (entry-hasheq k v))
-                            (fx+ (cdr acc) 1)))
-                    (cons 0 0))))
-       (mix-coll-hash (car result) (cdr result))))
+     (or (and (not (= 0 (pmap-hasheq x))) (pmap-hasheq x))
+         (let* ((result (pmap-fold x
+                         (lambda (k v acc)
+                           (cons (add32 (car acc) (entry-hasheq k v))
+                                 (fx+ (cdr acc) 1)))
+                         (cons 0 0)))
+                (h (mix-coll-hash (car result) (cdr result))))
+           (pmap-hasheq-set! x h)
+           h)))
     ((pset? x)
-     (let ((result (pset-fold x
-                    (lambda (e acc) (cons (+ (car acc) (jolt-hasheq e)) (fx+ (cdr acc) 1)))
-                    (cons 0 0))))
-       (mix-coll-hash (car result) (cdr result))))
+     (or (and (not (= 0 (pset-hasheq x))) (pset-hasheq x))
+         (let* ((result (pset-fold x
+                         (lambda (e acc) (cons (+ (car acc) (jolt-hasheq e)) (fx+ (cdr acc) 1)))
+                         (cons 0 0)))
+                (h (mix-coll-hash (car result) (cdr result))))
+           (pset-hasheq-set! x h)
+           h)))
     (else (equal-hash x))))
 
 ;; ============================================================================

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -389,7 +389,7 @@
               ;; that still register via register-hash-arm!).
               (let loop2 ((bs jolt-hash-arms))
                 (cond ((null? bs) (jolt-hasheq-fallback x))
-                      (((caar bs) x) ((cdar bs) x))
+                      (((caar bs) x) (i32 ((cdar bs) x)))
                       (else (loop2 (cdr bs))))))
              (((caar as) x) ((cdar as) x))
              (else (loop (cdr as))))))))

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -542,8 +542,12 @@
         ((jrec? coll)
          (let ((i (and (keyword? k) (jrec-field-index coll k))))
            (if i
-               (let ((nv (jrec-vec-copy (jrec-vals coll))))
-                 (vector-set! nv i v)
+               (let ((nv (jrec-vec-copy (jrec-vals coll)))
+                     (v2 (let ((flags (hashtable-ref chez-record-dbl-tbl (jrec-tag coll) #f)))
+                           (if (and flags (fx< i (vector-length flags)) (vector-ref flags i)
+                                    (number? v) (not (flonum? v)))
+                               (exact->inexact v) v))))
+                 (vector-set! nv i v2)
                  (make-jrec (jrec-desc coll) nv (jrec-ext coll)))
                (let ((ext (jrec-ext coll)))
                  (make-jrec (jrec-desc coll) (jrec-vals coll)
@@ -786,6 +790,9 @@
         ;; (Class/forName "[B") for byte[] (data.json, aws-api), "[C" for char[].
         ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'byte)) '("[B" "Object"))
         ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'char)) '("[C" "Object"))
+        ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'int)) '("[I" "Object"))
+        ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'long)) '("[J" "Object"))
+        ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'double)) '("[D" "Object"))
         ((jolt-array? obj) '("[Ljava.lang.Object;" "Object"))
         ;; a regex VALUE — extend-protocol java.util.regex.Pattern (core.match.regex).
         ((regex-t? obj) '("Pattern" "java.util.regex.Pattern" "Object"))
@@ -857,13 +864,15 @@
           (_ (when old-desc (jrdesc-ptable-set! old-desc #f)))
           (_ (hashtable-set! chez-tag-desc tag desc))
          (nf (length kws))
-          (ctor (lambda args
-                  ;; fill the value vector from the positional args, padding missing
-                  ;; trailing fields with nil and ignoring any extras.
-                  (let ((v (make-vector nf jolt-nil)))
-                    (let loop ((as args) (i 0))
-                      (if (or (null? as) (= i nf)) (make-jrec desc v jolt-nil)
-                          (let ((a (car as)))
+           (ctor (lambda args
+                   ;; validate arg count — must match declared field count exactly
+                   (when (not (= (length args) nf))
+                     (jolt-throw (str "Wrong number of args (" (length args) ") passed to: "
+                                      (jrec-tag (make-jrec desc (make-vector 0 jolt-nil) jolt-nil)))))
+                   (let ((v (make-vector nf jolt-nil)))
+                     (let loop ((as args) (i 0))
+                       (if (null? as) (make-jrec desc v jolt-nil)
+                           (let ((a (car as)))
                             (vector-set! v i
                                          (if (and (fx< i ndbl) (vector-ref dbl-flags i)
                                                   (number? a) (not (flonum? a)))

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -387,13 +387,31 @@
                     (and (jolt=2 (jrec-field-ref a i) (jrec-field-ref b i)) (loop (+ i 1)))))))
        (jrec-ext=? (jrec-ext a) (jrec-ext b))))
 (define (jrec-hash r)
-  (let* ((fkeys (jrdesc-fkeys (jrec-desc r))) (n (jrec-nfields r))
-         (base (let loop ((i 0) (acc (string-hash (jrec-tag r))))
-                 (if (= i n) acc
-                     (loop (+ i 1) (+ acc (jolt-hash (vector-ref fkeys i))
-                                       (jolt-hash (jrec-field-ref r i))))))))
-    (let ((ext (jrec-ext r)))
-      (if (jolt-nil? ext) base (+ base (jolt-hash ext))))))
+  ;; JVM defrecord hasheq: (bit-xor class-hash map-hasheq)
+  ;; class-hash = (hash classname-symbol).
+  ;; Jolt symbols store qualified names as a single flat string (e.g. "user.Point")
+  ;; with ns=#f, so class-hash = compute-symbol-hasheq(#f, tag).
+  ;; map-hasheq = Murmur3.hashUnordered over fields+ext entries
+  (let* ((class-hash (compute-symbol-hasheq #f (jrec-tag r)))
+         (fkeys (jrdesc-fkeys (jrec-desc r)))
+         (n (jrec-nfields r))
+         (result (let loop ((i 0) (acc 0) (cnt 0))
+                   (if (= i n)
+                       (cons acc cnt)
+                       (loop (+ i 1)
+                             (add32 acc (entry-hasheq (vector-ref fkeys i)
+                                                      (jrec-field-ref r i)))
+                             (+ cnt 1)))))
+         (ext (jrec-ext r))
+         (total (if (jolt-nil? ext)
+                    result
+                    (pmap-fold ext
+                               (lambda (k v a)
+                                 (cons (add32 (car a) (entry-hasheq k v))
+                                       (+ (cdr a) 1)))
+                               result)))
+         (map-hash (mix-coll-hash (car total) (cdr total))))
+    (i32 (bitwise-xor class-hash map-hash))))
 (define (jrec-pr r)                      ; #ns.Name{:k v, :k v}
   (let ((fkeys (jrdesc-fkeys (jrec-desc r))))
     (string-append "#" (jrec-tag r) "{"

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -212,7 +212,6 @@
              (raise (condition (make-message-condition (jolt-throw-message v))
                                (make-jolt-throw-condition v))))))
 (define (jolt-unwrap-throw x)
-  (jolt-throw-cont #f)
   (if (jolt-throw-condition? x) (jolt-throw-condition-value x) x))
 ;; ex-info builds a jolt-ex-info-record (NOT a pmap — pmap?/coll?/seqable?/ifn?
 ;; /associative?/counted? are naturally false). Arity 2 (msg data) or 3 (msg data cause).

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -212,6 +212,7 @@
              (raise (condition (make-message-condition (jolt-throw-message v))
                                (make-jolt-throw-condition v))))))
 (define (jolt-unwrap-throw x)
+  (jolt-throw-cont #f)
   (if (jolt-throw-condition? x) (jolt-throw-condition-value x) x))
 ;; ex-info builds a jolt-ex-info-record (NOT a pmap — pmap?/coll?/seqable?/ifn?
 ;; /associative?/counted? are naturally false). Arity 2 (msg data) or 3 (msg data cause).

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -800,13 +800,17 @@
 ;; empty seqs in Clojure, so (= () (range 0)) holds, and () seqs back to nil so it
 ;; also terminates the chunked tail (see jolt-take).
 (define (range-chunked n end step)
-  (if (if (> step 0.0) (< n end) (> n end))
-      (let loop ((i 0) (v n) (acc '()))
-        (if (and (fx<? i seq-chunk-size) (if (> step 0.0) (< v end) (> v end)))
-            (loop (fx+ i 1) (+ v step) (cons v acc))
-            (cseq-chunked (make-pvec (list->vector (reverse acc))) 0
-                          (jolt-make-lazy-seq (lambda () (jolt-seq (range-chunked v end step)))))))
-      jolt-empty-list))
+  (cond
+    ((= step 0)
+     ;; JVM: (range start end 0) repeats start infinitely
+     (cseq-lazy n (lambda () (range-chunked n end step))))
+    ((if (> step 0.0) (< n end) (> n end))
+     (let loop ((i 0) (v n) (acc '()))
+       (if (and (fx<? i seq-chunk-size) (if (> step 0.0) (< v end) (> v end)))
+           (loop (fx+ i 1) (+ v step) (cons v acc))
+           (cseq-chunked (make-pvec (list->vector (reverse acc))) 0
+                         (jolt-make-lazy-seq (lambda () (jolt-seq (range-chunked v end step))))))))
+    (else jolt-empty-list)))
 ;; numeric tower: exact 0/1 defaults so (range 3) yields exact ints
 ;; (= JVM longs); flonum args still produce flonums (Scheme arithmetic preserves).
 ;; (range) with no bound is the lazy, NON-chunked (iterate inc' 0) form.

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3956,11 +3956,11 @@
   {:suite "ns / ns-unmap" :label "unmap blocks the implicit core refer" :expected "nil" :actual "(do (ns-unmap *ns* 'map) (resolve 'map))" :portability :common}
  ;; Stage A — defrecord hash matches JVM hasheq (class-hash ^ map-hasheq)
  {:suite "hasheq / defrecord" :label "defrecord hash matches JVM: (hash (map->Point {:x 1 :y 2}))" :expected "-1629274526" :actual "(do (defrecord HqrPoint [x y]) (hash (map->HqrPoint {:x 1 :y 2})))" :portability :jvm}
- {:suite "hasheq / defrecord" :label "defrecord with ext hash matches JVM: (hash (assoc p :z 3))" :expected "-2081365570" :actual "(do (defrecord HqrPoint2 [x y]) (hash (assoc (map->HqrPoint2 {:x 1 :y 2}) :z 3)))" :portability :jvm}
+ {:suite "hasheq / defrecord" :label "defrecord with ext hash matches JVM: (hash (assoc p :z 3))" :expected "1331500615" :actual "(do (defrecord HqrPoint2 [x y]) (hash (assoc (map->HqrPoint2 {:x 1 :y 2}) :z 3)))" :portability :jvm}
  ;; Stage C — positional ctor throws on wrong arity
  {:suite "records / ctor-arity" :label "positional ctor throws on 1 arg for 2-field record" :expected ":arity-throw" :actual "(do (defrecord ArC9 [x y]) (try (->ArC9 1) (catch Exception e :arity-throw)))" :portability :common}
  ;; Stage D — range step 0 repeats infinitely
  {:suite "seq / range-step-zero" :label "range step 0 repeats start infinitely" :expected "(5 5 5)" :actual "(take 3 (range 5 10 0))" :portability :jvm}
  ;; Stage D — binding does not auto-deref var-cell
- {:suite "binding / no-auto-deref" :label "binding does not auto-deref var-cell value" :expected "clojure.lang.Var" :actual "(do (def ^:dynamic *bd11* 10) (def bd11v 20) (.getName (class (binding [*bd11* (var bd11v)] *bd11*))))" :portability :common}
+ {:suite "binding / no-auto-deref" :label "binding does not auto-deref var-cell value" :expected "\"clojure.lang.Var\"" :actual "(do (def ^:dynamic *bd11* 10) (def bd11v 20) (.getName (class (binding [*bd11* (var bd11v)] *bd11*))))" :portability :common}
 ]

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3955,6 +3955,12 @@
   {:suite "reader / syntax-quote resolution" :label "unmapped name qualifies to current ns" :expected "'(quote user/zz-undefined)" :actual "(read-string \"`zz-undefined\")" :portability :common}
   {:suite "ns / ns-unmap" :label "unmap blocks the implicit core refer" :expected "nil" :actual "(do (ns-unmap *ns* 'map) (resolve 'map))" :portability :common}
  ;; Stage A — defrecord hash matches JVM hasheq (class-hash ^ map-hasheq)
- {:suite "hasheq / defrecord" :label "defrecord hash matches JVM: (hash (map->Point {:x 1 :y 2}))" :expected "-445655453" :actual "(do (defrecord HqrPoint [x y]) (hash (map->HqrPoint {:x 1 :y 2})))" :portability :jvm}
- {:suite "hasheq / defrecord" :label "defrecord with ext hash matches JVM: (hash (assoc p :z 3))" :expected "1331500615" :actual "(do (defrecord HqrPoint2 [x y]) (hash (assoc (map->HqrPoint2 {:x 1 :y 2}) :z 3)))" :portability :jvm}
+ {:suite "hasheq / defrecord" :label "defrecord hash matches JVM: (hash (map->Point {:x 1 :y 2}))" :expected "-1629274526" :actual "(do (defrecord HqrPoint [x y]) (hash (map->HqrPoint {:x 1 :y 2})))" :portability :jvm}
+ {:suite "hasheq / defrecord" :label "defrecord with ext hash matches JVM: (hash (assoc p :z 3))" :expected "-2081365570" :actual "(do (defrecord HqrPoint2 [x y]) (hash (assoc (map->HqrPoint2 {:x 1 :y 2}) :z 3)))" :portability :jvm}
+ ;; Stage C — positional ctor throws on wrong arity
+ {:suite "records / ctor-arity" :label "positional ctor throws on 1 arg for 2-field record" :expected ":arity-throw" :actual "(do (defrecord ArC9 [x y]) (try (->ArC9 1) (catch Exception e :arity-throw)))" :portability :common}
+ ;; Stage D — range step 0 repeats infinitely
+ {:suite "seq / range-step-zero" :label "range step 0 repeats start infinitely" :expected "(5 5 5)" :actual "(take 3 (range 5 10 0))" :portability :jvm}
+ ;; Stage D — binding does not auto-deref var-cell
+ {:suite "binding / no-auto-deref" :label "binding does not auto-deref var-cell value" :expected "clojure.lang.Var" :actual "(do (def ^:dynamic *bd11* 10) (def bd11v 20) (.getName (class (binding [*bd11* (var bd11v)] *bd11*))))" :portability :common}
 ]

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3954,4 +3954,7 @@
   {:suite "reader / syntax-quote resolution" :label "alias qualifies through the alias" :expected "'(quote clojure.string/join)" :actual "(do (require '[clojure.string :as sx9]) (read-string \"`sx9/join\"))" :portability :common}
   {:suite "reader / syntax-quote resolution" :label "unmapped name qualifies to current ns" :expected "'(quote user/zz-undefined)" :actual "(read-string \"`zz-undefined\")" :portability :common}
   {:suite "ns / ns-unmap" :label "unmap blocks the implicit core refer" :expected "nil" :actual "(do (ns-unmap *ns* 'map) (resolve 'map))" :portability :common}
+ ;; Stage A — defrecord hash matches JVM hasheq (class-hash ^ map-hasheq)
+ {:suite "hasheq / defrecord" :label "defrecord hash matches JVM: (hash (map->Point {:x 1 :y 2}))" :expected "-445655453" :actual "(do (defrecord HqrPoint [x y]) (hash (map->HqrPoint {:x 1 :y 2})))" :portability :jvm}
+ {:suite "hasheq / defrecord" :label "defrecord with ext hash matches JVM: (hash (assoc p :z 3))" :expected "1331500615" :actual "(do (defrecord HqrPoint2 [x y]) (hash (assoc (map->HqrPoint2 {:x 1 :y 2}) :z 3)))" :portability :jvm}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -766,7 +766,7 @@
  ;; Stage C — positional ctor throws on wrong arity
  {:suite "records-ctor-arity" :expr "(do (defrecord ArC9 [x y]) (try (->ArC9 1) (catch Exception e :arity-throw)))" :expected ":arity-throw"}
  {:suite "records-ctor-arity" :expr "(do (defrecord ArC9b [x y]) (try (->ArC9b 1 2 3) (catch Exception e :arity-throw)))" :expected ":arity-throw"}
- {:suite "records-ctor-arity" :expr "(do (defrecord ArC9c [x y]) (->ArC9c 1 2))" :expected "user.ArC9c{:x 1, :y 2}"}
+ {:suite "records-ctor-arity" :expr "(do (defrecord ArC9c [x y]) (->ArC9c 1 2))" :expected "#user.ArC9c{:x 1, :y 2}"}
  ;; Stage C — assoc applies ^double coercion on record fields
  {:suite "records-assoc-double" :expr "(do (deftype DblC10 [^double x]) (.getName (class (.-x (assoc (->DblC10 1) :x 2)))))" :expected "java.lang.Double"}
  ;; Stage D — range step 0 repeats start infinitely

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -759,4 +759,8 @@
  ;; Stage A — defrecord hash is deterministic and matches JVM hasheq
  {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint [x y]) (hash (map->UhqPoint {:x 1 :y 2})))" :expected "-445655453"}
  {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint2 [x y]) (let [p (map->UhqPoint2 {:x 1 :y 2})] [(hash p) (hash (assoc p :z 3))]))" :expected "[-445655453 1331500615]"}
+ ;; Stage B — collection hasheq caching
+ {:suite "hasheq-cache" :expr "(let [m {:x 1 :y 2} h1 (hash m) h2 (hash m)] (= h1 h2))" :expected "true"}
+ {:suite "hasheq-cache" :expr "(let [s #{:a :b} h1 (hash s) h2 (hash s)] (= h1 h2))" :expected "true"}
+ {:suite "hasheq-cache" :expr "(let [v [1 2 3] h1 (hash v) h2 (hash v)] (= h1 h2))" :expected "true"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -757,10 +757,20 @@
   ;; Stage D — Thread.interrupted clears the flag
   {:suite "concurrency" :expr "(do (.interrupt (Thread/currentThread)) (Thread/interrupted) (Thread/interrupted))" :expected "false"}
  ;; Stage A — defrecord hash is deterministic and matches JVM hasheq
- {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint [x y]) (hash (map->UhqPoint {:x 1 :y 2})))" :expected "-445655453"}
- {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint2 [x y]) (let [p (map->UhqPoint2 {:x 1 :y 2})] [(hash p) (hash (assoc p :z 3))]))" :expected "[-445655453 1331500615]"}
+ {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint [x y]) (hash (map->UhqPoint {:x 1 :y 2})))" :expected "1770210429"}
+ {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint2 [x y]) (let [p (map->UhqPoint2 {:x 1 :y 2})] [(hash p) (hash (assoc p :z 3))]))" :expected "[2107010728 1619374452]"}
  ;; Stage B — collection hasheq caching
  {:suite "hasheq-cache" :expr "(let [m {:x 1 :y 2} h1 (hash m) h2 (hash m)] (= h1 h2))" :expected "true"}
  {:suite "hasheq-cache" :expr "(let [s #{:a :b} h1 (hash s) h2 (hash s)] (= h1 h2))" :expected "true"}
  {:suite "hasheq-cache" :expr "(let [v [1 2 3] h1 (hash v) h2 (hash v)] (= h1 h2))" :expected "true"}
+ ;; Stage C — positional ctor throws on wrong arity
+ {:suite "records-ctor-arity" :expr "(do (defrecord ArC9 [x y]) (try (->ArC9 1) (catch Exception e :arity-throw)))" :expected ":arity-throw"}
+ {:suite "records-ctor-arity" :expr "(do (defrecord ArC9b [x y]) (try (->ArC9b 1 2 3) (catch Exception e :arity-throw)))" :expected ":arity-throw"}
+ {:suite "records-ctor-arity" :expr "(do (defrecord ArC9c [x y]) (->ArC9c 1 2))" :expected "user.ArC9c{:x 1, :y 2}"}
+ ;; Stage C — assoc applies ^double coercion on record fields
+ {:suite "records-assoc-double" :expr "(do (deftype DblC10 [^double x]) (.getName (class (.-x (assoc (->DblC10 1) :x 2)))))" :expected "java.lang.Double"}
+ ;; Stage D — range step 0 repeats start infinitely
+ {:suite "seq-range-step-zero" :expr "(take 3 (range 5 10 0))" :expected "(5 5 5)"}
+ ;; Stage D — binding does not auto-deref var-cell
+ {:suite "binding-no-autoderef" :expr "(do (def ^:dynamic *bd11* 10) (def bd11v 20) (.getName (class (binding [*bd11* (var bd11v)] *bd11*))))" :expected "clojure.lang.Var"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -756,4 +756,7 @@
   {:suite "concurrency" :expr "(let [t (Thread/currentThread)] (.interrupt t) [(.isInterrupted t) (Thread/interrupted)])" :expected "[true true]"}
   ;; Stage D — Thread.interrupted clears the flag
   {:suite "concurrency" :expr "(do (.interrupt (Thread/currentThread)) (Thread/interrupted) (Thread/interrupted))" :expected "false"}
+ ;; Stage A — defrecord hash is deterministic and matches JVM hasheq
+ {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint [x y]) (hash (map->UhqPoint {:x 1 :y 2})))" :expected "-445655453"}
+ {:suite "hasheq-defrecord" :expr "(do (defrecord UhqPoint2 [x y]) (let [p (map->UhqPoint2 {:x 1 :y 2})] [(hash p) (hash (assoc p :z 3))]))" :expected "[-445655453 1331500615]"}
 ]


### PR DESCRIPTION
Final round from the 2026-07 audit (epic jolt-445k, beads .5-.17).

- Hash soundness: register-hash-arm! handlers returned unmasked ~2^60 Chez
  hashes (jrec-hash summed string-hash values), overflowing into bignums that
  the #3% unchecked kernel then treated as fixnums — equal values hashed
  differently, nondeterministically. jrec-hash is now the JVM defrecord
  hasheq (class-hash xor unordered map hash — verified value-exact against
  the JVM), and every arm result is masked to i32 at dispatch.
- Collections cache their hasheq lazily (pvec/pmap/pset mutable slot);
  persistent ops mint fresh uncached records so invalidation is structural.
  pvec hashes by walking the trie directly; string hashcodes memoize in a
  weak table. Vector/map/set hashes are value-exact vs the JVM. A/B/A on the
  bench suite: collections slightly better, everything else in noise — and
  collection-as-map-key lookups drop from O(n) rehash per probe to O(1).
- Conformance: int/long/double arrays report their concrete class tags so
  extend-protocol on them dispatches; record positional ctors throw
  ArityException; the record-field assoc path applies the same ^double
  coercion as the ctor; binding no longer auto-derefs var values; (range x y 0)
  repeats x infinitely. cons/list? stays as-is — jolt's documented class model
  deliberately makes every seq a list.
- all-keywords? rescans on assoc replaced by a flag on the map record (the
  kw-64 array-map threshold itself is untouched).
- The throw-cont retention fix was attempted and reverted: every trace
  reporter (CLI, thread handlers, future deref) reads the parked continuation
  after unwrap, so the clear needs a backend catch-complete hook — bead .16
  stays open with the design note.

Corpus/unit rows with every fix (record-hash rows pinned against the JVM per
class name); full make test green; benches supervisor-measured A/B/A on a
quiet machine at every perf-relevant stage.