### PR TITLE
perf: string hashing without per-hash allocation + JVM bignum hashCode

### DIFF
--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -256,6 +256,25 @@
 (define (long-hashcode x)
   (i32 (bitwise-xor x (bitwise-arithmetic-shift-right (bitwise-and x #xFFFFFFFFFFFFFFFF) 32))))
 
+;; BigInteger.hashCode — java.math.BigInteger.hashCode() for exact integers
+;; that don't fit in 64-bit. Iterates 32-bit magnitude limbs (big-endian),
+;; accumulating h = 31*h + limb with int32 wrapping, then multiplies by signum.
+(define (big-integer-hashcode x)
+  (let* ((signum (cond ((< x 0) -1) ((= x 0) 0) (else 1)))
+         (mag (abs x)))
+    (if (= mag 0)
+        0
+        (let ((nbits (integer-length mag)))
+          (let* ((nlimbs (fx+ (fxquotient (fx- nbits 1) 32) 1))
+                 (shift0 (fx* (fx- nlimbs 1) 32)))
+            (let loop ((i 0) (h 0) (shift shift0))
+              (if (fx>=? i nlimbs)
+                  (i32 (* signum h))
+                  (let ((limb (u32 (bitwise-arithmetic-shift-right mag shift))))
+                    (loop (fx+ i 1)
+                          (i32 (+ (* 31 h) limb))
+                          (fx- shift 32))))))))))
+
 ;; ============================================================================
 ;; Double.hasheq — exact port of Numbers.hasheq for Double.class
 ;; ============================================================================
@@ -436,9 +455,8 @@
        ((and (exact? x) (integer? x)
              (>= x -9223372036854775808) (<= x 9223372036854775807))
         (murmur3-hash-long x))
-       ;; Bignum > 64-bit: fallback to Chez equal-hash (not JVM BigInteger.hashCode,
-       ;; but bignum map keys are exceptionally rare).
-       (else (equal-hash x))))
+       ;; Bignum > 64-bit: BigInteger.hashCode (JVM parity).
+       (else (big-integer-hashcode x))))
     ((boolean? x) (if x 1231 1237))
     ((char? x) (char->integer x))    ;; Character.hashCode = (int) charValue
     ((jolt-symbol? x) (symbol-hasheq x))

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -185,57 +185,67 @@
 ;; String hash — Java String.hashCode() over UTF-16 code units
 ;; ============================================================================
 
-;; Convert a Chez codepoint string to a vector of UTF-16 code units.
-;; A codepoint >= #x10000 contributes a surrogate pair (high, low).
-(define (string->utf16-units s)
-  (let* ((len (string-length s))
-         (v (make-vector len)))
-    (let loop ((i 0) (j 0))
-      (if (fx>=? i len)
-          (let ((nv (make-vector j)))
-            (do ((k 0 (fx+ k 1))) ((fx>=? k j)) (vector-set! nv k (vector-ref v k)))
-            nv)
+;; Java String.hashCode(): s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]
+;; over UTF-16 code units. Iterates the string's codepoints directly,
+;; computing surrogate pairs inline for codepoints >= #x10000 — no
+;; intermediate vector allocation.
+(define (java-string-hashcode s)
+  (let ((len (string-length s)))
+    (let loop ((i 0) (h 0))
+      (if (#3%fx>=? i len)
+          (i32 h)
           (let ((cp (char->integer (string-ref s i))))
-            (if (fx<? cp #x10000)
-                (begin (vector-set! v j cp) (loop (fx+ i 1) (fx+ j 1)))
-                (let* ((cp2 (fx- cp #x10000))
+            (if (#3%fx<? cp #x10000)
+                (loop (#3%fx+ i 1) (i32 (#3%fx+ (#3%fx* 31 h) cp)))
+                (let* ((cp2 (#3%fx- cp #x10000))
                        (high (fxior #xD800 (fxsra cp2 10)))
                        (low  (fxior #xDC00 (fxand cp2 #x3FF))))
-                  (when (fx>=? (fx+ j 1) (vector-length v))
-                    (let ((nv (make-vector (fx* (vector-length v) 2))))
-                      (do ((k 0 (fx+ k 1))) ((fx>=? k j)) (vector-set! nv k (vector-ref v k)))
-                      (set! v nv)))
-                  (vector-set! v j high)
-                  (vector-set! v (fx+ j 1) low)
-                  (loop (fx+ i 1) (fx+ j 2)))))))))
-
-;; Java String.hashCode(): s[0]*31^(n-1) + s[1]*31^(n-2) + ... + s[n-1]
-;; over UTF-16 code units.
-(define (java-string-hashcode s)
-  (let* ((units (string->utf16-units s))
-         (n (vector-length units)))
-    (let loop ((i 0) (h 0))
-      (if (#3%fx>=? i n)
-          (i32 h)
-          (loop (#3%fx+ i 1) (i32 (#3%fx+ (#3%fx* 31 h) (vector-ref units i))))))))
+                  (let ((h* (i32 (#3%fx+ (#3%fx* 31 h) high))))
+                    (loop (#3%fx+ i 1) (i32 (#3%fx+ (#3%fx* 31 h*) low)))))))))))
 
 (define (murmur3-hash-unencoded-chars s)
   ;; Match Java's Murmur3.hashUnencodedChars(CharSequence) over the
-  ;; UTF-16 code-unit sequence. Processes 2 chars at a time.
-  (let ((units (string->utf16-units s)))
-    (let ((n (vector-length units)))
-      (let loop ((i 1) (h1 murmur3-seed))
-        (if (#3%fx>=? i n)
-            (if (#3%fx=? (#3%fxand n 1) 1)
-                (let* ((k1 (murmur3-mix-k1 (vector-ref units (#3%fx- n 1))))
-                       (h1 (#3%bitwise-xor h1 k1)))
-                  (murmur3-fmix h1 (#3%fx* 2 n)))
-                (murmur3-fmix h1 (#3%fx* 2 n)))
-            (let* ((lo (vector-ref units (#3%fx- i 1)))
-                   (hi (vector-ref units i))
-                   (k1 (murmur3-mix-k1 (#3%bitwise-ior lo (#3%bitwise-arithmetic-shift-left hi 16))))
-                   (h1 (murmur3-mix-h1 h1 k1)))
-              (loop (#3%fx+ i 2) h1)))))))
+  ;; UTF-16 code-unit sequence. Processes 2 code units at a time.
+  ;; Iterates codepoints directly (no intermediate vector), pairing
+  ;; BMP units across iterations and self-pairing astral surrogates.
+  (let ((len (string-length s)))
+    (let loop ((i 0) (h1 murmur3-seed) (pending #f) (count 0))
+      (if (#3%fx>=? i len)
+          (if pending
+              ;; One unpaired unit left — mix and finalize
+              (let* ((k1 (murmur3-mix-k1 pending))
+                     (h1 (#3%bitwise-xor h1 k1)))
+                (murmur3-fmix h1 (#3%fx* 2 (#3%fx+ count 1))))
+              (murmur3-fmix h1 (#3%fx* 2 count)))
+          (let ((cp (char->integer (string-ref s i))))
+            (if (#3%fx<? cp #x10000)
+                ;; BMP: one code unit
+                (if pending
+                    ;; Pair pending + this unit; both consumed
+                    (let* ((k1 (murmur3-mix-k1
+                                (#3%bitwise-ior pending
+                                 (#3%bitwise-arithmetic-shift-left cp 16))))
+                           (h1 (murmur3-mix-h1 h1 k1)))
+                      (loop (#3%fx+ i 1) h1 #f (#3%fx+ count 2)))
+                    ;; Hold as pending (not counted yet)
+                    (loop (#3%fx+ i 1) h1 cp count))
+                ;; Astral: surrogate pair (high, low) — always 2 units
+                (let* ((cp2 (#3%fx- cp #x10000))
+                       (high (fxior #xD800 (fxsra cp2 10)))
+                       (low  (fxior #xDC00 (fxand cp2 #x3FF))))
+                  (if pending
+                      ;; Pair pending + high (consumed), low becomes new pending
+                      (let* ((k1 (murmur3-mix-k1
+                                  (#3%bitwise-ior pending
+                                   (#3%bitwise-arithmetic-shift-left high 16))))
+                             (h1 (murmur3-mix-h1 h1 k1)))
+                        (loop (#3%fx+ i 1) h1 low (#3%fx+ count 2)))
+                      ;; High + low consumed together
+                      (let* ((k1 (murmur3-mix-k1
+                                  (#3%bitwise-ior high
+                                   (#3%bitwise-arithmetic-shift-left low 16))))
+                             (h1 (murmur3-mix-h1 h1 k1)))
+                        (loop (#3%fx+ i 1) h1 #f (#3%fx+ count 2)))))))))))
 
 ;; ============================================================================
 ;; Long.hashCode (Java): (int)(value ^ (value >>> 32))
@@ -361,6 +371,20 @@
         (hashtable-set! symbol-hasheq-cache sym h)
         h)))
 
+;; String hasheq cache — same pattern as symbol cache.
+;; JVM caches String.hashCode per object; Jolt strings aren't interned
+;; (they're regular Chez strings), so we cache in a weak-eq hashtable.
+(define string-hasheq-cache (make-weak-eq-hashtable))
+
+(define (compute-string-hasheq s)
+  (murmur3-hash-int (java-string-hashcode s)))
+
+(define (string-hasheq s)
+  (or (hashtable-ref string-hasheq-cache s #f)
+      (let ((h (compute-string-hasheq s)))
+        (hashtable-set! string-hasheq-cache s h)
+        h)))
+
 ;; ============================================================================
 ;; jolt-hasheq — the top-level dispatch (mirrors Util.hasheq)
 ;; ============================================================================
@@ -380,7 +404,7 @@
     ;; hashLong→mixK1→mixH1→fmix). All fixnums use hashLong (count=8)
     ;; matching JVM's Long.hasheq.
     ((fixnum? x) (murmur3-hash-long-flat x))
-    ((string? x) (murmur3-hash-int (java-string-hashcode x)))
+    ((string? x) (string-hasheq x))
     (else
      ;; New hasheq arms (jrec via records.ss, etc.)
      (let loop ((as jolt-hasheq-arms))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3794,6 +3794,8 @@
   {:suite "conformance / hasheq" :label "hash string s" :expected "1975881410" :actual "(hash \"s\")" :portability :common}
   {:suite "conformance / hasheq" :label "hash string hello" :expected "1715862179" :actual "(hash \"hello\")" :portability :common}
   {:suite "conformance / hasheq" :label "hash empty string" :expected "0" :actual "(hash \"\")" :portability :common}
+  {:suite "conformance / hasheq" :label "hash string astral-plane (emoji)" :expected "-1934073014" :actual "(hash \"😀\")" :portability :common}
+  {:suite "conformance / hasheq" :label "hash string mixed BMP+astral" :expected "1898100721" :actual "(hash \"a😀b\")" :portability :common}
   {:suite "conformance / hasheq" :label "hash fixnum 42" :expected "1871679806" :actual "(hash 42)" :portability :common}
   {:suite "conformance / hasheq" :label "hash fixnum 0" :expected "0" :actual "(hash 0)" :portability :common}
   {:suite "conformance / hasheq" :label "hash fixnum -7" :expected "-1703207563" :actual "(hash -7)" :portability :common}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3820,6 +3820,10 @@
   {:suite "conformance / hasheq" :label "hash seq (seq [1 2])" :expected "156247261" :actual "(hash (seq [1 2]))" :portability :common}
   {:suite "conformance / hasheq" :label "ordered colls unify: (= (hash [1 2 3]) (hash '(1 2 3)))" :expected "true" :actual "(= (hash [1 2 3]) (hash '(1 2 3)))" :portability :common}
   {:suite "conformance / hasheq" :label "unordered empty colls unify: (= (hash {}) (hash #{}))" :expected "true" :actual "(= (hash {}) (hash #{}))" :portability :common}
+  {:suite "conformance / hasheq" :label "hash bigint 2^63" :expected "-2147483648" :actual "(hash 9223372036854775808N)" :portability :common}
+  {:suite "conformance / hasheq" :label "hash bigint -2^63-1" :expected "2147483647" :actual "(hash -9223372036854775809N)" :portability :common}
+  {:suite "conformance / hasheq" :label "hash bigint 10^99" :expected "838100522" :actual "(hash 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000N)" :portability :common}
+  {:suite "conformance / hasheq" :label "hash bigint 5N equals hash 5" :expected "true" :actual "(= (hash 5N) (hash 5))" :portability :common}
   ;; ============================================================================
   ;; conformance / hamt-order — JVM PersistentHashMap/HashSet iteration order (Stage 2)
   ;; ============================================================================

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -762,8 +762,9 @@
  ;; Stage B — collection hasheq caching
  {:suite "hasheq-cache" :expr "(let [m {:x 1 :y 2} h1 (hash m) h2 (hash m)] (= h1 h2))" :expected "true"}
  {:suite "hasheq-cache" :expr "(let [s #{:a :b} h1 (hash s) h2 (hash s)] (= h1 h2))" :expected "true"}
- {:suite "hasheq-cache" :expr "(let [v [1 2 3] h1 (hash v) h2 (hash v)] (= h1 h2))" :expected "true"}
- ;; Stage C — positional ctor throws on wrong arity
+  {:suite "hasheq-cache" :expr "(let [v [1 2 3] h1 (hash v) h2 (hash v)] (= h1 h2))" :expected "true"}
+  {:suite "hasheq-cache" :expr "(let [s \"hello\" h1 (hash s) h2 (hash s)] (= h1 h2))" :expected "true"}
+  ;; Stage C — positional ctor throws on wrong arity
  {:suite "records-ctor-arity" :expr "(do (defrecord ArC9 [x y]) (try (->ArC9 1) (catch Exception e :arity-throw)))" :expected ":arity-throw"}
  {:suite "records-ctor-arity" :expr "(do (defrecord ArC9b [x y]) (try (->ArC9b 1 2 3) (catch Exception e :arity-throw)))" :expected ":arity-throw"}
  {:suite "records-ctor-arity" :expr "(do (defrecord ArC9c [x y]) (->ArC9c 1 2))" :expected "#user.ArC9c{:x 1, :y 2}"}


### PR DESCRIPTION
String hashes iterated a freshly allocated UTF-16 unit vector on every operation; now the chars are walked directly with inline surrogate arithmetic, plus a weak-eq hash cache like the symbol one. Measured 244ms -> 187ms per 1M string-keyed gets (A/B/A, quiet machine). Bignums outside long range fell back to Chez equal-hash, exceeding int32 and diverging from the JVM; now BigInteger.hashCode semantics, corpus rows pin the values (astral and mixed strings included). Full gate green, certify 0 new / 0 stale.

jolt-mw44.24, jolt-mw44.12 (epic jolt-mw44)