### PR TITLE
compiler-review R5: reader octal + refer filters

### DIFF
--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -377,14 +377,29 @@
   (hashtable-delete! ns-alias-table (cons (ns-desig->name ns-desig) (symbol-t-name alias-sym)))
   jolt-nil)
 
-;; refer: bring every public var of `ns-sym` into the current ns as an unqualified
-;; name (filters accepted/ignored — the corpus uses the bare form). refer-clojure
-;; is a no-op (clojure.core always resolves on Chez).
-(define (jolt-refer ns-sym . _filters)
-  (let ((target (ns-desig->name ns-sym)) (cns (chez-current-ns)))
+;; refer: bring the public vars of `ns-sym` into the current ns as unqualified
+;; names. :only [names] restricts to those names; :exclude [names] drops them.
+;; (:rename is not yet supported — the refer table keys on the plain name.)
+(define (jolt-refer ns-sym . filters)
+  (let ((target (ns-desig->name ns-sym)) (cns (chez-current-ns))
+        (only #f) (excl '()))
+    ;; parse :only / :exclude name lists into string sets
+    (let loop ((a filters))
+      (when (and (pair? a) (pair? (cdr a)))
+        (let ((k (car a)) (v (cadr a)))
+          (when (keyword? k)
+            (let ((names (lambda () (let ((xs (seq->list v)))
+                                      (map symbol-t-name (filter symbol-t? xs))))))
+              (cond
+                ((string=? (keyword-t-name k) "only")    (set! only (names)))
+                ((string=? (keyword-t-name k) "exclude") (set! excl (names)))))))
+        (loop (cddr a))))
     (vector-for-each
-      (lambda (c) (when (and (string=? (var-cell-ns c) target) (var-cell-defined? c))
-                    (chez-register-refer! cns (var-cell-name c) target)))
+      (lambda (c)
+        (when (and (string=? (var-cell-ns c) target) (var-cell-defined? c))
+          (let ((nm (var-cell-name c)))
+            (when (and (or (not only) (member nm only)) (not (member nm excl)))
+              (chez-register-refer! cns nm target)))))
       (hashtable-values var-table))
     jolt-nil))
 ;; (:refer-clojure :exclude [names…]) — clojure.core always resolves on Chez, so

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -160,11 +160,15 @@
                (and radix (integer? radix) (>= radix 2) (<= radix 36)
                     (let ((v (rdr-parse-radix digits radix)))
                       (and v (* sign v)))))))
-      ;; octal 0NNN: a leading 0 followed by octal digits (Clojure reads 042 as 34,
-      ;; not decimal 42). "0" alone, 0x.., 0r.. and a float "0.5" are handled
-      ;; elsewhere or fall through (a non-octal digit fails rdr-all-octal?).
-      ((and (>= blen 2) (char=? (string-ref body 0) #\0) (rdr-all-octal? body 1 blen))
-       (let ((o (rdr-parse-radix (substring body 1 blen) 8))) (and o (* sign o))))
+      ;; octal 0NNN, optionally with a bigint N suffix: a leading 0 followed by
+      ;; octal digits (Clojure reads 042 as 34 and 0177N as octal 127, not the
+      ;; decimal that the N-suffix branch below would otherwise produce). "0"
+      ;; alone, 0x.., 0r.. and a float "0.5" are handled elsewhere or fall through.
+      ((and (>= blen 2) (char=? (string-ref body 0) #\0)
+            (let ((end (if (char=? (string-ref body (- blen 1)) #\N) (- blen 1) blen)))
+              (and (> end 1) (rdr-all-octal? body 1 end) end)))
+       => (lambda (end)
+            (let ((o (rdr-parse-radix (substring body 1 end) 8))) (and o (* sign o)))))
       ;; a leading zero on a plain multi-digit integer is invalid (the octal
       ;; branch above accepted real octals; 08/09 match the JVM's trailing
       ;; "invalid number" alternative)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1098,4 +1098,12 @@
   {:suite "r7-transient" :expr "(empty? (transient [1 2]))" :expected "false"}
   {:suite "r7-transient" :expr "[(empty? (transient {})) (empty? (transient #{})) (empty? (transient #{1}))]" :expected "[true true false]"}
   {:suite "r7-transient" :expr "(let [t (transient [])] (conj! t 1) (empty? t))" :expected "false"}
+  {:suite "r5-reader" :expr "0177N" :expected "127"}
+  {:suite "r5-reader" :expr "0177" :expected "127"}
+  {:suite "r5-reader" :expr "042" :expected "34"}
+  {:suite "r5-reader" :expr "0" :expected "0"}
+  {:suite "r5-reader" :expr "(try (eval (read-string \"08\")) (catch Throwable e :threw))" :expected ":threw"}
+  {:suite "r5-refer" :expr "(do (refer (quote clojure.set) :only (quote [union])) [(some? (resolve (quote union))) (resolve (quote difference))])" :expected "[true nil]"}
+  {:suite "r5-refer" :expr "(do (refer (quote clojure.set) :exclude (quote [difference])) [(some? (resolve (quote union))) (resolve (quote difference))])" :expected "[true nil]"}
+  {:suite "r5-refer" :expr "(do (refer (quote clojure.set) :only (quote [union])) (union #{1} #{2}))" :expected "#{1 2}"}
 ]


### PR DESCRIPTION
Epic jolt-ox7c .22, .24.

- Octal integer literals with a bigint N suffix (0177N) parsed as decimal via the N-suffix branch; they now read as octal (0177N = 127, 042 = 34).
- refer honors :only and :exclude name filters instead of always bringing in every public var. (:rename still unsupported — remaining R5 items .23/.25-.34 tracked separately.)

Runtime .ss only (reader.ss/ns.ss load fresh; selfcheck confirms a byte-identical seed — no remint). Gates: unit 941/941, corpus 3800/3819 (0 new divergences), numwp 8/8, cts passed (matches baseline).