### PR TITLE
jolt build: direct-link + whole-program inference by default

### DIFF
--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -55,6 +55,47 @@ if [ "$got" != "$want" ]; then
   exit 1
 fi
 
+# --- release now defaults to direct-linking + whole-program inference ------------
+# A plain `jolt build` (release, no flags) must direct-link app->app calls (the
+# throughput lever the perf audit identified) AND run wp-infer — both were opt-in
+# (--direct-link / --opt) before. $out is still the plain release build here.
+
+# The cross-ns app.core -> app.util/shout call lowers to a direct jv$ binding in
+# the plain release build, not var-deref.
+if ! grep -q '(jv\$app.util\$shout' "$out.build/flat.ss"; then
+  echo "  FAIL: release build did not direct-link the app->app call"; exit 1
+fi
+
+# wp-infer ran: a hintless double fn (app.util/area, called with 2.0) gets its
+# param seeded :double, so its * lowers to a flonum op. The same build with
+# JOLT_NO_WP_INFER=1 skips the fixpoint — the fl-op count must drop (area is the
+# delta). Same numeric result either way; this is the emit-level proof it ran.
+if ! JOLT_PWD="$app" JOLT_NO_WP_INFER=1 bin/joltc build -m app.core -o "$out.noop" >/dev/null 2>&1; then
+  echo "  FAIL: JOLT_NO_WP_INFER build exited non-zero"; exit 1
+fi
+default_fl=$(grep -c '#3%fl' "$out.build/flat.ss" || true)
+noop_fl=$(grep -c '#3%fl' "$out.noop.build/flat.ss" || true)
+if [ "$default_fl" -le "$noop_fl" ]; then
+  echo "  FAIL: wp-infer added no fl-ops to the release build (default=$default_fl noop=$noop_fl)"; exit 1
+fi
+
+# --no-direct-link opts back out of the release default: the app->app call must
+# NOT lower to a jv$ binding (stays var-routed, dynamically linked).
+if ! JOLT_PWD="$app" bin/joltc build -m app.core -o "$out.nodl" --no-direct-link >/dev/null 2>&1; then
+  echo "  FAIL: jolt build --no-direct-link exited non-zero"; exit 1
+fi
+if grep -q '(jv\$app.util\$shout' "$out.nodl.build/flat.ss"; then
+  echo "  FAIL: --no-direct-link still direct-linked the app->app call"; exit 1
+fi
+
+# ^:redef / ^:dynamic opt out of direct-linking, so runtime redef/binding still
+# take effect in the built binary even with direct-link the release default.
+got_rd="$(cd / && "$out" --redef 2>&1)"
+if ! printf '%s' "$got_rd" | grep -q '^redef: :patched$'    || ! printf '%s' "$got_rd" | grep -q '^dyn: :bound$'; then
+  echo "  FAIL: ^:redef/:dynamic opt-out — want 'redef: :patched' and 'dyn: :bound' lines"
+  echo "--- got ----"; echo "$got_rd"; exit 1
+fi
+
 # Portable embed: remove the build-time source tree and run from / — the
 # embedded resource must still resolve (contents baked as literals, not
 # read-file-string at startup).

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -291,19 +291,31 @@
             (for-each
               (lambda (f)
                 (ce-scan-requires! f (car nf))
-                (unless (or (ei-ns-form? f) (ce-macro-form? f))
-                  ;; a form the analyzer rejects here only loses whole-program
-                  ;; type info (per-form emit still errors the build if it's
-                  ;; truly broken) — but say so, or an optimized build silently
-                  ;; loses inference for the namespace.
-                  (guard (e (#t (display (string-append
-                                          "jolt build: note: whole-program inference skipped a form in "
-                                          (car nf) "\n")
-                                         (current-error-port))
-                                #f))
-                    (let ((n (jolt-ce-analyze (make-analyze-ctx (car nf)) f)))
-                      (set! nodes (cons n nodes))
-                      (set! per-ns (cons n per-ns))))))
+                ;; per-ns is consumed POSITIONALLY by the emit walk
+                ;; (ei-next-cached, one pop per form ei-for-each-form
+                ;; dispatches). The emit walk compiles MACRO forms too, and
+                ;; keeps going past a form this analysis rejects — so both get
+                ;; a #f placeholder (ei-compile-form falls back to a fresh
+                ;; analysis on #f). Skipping them here shifted every later
+                ;; form's cached IR by one: a macro's def-var! captured the
+                ;; NEXT def's emission — invalid Scheme under direct-link, a
+                ;; silently corrupted expander before it. Only the ns form is
+                ;; skipped by BOTH walks.
+                (unless (ei-ns-form? f)
+                  (if (ce-macro-form? f)
+                      (set! per-ns (cons #f per-ns))
+                      ;; a form the analyzer rejects here only loses
+                      ;; whole-program type info (per-form emit still errors
+                      ;; the build if it's truly broken) — but say so, or an
+                      ;; optimized build silently loses inference for the ns.
+                      (guard (e (#t (display (string-append
+                                              "jolt build: note: whole-program inference skipped a form in "
+                                              (car nf) "\n")
+                                             (current-error-port))
+                                    (set! per-ns (cons #f per-ns))))
+                        (let ((n (jolt-ce-analyze (make-analyze-ctx (car nf)) f)))
+                          (set! nodes (cons n nodes))
+                          (set! per-ns (cons n per-ns)))))))
               (ei-read-all src)))
           (set! ns-nodes (cons (cons (car nf) (reverse per-ns)) ns-nodes))))
       ordered)
