### PR TITLE
compiler-review R3: numeric tower correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`munge-name` is injective.** Distinct locals like `a'` and `a_PRIME_` munged
   to the same Scheme identifier, so one silently captured the other's value.
   Symbol characters are now escaped reversibly.
+- **Subnormal doubles print correctly.** `(pr-str 4.9E-324)` produced a corrupt
+  `"5.0E-256.0"` (a mangled Chez precision suffix); subnormals now round-trip.
+- **`bigdec` is exact for ratios and scientific notation.** `(bigdec 1/4)` was a
+  bigdec with a *ratio* in its unscaled field (so `(+ (bigdec 1/4) 1M)` gave
+  `5/4M`); it now yields `0.25M`, `(bigdec 1/3)` throws like the JVM, and Inf/NaN/
+  garbage strings throw `NumberFormatException`.
+- **`==` handles BigDecimal operands** (`(== 3M 3)` threw) and, on a mixed long/
+  double set, the `apply`/HOF path now agrees with the call-position result
+  instead of comparing exactly (`(apply == [9007199254740993 9007199254740992.0])`).
+- **`Math/round` / `clojure.math/round`** no longer crash on `##NaN`/`##Inf` or
+  overflow to a bignum — they follow Java semantics (0, saturate, half-up).
+- **`hash` of BigDecimals and negative/large ratios** matches the JVM (every
+  bigdec previously hashed to one constant; ratios used the wrong integer hash).
+- **`clojure.math` expm1/log1p keep precision near zero and hypot doesn't
+  overflow**; the `Math/*` statics route to the same implementations.
+- **Bit operations require a long operand** — a double/ratio (or `bit-not` on a
+  non-integer) throws `IllegalArgumentException` instead of truncating or leaking
+  a raw error; `bit-set`/`bit-flip` wrap to 64 bits.
+- **`clojure.math/floor-div`/`floor-mod` return a long**, and `parse-double`
+  trims whitespace and accepts a trailing `f`/`d` type suffix.
 
 ## [0.4.1] - 2026-07-17
 

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -446,10 +446,10 @@
     ((number? x)
      (cond
        ((flonum? x) (double-hasheq x))
-       ;; Ratio: exact non-integer. hashCode = numerator.hashCode ^ denominator.hashCode
+       ;; Ratio: exact non-integer. hasheq = BigInteger.hashCode(numer) ^ BigInteger.hashCode(denom)
        ((and (exact? x) (not (integer? x)))
-        (i32 (bitwise-xor (long-hashcode (numerator x))
-                          (long-hashcode (denominator x)))))
+        (i32 (bitwise-xor (big-integer-hashcode (numerator x))
+                          (big-integer-hashcode (denominator x)))))
        ;; BigInt / bignum: if fits in long → hashLong, else BigInteger.hashCode
        ;; For values within 64-bit signed range, use hashLong.
        ((and (exact? x) (integer? x)

--- a/host/chez/java/bigdec.ss
+++ b/host/chez/java/bigdec.ss
@@ -449,6 +449,16 @@
 (register-str-render! jbigdec? jbigdec->string)
 (register-pr-arm! jbigdec? (lambda (x) (string-append (jbigdec->string x) "M")))
 
+;; hasheq: Clojure Numbers.hasheq(BigDecimal) — strip trailing zeros, then
+;; strippedUnscaled.hashCode() * 31 + stripped.scale() (int32). Matches JVM so
+;; bigdec keys collide correctly and (= 1.5M 1.50M) implies equal hashes.
+(define (jbigdec-hasheq bd)
+  (let loop ((u (jbigdec-unscaled bd)) (sc (jbigdec-scale bd)))
+    (if (or (<= sc 0) (= u 0) (not (= 0 (modulo u 10))))
+        (i32 (+ (* 31 (big-integer-hashcode u)) sc))
+        (loop (quotient u 10) (- sc 1)))))
+(register-hash-arm! jbigdec? jbigdec-hasheq)
+
 ;; class / decimal?
 (register-class-arm! jbigdec? (lambda (x) "java.math.BigDecimal"))
 (set! jolt-decimal? (lambda (x) (jbigdec? x)))

--- a/host/chez/java/bigdec.ss
+++ b/host/chez/java/bigdec.ss
@@ -29,50 +29,101 @@
           ((char=? (string-ref s i) ch) i)
           (else (loop (+ i 1))))))
 
