### PR TITLE
syntax-quote data path: `() and interop/class heads (jolt-ox7c.23 correctness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expression after a `catch`, a second `finally` (or one that isn't last), and a
   `recur` whose argument count doesn't match the enclosing `loop`/`fn` are rejected
   at compile time instead of silently miscompiling or failing only at runtime.
+- **`read-string` of a syntax-quote matches the JVM in more cases.** `` `() ``
+  read as data was `(clojure.core/list ())` (evaluating to `(())`); it is now
+  `(clojure.core/list)` = `()`. An interop head or fully-qualified class name in a
+  read-time backquote (`` `.foo ``, `` `foo. ``) stays bare instead of being
+  qualified to the current namespace, matching the compile path.
 
 ## [0.4.1] - 2026-07-17
 

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -1030,6 +1030,10 @@
                (let ((g (rdr-sq-gensym (substring nm 0 (fx- (string-length nm) 1)))))
                  (hashtable-set! gsmap nm g) g)))
            ((member nm rdr-sq-specials) sym)
+           ((hc-interop-head? nm) sym)   ; interop (.method / Class. / .-field): bare
+           ;; a fully-qualified class name (java.util.Map) is a class token, not a
+           ;; var to namespace-qualify — leave it bare like the compile path.
+           ((hc-fq-class-name? nm) sym)
            (else
             ;; JVM syntax-quote resolution: the ns's own interned var wins, then
             ;; refers/aliased refers, then the implicit clojure.core default,
@@ -1056,8 +1060,9 @@
     ((symbol-t? form)
      (jolt-list (jolt-symbol #f "quote")
                 (rdr-sq-symbol form gsmap)))
+    ;; `() is (clojure.core/list) => (), NOT (clojure.core/list ()) => (()).
     ((empty-list-t? form)
-     (jolt-list (jolt-symbol "clojure.core" "list") form))
+     (jolt-list (jolt-symbol "clojure.core" "list")))
     ((cseq? form)
      (if (rdr-syntax-quote-form? form)
          ;; nested backquote: lower it first (with a fresh gsmap — auto-gensyms in

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1106,6 +1106,11 @@
   {:suite "r5-refer" :expr "(do (refer (quote clojure.set) :only (quote [union])) [(some? (resolve (quote union))) (resolve (quote difference))])" :expected "[true nil]"}
   {:suite "r5-refer" :expr "(do (refer (quote clojure.set) :exclude (quote [difference])) [(some? (resolve (quote union))) (resolve (quote difference))])" :expected "[true nil]"}
   {:suite "r5-refer" :expr "(do (refer (quote clojure.set) :only (quote [union])) (union #{1} #{2}))" :expected "#{1 2}"}
+  {:suite "r5-syntax-quote" :expr "(pr-str (eval (read-string \"(pr-str `())\")))" :expected "\"()\""}
+  {:suite "r5-syntax-quote" :expr "(pr-str (read-string \"`.foo\"))" :expected "(quote .foo)"}
+  {:suite "r5-syntax-quote" :expr "(pr-str (read-string \"`foo.\"))" :expected "(quote foo.)"}
+  {:suite "r5-syntax-quote" :expr "(pr-str `())" :expected "()"}
+  {:suite "r5-syntax-quote" :expr "(pr-str (eval (read-string \"`(a b)\")))" :expected "(user/a user/b)"}
   {:suite "r6-kernel-throws" :expr "(try (conj {} [1]) (catch IllegalArgumentException e :iae) (catch Throwable t :other))" :expected ":iae"}
   {:suite "r6-kernel-throws" :expr "(try (conj {} [1]) (catch NullPointerException e :npe) (catch Throwable t :t))" :expected ":t"}
   {:suite "r6-kernel-throws" :expr "(try (nth :x 0) (catch UnsupportedOperationException e :uoe) (catch Throwable t :other))" :expected ":uoe"}


### PR DESCRIPTION
Fixes the verified read-string syntax-quote divergences from bead .23 (data path, runtime-only, no remint):
- `() => (clojure.core/list) = () (was (clojure.core/list ()) = (()))
- `.foo / `foo. / FQ class names stay bare like the compile path

Gates: unit 962/962, selfcheck holds, corpus 3800/3819 (0 new divergences), cts passed. Full one-engine unification deferred to R8 (jolt-1prb).