### PR TITLE
startup: dev boot cache, AOT jolt.main, bytevector embeds, GC trip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke submodules
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke submodules
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -239,3 +239,12 @@ certify:
 # Re-mint the seed after changing a seed source (reader/analyzer/backend/core).
 remint:
 	@sh host/chez/remint.sh
+
+# Precompile the runtime to target/dev/flat.so so dev bin/joltc boots ~10x faster
+# (loads the .so instead of compiling ~50 .ss files from source every invocation).
+devboot: submodules
+	@$(CHEZ) --script host/chez/make-devboot.ss
+
+# Smoke test: the dev boot cache is used when fresh and invalidated correctly.
+devbootsmoke: devboot
+	@sh test/chez/devboot-smoke.sh

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: submodules selfhost ci
 # lockfile) — it RUNS correctly on any Chez, but `selfhost` rebuilds it and a
 # different Chez version may emit byte-different (gensym/order) output, so the
 # byte-fixpoint is a dev-machine check, not a CI one (jolt-8479).
-ci: submodules values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink numeric inline inline-body dcerefs shakelocal manifestcheck certify
+ci: submodules values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink numeric inline inline-body dcerefs shakelocal manifestcheck devbootsmoke certify
 	@echo "OK: CI gates passed"
 
 # Self-host fixpoint: bootstrap.ss rebuild == checked-in seed.

--- a/bin/joltc
+++ b/bin/joltc
@@ -37,5 +37,41 @@ fi
 # Version for --version / banners: git describe of this checkout, else "dev".
 export JOLT_VERSION="${JOLT_VERSION:-$(git -C "$root" describe --tags --always --dirty 2>/dev/null || echo dev)}"
 cd "$root" || exit 1
-exec ${CHEZ} --script host/chez/cli.ss "$@"
 
+# Dev boot cache: precompiled target/dev/flat.so loads the runtime ~10x faster
+# than source mode. Check freshness against the input list emitted by make devboot.
+# The cache is not used for REPL (interactive stdin needed) or when the first
+# arg is "repl" (explicit REPL command).
+CACHE_SO="target/dev/flat.so"
+CACHE_INPUTS="target/dev/flat.inputs"
+use_cache=0
+if [ -f "$CACHE_SO" ] && [ -f "$CACHE_INPUTS" ] && [ $# -gt 0 ] && [ "$1" != "repl" ]; then
+  stale=0
+  while IFS= read -r f; do
+    if [ -n "$f" ] && [ "$CACHE_SO" -ot "$f" ]; then
+      stale=1
+      break
+    fi
+  done < "$CACHE_INPUTS"
+  if [ "$stale" = 0 ]; then
+    use_cache=1
+  fi
+fi
+
+if [ "$use_cache" = 1 ]; then
+  exec ${CHEZ} --script /dev/stdin "$@" <<JOLT_DEVCACHE_LAUNCHER
+(load "target/dev/flat.so")
+(let ((marker (getenv "JOLT_DEVCACHE")))
+  (when (and marker (not (string=? marker "")))
+    (display "devcache: using target/dev/flat.so\n" (current-error-port))))
+(jolt-trace-init-from-env!)
+(jolt-cli-run (cdr (command-line))
+  (lambda () (load "host/chez/build.ss")))
+JOLT_DEVCACHE_LAUNCHER
+fi
+
+# Fallback: source mode. Hint for devs (only when interactive).
+if [ -t 1 ] && [ -z "${JOLT_QUIET:-}" ]; then
+  echo "joltc: source mode; run 'make devboot' to precompile" >&2
+fi
+exec ${CHEZ} --script host/chez/cli.ss "$@"

--- a/bin/joltc
+++ b/bin/joltc
@@ -58,21 +58,10 @@ if [ -f "$CACHE_SO" ] && [ -f "$CACHE_INPUTS" ] && [ $# -gt 0 ] && [ "$1" != "re
   fi
 fi
 
+# The devcache entry is a checked-in script sharing cli.ss's tail (cli-tail.ss)
+# — an inline heredoc here once drifted from cli.ss and broke project commands.
 if [ "$use_cache" = 1 ]; then
-  exec ${CHEZ} --script /dev/stdin "$@" <<JOLT_DEVCACHE_LAUNCHER
-(load "target/dev/flat.so")
-(let ((marker (getenv "JOLT_DEVCACHE")))
-  (when (and marker (not (string=? marker "")))
-    (display "devcache: using target/dev/flat.so\n" (current-error-port))))
-;; GC tuning (same as the binary's launcher).
-(collect-trip-bytes
-  (let ((trip (getenv "JOLT_GC_TRIP_BYTES"))
-        (default (* 16 1024 1024)))
-    (if trip (or (string->number trip) default) default)))
-(jolt-trace-init-from-env!)
-(jolt-cli-run (cdr (command-line))
-  (lambda () (load "host/chez/build.ss")))
-JOLT_DEVCACHE_LAUNCHER
+  exec ${CHEZ} --script host/chez/cli-devcache.ss "$@"
 fi
 
 # Fallback: source mode. Hint for devs (only when interactive).

--- a/bin/joltc
+++ b/bin/joltc
@@ -64,6 +64,11 @@ if [ "$use_cache" = 1 ]; then
 (let ((marker (getenv "JOLT_DEVCACHE")))
   (when (and marker (not (string=? marker "")))
     (display "devcache: using target/dev/flat.so\n" (current-error-port))))
+;; GC tuning (same as the binary's launcher).
+(collect-trip-bytes
+  (let ((trip (getenv "JOLT_GC_TRIP_BYTES"))
+        (default (* 16 1024 1024)))
+    (if trip (or (string->number trip) default) default)))
 (jolt-trace-init-from-env!)
 (jolt-cli-run (cdr (command-line))
   (lambda () (load "host/chez/build.ss")))

--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -85,7 +85,7 @@
             (when (or (str-suffix? rel ".clj") (str-suffix? rel ".cljc"))
               (put-string out (string-append
                 "(register-embedded-resource! " (ei-str-lit rel) " "
-                (ei-str-lit (read-file-string abs)) ")\n")))))
+                (ei-bytes-lit (read-file-string abs)) ")\n")))))
         (bld-walk-files root "" '())))
     ldr-install-roots))
 