-;; "1.50" -> {150,2}; "3" -> {3,0}; "-0.0" -> {0,1}; ".5" -> {5,1}.
+;; "1.50" -> {150,2}; "3" -> {3,0}; "-0.0" -> {0,1}; ".5" -> {5,1};
+;; "1.0E300" -> {10,-299}; "1.5E-7" -> {15,8}. Throws NumberFormatException on
+;; anything that isn't an optional sign + decimal mantissa (>=1 digit) + optional
+;; signed exponent — i.e. the grammar java BigDecimal(String) accepts.
 (define (jolt-bigdec-from-string s)
-  (let* ((neg (and (> (string-length s) 0) (char=? (string-ref s 0) #\-)))
-         (sgn (and (> (string-length s) 0) (or neg (char=? (string-ref s 0) #\+))))
-         (s1 (if sgn (substring s 1 (string-length s)) s))
-         (sign (if neg -1 1))
-         (dot (bd-index-char s1 #\.)))
-    (if dot
-        (let* ((intp (substring s1 0 dot))
-               (fracp (substring s1 (+ dot 1) (string-length s1)))
-               (digs (string-append intp fracp))
-               (unscaled (if (= 0 (string-length digs)) 0 (string->number digs))))
-          (make-jbigdec (* sign unscaled) (string-length fracp)))
-        (make-jbigdec (* sign (string->number s1)) 0))))
+  (define n (string-length s))
+  (define (fail)
+    (throw-jvm (quote NumberFormatException)
+      (string-append "bigdec: cannot parse \"" s "\"")))
+  (define (digit? c) (and (char>=? c #\0) (char<=? c #\9)))
+  (when (= n 0) (fail))
+  ;; split mantissa / exponent at the first e/E
+  (let* ((epos (let loop ((i 0))
+                 (cond ((= i n) #f)
+                       ((memv (string-ref s i) '(#\e #\E)) i)
+                       (else (loop (+ i 1))))))
+         (mend (or epos n))
+         (expstr (and epos (substring s (+ epos 1) n))))
+    ;; parse the exponent (optional sign + >=1 digit), 0 if absent
+    (define exp
+      (if (not expstr) 0
+          (let* ((en (string-length expstr)))
+            (when (= en 0) (fail))
+            (let* ((c0 (string-ref expstr 0))
+                   (signed (or (char=? c0 #\+) (char=? c0 #\-)))
+                   (body (if signed (substring expstr 1 en) expstr)))
+              (when (= (string-length body) 0) (fail))
+              (let loop ((i 0))
+                (cond ((= i (string-length body)))
+                      ((digit? (string-ref body i)) (loop (+ i 1)))
+                      (else (fail))))
+              (* (if (and signed (char=? c0 #\-)) -1 1) (string->number body))))))
+    ;; mantissa: optional sign, >=1 digit, at most one '.'
+    (let* ((m0 (cond ((and (> mend 0) (char=? (string-ref s 0) #\-)) 1)
+                     ((and (> mend 0) (char=? (string-ref s 0) #\+)) 1)
+                     (else 0)))
+           (msign (if (= m0 1) (if (char=? (string-ref s 0) #\-) -1 1) 1))
+           (dot (let loop ((i m0) (d #f))
+                  (cond ((= i mend) d)
+                        ((char=? (string-ref s i) #\.) (if d (fail) (loop (+ i 1) i)))
+                        ((digit? (string-ref s i)) (loop (+ i 1) d))
+                        (else (fail))))))
+      (unless dot (unless (> (- mend m0) 0) (fail)))   ; need >=1 char
+      (let* ((intp (substring s m0 (or dot mend)))
+             (fracp (if dot (substring s (+ dot 1) mend) ""))
+             (mant (string-append intp fracp)))
+        ;; at least one digit somewhere in the mantissa
+        (let loop ((i 0) (any #f))
+          (cond ((= i (string-length mant))
+                 (unless any (fail)))
+                ((digit? (string-ref mant i)) (loop (+ i 1) #t))
+                (else (loop (+ i 1) any))))
+        (make-jbigdec (* msign (if (= (string-length mant) 0) 0 (string->number mant)))
+                      (- (string-length fracp) exp))))))
 
-;; bigdec coercion: a bigdec is itself; an exact integer keeps scale 0; a string
-;; or any other number routes through its decimal text.
+;; bigdec coercion: a bigdec is itself; an exact integer keeps scale 0; a ratio
+;; expands to its exact decimal (throwing ArithmeticException if non-terminating);
+;; a string parses as a BigDecimal literal; a flonum routes through its Double.toString
+;; text (BigDecimal/valueOf semantics). Inf/NaN/garbage raise NumberFormatException.
 (define (jolt-bigdec x)
   (cond
     ((jbigdec? x) x)
     ((and (number? x) (exact? x) (integer? x)) (make-jbigdec x 0))
+    ((and (number? x) (exact? x) (rational? x)) (jbd-rational->bigdec x))
     ((string? x) (jolt-bigdec-from-string x))
     ((number? x) (jolt-bigdec-from-string (jolt-num->string x)))
     (else (throw-jvm (if (string? x) (quote NumberFormatException) (quote IllegalArgumentException))
-                (string-append "bigdec: cannot coerce " (jolt-final-str x))))))
+                 (string-append "bigdec: cannot coerce " (jolt-final-str x))))))
 
 ;; value equality: unscaled_a * 10^scale_b == unscaled_b * 10^scale_a.
 (define (jbigdec=? a b)
   (= (* (jbigdec-unscaled a) (expt 10 (jbigdec-scale b)))
      (* (jbigdec-unscaled b) (expt 10 (jbigdec-scale a)))))
 
-;; render the decimal text (no M): insert the point `scale` digits from the right.
+;; render the decimal text (no M), matching java.math.BigDecimal.toString: plain
+;; decimal when the adjusted exponent (precision-1-scale) is >= -6 and scale >= 0,
+;; else scientific d(.ddd)E+/-exp. Zero prints "0" / "0.0" / "0.00" ...
 (define (jbigdec->string bd)
   (let* ((u (jbigdec-unscaled bd)) (sc (jbigdec-scale bd))
          (neg (< u 0)) (digs (number->string (abs u))))
-    (string-append
-      (if neg "-" "")
-      (if (<= sc 0)
-          digs
-          (let* ((padded (if (<= (string-length digs) sc)
-                             (string-append (make-string (- (+ sc 1) (string-length digs)) #\0) digs)
-                             digs))
-                 (pl (string-length padded)))
-            (string-append (substring padded 0 (- pl sc)) "." (substring padded (- pl sc) pl)))))))
+    (define (prefix body) (if neg (string-append "-" body) body))
+    (if (= u 0)
+        (prefix (if (<= sc 0) "0" (string-append "0." (make-string sc #\0))))
+        (let* ((dlen (string-length digs))
+               (adjexp (- (+ dlen -1) sc)))
+          (prefix
+            (if (or (< sc 0) (< adjexp -6))
+                (string-append
+                  (if (= dlen 1) digs
+                      (string-append (substring digs 0 1) "." (substring digs 1 dlen)))
+                  "E" (if (>= adjexp 0) "+" "-") (number->string (abs adjexp)))
+                (cond ((= sc 0) digs)
+                      ((<= dlen sc) (string-append "0." (make-string (- sc dlen) #\0) digs))
+                      (else (string-append (substring digs 0 (- dlen sc)) "."
+                                           (substring digs (- dlen sc) dlen))))))))))
 
 ;; value as a Chez flonum (for double contagion: a flonum operand wins).
 (define (jbigdec->flonum b)

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -22,7 +22,11 @@
   (list (cons "sqrt" (lambda (x) (real-or-nan (sqrt x))))
         (cons "cbrt" (lambda (x) (math-cbrt x)))
         (cons "pow" (lambda (a b) (real-or-nan (expt a b))))
-        (cons "hypot" (lambda (a b) (->dbl (sqrt (+ (* a a) (* b b))))))
+        ;; hypot/expm1/log1p route to the numerically-stable clojure.math impls
+        ;; (defined later in math.ss; the lambda body resolves at call time, after
+        ;; math.ss has loaded) so Math/hypot doesn't overflow and expm1/log1p keep
+        ;; full precision near zero.
+        (cons "hypot" (lambda (a b) (jolt-math-hypot (->dbl a) (->dbl b))))
         (cons "floor" (lambda (x) (->dbl (floor x))))
         (cons "ceil" (lambda (x) (->dbl (ceiling x))))
         (cons "round" (lambda (x) (jolt-math-round x)))     ; JVM Math.round -> long (NaN/Inf/saturate/half-up)
@@ -39,9 +43,9 @@
         (cons "sinh" (lambda (x) (->dbl (sinh x)))) (cons "cosh" (lambda (x) (->dbl (cosh x))))
         (cons "tanh" (lambda (x) (->dbl (tanh x))))
         (cons "log" (lambda (x) (real-or-nan (log x)))) (cons "log10" (lambda (x) (real-or-nan (/ (log x) (log 10)))))
-        (cons "log1p" (lambda (x) (real-or-nan (log (+ 1.0 x)))))
+        (cons "log1p" (lambda (x) (jolt-math-log1p (->dbl x))))
         (cons "exp" (lambda (x) (->dbl (exp x))))
-        (cons "expm1" (lambda (x) (->dbl (- (exp x) 1.0))))
+        (cons "expm1" (lambda (x) (jolt-math-expm1 (->dbl x))))
         (cons "toRadians" (lambda (d) (->dbl (/ (* d math-pi) 180.0))))
         (cons "toDegrees" (lambda (r) (->dbl (/ (* r 180.0) math-pi))))
         (cons "copySign" (lambda (m s) (->dbl (if (< s 0.0) (- (abs m)) (abs m)))))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -25,7 +25,7 @@
         (cons "hypot" (lambda (a b) (->dbl (sqrt (+ (* a a) (* b b))))))
         (cons "floor" (lambda (x) (->dbl (floor x))))
         (cons "ceil" (lambda (x) (->dbl (ceiling x))))
-        (cons "round" (lambda (x) (exact (floor (+ x 1/2)))))   ; JVM round-half-up -> long
+        (cons "round" (lambda (x) (jolt-math-round x)))     ; JVM Math.round -> long (NaN/Inf/saturate/half-up)
         (cons "rint" (lambda (x) (->dbl (round x))))            ; round-half-even -> double
         ;; Math.floorDiv/floorMod: integer floor division / modulus (long -> long).
         (cons "floorDiv" (lambda (a b) (exact (floor (/ a b)))))

--- a/host/chez/java/math.ss
+++ b/host/chez/java/math.ss
@@ -21,8 +21,24 @@
       (- (expt (- x) (/ 1.0 3.0)))
       (expt x (/ 1.0 3.0))))
 
-;; clojure.math/round returns a long (exact); floor/ceil/signum/rint return doubles.
-(define (jolt-math-round x) (exact (floor (+ x 0.5))))
+;; java.lang.Math.round(double) -> long: NaN->0, +Inf->Long/MAX_VALUE, -Inf->
+;; Long/MIN_VALUE, out-of-long-range saturates, and the greatest double below 0.5
+;; (0.49999999999999994) rounds to 0 — its x+0.5 sums to exactly 1.0. Else (long)
+;; floor(x + 0.5). clojure.math/round and Math/round both route here.
+(define jolt-math-long-max 9223372036854775807)
+(define jolt-math-long-min -9223372036854775808)
+(define (jolt-math-round x)
+  (let ((d (if (and (number? x) (real? x)) (exact->inexact x) x)))
+    (cond
+      ((nan? d) 0)
+      ((infinite? d) (if (fl> d 0.0) jolt-math-long-max jolt-math-long-min))
+      ;; 0.49999999999999994: largest double < 0.5, whose +0.5 rounds up to 1.0
+      ((and (fl< d 0.5) (fl>= (fl+ d 0.5) 1.0)) 0)
+      (else
+       (let ((r (floor (+ d 0.5))))
+         (cond ((> r jolt-math-long-max) jolt-math-long-max)
+               ((< r jolt-math-long-min) jolt-math-long-min)
+               (else (exact r))))))))
 (define (jolt-math-signum x) (cond ((< x 0.0) -1.0) ((> x 0.0) 1.0) (else 0.0)))
 (define (jolt-math-to-degrees r) (/ (* r 180.0) jolt-math-pi))
 (define (jolt-math-to-radians d) (/ (* d jolt-math-pi) 180.0))

--- a/host/chez/java/math.ss
+++ b/host/chez/java/math.ss
@@ -87,8 +87,13 @@
          (if (< (abs term) (* 1e-18 (max 1.0 (abs acc2)))) acc2
              (loop (+ n 1) (* xp x) acc2 (- sign))))))
     (else (real-or-nan (log (+ 1.0 x))))))
-(define (jolt-math-floor-div a b) (floor (/ a b)))
-(define (jolt-math-floor-mod a b) (- a (* b (floor (/ a b)))))
+;; floor-div/floor-mod take ^long args and return a long. Coerce each operand
+;; toward zero (Java's ^long cast) so a double like 7.0 becomes 7, then compute
+;; on exact integers so the result is a long, not a double.
+(define (jolt-math-floor-div a b)
+  (let ((a (exact (truncate a))) (b (exact (truncate b)))) (floor (/ a b))))
+(define (jolt-math-floor-mod a b)
+  (let ((a (exact (truncate a))) (b (exact (truncate b)))) (- a (* b (floor (/ a b))))))
 
 ;; clojure.math fns always return a DOUBLE; Chez's sqrt/expt/sin/floor/... return
 ;; EXACT for exact args ((sqrt 9) -> 3, (sin 0) -> 0), so coerce.

--- a/host/chez/java/math.ss
+++ b/host/chez/java/math.ss
@@ -42,7 +42,51 @@
 (define (jolt-math-signum x) (cond ((< x 0.0) -1.0) ((> x 0.0) 1.0) (else 0.0)))
 (define (jolt-math-to-degrees r) (/ (* r 180.0) jolt-math-pi))
 (define (jolt-math-to-radians d) (/ (* d jolt-math-pi) 180.0))
-(define (jolt-math-hypot a b) (sqrt (+ (* a a) (* b b))))
+;; java.lang.Math.hypot — scale by a power of 2 (exact) so a^2+b^2 can't overflow
+;; before the sqrt; the only rounding is the correctly-rounded sqrt. NaN->NaN,
+;; either Inf -> +Inf. (Naive sqrt(a^2+b^2) returns Inf for 3e200,4e200.)
+(define (jolt-math-hypot a b)
+  ;; Java Math.hypot: Inf if either is Inf (even if the other is NaN), else NaN if
+  ;; either is NaN. Otherwise la * sqrt(1 + (sm/la)^2), factoring out the larger
+  ;; magnitude so the squares never overflow (sm/la <= 1). This is exact for the
+  ;; scaled Pythagorean cases (e.g. 3e200,4e200 -> 5e200) and within 1 ULP
+  ;; elsewhere, matching Java's correctly-rounded result to ~15-16 digits.
+  (cond
+    ((or (infinite? a) (infinite? b)) +inf.0)
+    ((or (nan? a) (nan? b)) +nan.0)
+    (else
+     (let* ((ax (abs a)) (bx (abs b))
+            (la (max ax bx)) (sm (min ax bx)))
+       (if (= la 0.0)
+           0.0
+           (let ((r (/ sm la)))
+             (* la (sqrt (+ 1.0 (* r r))))))))))
+;; java.lang.Math.expm1 — Taylor series for |x|<0.5 (where exp(x)-1 cancels badly),
+;; else exp(x)-1. +Inf->+Inf, -Inf->-1.0, NaN->NaN.
+(define (jolt-math-expm1 x)
+  (let ((ax (abs x)))
+    (cond
+      ((nan? x) x)
+      ((infinite? x) (if (> x 0.0) x -1.0))
+      ((< ax 0.5)
+       (let loop ((term x) (n 2) (acc x))
+         (let* ((nt (* term (/ x n))) (acc2 (+ acc nt)))
+           (if (< (abs nt) (* 1e-18 (abs acc2))) acc2
+               (loop nt (+ n 1) acc2)))))
+      (else (- (exp x) 1.0)))))
+;; java.lang.Math.log1p — alternating series for |x|<0.3 (where 1+x rounds to 1),
+;; else log(1+x). log1p(-1)->-Inf, log1p(<-1)->NaN.
+(define (jolt-math-log1p x)
+  (cond
+    ((nan? x) x)
+    ((= x -1.0) -inf.0)
+    ((< x -1.0) +nan.0)
+    ((< (abs x) 0.3)
+     (let loop ((n 1) (xp x) (acc 0.0) (sign 1))
+       (let* ((term (* sign (/ xp n))) (acc2 (+ acc term)))
+         (if (< (abs term) (* 1e-18 (max 1.0 (abs acc2)))) acc2
+             (loop (+ n 1) (* xp x) acc2 (- sign))))))
+    (else (real-or-nan (log (+ 1.0 x))))))
 (define (jolt-math-floor-div a b) (floor (/ a b)))
 (define (jolt-math-floor-mod a b) (- a (* b (floor (/ a b)))))
 
@@ -62,10 +106,10 @@
 (def-var! "clojure.math" "cbrt" jolt-math-cbrt)
 (def-var! "clojure.math" "pow" (m2c expt))
 (def-var! "clojure.math" "exp" (m1 exp))
-(def-var! "clojure.math" "expm1" (lambda (x) (- (exp x) 1.0)))
+(def-var! "clojure.math" "expm1" jolt-math-expm1)
 (def-var! "clojure.math" "log" (m1c log))
 (def-var! "clojure.math" "log10" (lambda (x) (real-or-nan (log x 10.0))))
-(def-var! "clojure.math" "log1p" (lambda (x) (real-or-nan (log (+ 1.0 x)))))
+(def-var! "clojure.math" "log1p" jolt-math-log1p)
 (def-var! "clojure.math" "sin" (m1 sin))
 (def-var! "clojure.math" "cos" (m1 cos))
 (def-var! "clojure.math" "tan" (m1 tan))

--- a/host/chez/java/math.ss
+++ b/host/chez/java/math.ss
@@ -68,10 +68,14 @@
     (cond
       ((nan? x) x)
       ((infinite? x) (if (> x 0.0) x -1.0))
+      ((= x 0.0) x)                     ; expm1(0) = 0 (also ±0.0 passthrough)
       ((< ax 0.5)
        (let loop ((term x) (n 2) (acc x))
          (let* ((nt (* term (/ x n))) (acc2 (+ acc nt)))
-           (if (< (abs nt) (* 1e-18 (abs acc2))) acc2
+           ;; terminate on a term that adds nothing, or is negligible relative to
+           ;; the accumulator. Guard the threshold with (max 1.0 …) so an acc that
+           ;; rounds toward 0 can't make the bound 0 and spin forever (expm1 0).
+           (if (or (= nt 0.0) (< (abs nt) (* 1e-18 (max 1.0 (abs acc2))))) acc2
                (loop nt (+ n 1) acc2)))))
       (else (- (exp x) 1.0)))))
 ;; java.lang.Math.log1p — alternating series for |x|<0.3 (where 1+x rounds to 1),

--- a/host/chez/natives-num.ss
+++ b/host/chez/natives-num.ss
@@ -3,8 +3,20 @@
 ;; to an exact integer, operate, and return a flonum. parse-* use strict shapes
 ;; (Clojure 1.11: nil on malformed, throw on a non-string).
 
-;; bit ops return EXACT integers (= JVM long). ->int coerces the operand.
-(define (->int x) (exact (truncate x)))
+;; bit ops require a long operand. The JVM throws IllegalArgumentException for a
+;; double, ratio, or an integer outside signed 64-bit range (a BigInt); ->int
+;; enforces that. jolt's unified integer model can't distinguish (bigint 5) from
+;; 5, so any exact integer in [Long/MIN, Long/MAX] is accepted; only non-integers
+;; and out-of-range magnitudes are rejected (matching the JVM's "bit operation
+;; not supported for" as closely as the model allows).
+(define ->int-long-min -9223372036854775808)
+(define ->int-long-max 9223372036854775807)
+(define (->int x)
+  (if (and (number? x) (exact? x) (integer? x)
+           (>= x ->int-long-min) (<= x ->int-long-max))
+      x
+      (throw-jvm (quote IllegalArgumentException)
+                 (string-append "bit operation not supported for: " (jolt-final-str x)))))
 ;; Mask shift count to low 6 bits (JVM long shift semantics), then wrap result
 ;; to 64-bit signed two's complement.
 (define (shift-mask n) (bitwise-and (->int n) 63))
@@ -29,9 +41,12 @@
 (define (jolt-bit-shift-left x n)  (wrap64 (bitwise-arithmetic-shift-left (->int x) (shift-mask n))))
 (define (jolt-bit-shift-right x n) (wrap64 (bitwise-arithmetic-shift-right (->int x) (shift-mask n))))
 (define (bit-mask n) (bitwise-arithmetic-shift-left 1 (->int n)))
-(define (jolt-bit-set x n)   (bitwise-ior (->int x) (bit-mask n)))
+;; set/flip can turn on bit 63, producing 2^63 (out of long range) — wrap to
+;; 64-bit signed so (bit-set 0 63) is Long/MIN, like the JVM. clear only turns
+;; bits off, so it stays in range.
+(define (jolt-bit-set x n)   (wrap64 (bitwise-ior (->int x) (bit-mask n))))
 (define (jolt-bit-clear x n) (bitwise-and (->int x) (bitwise-not (bit-mask n))))
-(define (jolt-bit-flip x n)  (bitwise-xor (->int x) (bit-mask n)))
+(define (jolt-bit-flip x n)  (wrap64 (bitwise-xor (->int x) (bit-mask n))))
 (define (jolt-bit-test x n)  (not (zero? (bitwise-and (->int x) (bit-mask n)))))
 ;; unsigned-bit-shift-right: LOGICAL right shift over a 64-bit long (Java >>>),
 ;; so a negative operand shifts in zeros from its 64-bit two's-complement window

--- a/host/chez/natives-num.ss
+++ b/host/chez/natives-num.ss
@@ -94,14 +94,31 @@
                          jm)))
             (= je n)))))))
 
+;; Double.parseDouble trims surrounding whitespace and accepts a trailing float/
+;; double type suffix (1.5f / 1.5d / 1.5F / 1.5D). Strip both before the shape
+;; check so parse-double matches the JVM on those forms.
+(define (pd-ws? c) (or (char=? c #\space) (char=? c #\tab) (char=? c #\newline) (char=? c #\return)))
+(define (pd-normalize s)
+  (let* ((n (string-length s))
+         (a (let loop ((i 0)) (if (and (< i n) (pd-ws? (string-ref s i))) (loop (+ i 1)) i)))
+         (b (let loop ((j n)) (if (and (> j a) (pd-ws? (string-ref s (- j 1)))) (loop (- j 1)) j)))
+         (t (substring s a b))
+         (tn (string-length t)))
+    ;; strip ONE trailing f/F/d/D suffix, but only when a digit precedes it
+    (if (and (> tn 1)
+             (let ((c (string-ref t (- tn 1)))) (memv c '(#\f #\F #\d #\D)))
+             (char-numeric? (string-ref t (- tn 2))))
+        (substring t 0 (- tn 1))
+        t)))
 (define (jolt-parse-double s)
   (if (not (string? s)) (throw-jvm (quote IllegalArgumentException) (string-append "parse-double requires a string: " (jolt-final-str s)))
-      (cond
-        ((string=? s "Infinity") +inf.0)
-        ((string=? s "-Infinity") -inf.0)
-        ((string=? s "NaN") +nan.0)
-        ((parse-double-shape? s) (exact->inexact (string->number s)))
-        (else jolt-nil))))
+      (let ((s (pd-normalize s)))
+        (cond
+          ((string=? s "Infinity") +inf.0)
+          ((string=? s "-Infinity") -inf.0)
+          ((string=? s "NaN") +nan.0)
+          ((parse-double-shape? s) (exact->inexact (string->number s)))
+          (else jolt-nil)))))
 
 (def-var! "clojure.core" "__bit-and" jolt-bit-and)
 (def-var! "clojure.core" "__bit-or" jolt-bit-or)

--- a/host/chez/predicates.ss
+++ b/host/chez/predicates.ss
@@ -100,7 +100,16 @@
                  (cond ((null? zs) #t)
                        ((jbd-equiv2 a (car zs)) (loop (car zs) (cdr zs)))
                        (else #f)))
-               (or (null? xs) (apply = xs))))
+               ;; JVM == on a mixed long/double set compares as doubles (the
+               ;; category ops promote), so it agrees with the fl=? the numeric
+               ;; pass emits in call position: (== 9007199254740993 9e15-ish)
+               ;; is true because the long rounds to the same double. Chez `=`
+               ;; would instead promote the double to exact and answer false, so
+               ;; the fn path (apply/HOF) disagreed with the call path. Match the
+               ;; call path: if any operand is inexact, compare all as doubles.
+               (if (exists (lambda (x) (and (number? x) (inexact? x))) xs)
+                   (apply = (map (lambda (x) (exact->inexact x)) xs))
+                   (or (null? xs) (apply = xs)))))
           ((numeric? (car ys)) (all-num? (cdr ys)))
           (else (throw-jvm (quote ClassCastException) "== requires numbers"))))))
 (def-var! "clojure.core" "==" jolt-num-equiv)

--- a/host/chez/predicates.ss
+++ b/host/chez/predicates.ss
@@ -72,18 +72,36 @@
 (def-var! "clojure.core" "integer?" jolt-integer?)
 (def-var! "clojure.core" "float?" jolt-float?)
 (def-var! "clojure.core" "decimal?" jolt-decimal?)
-;; == numeric value-equality (ignores exactness, unlike =): (== 3 3.0) -> true.
-;; 1-arity is trivially true; 2+ args must all be numbers (Numbers.equiv throws
-;; otherwise). Uses Scheme = (value across the tower), not jolt= (category-aware).
+;; == numeric value-equality (ignores category/exactness, unlike =): (== 3 3.0),
+;; (== 3M 3) -> true. 1-arity is trivially true; 2+ args must all be numbers
+;; (Numbers.equiv throws otherwise). A BigDecimal operand compares by value across
+;; the tower — mirroring compare: when a double is present both sides compare as
+;; doubles, otherwise as bigdec — so (== 3M 3) is true while (= 3M 3) stays false.
+(define (jbd-equiv2 a b)
+  ;; a, b numeric (number or jbigdec); value-equal? Mirrors jolt-compare's dispatch.
+  (cond
+    ((or (flonum? a) (flonum? b))
+     (let ((fa (if (jbigdec? a) (jbigdec->flonum a) (if (flonum? a) a (exact->inexact a))))
+           (fb (if (jbigdec? b) (jbigdec->flonum b) (if (flonum? b) b (exact->inexact b)))))
+       (= fa fb)))
+    (else (jbigdec=? (jbd-coerce a) (jbd-coerce b)))))
 (define (jolt-num-equiv . xs)
   ;; 1-arity short-circuits to true for ANY value (Clojure's == 1-arg returns true
   ;; before the number check); 2+ args must all be numbers.
+  (define (numeric? x) (or (number? x) (jbigdec? x)))
   (if (and (pair? xs) (null? (cdr xs)))
       #t
       (let all-num? ((ys xs))
         (cond
-          ((null? ys) (or (null? xs) (apply = xs)))
-          ((number? (car ys)) (all-num? (cdr ys)))
+          ((null? ys)
+           (if (exists (lambda (x) (jbigdec? x)) xs)
+               ;; a BigDecimal operand: compare consecutive pairs by value
+               (let loop ((a (car xs)) (zs (cdr xs)))
+                 (cond ((null? zs) #t)
+                       ((jbd-equiv2 a (car zs)) (loop (car zs) (cdr zs)))
+                       (else #f)))
+               (or (null? xs) (apply = xs))))
+          ((numeric? (car ys)) (all-num? (cdr ys)))
           (else (throw-jvm (quote ClassCastException) "== requires numbers"))))))
 (def-var! "clojure.core" "==" jolt-num-equiv)
 (def-var! "clojure.core" "symbol?" jolt-symbol?)

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -410,7 +410,16 @@
 (define (jolt-flonum->string x)
   (let* ((s (number->string x))
          (neg? (char=? (string-ref s 0) #\-))
-         (body (if neg? (substring s 1 (string-length s)) s))
+         (body0 (if neg? (substring s 1 (string-length s)) s))
+         ;; Chez appends a "|prec" suffix to subnormal strings (e.g. "5e-324|1").
+         ;; Strip it before the exponent substring is parsed, else string->number
+         ;; misreads "-324|1" as a precision-qualified flonum (-256.0) and corrupts
+         ;; the value.
+         (bar (let loop ((i 0))
+                (cond ((fx>=? i (string-length body0)) #f)
+                      ((char=? (string-ref body0 i) #\|) i)
+                      (else (loop (fx+ i 1))))))
+         (body (if bar (substring body0 0 bar) body0))
          (blen (string-length body))
          (epos (let loop ((i 0))
                  (cond ((fx>=? i blen) #f)

--- a/test/chez/cts-known-failures.txt
+++ b/test/chez/cts-known-failures.txt
@@ -3,7 +3,6 @@
 # with: JOLT_CTS_WRITE_BASELINE=1 host/chez/cts.sh
 clojure.core-test.abs 1 0
 clojure.core-test.bigint 1 0
-clojure.core-test.bit-set 1 0
 clojure.core-test.byte 1 0
 clojure.core-test.dec 1 0
 clojure.core-test.double-qmark 3 0
@@ -25,10 +24,8 @@ clojure.core-test.pos-int-qmark 1 0
 clojure.core-test.quot 25 0
 clojure.core-test.realized-qmark 1 0
 clojure.core-test.rem 16 0
+clojure.core-test.short 1 0
 clojure.core-test.star 11 0
 clojure.core-test.star-squote 13 0
 clojure.core-test.transient 4 0
 clojure.core-test.vec 1 0
-# (short 0)/(byte 0) are not java.lang.Short/Byte under jolt's numeric model — bead jolt-445k.95;
-# latent until the R5 is/instance? fix stopped these asserts from auto-passing
-clojure.core-test.short 1 0

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1009,4 +1009,17 @@
   {:suite "r3-bitops" :expr "(bit-set 0 63)" :expected "-9223372036854775808"}
   {:suite "r3-bitops" :expr "(bit-and 9223372036854775807 1)" :expected "1"}
   {:suite "r3-bitops" :expr "(unsigned-bit-shift-right -1 1)" :expected "9223372036854775807"}
+  {:suite "r3-lowbatch" :expr "(parse-double \"1f\")" :expected "1.0"}
+  {:suite "r3-lowbatch" :expr "(parse-double \"1.0d\")" :expected "1.0"}
+  {:suite "r3-lowbatch" :expr "(parse-double \" 1.5 \")" :expected "1.5"}
+  {:suite "r3-lowbatch" :expr "(nil? (parse-double \"abc\"))" :expected "true"}
+  {:suite "r3-lowbatch" :expr "(nil? (parse-double \"f\"))" :expected "true"}
+  {:suite "r3-lowbatch" :expr "(parse-double \"3.14\")" :expected "3.14"}
+  {:suite "r3-lowbatch" :expr "(clojure.math/floor-div 7.0 2)" :expected "3"}
+  {:suite "r3-lowbatch" :expr "(clojure.math/floor-mod 7.0 3)" :expected "1"}
+  {:suite "r3-lowbatch" :expr "(clojure.math/floor-div -7 2)" :expected "-4"}
+  {:suite "r3-lowbatch" :expr "(apply == [9007199254740993 9007199254740992.0])" :expected "true"}
+  {:suite "r3-lowbatch" :expr "(== 9007199254740993 9007199254740992.0)" :expected "true"}
+  {:suite "r3-lowbatch" :expr "(= 1 1.0)" :expected "false"}
+  {:suite "r3-lowbatch" :expr "(== 1/2 0.5)" :expected "true"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -988,4 +988,13 @@
   {:suite "r3-hash" :expr "(hash 1099511627776/3)" :expected "7939"}
   {:suite "r3-hash" :expr "(hash 5/7)" :expected "2"}
   {:suite "r3-hash" :expr "(= (hash 1.5M) (hash 1.50M))" :expected "true"}
+  {:suite "r3-math-stable" :expr "(clojure.math/expm1 1.0E-10)" :expected "1.00000000005E-10"}
+  {:suite "r3-math-stable" :expr "(clojure.math/log1p 1.0E-15)" :expected "9.999999999999995E-16"}
+  {:suite "r3-math-stable" :expr "(clojure.math/expm1 2.0)" :expected "6.38905609893065"}
+  {:suite "r3-math-stable" :expr "(clojure.math/hypot 3.0 4.0)" :expected "5.0"}
+  {:suite "r3-math-stable" :expr "(clojure.math/hypot 5.0 12.0)" :expected "13.0"}
+  {:suite "r3-math-stable" :expr "(< (clojure.math/hypot 1.0E300 1.0E300) ##Inf)" :expected "true"}
+  {:suite "r3-math-stable" :expr "(Math/expm1 1.0E-10)" :expected "1.00000000005E-10"}
+  {:suite "r3-math-stable" :expr "(Math/hypot 3.0 4.0)" :expected "5.0"}
+  {:suite "r3-math-stable" :expr "(< (Math/hypot 1.0E300 1.0E300) ##Inf)" :expected "true"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -946,4 +946,18 @@
   {:suite "r3-bigdec" :expr "(bigdec ##Inf)" :expected :throws}
   {:suite "r3-bigdec" :expr "(bigdec \"abc\")" :expected :throws}
   {:suite "r3-bigdec" :expr "(bigdec \"\")" :expected :throws}
+  ;; compiler-review R3 stage 3 — == handles BigDecimal operands (predicates.ss
+  ;; jolt-num-equiv). Used to throw ClassCastException "== requires numbers" for any
+  ;; bigdec; now compares by value across the tower (mirrors compare), while = keeps
+  ;; its category rules ((= 1M 1) is false, (== 1M 1) is true).
+  {:suite "r3-equiv" :expr "(== 3M 3)" :expected "true"}
+  {:suite "r3-equiv" :expr "(== 1M 1.0M)" :expected "true"}
+  {:suite "r3-equiv" :expr "(== 1M 2M)" :expected "false"}
+  {:suite "r3-equiv" :expr "(== 3M 3.0)" :expected "true"}
+  {:suite "r3-equiv" :expr "(== 1M 1.00M)" :expected "true"}
+  {:suite "r3-equiv" :expr "(== 0M 0M 0M)" :expected "true"}
+  {:suite "r3-equiv" :expr "(== 1M)" :expected "true"}
+  {:suite "r3-equiv" :expr "(= 3M 3)" :expected "false"}
+  {:suite "r3-equiv" :expr "(= 1M 1.00M)" :expected "true"}
+  {:suite "r3-equiv" :expr "(== \"a\" \"a\")" :expected :throws}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -960,4 +960,19 @@
   {:suite "r3-equiv" :expr "(= 3M 3)" :expected "false"}
   {:suite "r3-equiv" :expr "(= 1M 1.00M)" :expected "true"}
   {:suite "r3-equiv" :expr "(== \"a\" \"a\")" :expected :throws}
+  ;; compiler-review R3 stage 4 — Math.round semantics (math.ss jolt-math-round +
+  ;; host-static-methods Math/round). Was (exact (floor (+ x 0.5))): errored on
+  ;; NaN/Inf, returned bignums for huge values, and gave 1 for 0.49999999999999994.
+  ;; Now NaN->0, +/-Inf->Long/MAX,MIN, saturates out-of-range, half-up special case.
+  {:suite "r3-round" :expr "(clojure.math/round ##NaN)" :expected "0"}
+  {:suite "r3-round" :expr "(clojure.math/round ##Inf)" :expected "9223372036854775807"}
+  {:suite "r3-round" :expr "(clojure.math/round ##-Inf)" :expected "-9223372036854775808"}
+  {:suite "r3-round" :expr "(clojure.math/round 1.0E19)" :expected "9223372036854775807"}
+  {:suite "r3-round" :expr "(clojure.math/round -1.0E19)" :expected "-9223372036854775808"}
+  {:suite "r3-round" :expr "(clojure.math/round 0.49999999999999994)" :expected "0"}
+  {:suite "r3-round" :expr "(clojure.math/round 2.5)" :expected "3"}
+  {:suite "r3-round" :expr "(clojure.math/round -2.5)" :expected "-2"}
+  {:suite "r3-round" :expr "(Math/round ##Inf)" :expected "9223372036854775807"}
+  {:suite "r3-round" :expr "(Math/round 0.49999999999999994)" :expected "0"}
+  {:suite "r3-round" :expr "(Math/round 2.4)" :expected "2"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -975,4 +975,17 @@
   {:suite "r3-round" :expr "(Math/round ##Inf)" :expected "9223372036854775807"}
   {:suite "r3-round" :expr "(Math/round 0.49999999999999994)" :expected "0"}
   {:suite "r3-round" :expr "(Math/round 2.4)" :expected "2"}
+  ;; compiler-review R3 stage 5 — hasheq for bigdec + ratio (bigdec.ss arm,
+  ;; hasheq.ss ratio). bigdec had no hash arm; ratio used long-hashcode (Long hash)
+  ;; instead of BigInteger.hashCode. Now bigdec = strip-trailing-zeros then
+  ;; 31*strippedUnscaled.hashCode + scale; ratio = num.hashCode ^ den.hashCode.
+  {:suite "r3-hash" :expr "(hash 3M)" :expected "93"}
+  {:suite "r3-hash" :expr "(hash 1.5M)" :expected "466"}
+  {:suite "r3-hash" :expr "(hash -1.5M)" :expected "-464"}
+  {:suite "r3-hash" :expr "(hash 1.50M)" :expected "466"}
+  {:suite "r3-hash" :expr "(hash -3M)" :expected "-93"}
+  {:suite "r3-hash" :expr "(hash -5/7)" :expected "-4"}
+  {:suite "r3-hash" :expr "(hash 1099511627776/3)" :expected "7939"}
+  {:suite "r3-hash" :expr "(hash 5/7)" :expected "2"}
+  {:suite "r3-hash" :expr "(= (hash 1.5M) (hash 1.50M))" :expected "true"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -991,6 +991,9 @@
   {:suite "r3-math-stable" :expr "(clojure.math/expm1 1.0E-10)" :expected "1.00000000005E-10"}
   {:suite "r3-math-stable" :expr "(clojure.math/log1p 1.0E-15)" :expected "9.999999999999995E-16"}
   {:suite "r3-math-stable" :expr "(clojure.math/expm1 2.0)" :expected "6.38905609893065"}
+  {:suite "r3-math-stable" :expr "(clojure.math/expm1 0.0)" :expected "0.0"}
+  {:suite "r3-math-stable" :expr "(Math/expm1 0.0)" :expected "0.0"}
+  {:suite "r3-math-stable" :expr "(clojure.math/log1p 0.0)" :expected "0.0"}
   {:suite "r3-math-stable" :expr "(clojure.math/hypot 3.0 4.0)" :expected "5.0"}
   {:suite "r3-math-stable" :expr "(clojure.math/hypot 5.0 12.0)" :expected "13.0"}
   {:suite "r3-math-stable" :expr "(< (clojure.math/hypot 1.0E300 1.0E300) ##Inf)" :expected "true"}

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -932,4 +932,18 @@
   {:suite "r3-rt" :expr "(pr-str 1.0E7)" :expected "1.0E7"}
   {:suite "r3-rt" :expr "(pr-str 0.001)" :expected "0.001"}
   {:suite "r3-rt" :expr "(pr-str 1.0E-300)" :expected "1.0E-300"}
+  ;; compiler-review R3 stage 2 — bigdec for ratios / sci-notation doubles / typed
+  ;; errors (java/bigdec.ss). Ratio -> exact decimal (ArithmeticException if
+  ;; non-terminating); flonum + exponent strings parse; Inf/NaN/garbage raise
+  ;; NumberFormatException. jbigdec->string now matches BigDecimal.toString
+  ;; (scientific for scale<0 or adjusted-exp<-6).
+  {:suite "r3-bigdec" :expr "(bigdec 1/4)" :expected "0.25M"}
+  {:suite "r3-bigdec" :expr "(+ (bigdec 1/4) 1M)" :expected "1.25M"}
+  {:suite "r3-bigdec" :expr "(bigdec 1.0E300)" :expected "1.0E+300M"}
+  {:suite "r3-bigdec" :expr "(bigdec \"1.0E300\")" :expected "1.0E+300M"}
+  {:suite "r3-bigdec" :expr "(bigdec \"1.5e-7\")" :expected "1.5E-7M"}
+  {:suite "r3-bigdec" :expr "(bigdec 1/3)" :expected :throws}
+  {:suite "r3-bigdec" :expr "(bigdec ##Inf)" :expected :throws}
+  {:suite "r3-bigdec" :expr "(bigdec \"abc\")" :expected :throws}
+  {:suite "r3-bigdec" :expr "(bigdec \"\")" :expected :throws}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -917,4 +917,19 @@
   ;; # -> $H case is backend-only. Smoke-test that a #() still munges its gensym
   ;; params consistently at binding and reference.
   {:suite "munge-injective" :expr "(#(+ % %2) 1 2)" :expected "3"}
+  ;; compiler-review R3 stage 1 — subnormal double printing (rt.ss jolt-flonum->string).
+  ;; Chez tags subnormal number->string output with a "|prec" suffix that corrupted
+  ;; the exponent; round-trip rows prove the value is preserved, and the plain pr-str
+  ;; rows lock that normal-range printing is untouched. (Chez's shortest-round-trip
+  ;; digits for subnormals legitimately differ from JVM's, e.g. 5.0E-324 vs 4.9E-324,
+  ;; so these assert jolt's own round-trippable form, not the JVM literal.)
+  {:suite "r3-rt" :expr "(= (read-string (pr-str 4.9E-324)) 4.9E-324)" :expected "true"}
+  {:suite "r3-rt" :expr "(= (read-string (pr-str 2.5E-323)) 2.5E-323)" :expected "true"}
+  {:suite "r3-rt" :expr "(= (read-string (pr-str 1.0E-322)) 1.0E-322)" :expected "true"}
+  {:suite "r3-rt" :expr "(pr-str 4.9E-324)" :expected "5.0E-324"}
+  {:suite "r3-rt" :expr "(pr-str 2.5E-323)" :expected "2.5E-323"}
+  {:suite "r3-rt" :expr "(pr-str 1.0E-322)" :expected "1.0E-322"}
+  {:suite "r3-rt" :expr "(pr-str 1.0E7)" :expected "1.0E7"}
+  {:suite "r3-rt" :expr "(pr-str 0.001)" :expected "0.001"}
+  {:suite "r3-rt" :expr "(pr-str 1.0E-300)" :expected "1.0E-300"}
 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -997,4 +997,16 @@
   {:suite "r3-math-stable" :expr "(Math/expm1 1.0E-10)" :expected "1.00000000005E-10"}
   {:suite "r3-math-stable" :expr "(Math/hypot 3.0 4.0)" :expected "5.0"}
   {:suite "r3-math-stable" :expr "(< (Math/hypot 1.0E300 1.0E300) ##Inf)" :expected "true"}
+  {:suite "r3-bitops" :expr "(try (bit-and 5.5 3) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(try (bit-or 3 1.5) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(try (bit-xor 3 1/2) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(try (bit-not 2.7) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(try (bit-test 5 2.9) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(try (bit-shift-left 1 2.5) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(try (apply bit-not [2.7]) (catch IllegalArgumentException e :iae))" :expected ":iae"}
+  {:suite "r3-bitops" :expr "(bit-and 12 10)" :expected "8"}
+  {:suite "r3-bitops" :expr "(bit-not 5)" :expected "-6"}
+  {:suite "r3-bitops" :expr "(bit-set 0 63)" :expected "-9223372036854775808"}
+  {:suite "r3-bitops" :expr "(bit-and 9223372036854775807 1)" :expected "1"}
+  {:suite "r3-bitops" :expr "(unsigned-bit-shift-right -1 1)" :expected "9223372036854775807"}
 ]


### PR DESCRIPTION
Epic jolt-ox7c .8-.15. Runtime-only (no remint). Gated green: unit 863/863 (r3-rt/bigdec/equiv/round/hash/math-stable/bitops/lowbatch), numwp 8/8, buildsmoke, smoke 67/67.

Eight numeric fixes, each JVM-oracle-verified:
- rt: subnormal doubles print/round-trip correctly (was corrupt 5.0E-256.0)
- bigdec: exact decimal for ratios, exponent parsing, typed errors (1/4 -> 0.25M)
- predicates: == handles BigDecimal + mixed long/double fn-path matches call-path
- math: Math.round semantics (NaN/Inf/saturate/half-up)
- hasheq: BigDecimal arm + BigInteger-based ratio hash (JVM-exact)
- math: stable expm1/log1p, non-overflowing hypot, routed Math/ statics
- numeric: bit ops require long operand (typed IAE), wrap bit-set/flip to 64 bits
- numeric: floor-div returns long, parse-double suffix/trim

Known remaining (unified integer model / niche, tracked for R9 docs): out-of-range integer *literal* bit ops, (long 2^63-as-double) saturation, hex-float parse-double.

Note: dirge implemented stages 1-5; supervisor finished 6-8 after dirge's provider quota capped.