### PR TITLE
nio: stat-layout guard for unverified hosts; changelog 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-16
+
+Full-codebase audit release: seven review rounds plus follow-ups (PRs
+#362-#373), every behavioral fix certified against reference JVM Clojure.
+
+### Fixed
+
+- Build: `--embed` resources are baked into the binary at build time (shipped
+  binaries no longer re-read build-machine paths at startup); tree-shaking is
+  sound for redefined vars (duplicate-fqn refs union); binary namespace roots
+  derive from the require graph, so namespaces loaded before the build hook
+  (data-reader helpers and their requires) ship correctly.
+- core.async: `alts!`/`alts!!` use handler registration — an alts put and an
+  alts take on an unbuffered channel rendezvous instead of livelocking, and
+  blocked alts no longer busy-poll. Fixed-buffer channels with transducers get
+  real backpressure; pending rendezvous puts park through `close!` until a
+  taker consumes their value (JVM-verified); `timeout` channels share one
+  timer thread.
+- Hashing: record hashes are JVM-exact defrecord hasheq (a bignum overflow
+  into unchecked fixnum ops previously made equal values hash differently,
+  nondeterministically); collections cache their hasheq lazily; vector/map/
+  set hashes are value-identical to the JVM.
+- Inference soundness: a `reduce` accumulator seeded `:double` no longer
+  forces a coercion crash on nil-returning reducers; same-named records in
+  different namespaces resolve exactly instead of by suffix; user `^double`
+  hints survive HOF seeding; locals named like runtime identifiers
+  (`jolt-nil`, `fl+`, …) are munged instead of shadowing.
+- Reader/regex: mid-pattern `(?i)` applies to the remainder and `(?-i)`
+  actually removes flags; `\Q…\E` quantifier scope, strict `\p{…}`, Java
+  octal escapes, possessive quantifiers as atomic groups; radix-aware `N`
+  literals (`042N` ⇒ `34N`); positioned EOF errors in string escapes;
+  top-level `#?@` throws; record literals construct records; `#!` is a
+  to-EOL comment (clojure reader only — EDN rejects it); syntax-quote
+  resolves through the full alias/refer/core chain (`` `map `` ⇒
+  `clojure.core/map`); core macros resolve as vars with `:macro` meta.
+- clojure.test: `(is (instance? C x))` actually asserts; every assertion
+  dispatches through the `report` multimethod; interned `:test`-meta tests
+  run inside `:once` fixtures.
+- Destructuring `:or` defaults are `get`'s not-found argument (JVM-exact:
+  eager, sibling bindings in scope) — `{:or {b (inc a)}}` no longer throws.
+- Laziness: `not-empty` uses `seq` (no more hanging on infinite seqs);
+  `pmap` is semi-lazy with bounded look-ahead; `pprint` honors
+  `*print-length*` by stopping; `when-first` tests the seq.
+- Java compat: `io/copy` between files copies bytes (binary files no longer
+  corrupted through a UTF-8 round-trip); deleting a non-empty directory
+  throws/returns false; parsed timezone offsets apply; FQN and short class
+  names share one statics table; bitwise `Math/getExponent`;
+  `awaitTermination` actually waits; `ReentrantLock` is reentrant;
+  interruptible bodies unwind their timers; `getAbsoluteFile` shares
+  `getAbsolutePath`'s base; `(System/getenv)` reads the environment directly
+  (multi-line values intact); shared counters and caches are mutex-guarded;
+  string `index-of`/`last-index-of` from-args clamp like the JVM; `assert`
+  messages evaluate at failure time.
+- Memory: caught exceptions no longer root the captured continuation (a
+  catch-complete hook clears it after the handler finishes; traces intact).
+- On hosts with an unverified `struct stat` layout (e.g. aarch64 Linux),
+  `getPosixFilePermissions`/`getOwner` throw a clear
+  `UnsupportedOperationException` instead of reading garbage.
+
+### Changed
+
+- The whole-program shake's hand-maintained name lists are gate-verified; the
+  17 run-gate scripts share one harness; `--opt` builds reuse the
+  whole-program pass's analysis at emission; one mode→Chez-parameters table;
+  the layered `Files` registrations collapse to one block per class; dead
+  code across the runtime removed (shakesmoke byte-identity verified).
+- The long-only integer boxing model is documented as the SPEC feature
+  `:numerics/long-only` (`(short x)` range-checks but boxes as Long).
+
+### Performance
+
+- `subseq`/`rsubseq` seek from the comparator bound and walk lazily
+  (O(log n) instead of materializing the collection); string scans stop
+  allocating per candidate offset (`.indexOf` −20%, `replace` −12%);
+  regex literals compile once per source string (~30× on literal-in-loop
+  patterns); collection-as-map-key lookups no longer rehash O(n) per probe.
+
 ## [0.3.2] - 2026-07-15
 
 ### Changed

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -697,15 +697,38 @@
       (cond ((> (+ i 3) (string-length m)) #f)
             ((string=? (substring m i (+ i 3)) "osx") #t)
             (else (loop (+ i 1)))))))
+;; struct stat field offsets are platform ABIs, not portable: verified for
+;; Darwin (st_mode@4/st_uid@16, all arches) and x86_64 Linux glibc
+;; (st_mode@24/st_uid@28 -- ground-truthed via offsetof probes). aarch64 Linux
+;; DIFFERS (st_mode@16/st_uid@24), and other hosts are unknown -- reading the
+;; hardcoded offsets there returns garbage, so the mode/uid readers throw a
+;; clear error instead. st_mtim@88 is identical on both Linux ABIs, so the
+;; mtime readers stay unguarded. Add a verified branch (not a guess) when a
+;; new host is brought up.
+(define nio-x86-64-linux?
+  (let* ((m (symbol->string (machine-type))) (n (string-length m)))
+    (and (>= n 2) (string=? (substring m (- n 2) n) "le")
+         (let loop ((i 0))
+           (cond ((> (+ i 2) n) #f)
+                 ((string=? (substring m i (+ i 2)) "a6") #t)
+                 (else (loop (+ i 1))))))))
+(define nio-stat-layout-known? (or nio-macos? nio-x86-64-linux?))
+(define (nio-stat-layout-guard! who)
+  (unless nio-stat-layout-known?
+    (jolt-throw (jolt-host-throwable "java.lang.UnsupportedOperationException"
+      (string-append who " is not supported on this host: unverified struct stat layout for "
+                     (symbol->string (machine-type)))))))
 (define c-stat (jolt-foreign-proc-safe "stat" '(string u8*) 'int))
 (define c-realpath (jolt-foreign-proc-safe "realpath" '(string u8*) 'iptr))
 (define (nio-stat-mode fp)
   (and c-stat
-       (let ((buf (make-bytevector 256 0)))
-         (and (= 0 (c-stat fp buf))
-              (if nio-macos?
-                  (bytevector-u16-ref buf 4 (native-endianness))
-                  (bytevector-u32-ref buf 24 (native-endianness)))))))
+       (begin
+         (nio-stat-layout-guard! "getPosixFilePermissions")
+         (let ((buf (make-bytevector 256 0)))
+           (and (= 0 (c-stat fp buf))
+                (if nio-macos?
+                    (bytevector-u16-ref buf 4 (native-endianness))
+                    (bytevector-u32-ref buf 24 (native-endianness))))))))
 (define (nio-cstr buf)                          ; buf up to the first NUL, as a string
   (let loop ((i 0))
     (cond ((>= i (bytevector-length buf)) (utf8->string buf))
@@ -933,8 +956,10 @@
       (if (= b 0) (list->string (map integer->char (reverse acc)))
           (loop (+ i 1) (cons b acc))))))
 (define (nio-stat-uid fp)
-  (and c-stat (let ((buf (make-bytevector 256 0)))
-                (and (= 0 (c-stat fp buf)) (bytevector-u32-ref buf (if nio-macos? 16 28) (native-endianness))))))
+  (and c-stat (begin
+                (nio-stat-layout-guard! "getOwner")
+                (let ((buf (make-bytevector 256 0)))
+                  (and (= 0 (c-stat fp buf)) (bytevector-u32-ref buf (if nio-macos? 16 28) (native-endianness)))))))
 (define (nio-uid->name uid)
   (and c-getpwuid (let ((pw (c-getpwuid uid))) (and (not (= 0 pw)) (nio-cstr-at (foreign-ref 'iptr pw 0))))))
 ;; user-principal values compare and hash by name; getOwner honors NOFOLLOW.
@@ -943,8 +968,10 @@
                   (lambda (a b) (string=? (jhost-state a) (jhost-state b))))
 (register-hash-arm! nio-userprin? (lambda (x) (string-hash (jhost-state x))))
 (define (nio-lstat-uid fp)
-  (and c-lstat (let ((buf (make-bytevector 256 0)))
-                 (and (= 0 (c-lstat fp buf)) (bytevector-u32-ref buf (if nio-macos? 16 28) (native-endianness))))))
+  (and c-lstat (begin
+                 (nio-stat-layout-guard! "getOwner")
+                 (let ((buf (make-bytevector 256 0)))
+                   (and (= 0 (c-lstat fp buf)) (bytevector-u32-ref buf (if nio-macos? 16 28) (native-endianness)))))))
 (let ((files-owner2
        (list (cons "getOwner" (lambda (p . opts)
                                 (let* ((fp (nfp p))


### PR DESCRIPTION
Closes the last audit bead (jolt-445k.70) and stages the 0.3.3 release notes.

struct stat offsets are per-ABI. Darwin and x86_64 Linux are verified (the
x86_64 offsets were ground-truthed with offsetof probes in podman: st_mode@24
st_uid@28; aarch64 differs at st_mode@16 st_uid@24). On any other host with a
live stat symbol, getPosixFilePermissions/getOwner throw a clear
UnsupportedOperationException naming the machine type instead of reading
garbage. st_mtim@88 is identical on both Linux ABIs, so mtime reads are
untouched. When an aarch64 CI host exists, the verified offsets above are the
branch to add.

Plus the CHANGELOG entry for 0.3.3 covering the audit epic and follow-ups
(PRs #362-#373).

Full make test green.