@@ -313,7 +325,10 @@
     ;; devirtualized call site. Run per-ns after wp-infer! (rich field types must be
     ;; live) so a devirt site can resolve the clone regardless of emit order.
     (jolt-reset-clone-prepass!)
-    (for-each (lambda (p) (jolt-contagion-prepass! (apply jolt-vector (cdr p)) (car p))) ns-nodes)
+    ;; drop the #f alignment placeholders — the prepass wants real IR only.
+    (for-each (lambda (p) (jolt-contagion-prepass!
+                            (apply jolt-vector (filter (lambda (n) n) (cdr p))) (car p)))
+              ns-nodes)
     (jolt-contagion-prepass-done!)
     (reverse ns-nodes)))
 
@@ -512,14 +527,15 @@
 ;; --- the build --------------------------------------------------------------
 ;; entry-ns: the app's main namespace (a string). out-path: the binary to write.
 ;; mode: "dev" | "release" | "optimized". Every form runs through jolt.passes/
-;; run-passes (const-fold always; inline + type inference when optimized turns on
-;; direct-linking). Deps + source roots are already applied by the caller.
+;; run-passes (const-fold always; type inference in release+optimized; inline +
+;; scalar-replace additionally when optimized). Deps + source roots are already
+;; applied by the caller.
 ;; natives: encoded :jolt/native libs to load at startup. embed-dirs: dirs whose
 ;; files bake into the binary (single-file). ext-roots: project-relative io/resource
 ;; roots resolved at runtime against JOLT_PWD (ship-alongside resources).
-;; direct-link?: opt-in closed-world direct-linking (app->app calls bind directly,
-;; no runtime redefinition). Off by default in every mode — release stays
-;; dynamically linked.
+;; direct-link?: closed-world direct-linking (app->app calls bind directly; a plain
+;; def is frozen, ^:redef/^:dynamic stay var-routed). The caller (jolt.main) turns
+;; this ON for release and optimized and OFF for --dev / --no-direct-link.
 (define (bld-suffix? s suf)
   (let ((n (string-length s)) (m (string-length suf)))
     (and (>= n m) (string=? (substring s (- n m) n) suf))))
