### PR TITLE
corpus gate: assert :throws rows on jolt, baseline the crash bucket

### DIFF
--- a/host/chez/compile-eval.ss
+++ b/host/chez/compile-eval.ss
@@ -310,25 +310,30 @@
 (define (jolt-load-string s)
   (let ((end (string-length s))
         (drl (guard (_ (#t #f)) data-readers-active)))
-    (jolt-push-thread-bindings
-      (jolt-hash-map
-        (jolt-var "clojure.core" "*warn-on-reflection*")
-          (var-cell-root (jolt-var "clojure.core" "*warn-on-reflection*"))
-        (jolt-var "clojure.core" "*assert*")
-          (var-cell-root (jolt-var "clojure.core" "*assert*"))))
-    (let ((result (let loop ((i 0) (result jolt-nil))
-                    (if (>= i end)
-                        result
-                        (let-values (((form j) (rdr-read-form s i end)))
-                          (if (> j i)
-                              (loop j (if (rdr-eof? form)
-                                          result
-                                          (jolt-compile-eval-form
-                                           (if drl (ldr-apply-readers form) form)
-                                           (chez-current-ns))))
-                              result))))))
-      (jolt-pop-thread-bindings)
-      result)))
+    ;; dynamic-wind: a throw mid-load must still pop, or the frame leaks into
+    ;; the caller's binding stack for the rest of the thread (observed poisoning
+    ;; every later corpus case in a shared-process run).
+    (dynamic-wind
+      (lambda ()
+        (jolt-push-thread-bindings
+          (jolt-hash-map
+            (jolt-var "clojure.core" "*warn-on-reflection*")
+              (var-cell-root (jolt-var "clojure.core" "*warn-on-reflection*"))
+            (jolt-var "clojure.core" "*assert*")
+              (var-cell-root (jolt-var "clojure.core" "*assert*")))))
+      (lambda ()
+        (let loop ((i 0) (result jolt-nil))
+          (if (>= i end)
+              result
+              (let-values (((form j) (rdr-read-form s i end)))
+                (if (> j i)
+                    (loop j (if (rdr-eof? form)
+                                result
+                                (jolt-compile-eval-form
+                                 (if drl (ldr-apply-readers form) form)
+                                 (chez-current-ns))))
+                    result)))))
+      (lambda () (jolt-pop-thread-bindings)))))
 
 ;; eval / load-string are FUNCTIONS on the spine (the compiler image is resident
 ;; at runtime). eval takes an already-read FORM (e.g. from quote / list); it and

--- a/host/chez/run-corpus.ss
+++ b/host/chez/run-corpus.ss
@@ -87,7 +87,10 @@
     "reader conditional" "reader cond :jolt" "reader cond no match"
     "reader cond splice" "reader cond splice no match"
     "nil nested" "bool nested"
-    "no param vector"))
+    "no param vector"
+    ;; jolt-mw44.52: argument-validation gaps — these :throws rows do not raise
+    ;; yet; remove with the fix.
+    "symbol bad 2-arg" "bit-and single arg throws"))
 (define known-fail (make-hashtable string-hash string=?))
 (for-each (lambda (l) (hashtable-set! known-fail l #t)) known-fail-labels)
 
@@ -102,6 +105,10 @@
 (define skip-blocking (make-hashtable string-hash string=?))
 (for-each (lambda (l) (hashtable-set! skip-blocking l #t))
           '("promise undelivered"
+            ;; the corpus runner deliberately loads NO loader (alias-only
+            ;; require) — a missing-lib require/use cannot throw here; the
+            ;; behavior is covered by smoke/unit through the real CLI.
+            "require missing lib throws" "use missing lib throws"
             "cancel an in-flight future returns true"
             "future-cancelled? after cancel"))
 
@@ -142,8 +149,24 @@
            (ev-src (jolt-get row kw-expected))
            (av-src (jolt-get row kw-actual)))
       (cond
-        ((or (eq? ev-src kw-throws) (hashtable-ref skip-blocking label #f))
+        ((hashtable-ref skip-blocking label #f)
          (set! throws (+ throws 1)))
+        ;; a :throws row asserts jolt RAISES evaluating :actual — a returned
+        ;; value is a divergence. (These rows were previously skipped on the
+        ;; jolt side and only certify checked the JVM half, so a jolt-side
+        ;; behavioral regression on a :throws row was invisible.)
+        ((eq? ev-src kw-throws)
+         (let* ((sink (open-output-string))
+                (outcome (guard (e (#t 'raised))
+                           (parameterize ((current-output-port sink))
+                             (jolt-compile-eval av-src "user"))
+                           'returned)))
+           (if (eq? outcome 'raised)
+               (set! throws (+ throws 1))
+               (if (hashtable-ref known-fail label #f)
+                   (set! known-hit (cons label known-hit))
+                   (set! diverged (cons (cons label "expected :throws, returned a value") diverged)))))
+         (zj-reset!))
         (else
          (guard (e (#t (let ((r (crash-reason (zj-clean (zj-err->str e)))))
                          (bucket! crash-keys r)
@@ -165,7 +188,7 @@
                (+ (time-second d) (/ (time-nanosecond d) 1e9))))
 (printf "\nCorpus parity: ~a/~a evaluated cases pass  (~as)\n"
         pass n-eval (/ (round (* secs 10)) 10.0))
-(printf "  crash: ~a   NEW divergence: ~a   known: ~a   (throws skipped: ~a)\n"
+(printf "  crash: ~a   NEW divergence: ~a   known: ~a   (throws verified: ~a)\n"
         (length crashes) (length diverged) (length known-hit) throws)
 
 (when (> (hashtable-size crash-keys) 0)
@@ -188,11 +211,50 @@
   (printf "\n~a known (allowlisted) failures tolerated.\n" (length known-hit)))
 
 ;; Regression floor: fail on any NEW divergence or if pass drops below the floor.
+;; Crash baseline (jolt-mw44.50): the crash bucket was ungated and silently
+;; absorbed 32 regressions during the audit. Exact-label gating like cts:
+;; a crash NOT in test/chez/corpus-crash-baseline.txt is a regression; a
+;; baseline label that no longer crashes is STALE (fails until the baseline
+;; is updated in the same change). JOLT_CORPUS_CRASH_WRITE=1 regenerates.
+(define crash-baseline-file "test/chez/corpus-crash-baseline.txt")
+(define crash-baseline
+  (let ((h (make-hashtable string-hash string=?)))
+    (when (file-exists? crash-baseline-file)
+      (call-with-input-file crash-baseline-file
+        (lambda (p)
+          (let loop ()
+            (let ((l (get-line p)))
+              (unless (eof-object? l)
+                (when (> (string-length l) 0) (hashtable-set! h l #t))
+                (loop)))))))
+    h))
+(define crash-labels (map car crashes))
+(define crash-new
+  (filter (lambda (l) (not (hashtable-ref crash-baseline l #f))) crash-labels))
+(define crash-stale
+  (let ((seen (make-hashtable string-hash string=?)))
+    (for-each (lambda (l) (hashtable-set! seen l #t)) crash-labels)
+    (filter (lambda (l) (not (hashtable-ref seen l #f)))
+            (vector->list (hashtable-keys crash-baseline)))))
+(when (getenv "JOLT_CORPUS_CRASH_WRITE")
+  (call-with-output-file crash-baseline-file
+    (lambda (p) (for-each (lambda (l) (put-string p l) (newline p))
+                          (list-sort string<? crash-labels)))
+    'replace)
+  (printf "crash baseline written: ~a labels\n" (length crash-labels)))
+(when (pair? crash-new)
+  (printf "\nNEW crashes (not in ~a) — gate FAILS:\n" crash-baseline-file)
+  (for-each (lambda (l) (printf "  ~a\n" l)) crash-new))
+(when (pair? crash-stale)
+  (printf "\nSTALE crash-baseline entries (no longer crash — update the baseline):\n")
+  (for-each (lambda (l) (printf "  ~a\n" l)) crash-stale))
+
 (define base-floor (let ((s (getenv "JOLT_CHEZ_ZJ_FLOOR")))
                      (if s (string->number s) 3390)))
 (define floor (if limit 0 base-floor))
-(when (or (> (length diverged) 0) (< pass floor))
-  (printf "REGRESSION: pass ~a < floor ~a or ~a new divergence(s)\n"
-          pass floor (length diverged)))
+(define crash-gate-fails (and (not limit) (or (pair? crash-new) (pair? crash-stale))))
+(when (or (> (length diverged) 0) (< pass floor) crash-gate-fails)
+  (printf "REGRESSION: pass ~a < floor ~a, ~a new divergence(s), ~a new / ~a stale crash(es)\n"
+          pass floor (length diverged) (length crash-new) (length crash-stale)))
 (flush-output-port)
-(exit (if (or (> (length diverged) 0) (< pass floor)) 1 0))
+(exit (if (or (> (length diverged) 0) (< pass floor) crash-gate-fails) 1 0))

--- a/test/chez/corpus-crash-baseline.txt
+++ b/test/chez/corpus-crash-baseline.txt
@@ -1,0 +1,10 @@
+#?@ at top level throws
+1e2N rejects float with N suffix
+\\u with <4 hex digits throws
+\ud800 in string throws Invalid character constant
+keys and vals accept a seq of map entries
+range step 0 repeats start infinitely
+rest-pattern over a vector unchanged
+rest-pattern positional elements walk the seq (a map destructures)
+trailing backslash in regex throws
+zipmap 12 entries hash-iteration order

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -3985,11 +3985,11 @@
   {:suite "vars / set! binding" :label "set! outside binding throws" :expected :throws :actual "(do (def ^:dynamic *set-test44* 0) (set! *set-test44* 9))" :portability :common}
   {:suite "vars / set! binding" :label "set! inside binding works" :expected "[42 0]" :actual "(do (def ^:dynamic *set-test44b* 0) [(binding [*set-test44b* 99] (set! *set-test44b* 42) *set-test44b*) *set-test44b*])" :portability :common}
   {:suite "vars / binding dynamic" :label "binding on non-dynamic var throws" :expected :throws :actual "(do (def not-dynamic-44c 0) (binding [not-dynamic-44c 1] not-dynamic-44c))" :portability :common}
-   {:suite "resolution / unresolved symbol" :label "unresolved bare symbol throws at compile time" :expected :throws :actual "(try (eval 'undefined-xyz-jolt-mw442) :no-throw (catch :default e :throws))" :portability :common}
-   {:suite "resolution / unresolved symbol" :label "unresolved in operator position throws" :expected :throws :actual "(try (eval '(undefined-fn-jolt-mw442 1 2)) :no-throw (catch :default e :throws))" :portability :common}
+   {:suite "resolution / unresolved symbol" :label "unresolved bare symbol throws at compile time" :expected :throws :actual "(eval 'undefined-xyz-jolt-mw442)" :portability :common}
+   {:suite "resolution / unresolved symbol" :label "unresolved in operator position throws" :expected :throws :actual "(eval '(undefined-fn-jolt-mw442 1 2))" :portability :common}
    {:suite "resolution / declare forward ref" :label "declared forward ref still works" :expected "42" :actual "(do (declare forward-ref-jolt-mw442) (defn forward-ref-jolt-mw442 [] 42) (forward-ref-jolt-mw442))" :portability :common}
    {:suite "resolution / file load" :label "loading file with unresolved symbol throws" :expected :throws :actual "(try (load-file \"test/chez/resolution-bad-load.clj\") :no-throw (catch :default e :throws))" :portability :common}
-   {:suite "resolution / file load" :label "load-string with unresolved symbol throws" :expected :throws :actual "(try (load-string \"(do (def _mw44z 1) undefined-xyz-load-string-test-mw44)\") :no-throw (catch :default e :throws))" :portability :common}
+   {:suite "resolution / file load" :label "load-string with unresolved symbol throws" :expected :throws :actual "(load-string \"undefined-xyz-load-string-t\")" :portability :common}
   {:suite "for / :while basic" :label ":while stops iteration" :expected "'(0 1 2 3 4)" :actual "(for [x (range 10) :while (< x 5)] x)" :portability :common}
   {:suite "for / :while sees :let" :label ":while can see preceding :let bindings" :expected "'(0 1 2 3 4)" :actual "(for [x (range 10) :let [y (* x 2)] :while (< y 10)] x)" :portability :common}
   {:suite "for / :while ordering" :label ":while runs after :when in source order" :expected "'(1 3)" :actual "(for [x (range 10) :when (odd? x) :while (< x 5)] x)" :portability :common}


### PR DESCRIPTION
Closes the two blind spots that let a set!-semantics regression sail through green gates during the audit (jolt-mw44.50):

- :expected :throws rows were skipped by the jolt-side runner (only certify checked the JVM half) — a jolt-side behavioral regression on any throws row was invisible. The runner now evaluates the row's :actual and fails when it returns a value. 172 rows go from skipped to verified.
- the crash bucket was ungated (it went 10 -> 42 during the audit with corpus exit 0). Crashes now gate against exact labels in test/chez/corpus-crash-baseline.txt: a new crash is a regression, an entry that stops crashing is stale until the baseline is updated in the same change, JOLT_CORPUS_CRASH_WRITE=1 regenerates. Both directions negative-tested.

Turning the assertion on immediately surfaced real findings, all handled: three resolution rows were self-defeating (the :actual caught its own throw and returned a keyword — normalized); require/use-missing-lib rows can't throw in the loader-less runner (skip-listed with the reason); jolt-load-string leaked its compiler-var binding frame when loaded source threw (now dynamic-wind) — that leak had been poisoning every later case in the shared runner process; (symbol :a "b") and (bit-and 5) miss JVM-typed validation throws — allowlisted against jolt-mw44.52 and assigned to the in-flight typed-throws session.

Full gate green.