### PR TITLE
R8 java-layer: derive value-host-tags from class graph, registry consolidation, host-call type check

### DIFF
--- a/host/chez/host-contract.ss
+++ b/host/chez/host-contract.ss
@@ -314,8 +314,7 @@
 ;; `(Long/parseLong x)` slash form.
 (define (hc-host-class-name? nm)
   (or (hc-fq-class-name? nm)
-      (and (hashtable-ref class-statics-tbl nm #f) #t)
-      (and (hashtable-ref class-ctors-tbl nm #f) #t)))
+      (host-class-registered? nm)))
 
 (define (hc-resolve-global ctx sym)
   (let* ((nm (symbol-t-name sym))
@@ -334,7 +333,7 @@
           ;; `(. ZonedDateTime parse s)`). Only when otherwise unresolved, so a
           ;; same-named var still wins.
           ((and (fx>? (string-length nm) 0) (char-upper-case? (string-ref nm 0))
-                (hashtable-ref class-statics-tbl nm #f))
+                (host-class-has-statics? nm))
            (jolt-hash-map hc-kw-kind hc-kw-class hc-kw-name nm))
           (else (jolt-hash-map hc-kw-kind hc-kw-unresolved hc-kw-name nm))))))
 

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -387,6 +387,72 @@
 (jch-register-supers! "java.util.GregorianCalendar" '())
 (jch-register-supers! "java.util.Locale" '())
 (jch-register-supers! "java.util.TimeZone" '())
+;; #inst / (Date.) classes. java.sql.Date and java.sql.Timestamp are Date
+;; subclasses (jolt's one #inst value reports Date only — see inst-time.ss, which
+;; answers instance? Timestamp #f — so these rows exist for the sql-date shim and
+;; for isa?/supers of the class tokens, not for the #inst value's dispatch tags).
+(jch-register-supers! "java.util.Date" '("java.lang.Comparable"))
+(jch-register-supers! "java.sql.Date" '("java.util.Date"))
+(jch-register-supers! "java.sql.Timestamp" '("java.util.Date"))
+(jch-register-supers! "java.nio.ByteBuffer" '("java.lang.Comparable"))
+
+;; ---- jhost value tag -> FQN (single value-discriminator registry) --------------
+;; A value-layer shim value (make-jhost tag …) reports its JVM class by this map;
+;; value-host-tags (records.ss) and (class x)/instance? (host-static-classes.ss)
+;; both derive from it, so a shim value's protocol-dispatch tags, class name, and
+;; instance? answers stay in agreement and inherit the graph's supers (an Instant
+;; is a Temporal, a StringWriter is a Writer). Add a row here, not in three places.
+(define jhost-tag->fqn (make-hashtable string-hash string=?))
+(for-each (lambda (p) (hashtable-set! jhost-tag->fqn (car p) (cdr p)))
+  '(("instant" . "java.time.Instant")
+    ("local-date" . "java.time.LocalDate")
+    ("local-time" . "java.time.LocalTime")
+    ("local-date-time" . "java.time.LocalDateTime")
+    ("zoned-dt" . "java.time.ZonedDateTime")
+    ("zoned-date-time" . "java.time.ZonedDateTime")
+    ("offset-date-time" . "java.time.OffsetDateTime")
+    ("offset-time" . "java.time.OffsetTime")
+    ("duration" . "java.time.Duration")
+    ("period" . "java.time.Period")
+    ("year" . "java.time.Year")
+    ("year-month" . "java.time.YearMonth")
+    ("zone-id" . "java.time.ZoneId")
+    ("zone-offset" . "java.time.ZoneOffset")
+    ("zone-rules" . "java.time.zone.ZoneRules")
+    ("chrono-unit" . "java.time.temporal.ChronoUnit")
+    ("chrono-field" . "java.time.temporal.ChronoField")
+    ("month-enum" . "java.time.Month")
+    ("dow-enum" . "java.time.DayOfWeek")
+    ("clock" . "java.time.Clock")
+    ("dt-formatter" . "java.time.format.DateTimeFormatter")
+    ("sdf" . "java.text.SimpleDateFormat")
+    ("calendar" . "java.util.GregorianCalendar")
+    ("locale" . "java.util.Locale")
+    ("timezone" . "java.util.TimeZone")
+    ("sql-date" . "java.sql.Date")
+    ("uri" . "java.net.URI")
+    ("byte-buffer" . "java.nio.ByteBuffer")
+    ("arraylist" . "java.util.ArrayList")
+    ("linkedlist" . "java.util.LinkedList")
+    ("arraydeque" . "java.util.ArrayDeque")
+    ("hashmap" . "java.util.HashMap")
+    ("hashset" . "java.util.HashSet")
+    ;; io writer/reader shims: *out* is a PrintWriter like the JVM REPL's
+    ("port-writer" . "java.io.PrintWriter")
+    ("print-writer" . "java.io.PrintWriter")
+    ("file-writer" . "java.io.FileWriter")
+    ("writer" . "java.io.StringWriter")
+    ("string-reader" . "java.io.StringReader")
+    ("pushback-reader" . "java.io.PushbackReader")
+    ("char-writer" . "java.io.OutputStreamWriter")
+    ("char-reader" . "java.io.InputStreamReader")))
+;; FQN for a jhost tag, or #f if the tag names no modeled class (e.g. "class",
+;; "in-stream", "jolt-comparator") — callers fall through on #f.
+(define (jhost-fqn tag) (hashtable-ref jhost-tag->fqn tag #f))
+;; the protocol-dispatch / instance? tag list for a jhost value's tag, or #f.
+(define (jhost-value-tags tag)
+  (let ((fqn (hashtable-ref jhost-tag->fqn tag #f)))
+    (and fqn (jch-tags fqn))))
 
 ;; Public seam: libraries extend the modeled hierarchy.
 (def-var! "jolt.host" "register-class-supers!"

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1335,49 +1335,12 @@
 ;; jhost-backed shims report their JVM class instead of falling through to the
 ;; opaque :object rendering, so class-driven dispatch (and type-classification
 ;; libraries reading (type x)) see the real name.
-(define jhost-class-names
-  '(("instant" . "java.time.Instant")
-    ("local-date" . "java.time.LocalDate")
-    ("local-time" . "java.time.LocalTime")
-    ("local-date-time" . "java.time.LocalDateTime")
-    ("zoned-dt" . "java.time.ZonedDateTime")
-    ("zoned-date-time" . "java.time.ZonedDateTime")
-    ("offset-date-time" . "java.time.OffsetDateTime")
-    ("offset-time" . "java.time.OffsetTime")
-    ("duration" . "java.time.Duration")
-    ("period" . "java.time.Period")
-    ("year" . "java.time.Year")
-    ("year-month" . "java.time.YearMonth")
-    ("zone-id" . "java.time.ZoneId")
-    ("zone-offset" . "java.time.ZoneOffset")
-    ("zone-rules" . "java.time.zone.ZoneRules")
-    ("chrono-unit" . "java.time.temporal.ChronoUnit")
-    ("chrono-field" . "java.time.temporal.ChronoField")
-    ("month-enum" . "java.time.Month")
-    ("dow-enum" . "java.time.DayOfWeek")
-    ("clock" . "java.time.Clock")
-    ("dt-formatter" . "java.time.format.DateTimeFormatter")
-    ("sdf" . "java.text.SimpleDateFormat")
-    ("calendar" . "java.util.GregorianCalendar")
-    ("locale" . "java.util.Locale")
-    ("timezone" . "java.util.TimeZone")
-    ("arraylist" . "java.util.ArrayList")
-    ("linkedlist" . "java.util.LinkedList")
-    ("arraydeque" . "java.util.ArrayDeque")
-    ("hashmap" . "java.util.HashMap")
-    ("hashset" . "java.util.HashSet")
-    ;; io writer/reader shims: *out* is a PrintWriter like the JVM REPL's
-    ("port-writer" . "java.io.PrintWriter")
-    ("print-writer" . "java.io.PrintWriter")
-    ("file-writer" . "java.io.FileWriter")
-    ("writer" . "java.io.StringWriter")
-    ("string-reader" . "java.io.StringReader")
-    ("pushback-reader" . "java.io.PushbackReader")
-    ("char-writer" . "java.io.OutputStreamWriter")
-    ("char-reader" . "java.io.InputStreamReader")))
+;; jhost value class names derive from the single jhost-tag->fqn registry
+;; (class-hierarchy.ss) — one row per shim tag, shared with value-host-tags and
+;; the instance? arm below so all three stay in agreement.
 (register-class-arm!
-  (lambda (x) (and (jhost? x) (assoc (jhost-tag x) jhost-class-names) #t))
-  (lambda (x) (cdr (assoc (jhost-tag x) jhost-class-names))))
+  (lambda (x) (and (jhost? x) (jhost-fqn (jhost-tag x)) #t))
+  (lambda (x) (jhost-fqn (jhost-tag x))))
 ;; sorted collections and transients report their JVM classes. jolt's one
 ;; transient-map representation reports TransientHashMap (the JVM also has
 ;; PersistentArrayMap$TransientArrayMap for small maps).
@@ -1395,17 +1358,17 @@
       ((set) "clojure.lang.PersistentHashSet$TransientHashSet")
       (else "clojure.lang.ATransientCollection"))))
 ;; instance? for these shims derives from the class graph: the value's class name
-;; (jhost-class-names) walked through jch-isa? answers interface questions —
+;; (jhost-fqn) walked through jch-isa? answers interface questions —
 ;; (instance? java.util.List an-ArrayList), Deque/Queue/Collection/Iterable chains.
 ;; Widening only: an unknown pairing passes to the other arms, never denies.
 (register-instance-check-arm!
   (lambda (type-sym val)
     (if (and (jhost? val) (symbol-t? type-sym))
-        (let ((p (assoc (jhost-tag val) jhost-class-names)))
-          (if p
+        (let ((fqn (jhost-fqn (jhost-tag val))))
+          (if fqn
               (let* ((tname (symbol-t-name type-sym))
                      (q (or (resolve-class-hint tname) tname)))
-                (if (jch-isa? (cdr p) q) #t 'pass))
+                (if (jch-isa? fqn q) #t 'pass))
               'pass))
         'pass)))
 ;; count over the mutable collection shims, like RT.count over a java.util

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -394,11 +394,7 @@
 ;; thread-safe access. The shared-heap HashMap/ArrayList shims already serialize
 ;; individual ops adequately for these uses, so the wrapper returns its argument.
 (let ((ident (lambda (c . _) c)))
-  (register-class-statics! "Collections"
-    (list (cons "synchronizedMap" ident) (cons "synchronizedList" ident)
-          (cons "synchronizedSet" ident) (cons "unmodifiableMap" ident)
-          (cons "unmodifiableList" ident) (cons "unmodifiableSet" ident)
-          (cons "emptyList" (lambda _ (jolt-vector))) (cons "emptyMap" (lambda _ (jolt-hash-map)))))
+  ;; registering under the FQN also registers the short name (shared table)
   (register-class-statics! "java.util.Collections"
     (list (cons "synchronizedMap" ident) (cons "synchronizedList" ident)
           (cons "synchronizedSet" ident) (cons "unmodifiableMap" ident)
@@ -823,13 +819,18 @@
             (when (memv c (string->list meta)) (set! out (cons #\\ out)))
             (set! out (cons c out))
             (loop (+ i 1)))))))
-(register-class-statics! "Pattern"
-  (list (cons "compile" (lambda (s . flags)
-                          (if (and (pair? flags) (= (bitwise-and (jnum->exact (car flags)) 8) 8))
-                              (jolt-regex (string-append "(?m)" s))
-                              (jolt-regex s))))
-        (cons "quote" (lambda (s) (pattern-quote s)))
-        (cons "MULTILINE" pattern-multiline)))
+;; the one Pattern statics block (compile / quote / MULTILINE). nio-file and
+;; host-static-methods used to register competing compile/quote members that
+;; last-wins clobbered; this is now the single source.
+(let ((pattern-statics
+       (list (cons "compile" (lambda (s . flags)
+                               (if (and (pair? flags) (= (bitwise-and (jnum->exact (car flags)) 8) 8))
+                                   (jolt-regex (string-append "(?m)" s))
+                                   (jolt-regex s))))
+             (cons "quote" (lambda (s) (pattern-quote s)))
+             (cons "MULTILINE" pattern-multiline))))
+  (register-class-statics! "Pattern" pattern-statics)
+  (register-class-statics! "java.util.regex.Pattern" pattern-statics))
 ;; record-method-dispatch already routes string? -> jolt-string-method. Add a
 ;; regex-t arm (Pattern .split / .matcher-less surface used by corpus) by wrapping
 ;; once more — a regex-t isn't a jhost.

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -117,7 +117,6 @@
 
 ;; clojure.lang.LockingTransaction: jolt refs with serialized transactions.
 ;; isRunning -> true when a transaction is active on this thread.
-(register-class-statics! "LockingTransaction" (list (cons "isRunning" (lambda () (and (*txn*) #t)))))
 (register-class-statics! "clojure.lang.LockingTransaction" (list (cons "isRunning" (lambda () (and (*txn*) #t)))))
 
 ;; clojure.lang.LazilyPersistentVector/createOwning: build a vector from an array
@@ -182,19 +181,16 @@
                  ((and (fx>=? cp 65) (fx<=? cp 90)) (fx+ 10 (fx- cp 65)))   ; A-Z
                  (else 99))))
     (if (fx<? d radix) d -1)))
-(define character-statics
+;; Character's isDigit/isWhitespace/isUpperCase/isLowerCase/TYPE are registered
+;; in one block further below; these are the codepoint conversion statics.
+(register-class-statics! "java.lang.Character"
   (list (cons "digit" (lambda (ch radix) (->num (char-digit-value (char->cp ch) (jnum->exact radix)))))
         (cons "toChars" (lambda (cp) (na-char-array (jolt-vector (integer->char (char->cp cp))))))
-        (cons "isDigit" (lambda (ch) (let ((cp (char->cp ch))) (and (fx>=? cp 48) (fx<=? cp 57)))))
-        (cons "isWhitespace" (lambda (ch) (char-whitespace? (integer->char (char->cp ch)))))
         (cons "valueOf" (lambda (ch) (if (char? ch) ch (integer->char (char->cp ch)))))))
-(register-class-statics! "Character" character-statics)
-(register-class-statics! "java.lang.Character" character-statics)
 
-;; java.util.regex.Pattern/compile: a regex value from a string pattern.
-(define pattern-statics (list (cons "compile" (lambda (s) (jolt-regex (jolt-str-render-one s))))))
-(register-class-statics! "Pattern" pattern-statics)
-(register-class-statics! "java.util.regex.Pattern" pattern-statics)
+;; java.util.regex.Pattern statics (compile/quote/MULTILINE) are registered once
+;; in host-static-classes.ss — the flags-aware compile there subsumes the plain
+;; one-arg form this file used to register.
 
 ;; clojure.lang.BigInt / clojure.lang.Numbers: jolt has one exact-integer type
 ;; (Chez bignums auto-reduce), so BigInt.fromBigInteger and Numbers.reduceBigInt
@@ -202,8 +198,6 @@
 (define identity-num-statics (list (cons "fromBigInteger" (lambda (x) x))))
 (register-class-statics! "BigInt" identity-num-statics)
 (register-class-statics! "clojure.lang.BigInt" identity-num-statics)
-(register-class-statics! "Numbers"
-  (list (cons "reduceBigInt" (lambda (x) x)) (cons "toRatio" (lambda (x) x))))
 (register-class-statics! "clojure.lang.Numbers"
   (list (cons "reduceBigInt" (lambda (x) x)) (cons "toRatio" (lambda (x) x))))
 
@@ -237,9 +231,6 @@
         (cons "console" (lambda _ jolt-nil))
         (cons "lineSeparator" (lambda _ "\n"))
         (cons "identityHashCode" (lambda (x) (->num (equal-hash x))))))
-(register-class-statics! "java.lang.System"
-  (list (cons "console" (lambda _ jolt-nil))
-        (cons "lineSeparator" (lambda _ "\n"))))
 
 ;; java.lang.Long.bitCount: the population count of the value's 64-bit two's-
 ;; complement (mask to 64 bits so a negative long counts like the JVM, e.g.
@@ -323,7 +314,7 @@
         (cons "parseFloat" parse-double-or-throw) (cons "valueOf" ->double)))
 
 ;; Character: ASCII predicates (the engine is byte/ASCII oriented).
-(register-class-statics! "Character"
+(register-class-statics! "java.lang.Character"
   (list (cons "TYPE" "char")
         (cons "isUpperCase" (lambda (c) (let ((n (char-code c))) (and (>= n 65) (<= n 90)))))
         (cons "isLowerCase" (lambda (c) (let ((n (char-code c))) (and (>= n 97) (<= n 122)))))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -14,13 +14,12 @@
 ;; real results stay flonums, NaN/Inf pass through. real? is #f on a Chez complex.
 (define (real-or-nan x) (if (and (number? x) (real? x)) (exact->inexact x) +nan.0))
 (define math-pi (acos -1.0))
-;; sign-aware cube root: expt of a negative flonum to 1/3 goes complex.
-(define (math-cbrt x)
-  (let ((x (exact->inexact x)))
-    (if (< x 0.0) (- (expt (- x) (/ 1.0 3.0))) (expt x (/ 1.0 3.0)))))
 (register-class-statics! "Math"
   (list (cons "sqrt" (lambda (x) (real-or-nan (sqrt x))))
-        (cons "cbrt" (lambda (x) (math-cbrt x)))
+        ;; cbrt/log10 (and hypot/expm1/log1p below) share the clojure.math impls
+        ;; in math.ss (loaded after; the lambda bodies resolve at call time) so
+        ;; Math/x and clojure.math/x never diverge.
+        (cons "cbrt" (lambda (x) (jolt-math-cbrt (->dbl x))))
         (cons "pow" (lambda (a b) (real-or-nan (expt a b))))
         ;; hypot/expm1/log1p route to the numerically-stable clojure.math impls
         ;; (defined later in math.ss; the lambda body resolves at call time, after
@@ -42,7 +41,7 @@
         (cons "atan2" (lambda (y x) (->dbl (atan y x))))
         (cons "sinh" (lambda (x) (->dbl (sinh x)))) (cons "cosh" (lambda (x) (->dbl (cosh x))))
         (cons "tanh" (lambda (x) (->dbl (tanh x))))
-        (cons "log" (lambda (x) (real-or-nan (log x)))) (cons "log10" (lambda (x) (real-or-nan (/ (log x) (log 10)))))
+        (cons "log" (lambda (x) (real-or-nan (log x)))) (cons "log10" (lambda (x) (jolt-math-log10 (->dbl x))))
         (cons "log1p" (lambda (x) (jolt-math-log1p (->dbl x))))
         (cons "exp" (lambda (x) (->dbl (exp x))))
         (cons "expm1" (lambda (x) (jolt-math-expm1 (->dbl x))))

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -33,6 +33,17 @@
           ((char=? (string-ref s i) #\.) (substring s (+ i 1) (string-length s)))
           (else (loop (- i 1))))))
 
+;; A member re-registered with a DIFFERENT value across files is drift (two
+;; sources fighting over one static, last-wins silently deciding) — warn so it
+;; surfaces instead of shipping the wrong one (the Pattern/compile+quote bug).
+;; Registering the same member object twice (the FQN+short double-register below,
+;; or a value equal? to the prior one) is not a collision.
+(define (registry-collision! kind class member old new)
+  (when (and (not (eq? old new)) (not (equal? old new)))
+    (fprintf (current-error-port)
+             "warning: ~a member ~a/~a registered twice with different values\n"
+             kind class member)))
+
 (define (register-class-statics! name members)  ; members: list of (str . val/proc)
   (let* ((short (short-class-name name))
          (h (or (hashtable-ref class-statics-tbl name #f)
@@ -45,7 +56,11 @@
     (hashtable-set! class-statics-tbl name h)
     (unless (string=? name short)
       (hashtable-set! class-statics-tbl short h))
-    (for-each (lambda (p) (hashtable-set! h (car p) (cdr p))) members)))
+    (for-each (lambda (p)
+                (let ((old (hashtable-ref h (car p) #f)))
+                  (when old (registry-collision! "static" name (car p) old (cdr p))))
+                (hashtable-set! h (car p) (cdr p)))
+              members)))
 
 (define (register-class-ctor! name proc) (hashtable-set! class-ctors-tbl name proc))
 

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -25,6 +25,16 @@
 (define class-ctors-tbl   (make-hashtable string-hash string=?))   ; "Class" -> ctor proc
 (define host-methods-tbl  (make-hashtable string-hash string=?))   ; tag -> (method-ht)
 
+;; Does `nm` name a registered host class (has statics or a constructor)? The
+;; analyzer's contract layer asks this to treat a bare Capitalized symbol as a
+;; class; exposing it keeps the registry tables private to the java layer.
+(define (host-class-registered? nm)
+  (or (and (hashtable-ref class-statics-tbl nm #f) #t)
+      (and (hashtable-ref class-ctors-tbl nm #f) #t)))
+;; narrower: registered with STATICS (not just a constructor) — an imported class
+;; short name used as a static-call target, distinct from a deftype's bare name.
+(define (host-class-has-statics? nm) (and (hashtable-ref class-statics-tbl nm #f) #t))
+
 ;; A class token may arrive fully qualified (java.io.StringReader) or short
 ;; (StringReader). Register both; resolve by exact then by last dotted segment.
 (define (short-class-name s)

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -572,11 +572,9 @@
               (lambda (self name)
                 (let ((u (cl-get-resource self name)))
                   (if (jolt-nil? u) jolt-nil (host-new "StringReader" (jolt-slurp (url-strip-scheme (url-spec u))))))))))
-(register-class-statics! "ClassLoader" (list (cons "getSystemClassLoader" (lambda () the-classloader))))
 (register-class-statics! "java.lang.ClassLoader" (list (cons "getSystemClassLoader" (lambda () the-classloader))))
 ;; clojure.lang.RT/baseLoader — the resource-resolving class loader (RT/baseLoader
 ;; is how libraries reach Clojure's base loader, e.g. aws-api's resources ns).
-(register-class-statics! "RT" (list (cons "baseLoader" (lambda () the-classloader))))
 (register-class-statics! "clojure.lang.RT" (list (cons "baseLoader" (lambda () the-classloader))))
 ;; clojure.lang.RT/nextID — process-unique increasing id (AtomicInteger(1)
 ;; getAndIncrement), used by id generators such as core.logic's lvar.
@@ -655,10 +653,8 @@
     (if (pair? rest)
         (jolt-make-file (string-append (file-path-of a) "/" (file-path-of (car rest))))
         (jolt-make-file a))))
-;; UUID: randomUUID / fromString statics + a (UUID. s) string ctor.
-(register-class-statics! "UUID"
-  (list (cons "randomUUID" (lambda () (jolt-random-uuid)))
-        (cons "fromString" (lambda (s) (jolt-parse-uuid (jolt-str-render-one s))))))
+;; UUID: randomUUID / fromString statics + a (UUID. s) string ctor. Registering
+;; under the FQN also registers the short name (shared member table).
 (register-class-statics! "java.util.UUID"
   (list (cons "randomUUID" (lambda () (jolt-random-uuid)))
         (cons "fromString" (lambda (s) (jolt-parse-uuid (jolt-str-render-one s))))))
@@ -778,7 +774,6 @@
 (register-class-ctor! "URI" (lambda (s) (uri-parse (jolt-str-render-one s))))
 (register-class-ctor! "java.net.URI" (lambda (s) (uri-parse (jolt-str-render-one s))))
 ;; URI/create — the static factory, same as the (URI. s) constructor.
-(register-class-statics! "URI" (list (cons "create" (lambda (s) (uri-parse (jolt-str-render-one s))))))
 (register-class-statics! "java.net.URI" (list (cons "create" (lambda (s) (uri-parse (jolt-str-render-one s))))))
 (register-host-methods! "uri"
   (list (cons "toString" (lambda (u) (uri-field u 'string)))

--- a/host/chez/java/math.ss
+++ b/host/chez/java/math.ss
@@ -117,7 +117,10 @@
 (def-var! "clojure.math" "exp" (m1 exp))
 (def-var! "clojure.math" "expm1" jolt-math-expm1)
 (def-var! "clojure.math" "log" (m1c log))
-(def-var! "clojure.math" "log10" (lambda (x) (real-or-nan (log x 10.0))))
+;; base-10 log via Chez's base-arg log — also backs java.lang.Math/log10 so the
+;; two never disagree.
+(define (jolt-math-log10 x) (real-or-nan (log x 10.0)))
+(def-var! "clojure.math" "log10" jolt-math-log10)
 (def-var! "clojure.math" "log1p" jolt-math-log1p)
 (def-var! "clojure.math" "sin" (m1 sin))
 (def-var! "clojure.math" "cos" (m1 cos))

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -781,23 +781,12 @@
 ;; PosixFilePermissions/asFileAttribute -> a FileAttribute the create ops apply
 ;; by chmod after making the entry.
 (define (file-attr? x) (and (jhost? x) (string=? (jhost-tag x) "file-attribute")))
-(register-class-statics! "PosixFilePermissions"
-  (list (cons "asFileAttribute" (lambda (perms) (make-jhost "file-attribute" perms)))))
 (register-class-statics! "java.nio.file.attribute.PosixFilePermissions"
   (list (cons "asFileAttribute" (lambda (perms) (make-jhost "file-attribute" perms)))))
 
 
-;; java.util.regex.Pattern/quote — escape regex metacharacters in a literal.
-(define (nio-pattern-quote s)
-  (list->string
-   (fold-right (lambda (c acc)
-                 (if (memv c '(#\\ #\. #\* #\+ #\? #\( #\) #\[ #\] #\{ #\} #\^ #\$ #\|))
-                     (cons #\\ (cons c acc)) (cons c acc)))
-               '() (string->list s))))
-(register-class-statics! "Pattern" (list (cons "quote" nio-pattern-quote)))
-(register-class-statics! "java.util.regex.Pattern" (list (cons "quote" nio-pattern-quote)))
-
-
+;; java.util.regex.Pattern statics (incl. quote) are registered once in
+;; host-static-classes.ss — no per-file copy here.
 
 ;; ---- umask-masked create perms, symlink-aware move/copy ---------------------
 (define c-umask (jolt-foreign-proc-safe "umask" '(int) 'int))

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -795,22 +795,14 @@
               (list (string-append (class-munge-name (car p)) "$" (class-munge-name (cdr p)))
                     "AFunction" "clojure.lang.AFunction" "AFn" "clojure.lang.AFn"
                     "IFn" "clojure.lang.IFn" "Fn" "clojure.lang.Fn" "Object")))
-        ;; java.net.URI jhost — extend-protocol java.net.URI (hiccup ToURI/ToStr).
-        ((and (jhost? obj) (string=? (jhost-tag obj) "uri")) '("URI" "java.net.URI" "Object"))
-        ;; a ByteBuffer — extend-protocol java.nio.ByteBuffer (aws-api util).
-        ((and (jhost? obj) (string=? (jhost-tag obj) "byte-buffer")) '("ByteBuffer" "java.nio.ByteBuffer" "Object"))
-        ;; java.io readers/writers — so (extend-protocol java.io.Reader …) (data.csv)
-        ;; and the like dispatch on one. A PushbackReader is also a Reader.
-        ((and (jhost? obj) (string=? (jhost-tag obj) "string-reader"))
-         '("StringReader" "java.io.StringReader" "Reader" "java.io.Reader" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "pushback-reader"))
-         '("PushbackReader" "java.io.PushbackReader" "FilterReader" "java.io.FilterReader" "Reader" "java.io.Reader" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "char-reader"))
-         '("Reader" "java.io.Reader" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "char-writer"))
-         '("Writer" "java.io.Writer" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "writer"))
-         '("Writer" "java.io.Writer" "Object"))
+        ;; a value-layer shim value (java.time.*, URI, ByteBuffer, java.io reader/
+        ;; writer, ArrayList/HashMap, …) reports its class's whole ancestry from the
+        ;; single jhost-tag->fqn registry (class-hierarchy.ss). So (extend-protocol
+        ;; java.time.temporal.Temporal …) fires on an Instant, java.io.Reader on a
+        ;; PushbackReader, java.util.List on an ArrayList — each inheriting the
+        ;; modeled supers instead of a hand-copied literal that drifts. A tag naming
+        ;; no modeled class (in-stream, jolt-comparator) returns #f and falls through.
+        ((and (jhost? obj) (jhost-value-tags (jhost-tag obj))) => (lambda (tags) tags))
         ;; arrays dispatch by their JVM array-class name — extend-protocol to
         ;; (Class/forName "[B") for byte[] (data.json, aws-api), "[C" for char[].
         ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'byte)) '("[B" "Object"))
@@ -819,34 +811,14 @@
         ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'long)) '("[J" "Object"))
         ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'double)) '("[D" "Object"))
         ((jolt-array? obj) '("[Ljava.lang.Object;" "Object"))
-        ;; a regex VALUE — extend-protocol java.util.regex.Pattern (core.match.regex).
-        ((regex-t? obj) '("Pattern" "java.util.regex.Pattern" "Object"))
-        ;; host value types a library may extend a protocol to by class (data.json
-        ;; extends JSONWriter to java.util.UUID / java.util.Date / java.math.BigDecimal).
-        ((juuid? obj) '("UUID" "java.util.UUID" "Object"))
-        ((jinst? obj) '("Date" "java.util.Date" "Timestamp" "java.sql.Timestamp" "Object"))
-        ((jbigdec? obj) '("BigDecimal" "java.math.BigDecimal" "Number" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "instant")) '("Instant" "java.time.Instant" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "local-date")) '("LocalDate" "java.time.LocalDate" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "local-time")) '("LocalTime" "java.time.LocalTime" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "local-date-time")) '("LocalDateTime" "java.time.LocalDateTime" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "duration")) '("Duration" "java.time.Duration" "TemporalAmount" "java.time.temporal.TemporalAmount" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "period")) '("Period" "java.time.Period" "TemporalAmount" "java.time.temporal.TemporalAmount" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "month-enum")) '("Month" "java.time.Month" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "dow-enum")) '("DayOfWeek" "java.time.DayOfWeek" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "year")) '("Year" "java.time.Year" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "year-month")) '("YearMonth" "java.time.YearMonth" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "chrono-unit")) '("ChronoUnit" "java.time.temporal.ChronoUnit" "TemporalUnit" "java.time.temporal.TemporalUnit" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "chrono-field")) '("ChronoField" "java.time.temporal.ChronoField" "TemporalField" "java.time.temporal.TemporalField" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "zone-offset")) '("ZoneOffset" "java.time.ZoneOffset" "ZoneId" "java.time.ZoneId" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "zone-id")) '("ZoneId" "java.time.ZoneId" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "zoned-date-time")) '("ZonedDateTime" "java.time.ZonedDateTime" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "offset-date-time")) '("OffsetDateTime" "java.time.OffsetDateTime" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "offset-time")) '("OffsetTime" "java.time.OffsetTime" "Object"))
-        ((and (jhost? obj) (string=? (jhost-tag obj) "clock")) '("Clock" "java.time.Clock" "Object"))
-        ;; java.sql.Date — a distinct class from java.util.Date so a protocol
-        ;; extended to both (data.json's JSONWriter) routes a sql.Date to its impl.
-        ((and (jhost? obj) (string=? (jhost-tag obj) "sql-date")) '("java.sql.Date" "Date" "java.util.Date" "Object"))
+        ;; host value types with a distinct record repr (not jhost-backed): a regex,
+        ;; a #uuid, a #inst Date, a BigDecimal — each derives its ancestry from the
+        ;; class graph. A #inst is a java.util.Date (NOT a java.sql.Timestamp — the
+        ;; instance? arm in inst-time.ss agrees).
+        ((regex-t? obj) (jch-tags "java.util.regex.Pattern"))
+        ((juuid? obj) (jch-tags "java.util.UUID"))
+        ((jinst? obj) (jch-tags "java.util.Date"))
+        ((jbigdec? obj) (jch-tags "java.math.BigDecimal"))
         ;; a bare procedure (fn) — extend-protocol to clojure.lang.{Fn,IFn,AFn}.
         ((procedure? obj) (jch-tags "clojure.lang.AFunction"))
         ((jolt-nil? obj) '("nil"))
@@ -1008,11 +980,18 @@
                                ((char=? (string-ref type-name i) #\$) #t)
                                (else (loop (fx+ i 1)))))
        type-name)
-      ((or (hashtable-ref host-type-set base #f)
-           (and (not (hashtable-ref chez-simple-name-tag type-name #f))
-                (not (hashtable-ref chez-deftype-tag-set type-name #f))
-                (or (jch-known? base) (jch-known? type-name))))
-       base)
+      ;; a literal host-type-set member canonicalizes to its stripped base (which
+      ;; is already the simple segment or an FQN the value reports verbatim, e.g.
+      ;; "[Ljava.lang.Object;").
+      ((hashtable-ref host-type-set base #f) base)
+      ;; a graph-modeled class canonicalizes to its simple last segment — the tag
+      ;; value-host-tags emits via jch-tags. Using base here would leave a partial
+      ;; segment for nested packages (java.time.temporal.Temporal -> "temporal.Temporal"),
+      ;; which no dispatch tag matches, so a class-keyed protocol never fires.
+      ((and (not (hashtable-ref chez-simple-name-tag type-name #f))
+            (not (hashtable-ref chez-deftype-tag-set type-name #f))
+            (or (jch-known? base) (jch-known? type-name)))
+       (jch-last-segment type-name))
       (else #f))))
 ;; An extend/extend-type/extend-protocol registration marks the tag as an
 ;; extender of the protocol (recorded inside type-registry so the per-case prune

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -277,18 +277,18 @@
   (jolt-throw (jolt-host-throwable (jvm-throwable-fqn type) msg)))
 
 ;; --- host interop ------------------------------------------------------------
-;; (.method target arg*) lowers to (jolt-host-call "method" target arg*). JVM
-;; interop has no general Chez analog, but the few methods jolt-core's io tier
-;; calls map onto Chez equivalents: a writer's .write is a port display; a File's
-;; .isDirectory / .listFiles work over a path string (Chez has no File type, so
-;; file-seq's File branch is unreachable here — these keep the forms honest). An
-;; unsupported method raises rather than silently returning nil.
+;; (.method target arg*) with method in backend supported-host-methods
+;; (isDirectory/listFiles) lowers to (jolt-host-call "method" target arg*). Those
+;; map onto Chez path operations when the receiver is a path STRING; a File value
+;; is intercepted by io.ss's wrapper before reaching here. Any other receiver (a
+;; deftype/record with its own .isDirectory) routes to the normal method dispatch
+;; instead of misapplying file ops to it. record-method-dispatch is loaded later
+;; (records.ss) and resolved at call time.
 (define (jolt-host-call method target . args)
   (cond
-    ((string=? method "write") (display (car args) target) jolt-nil)
-    ((string=? method "isDirectory") (if (file-directory? target) #t #f))
-    ((string=? method "listFiles") (list->cseq (directory-list target)))
-    (else (error 'jolt-host-call (string-append "unsupported host method: ." method)))))
+    ((and (string=? method "isDirectory") (string? target)) (if (file-directory? target) #t #f))
+    ((and (string=? method "listFiles") (string? target)) (list->cseq (directory-list target)))
+    (else (record-method-dispatch target method (apply jolt-vector args)))))
 
 ;; --- var cells: late-bound global roots (Clojure vars) -----------------------
 ;; A var is a mutable cell keyed by "ns/name". A `:def` sets the root; a `:var`


### PR DESCRIPTION
R8 architecture batch (epic jolt-ox7c) for the java layer. All runtime .ss (no remint); make ci green locally, 0 new divergences.

**.47 (BUG)** — `value-host-tags` (records.ss) hand-copied ~30 java.* tag lists that drifted from the class graph: an Instant lacked Temporal/TemporalAdjuster (so `extend-protocol java.time.temporal.Temporal` never dispatched though `instance?` said true), the real zoned value (tag `zoned-dt`) had no ZonedDateTime tags, and a #inst claimed Timestamp while the instance? arm denies it. Collapsed to one `jhost-tag->fqn` registry in class-hierarchy.ss; value-host-tags, (class x), and the instance? arm all derive from it via `jch-tags`. Also fixed `canonical-host-tag` to canonicalize a graph-modeled class to its simple last segment (nested packages like `java.time.temporal.Temporal` stripped to `temporal.Temporal`, matching no dispatch tag).

**.48 (BUG)** — Pattern statics were registered in three files merged last-wins, so the shipped `quote` was nio's (no coercion, missing `-`/`&`). Consolidated to one block. `register-class-statics!` now warns on a member re-registered with a different value — which surfaced eight more drifting statics (Character isDigit/isWhitespace twice; UUID/URI/RT/ClassLoader/System/Collections/Numbers/LockingTransaction registered under short+FQN with duplicate lambdas). All consolidated; startup is warning-clean.

**.51 (BUG)** — `jolt-host-call` applied file ops to any `.isDirectory`/`.listFiles` receiver, so a user deftype with its own such method misrouted. Now guarded on a path-string receiver, else falls back to record-method-dispatch; the dead `write` arm is gone.

**.54 (partial)** — (a) Math/cbrt+Math/log10 duplicated math.ss with a different log10 formula; both now share the math.ss impls. (e) host-contract.ss reached into private java-layer tables; exposed `host-class-registered?`/`host-class-has-statics?` instead. (b/c/d — count/nth mechanism, priority constants, last-segment dedup — deferred as higher-churn/lower-value.)

Closes jolt-ox7c.47, jolt-ox7c.48, jolt-ox7c.51. Partially addresses jolt-ox7c.54.