@@ -705,14 +721,14 @@
                                           " — is it on the source roots?")))
       ;; 2. emit each app namespace. Release and optimized modes enable the
       ;; inference + record-shape setup passes (inference-enabled?); optimized
-      ;; mode with direct-link additionally runs the inline + flatten +
-      ;; scalar-replace fixpoint (inline-enabled?). Dev mode gets const-fold +
-      ;; numeric-annotate only.
-      ;; direct-link? (opt-in) commits to a closed world: app->app calls bind
-      ;; directly, giving up runtime redefinition of those vars. Off by default in
-      ;; every mode. The defined-set accumulates across the dependency-ordered
-      ;; namespaces, so a dep's defs are direct-linkable by the time the entry that
-      ;; calls them is emitted.
+      ;; mode additionally runs the inline + flatten + scalar-replace fixpoint
+      ;; (inline-enabled?). Dev mode gets const-fold + numeric-annotate only.
+      ;; direct-link? commits to a closed world: app->app calls bind directly, a
+      ;; plain def is frozen in the binary (^:redef/^:dynamic stay var-routed).
+      ;; The caller (jolt.main) turns it ON for release and optimized and OFF for
+      ;; --dev / --no-direct-link. The defined-set accumulates across the
+      ;; dependency-ordered namespaces, so a dep's defs are direct-linkable by the
+      ;; time the entry that calls them is emitted.
       ;; set-optimize!/set-direct-link! are process-global flags in the back end;
       ;; dynamic-wind guarantees they revert even if a strict form errors mid-emit
       ;; (a failing form errors the build by design), so the compiler isn't left in
@@ -734,8 +750,13 @@
                 ;; compiling itself) does NOT apply here, only to the seed mint,
                 ;; which keeps var-cache OFF (emit-image.ss). ON in both modes.
                 ((var-deref "jolt.backend-scheme" "set-var-cache!") #t)
-                ;; whole-program param-type fixpoint before per-form emit
-                (when (string=? mode "optimized")
+                ;; whole-program param-type fixpoint before per-form emit — runs in
+                ;; release and optimized (the inference modes). JOLT_NO_WP_INFER=1
+                ;; skips it: a documented escape for very large apps where the
+                ;; fixpoint's cost matters; emit then falls back to per-ns inference
+                ;; (run-passes still annotates from explicit ^double/^long hints).
+                (when (and (not (getenv "JOLT_NO_WP_INFER"))
+                           (or (string=? mode "release") (string=? mode "optimized")))
                   (let ((wp-cached (bld-wp-infer! ordered)))
                     (for-each (lambda (p) (ei-set-cached! (car p) (cdr p))) wp-cached))))
               (lambda ()

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -218,13 +218,18 @@
       (map? task) (do (apply-project! resolved) (apply-main-opts (:main-opts task) more))
       :else (throw (ex-info (str "bad task " name) {})))))
 
-;; build [-m NS | FILE] [-o OUT] [--opt | --dev] [--direct-link] — AOT-compile the
-;; app into a standalone executable. Resolves deps + roots like `run`, then hands the
-;; entry namespace to the host build driver (jolt.host/build-binary, defined by
-;; build.ss). Default mode is release; --opt selects optimized, --dev unoptimized.
-;; --direct-link (or deps.edn :jolt/build {:direct-link true}) opts into closed-world
-;; direct-linking: app->app calls bind directly, giving up runtime redefinition of
-;; those vars and eval/load-string. Off by default — release stays dynamically linked.
+ ;; build [-m NS | FILE] [-o OUT] [--opt | --dev] [--no-direct-link] — AOT-compile
+ ;; the app into a standalone executable. Resolves deps + roots like `run`, then hands
+ ;; the entry namespace to the host build driver (jolt.host/build-binary, defined by
+ ;; build.ss). Default mode is release; --opt selects optimized (release + the riskier
+ ;; inline/scalar-replace passes), --dev unoptimized.
+ ;; Release and optimized default to closed-world direct-linking + whole-program
+ ;; inference (the throughput lever the perf audit identified). The tradeoff is runtime
+ ;; redefinition: a plain def is frozen in the built binary (its eval/load-string and
+ ;; redef no-op), so a def that must stay redefinable carries ^:redef — a ^:dynamic var
+ ;; stays var-routed automatically. --no-direct-link (or deps.edn :jolt/build
+ ;; {:direct-link false}) opts back out to dynamic var routing; --dev stays dynamically
+ ;; linked. --direct-link is kept as a now-redundant alias.
 ;; The static-link description of a :jolt/native spec for this platform, or nil.
 ;; :static may be flat ({:archive "…"} / {:lib "z" :libdir "…"}) or per-platform
 ;; ({:darwin {…} :linux {…}}). Returns a vector build.ss reads and wraps in the