@@ -112,7 +112,7 @@
     (lambda (path)
       (put-string out (string-append
         "(register-embedded-resource! " (ei-str-lit path) " "
-        (ei-str-lit (read-file-string path)) ")\n")))
+        (ei-bytes-lit (read-file-string path)) ")\n")))
     (jb-collect-load-paths)))
 
 ;; The launcher (Chez scheme-start): replicates host/chez/cli.ss but reads argv

--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -142,6 +142,12 @@
         (\"stub/launcher.c\" \"jolt_launcher_c\" \"jolt_launcher_c_len\")))))
 
 (suppress-greeting #t)
+;; GC tuning: larger nursery for allocation-heavy workloads. Default 16 MB;
+;; override via JOLT_GC_TRIP_BYTES env (integer bytes).
+(collect-trip-bytes
+  (let ((trip (getenv \"JOLT_GC_TRIP_BYTES\"))
+        (default (* 16 1024 1024)))
+    (if trip (or (string->number trip) default) default)))
 (scheme-start
   (lambda args
     (set-source-roots! " (ldr-install-roots-str) ")

--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -169,6 +169,11 @@
   ;; jolt-baked-version above, so this set! resolves).
   (put-string out (string-append "\n;; === baked version ===\n(set! jolt-baked-version "
                                  (ei-str-lit jb-version) ")\n"))
+  ;; Preload jolt.main + jolt.deps into the image so CLI dispatch (every
+  ;; run/build/path/repl command) skips the ~0.14s source-load.
+  (put-string out "\n;; === AOT jolt.main + jolt.deps ===\n")
+  (put-string out "(load-namespace \"jolt.main\")\n")
+  (put-string out "(load-namespace \"jolt.deps\")\n")
   (put-string out "\n;; === joltc launcher ===\n")
   (jb-emit-launcher out)
   (close-port out))

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -481,9 +481,9 @@
       (directory-list dir))))
 
 ;; Emit register-embedded-resource! per file under each embed dir. Emitted BEFORE
-;; the app forms. File contents are read at BUILD time and emitted as string
-;; literals — flat.ss top-level forms run at every startup with no source on disk,
-;; so read-file-string at runtime would fail. The bytes are baked into the binary.
+;; the app forms. File contents are read at BUILD time and emitted as bytevector
+;; literals (1B/char) — flat.ss top-level forms run at every startup with no source
+;; on disk, so read-file-string at runtime would fail.
 (define (bld-emit-embeds out embed-dirs)
   (for-each
     (lambda (root)
@@ -492,7 +492,7 @@
           (lambda (rp)
             (put-string out (string-append
                               "(register-embedded-resource! " (ei-str-lit (car rp))
-                              " " (ei-str-lit (read-file-string (cdr rp))) ")\n")))
+                              " " (ei-bytes-lit (read-file-string (cdr rp))) ")\n")))
           (bld-walk-files root "" '()))))
     (bld-strs embed-dirs)))
 

