### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-18
+
+The bulk of a focused compiler review: identifier hygiene, the numeric tower,
+macro fidelity, reader/namespace behavior, typed throws, laziness/sorted
+collections, syntax-quote, `eval`-embedded constants, and multimethod dispatch —
+each change regression-tested and gated (`--opt` soundness pinned by a build
+assertion). Deliberate divergences from the JVM are now documented in
+`known-divergences.edn`.
+
 ### Fixed
 
 - **Locals named after emitted runtime heads no longer miscompile.** A local


### PR DESCRIPTION
Cut v0.4.2: the compiler-review correctness arc (R2-R7 + R5 low-batch + syntax-quote/.23 + eval-constants/.25 + multimethods + .46 scalar-replace soundness) plus documented divergences. Changelog-only; all content already merged and gated. Tag v0.4.2 after merge to trigger the release matrix + homebrew bump.