@@ -300,9 +305,12 @@
             ;; true}) keeps the old behavior — load a shared object at runtime.
             dynamic-natives? (boolean (or (some #{"--dynamic"} flag-args) (:dynamic-natives build)))
             natives (encode-natives (:natives resolved) dynamic-natives?)
-            ;; closed-world direct-linking is opt-in: the --direct-link flag or a
-            ;; deps.edn :jolt/build {:direct-link true}. Off otherwise.
-            direct-link? (boolean (or (some #{"--direct-link"} flag-args) (:direct-link build)))
+            ;; closed-world direct-linking is the release default: ON for release and
+            ;; optimized (the throughput lever), OFF for --dev. --no-direct-link (or
+            ;; deps.edn :jolt/build {:direct-link false}) opts back out; --direct-link
+            ;; is a now-redundant alias. ^:redef/^:dynamic defs always stay var-routed.
+            no-dl?       (or (some #{"--no-direct-link"} flag-args) (false? (:direct-link build)))
+            direct-link? (and (not (= mode "dev")) (not no-dl?))
             ;; tree-shaking (drop library code not reachable from -main): --tree-shake
             ;; or deps.edn :jolt/build {:tree-shake true}.
             tree-shake? (boolean (or (some #{"--tree-shake"} flag-args) (:tree-shake build)))

--- a/test/chez/build-app/src/app/core.clj
+++ b/test/chez/build-app/src/app/core.clj
@@ -16,6 +16,17 @@
   ;; native stack trace. Off the normal path, so default output is unchanged.
   (when (= (first args) "--boom")
     (util/mid-boom "not-a-number"))
+  ;; --num: call a hintless double fn so build-smoke can assert wp-infer ran in
+  ;; the release default build (the fl-op in flat.ss, not this output).
+  (when (= (first args) "--num")
+    (println "area:" (util/area 2.0)))
+  ;; --redef: with direct-link the release default, ^:redef/:dynamic must still
+  ;; opt out so runtime redefinition / binding take effect in the built binary.
+  (when (= (first args) "--redef")
+    (println "redef:" (with-redefs [util/redef-fn (fn [] :patched)]
+                        (util/redef-fn)))
+    (println "dyn:" (binding [util/*config* :bound]
+                      util/*config*)))
   ;; the resource is baked into the binary (deps.edn :jolt/build :embed), so this
   ;; resolves with no resources/ dir on disk, run from any cwd.
   (println (slurp (io/resource "greeting.txt")))

--- a/test/chez/build-app/src/app/util.clj
+++ b/test/chez/build-app/src/app/util.clj
@@ -4,6 +4,16 @@
 (defn shout [s]
   (str/upper-case (str s "!")))
 
+;; A hintless double fn: with wp-infer now the release default, its r param is
+;; seeded :double from the (area 2.0) call site in app.core, so the built binary
+;; lowers * to fl*. build-smoke greps flat.ss for the fl-op (proves wp-infer ran).
+(defn area [r] (* r r))
+
+;; ^:redef / ^:dynamic opt out of direct-linking even with it on by default (the
+;; release default now), so the built binary can still redef/bind them at runtime.
+(def ^:redef redef-fn (fn [] :original))
+(def ^:dynamic *config* :default)
+
 ;; A two-deep non-tail call chain that throws — exercises native stack traces in a
 ;; direct-link build (build-smoke runs -main with a --boom sentinel arg). deep-boom
 ;; is defined through a USER macro: its source registration only gets a real line

--- a/test/chez/directlink-test.ss
+++ b/test/chez/directlink-test.ss
@@ -44,6 +44,8 @@
 (jolt-compile-eval "(def hof (fn* ([] a)))" "app")
 (jolt-compile-eval "(def ^:dynamic d 5)" "app")
 (jolt-compile-eval "(def usesd (fn* ([] (d))))" "app")
+(jolt-compile-eval "(def ^:redef r 5)" "app")
+(jolt-compile-eval "(def usesr (fn* ([] (r))))" "app")
 (jolt-compile-eval "(def cfg {:a 1 :b 2})" "app")
 (jolt-compile-eval "(def usecfg (fn* ([] (cfg :a))))" "app")
 
@@ -90,6 +92,13 @@
 (let ((eu (emit-form "app" "(def usesd (fn* ([] (d))))")))
   (ok "on: call to a ^:dynamic var stays indirect" (contains? eu "(var-deref \"app\" \"d\")"))
   (ok "on: ^:dynamic var not direct-linked" (not (contains? eu "(jv$app$d)"))))
+
+;; ^:redef opts out too (a def redefinable after build stays var-routed).
+(let ((er (emit-form "app" "(def ^:redef r 5)")))
+  (ok "on: ^:redef def gets no jv$ binding" (not (contains? er "(define jv$app$r"))))
+(let ((eu (emit-form "app" "(def usesr (fn* ([] (r))))")))
+  (ok "on: call to a ^:redef var stays indirect" (contains? eu "(var-deref \"app\" \"r\")"))
+  (ok "on: ^:redef var not direct-linked" (not (contains? eu "(jv$app$r)"))))
 
 ;; A var only defined LATER in emission order is not yet in the set -> indirect.
 (direct-link-reset!)


### PR DESCRIPTION
A plain jolt build emitted (jolt-invoke1 (var-cell-deref cell) x) for every cross-fn call and ran no cross-fn type flow — the single biggest throughput lever the perf audit identified sat behind --direct-link/--opt. Release and optimized builds now direct-link app namespaces and run wp-infer.

Escape hatches, all smoke-asserted end to end: --dev and --no-direct-link (or deps.edn :jolt/build {:direct-link false}) opt out; --direct-link remains as a redundant alias; JOLT_NO_WP_INFER=1 skips the fixpoint for very large apps. The documented tradeoff: a plain def is frozen in the built binary, ^:redef/^:dynamic defs stay var-routed so runtime redefinition and binding keep working (asserted by running the built binary).

Running the two together exposed a latent wp-cache bug that had been silently corrupting macro expanders in every --opt build: bld-wp-infer!'s walk skipped macro and analyzer-rejected forms while the emit walk consumes the per-ns IR cache positionally — from the first macro in a namespace, every form got the NEXT form's IR. Invisible before (AOT binaries never call expanders); direct-link turned it into invalid-Scheme compile failures. Skipped forms now leave #f placeholders (fresh analysis on consumption), and the contagion prepass filters them.

Smoke: plain release direct-links the app->app call; wp-infer proven at the emit level (fl-op count drops under JOLT_NO_WP_INFER=1); --no-direct-link stays var-routed; ^:redef/^:dynamic behavior verified in the built binary. Baselines confirmed against origin/main in a detached worktree. Gated on the hardened corpus merged from main.

jolt-mw44.26 (session implementation; wp-cache fix + review by supervisor)