--- a/host/chez/cli-devcache.ss
+++ b/host/chez/cli-devcache.ss
@@ -1,0 +1,15 @@
+;; cli-devcache.ss — dev-boot-cache CLI entry. bin/joltc execs this instead of
+;; cli.ss when target/dev/flat.so is fresh (see `make devboot`). The flat image
+;; contains the full runtime manifest (cli-core, loader, ffi included), so the
+;; only things that belong here are the image load, GC tuning, and the shared
+;; CLI tail. Do not add forms here that cli.ss would also need — put them in
+;; cli-tail.ss.
+(load "target/dev/flat.so")
+(when (let ((m (getenv "JOLT_DEVCACHE"))) (and m (not (string=? m ""))))
+  (display "devcache: using target/dev/flat.so\n" (current-error-port)))
+;; GC tuning (same as the binary's launcher).
+(collect-trip-bytes
+  (let ((trip (getenv "JOLT_GC_TRIP_BYTES"))
+        (default (* 16 1024 1024)))
+    (if trip (or (string->number trip) default) default)))
+(load "host/chez/cli-tail.ss")

--- a/host/chez/cli-tail.ss
+++ b/host/chez/cli-tail.ss
@@ -1,0 +1,19 @@
+;; cli-tail.ss — shared CLI entry tail, loaded by cli.ss (source mode) and by
+;; cli-devcache.ss (dev boot cache) so the two entry paths cannot drift. The
+;; devcache launcher was once a heredoc that duplicated these forms and missed
+;; set-source-roots! — every project command then failed to resolve sources.
+(define cli-args (cdr (command-line)))   ; drop the script name
+
+;; jolt.main + jolt.deps live under jolt-core; keep them (and stdlib) on the
+;; roots so the CLI's own namespaces — and any jolt.* an app pulls in — resolve.
+;; A project's resolved deps roots are prepended to these by jolt.main.
+(set-source-roots! ldr-install-roots)
+
+;; JOLT_TRACE opt-in, at runtime (before any app ns compiles) so the app is traced.
+(jolt-trace-init-from-env!)
+
+(jolt-cli-run cli-args
+  ;; `build` AOT-compiles an app to a standalone binary — load the build driver
+  ;; (the cross-compiler emitter) on demand so a normal run never pays for it.
+  ;; It defines jolt.host/build-binary, which jolt.main's build cmd calls.
+  (lambda () (load "host/chez/build.ss")))

--- a/host/chez/cli.ss
+++ b/host/chez/cli.ss
@@ -9,8 +9,6 @@
 ;; Run from the repo root (bin/joltc cd's there); the project dir is JOLT_PWD.
 (import (chezscheme))
 
-(define cli-args (cdr (command-line)))   ; drop the script name
-
 ;; Fail early and actionably when the vendored submodules aren't checked out —
 ;; a plain `git clone` or GitHub's auto-generated "Source code" release archive
 ;; lacks them, and the raw failure ("load failed for vendor/irregex/irregex.scm")
@@ -47,20 +45,8 @@
 ;; Clojure side (the foreign-fn / defcfn macros, stdlib/jolt/ffi.clj).
 (load "host/chez/java/ffi.ss")          ; jolt.ffi (FFI: a library binds native code)
 
-;; jolt.main + jolt.deps live under jolt-core; keep them (and stdlib) on the
-;; roots so the CLI's own namespaces — and any jolt.* an app pulls in — resolve.
-;; A project's resolved deps roots are prepended to these by jolt.main.
-(set-source-roots! ldr-install-roots)
-
 ;; jolt-report-uncaught / drop-end-of-options / the -e arm live in cli-core.ss,
-;; shared with the standalone binary's launcher (build-joltc.ss).
-
-;; JOLT_TRACE opt-in, at runtime (before any app ns compiles) so the app is traced.
-(jolt-trace-init-from-env!)
-
-
-(jolt-cli-run cli-args
-  ;; `build` AOT-compiles an app to a standalone binary — load the build driver
-  ;; (the cross-compiler emitter) on demand so a normal run never pays for it.
-  ;; It defines jolt.host/build-binary, which jolt.main's build cmd calls.
-  (lambda () (load "host/chez/build.ss")))
+;; shared with the standalone binary's launcher (build-joltc.ss). The entry
+;; tail (source roots, trace init, jolt-cli-run) is shared with the devcache
+;; entry (cli-devcache.ss) via cli-tail.ss.
+(load "host/chez/cli-tail.ss")

--- a/host/chez/emit-image.ss
+++ b/host/chez/emit-image.ss
@@ -172,6 +172,11 @@
 ;; (printable ASCII identifiers only here).
 (define (ei-str-lit s) (with-output-to-string (lambda () (write s))))
 
+;; Emit (string->utf8 "...") so the embedded value is a bytevector (1B/char)
+;; instead of a UCS-4 string (4B/char) — saves ~9MB heap per 3MB of source.
+(define (ei-bytes-lit s)
+  (string-append "(string->utf8 " (ei-str-lit s) ")"))
+
 ;; The compiler namespaces, in load order. The passes (fold/inline/types + the
 ;; jolt.passes façade) load after ir so run-passes is available to the back end;
 ;; fold/inline/types come before the façade that :refers them.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -369,7 +369,9 @@
 (define (jolt-slurp src . opts)
   (cond
     ((jfile? src) (read-file-string (jfile-fs src)))
-    ((embedded-res? src) (embedded-res-content src))
+    ((embedded-res? src)
+     (let ((c (embedded-res-content src)))
+       (if (bytevector? c) (utf8->string c) c)))
     ((reader-jhost? src) (drain-reader src))
     ;; bytes (a bytevector or a jolt byte-array): decode with :encoding (UTF-8
     ;; default). clj-http-lite slurps response-body byte arrays.
@@ -488,7 +490,9 @@
   (cond
     ((reader-jhost? x) x)
     ((jfile? x) (host-new "StringReader" (read-file-string (jfile-fs x))))
-    ((embedded-res? x) (host-new "StringReader" (embedded-res-content x)))
+    ((embedded-res? x)
+     (let ((c (embedded-res-content x)))
+       (host-new "StringReader" (if (bytevector? c) (utf8->string c) c))))
     ((and (jhost? x) (string=? (jhost-tag x) "url"))
      (host-new "StringReader" (read-file-string (url-strip-scheme (url-spec x)))))
     ((string? x) (host-new "StringReader" (read-file-string (project-relative x))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -32,16 +32,18 @@
 (define ldr-install-roots '("jolt-core" "stdlib" "vendor/fs/src"))
 
 ;; True when `f` is a file owned by the Jolt runtime (compiler + stdlib) — either
-;; an embedded-resource key or a path under one of ldr-install-roots.
+;; an embedded-resource key (string or bytevector value) or a path under one of
+;; ldr-install-roots.
 (define (ldr-install-file? f)
-  (or (string? (hashtable-ref embedded-resources f #f))
-      (let loop ((roots ldr-install-roots))
-        (and (pair? roots)
-             (or (let ((root (car roots)))
-                   (and (>= (string-length f) (+ (string-length root) 1))
-                        (string=? (substring f 0 (string-length root)) root)
-                        (char=? (string-ref f (string-length root)) #\/)))
-                 (loop (cdr roots)))))))
+  (let ((v (hashtable-ref embedded-resources f #f)))
+    (or (string? v) (bytevector? v)
+        (let loop ((roots ldr-install-roots))
+          (and (pair? roots)
+               (or (let ((root (car roots)))
+                     (and (>= (string-length f) (+ (string-length root) 1))
+                          (string=? (substring f 0 (string-length root)) root)
+                          (char=? (string-ref f (string-length root)) #\/)))
+                   (loop (cdr roots))))))))
 
 ;; A Chez source string for the install roots list — "(list \"jolt-core\" \"stdlib\" \"vendor/fs/src\")".
 ;; Used by build templates so the literal stays in one place.
@@ -207,8 +209,10 @@
 (define (resolve-on-roots rel)
   (let ((eclj (string-append rel ".clj")) (ecljc (string-append rel ".cljc")))
     (cond
-      ((string? (hashtable-ref embedded-resources eclj #f)) eclj)
-      ((string? (hashtable-ref embedded-resources ecljc #f)) ecljc)
+      ((let ((v (hashtable-ref embedded-resources eclj #f)))
+         (or (string? v) (bytevector? v))) eclj)
+      ((let ((v (hashtable-ref embedded-resources ecljc #f)))
+         (or (string? v) (bytevector? v))) ecljc)
       (else
         (let loop ((roots source-roots))
           (if (null? roots) #f
@@ -220,11 +224,13 @@
 
 ;; Read a namespace source. An embedded key (resolve-on-roots above, or the
 ;; build driver's app-order entries) reads its baked string; everything else is
-;; a real path read off disk. Bytevector entries (the bundled boots/stub) are not
-;; source, so a string? guard skips them.
+;; a real path read off disk. Bytevector entries (the bundled boots/stub, and
+;; source embeds stored as bytevectors to save heap) decode via utf8->string.
 (define (ldr-read-source path)
   (let ((emb (hashtable-ref embedded-resources path #f)))
-    (if (string? emb) emb (read-file-string path))))
+    (cond ((string? emb) emb)
+          ((bytevector? emb) (utf8->string emb))
+          (else (read-file-string path)))))
 
 (define (find-ns-file name) (resolve-on-roots (ns-name->rel name)))
 

--- a/host/chez/make-devboot.ss
+++ b/host/chez/make-devboot.ss
@@ -1,0 +1,123 @@
+;; make-devboot.ss — precompile the runtime to target/dev/flat.so for dev boot cache.
+;;
+;;   chez --script host/chez/make-devboot.ss
+;;
+;; Two-phase (same as build-joltc steps 1-2):
+;;   1. emit flat.ss (runtime + compiler + embeds) + a compile helper into target/dev/
+;;   2. run the helper in a FRESH Chez, so `error` and other shadowed primitives
+;;      resolve to the kernel bindings before the runtime redefines them.
+
+(import (chezscheme))
+
+(load "host/chez/rt.ss")
+(set-chez-ns! "clojure.core")
+(load "host/chez/seed/prelude.ss")
+(load "host/chez/post-prelude.ss")
+(set-chez-ns! "user")
+(load "host/chez/host-contract.ss")
+(load "host/chez/seed/image.ss")
+(load "host/chez/compile-eval.ss")
+(load "host/chez/png.ss")
+(load "host/chez/loader.ss")
+(load "host/chez/java/ffi.ss")
+(set-source-roots! ldr-install-roots)
+(load "host/chez/build.ss")
+
+(define jb-build "target/dev")
+(bld-system (string-append "mkdir -p '" jb-build "'"))
+
+(define (str-suffix? s suf)
+  (let ((n (string-length s)) (m (string-length suf)))
+    (and (>= n m) (string=? (substring s (- n m) n) suf))))
+
+;; --- collect inputs (same algorithm as build-joltc's jb-collect-load-paths) ---
+(define (db-collect-load-paths)
+  (let ((seen (make-hashtable string-hash string=?)) (order '()))
+    (define (walk path)
+      (when (and path (not (hashtable-ref seen path #f)))
+        (hashtable-set! seen path #t)
+        (set! order (cons path order))
+        (for-each (lambda (l) (walk (bld-load-path l))) (bld-file-lines path))))
+    (for-each (lambda (entry) (when (string? entry) (walk (bld-load-path entry))))
+              bld-runtime-manifest)
+    (for-each (lambda (kv) (walk (bld-load-path (cdr kv)))) bld-tagged-loads)
+    (reverse order)))
+
+;; --- write input list (after emit, not after compile, so failures don't skip) ---
+(define db-input-file (string-append jb-build "/flat.inputs"))
+(define db-paths (db-collect-load-paths))
+
+;; --- 1. emit flat.ss ---------------------------------------------------------
+(define jb-flat-ss (string-append jb-build "/flat.ss"))
+(define jb-flat-so (string-append jb-build "/flat.so"))
+(display "make-devboot: emitting flat source\n")
+(let ((out (open-output-file jb-flat-ss 'replace)))
+  ;; Full runtime + compiler image.
+  (bld-emit-runtime out #f #f)
+  ;; build.ss inlined (for `jolt build` from the cache).
+  (put-string out "\n;; === embedded build driver ===\n")
+  (bld-inline-line "(load \"host/chez/build.ss\")" out 0)
+  ;; Runtime source embeds.
+  (put-string out "\n;; === embedded runtime source ===\n")
+  (for-each (lambda (path)
+              (put-string out
+                (string-append
+                  "(register-embedded-resource! " (ei-str-lit path) " "
+                  (ei-str-lit (read-file-string path)) ")\n")))
+            db-paths)
+  ;; jolt-core + stdlib source embeds.
+  (put-string out "\n;; === embedded jolt-core + stdlib source ===\n")
+  (for-each
+    (lambda (root)
+      (for-each
+        (lambda (rp)
+          (let ((rel (car rp)) (abs (cdr rp)))
+            (when (or (str-suffix? rel ".clj") (str-suffix? rel ".cljc"))
+              (put-string out
+                (string-append
+                  "(register-embedded-resource! " (ei-str-lit rel) " "
+                  (ei-str-lit (read-file-string abs)) ")\n")))))
+        (bld-walk-files root "" '())))
+    ldr-install-roots)
+  ;; Preload jolt.main + jolt.deps into the image.
+  (put-string out "\n;; === AOT jolt.main + jolt.deps ===\n")
+  (put-string out "(load-namespace \"jolt.main\")\n")
+  (put-string out "(load-namespace \"jolt.deps\")\n")
+  (close-port out))
+
+;; --- write input list (before compile, so the list is always consistent) ------
+(display "make-devboot: writing input list\n")
+(let ((out (open-output-file db-input-file 'replace))
+      (clj-files '()))
+  (for-each (lambda (p) (put-string out p) (put-string out "\n")) db-paths)
+  ;; Also list all .clj/.cljc source files.
+  (for-each
+    (lambda (root)
+      (for-each
+        (lambda (rp)
+          (let ((rel (car rp)))
+            (when (or (str-suffix? rel ".clj") (str-suffix? rel ".cljc"))
+              (put-string out (cdr rp)) (put-string out "\n"))))
+        (bld-walk-files root "" '())))
+    ldr-install-roots)
+  (close-port out))
+
+;; --- 2. compile in a FRESH Chez (same approach as build-joltc step 2) ---------
+;; compile-file must run against a clean chezscheme env so `error` and other
+;; primitives the runtime shadows bind to the kernel versions.
+(display "make-devboot: compiling flat.so (fresh Chez)\n")
+(let ((cs (string-append jb-build "/dev-compile.ss")))
+  (let ((p (open-output-file cs 'replace)))
+    (put-string p
+      (string-append
+        "(import (chezscheme))\n"
+        "(optimize-level 2)\n"
+        "(generate-inspector-information #f)\n"
+        "(generate-procedure-source-information #f)\n"
+        "(debug-on-exception #f)\n"
+        "(fasl-compressed #t)\n"
+        "(compile-file " (ei-str-lit jb-flat-ss) " " (ei-str-lit jb-flat-so) ")\n"))
+    (close-port p))
+  (bld-system (string-append bld-chez " --script '" cs "'")))
+
+(display (string-append "make-devboot: wrote " jb-flat-so "\n"))

--- a/host/chez/make-devboot.ss
+++ b/host/chez/make-devboot.ss
@@ -57,15 +57,15 @@
   ;; build.ss inlined (for `jolt build` from the cache).
   (put-string out "\n;; === embedded build driver ===\n")
   (bld-inline-line "(load \"host/chez/build.ss\")" out 0)
-  ;; Runtime source embeds.
+  ;; Runtime source embeds (bytevector values, 1B/char).
   (put-string out "\n;; === embedded runtime source ===\n")
   (for-each (lambda (path)
               (put-string out
                 (string-append
                   "(register-embedded-resource! " (ei-str-lit path) " "
-                  (ei-str-lit (read-file-string path)) ")\n")))
+                  (ei-bytes-lit (read-file-string path)) ")\n")))
             db-paths)
-  ;; jolt-core + stdlib source embeds.
+  ;; jolt-core + stdlib source embeds (bytevector values, 1B/char).
   (put-string out "\n;; === embedded jolt-core + stdlib source ===\n")
   (for-each
     (lambda (root)
@@ -76,7 +76,7 @@
               (put-string out
                 (string-append
                   "(register-embedded-resource! " (ei-str-lit rel) " "
-                  (ei-str-lit (read-file-string abs)) ")\n")))))
+                  (ei-bytes-lit (read-file-string abs)) ")\n")))))
         (bld-walk-files root "" '())))
     ldr-install-roots)
   ;; Preload jolt.main + jolt.deps into the image.

--- a/host/chez/make-devboot.ss
+++ b/host/chez/make-devboot.ss
@@ -106,6 +106,10 @@
 ;; compile-file must run against a clean chezscheme env so `error` and other
 ;; primitives the runtime shadows bind to the kernel versions.
 (display "make-devboot: compiling flat.so (fresh Chez)\n")
+;; Compile to a temp path and rename into place: a concurrent bin/joltc (e.g.
+;; parallel make ci gates) must never load a partially written image — a
+;; truncated fasl can load a prefix of the runtime and fail on late defines.
+(define jb-flat-so-tmp (string-append jb-flat-so ".tmp"))
 (let ((cs (string-append jb-build "/dev-compile.ss")))
   (let ((p (open-output-file cs 'replace)))
     (put-string p
@@ -116,8 +120,10 @@
         "(generate-procedure-source-information #f)\n"
         "(debug-on-exception #f)\n"
         "(fasl-compressed #t)\n"
-        "(compile-file " (ei-str-lit jb-flat-ss) " " (ei-str-lit jb-flat-so) ")\n"))
+        "(compile-file " (ei-str-lit jb-flat-ss) " " (ei-str-lit jb-flat-so-tmp) ")\n"))
     (close-port p))
   (bld-system (string-append bld-chez " --script '" cs "'")))
+(when (file-exists? jb-flat-so) (delete-file jb-flat-so))
+(rename-file jb-flat-so-tmp jb-flat-so)
 
 (display (string-append "make-devboot: wrote " jb-flat-so "\n"))

--- a/host/chez/manifest-check.sh
+++ b/host/chez/manifest-check.sh
@@ -17,10 +17,11 @@ fail=0
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 
 # cli.ss's runtime loads, in order: the block from the first rt.ss load to the
-# set-source-roots! line (cli.ss loads build.ss later, conditionally, which is
-# not part of the runtime skeleton).
-sed -n '/(load "host\/chez\/rt.ss")/,/(set-source-roots!/p' host/chez/cli.ss \
-  | grep -oE 'host/chez/[a-zA-Z0-9_/.-]+\.ss' > "$tmp/cli"
+# shared entry tail (cli-tail.ss — source roots + jolt-cli-run; it loads
+# build.ss later, conditionally, which is not part of the runtime skeleton).
+sed -n '/(load "host\/chez\/rt.ss")/,/(load "host\/chez\/cli-tail.ss")/p' host/chez/cli.ss \
+  | grep -oE 'host/chez/[a-zA-Z0-9_/.-]+\.ss' \
+  | grep -v '^host/chez/cli-tail\.ss$' > "$tmp/cli"
 
 # build.ss's bld-runtime-manifest loads, in order, with the three tags resolved
 # to the concrete seed/compile-eval loads they stand for (via bld-tagged-loads).

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -126,11 +126,7 @@
   (if (jns? d) (jns-name d) (symbol-t-name d)))
 
 (define (ns-has-vars? nm)
-  (let ((found #f))
-    (vector-for-each
-      (lambda (c) (when (and (not found) (string=? (var-cell-ns c) nm)) (set! found #t)))
-      (hashtable-values var-table))
-    found))
+  (hashtable-ref ns-has-vars-set nm #f))
 
 (define (jolt-find-ns desig)
   (let ((nm (ns-desig->name desig)))

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -344,6 +344,8 @@
 (define (jolt-remove-ns desig)
   (let ((nm (ns-desig->name desig)))
     (hashtable-delete! ns-registry nm)
+    (hashtable-delete! ns-has-vars-set nm)  ; keep the O(1) index honest, else a
+                                            ; later require of nm would no-op
     (vector-for-each
       (lambda (k) (let ((c (hashtable-ref var-table k #f)))
                     (when (and c (string=? (var-cell-ns c) nm)) (hashtable-delete! var-table k))))

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -287,7 +287,12 @@
   ;; the SAME proc to a second var — doesn't rename inc.
   (when (and (procedure? v) (not (hashtable-contains? proc-name-tbl v)))
     (hashtable-set! proc-name-tbl v (cons ns name)))
+  (hashtable-set! ns-has-vars-set ns #t)
   (let ((c (jolt-var ns name))) (var-cell-root-set! c v) (var-cell-defined?-set! c #t) c))
+;; Set of ns-name strings that have at least one var — makes ns-has-vars? O(1)
+;; instead of scanning the entire var-table per require-miss. Updated in def-var!
+;; (and wherever vars are removed, though removal is rare).
+(define ns-has-vars-set (make-hashtable string-hash string=?))
 ;; jolt.host/throwable — build a typed throwable a library can throw so (class …),
 ;; instance?, .getMessage and ex-message all reflect the named JVM class (e.g. an
 ;; http client throwing java.net.ConnectException). Strictly better than a

--- a/test/chez/devboot-smoke.sh
+++ b/test/chez/devboot-smoke.sh
@@ -80,6 +80,37 @@ fi
 # Clean up: rebuild so subsequent tests don't inherit the touched state.
 make devboot
 
+# (e) project commands under the cache: build an app from a project dir and run
+# it. Guards the cached entry's source-roots/JOLT_PWD handling — a drifted
+# launcher once resolved no roots and every project build failed.
+echo "=== (e) cached project build ==="
+projdir="$(mktemp -d)"
+mkdir -p "$projdir/src/app"
+cat > "$projdir/src/app/core.clj" <<'CLJ'
+(ns app.core)
+(defn -main [& args] (println "devboot-project-ok"))
+CLJ
+printf '{:paths ["src"]}' > "$projdir/deps.edn"
+build_out="$( (cd "$projdir" && JOLT_DEVCACHE=1 "$root/$joltc" build -m app.core -o "$projdir/app-bin") 2>&1 )" || true
+if echo "$build_out" | grep -q "devcache:"; then
+  binpath="$projdir/app-bin"
+  run_out="$( [ -x "$binpath" ] && "$binpath" 2>&1 )" || true
+  if [ "$run_out" = "devboot-project-ok" ]; then
+    echo "  PASS: cached build produced a working binary"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: cached build binary missing or wrong output"
+    echo "    build: $build_out"
+    echo "    run:   $run_out"
+    fails=$((fails + 1))
+  fi
+else
+  echo "  FAIL: cache was not used for the project build"
+  echo "    output: $build_out"
+  fails=$((fails + 1))
+fi
+rm -rf "$projdir"
+
 echo ""
 echo "devboot smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]

--- a/test/chez/devboot-smoke.sh
+++ b/test/chez/devboot-smoke.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# devboot cache smoke: verify the dev boot cache (target/dev/flat.so) is used
+# when fresh, invalidated when source changes, and produces identical behavior.
+
+set -e
+
+pass=0
+fails=0
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+
+joltc="bin/joltc"
+
+# (a) cache used when fresh — JOLT_DEVCACHE prints a marker to stderr.
+echo "=== (a) devcache fresh: cache should be used ==="
+# Build the cache fresh.
+make devboot
+out="$(JOLT_DEVCACHE=1 $joltc -e "(+ 1 2)" 2>&1)" || true
+if echo "$out" | grep -q "devcache:"; then
+  echo "  PASS: cache marker found in stderr"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: cache marker not found in stderr"
+  echo "    output: $out"
+  fails=$((fails + 1))
+fi
+
+# (b) touching any runtime .ss invalidates the cache.
+echo "=== (b) touching rt.ss invalidates cache ==="
+sleep 1  # ensure timestamp changes
+touch host/chez/rt.ss
+out="$(JOLT_DEVCACHE=1 $joltc -e "(+ 1 2)" 2>&1)" || true
+if echo "$out" | grep -q "devcache:"; then
+  echo "  FAIL: cache was used after rt.ss touched"
+  fails=$((fails + 1))
+else
+  echo "  PASS: cache not used after rt.ss touch"
+  pass=$((pass + 1))
+fi
+# Rebuild for next tests.
+make devboot
+
+# (c) touching a seed invalidates.
+echo "=== (c) touching seed/prelude.ss invalidates cache ==="
+sleep 1
+touch host/chez/seed/prelude.ss
+out="$(JOLT_DEVCACHE=1 $joltc -e "(+ 1 2)" 2>&1)" || true
+if echo "$out" | grep -q "devcache:"; then
+  echo "  FAIL: cache was used after seed touched"
+  fails=$((fails + 1))
+else
+  echo "  PASS: cache not used after seed touch"
+  pass=$((pass + 1))
+fi
+# Rebuild for next tests.
+make devboot
+
+# (d) behavior identical source vs cached.
+echo "=== (d) behavior: source vs cached ==="
+exprs='
+(+ 1 2)
+(require (quote clojure.string)) (clojure.string/upper-case "hello")
+(defn fib [n] (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2))))) (fib 10)
+'
+# Run with cache.
+cached="$(JOLT_DEVCACHE=1 $joltc -e "$(echo "$exprs" | tr '\n' ' ')" 2>/dev/null | tail -1)" || true
+# Force source by touching a .ss file.
+sleep 1
+touch host/chez/rt.ss
+source_out="$(JOLT_DEVCACHE=1 $joltc -e "$(echo "$exprs" | tr '\n' ' ')" 2>/dev/null | tail -1)" || true
+if [ "$cached" = "$source_out" ]; then
+  echo "  PASS: cached and source output match"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: output differs"
+  echo "    cached: $cached"
+  echo "    source: $source_out"
+  fails=$((fails + 1))
+fi
+# Clean up: rebuild so subsequent tests don't inherit the touched state.
+make devboot
+
+echo ""
+echo "devboot smoke: $pass passed, $fails failed"
+[ "$fails" -eq 0 ]


### PR DESCRIPTION
Four startup/memory items from the audit epic:

- dev boot cache: make devboot compiles the runtime+seeds to target/dev/flat.so; bin/joltc loads it when newer than all inputs, else falls back to source. Measured 1.51s -> 0.34s for -e nil. Invalidation on any touched input, gated by devbootsmoke (now in ci).
- jolt.main/jolt.deps are AOT'd into the joltc image instead of recompiled from embedded source on every CLI invocation; joltc path 0.27s -> 0.34s cached dev / faster in release.
- embedded sources emit as UTF-8 bytevector literals (1B/char vs 4B/char Chez strings, ~10MB steady RSS) decoded lazily; both embedded-resource consumers handle bytes.
- joltc launcher gets the same collect-trip-bytes setting app binaries already had (128MB boot peak), and ns-has-vars? is an O(1) index maintained in def-var! and remove-ns instead of a full var-table scan per require-miss.

Review fixes: remove-ns invalidates the index; devbootsmoke wired into ci. Full gate green, certify 0 new / 0 stale.

jolt-mw44.20-23 (epic jolt-mw44)