### PR TITLE
.32: reader low batch — invalid keyword/unicode tokens

### DIFF
--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -194,13 +194,19 @@
   (let loop ((k 0) (acc 0) (j i))
     (if (= k n)
         (values acc j)
-        (loop (+ k 1) (+ (* acc 16) (rdr-hexdigit (string-ref s j))) (+ j 1)))))
+        (let ((d (and (< j (string-length s)) (rdr-hexdigit (string-ref s j)))))
+          ;; a non-hex digit or a run shorter than n is a reader error with the
+          ;; source position (ex-info), not a raw Chez "bad hex digit" condition.
+          (if d
+              (loop (+ k 1) (+ (* acc 16) d) (+ j 1))
+              (rdr-error s (if (< j (string-length s)) j i)
+                         "Invalid unicode escape (expected hex digits)"))))))
 
-(define (rdr-hexdigit c)
+(define (rdr-hexdigit c)                 ; hex digit value, or #f if not a hex char
   (cond ((and (char>=? c #\0) (char<=? c #\9)) (- (char->integer c) 48))
         ((and (char>=? c #\a) (char<=? c #\f)) (+ 10 (- (char->integer c) 97)))
         ((and (char>=? c #\A) (char<=? c #\F)) (+ 10 (- (char->integer c) 65)))
-        (else (error 'reader "bad hex digit" c))))
+        (else #f)))
 
 ;; opening quote already consumed; read to the closing quote, processing escapes.
 (define (rdr-read-string-lit s i end)
@@ -280,10 +286,20 @@
     ((string=? name "backspace") #\backspace)
     ((string=? name "formfeed") #\page)
     ((char=? (string-ref name 0) #\u)
-      (let ((cp (string->number (substring name 1 (string-length name)) 16)))
-        (if (and cp (>= cp #xD800) (<= cp #xDFFF))
-            (jolt-throw (jolt-ex-info "Invalid character constant: lone surrogate \\u escape" empty-pmap))
-            (integer->char cp))))
+      (let* ((hex (substring name 1 (string-length name)))
+             (cp (string->number hex 16)))
+        (cond
+          ;; \uXXXX takes exactly 4 hex digits; a bad digit or wrong length is a
+          ;; reader error (ex-info), not a raw integer->char crash on #f.
+          ((not (= (string-length hex) 4))
+           (jolt-throw (jolt-ex-info (string-append "Invalid unicode character escape length: "
+                                                    (number->string (string-length hex)) ", should be: 4")
+                                     empty-pmap)))
+          ((not cp)
+           (jolt-throw (jolt-ex-info (string-append "Invalid unicode character: \\u" hex) empty-pmap)))
+          ((and (>= cp #xD800) (<= cp #xDFFF))
+           (jolt-throw (jolt-ex-info "Invalid character constant: lone surrogate \\u escape" empty-pmap)))
+          (else (integer->char cp)))))
     ((char=? (string-ref name 0) #\o)
      (let ((v (string->number (substring name 1 (string-length name)) 8)))
        (when (or (not v) (> v 255))
@@ -762,9 +778,12 @@
       (let-values (((tok j) (rdr-read-token s i end)))
         (let ((len (string-length tok)))
           ;; ":" and "::" alone, a leading or trailing slash (a name of exactly
-          ;; "/" is fine, :ns//), or an auto-resolved keyword in edn (no
-          ;; resolution context) are invalid tokens.
+          ;; "/" is fine, :ns//), a token that STARTS with ':' (:::foo — the
+          ;; leading colon(s) are already consumed, and a keyword name can't begin
+          ;; with a colon, though :foo:bar is fine mid-name), or an auto-resolved
+          ;; keyword in edn (no resolution context) are invalid tokens.
           (when (or (= len 0)
+                    (char=? (string-ref tok 0) #\:)
                     (and (> len 1) (char=? (string-ref tok 0) #\/))
                     (and (> len 1) (char=? (string-ref tok (- len 1)) #\/)
                          (not (and (> len 2) (char=? (string-ref tok (- len 2)) #\/)))))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1090,6 +1090,13 @@
   {:suite "r8-ns" :expr "(do (create-ns (quote r8a)) (create-ns (quote r8b)) (alias (quote a33) (quote r8a)) [(try (alias (quote a33) (quote r8a)) :ok (catch Throwable e :threw)) (try (alias (quote a33) (quote r8b)) :no (catch Throwable e :threw))])" :expected "[:ok :threw]"}
   {:suite "r8-ns" :expr "(do (create-ns (quote r8rm)) (ns-name (remove-ns (quote r8rm))))" :expected "r8rm"}
   {:suite "r8-ns" :expr "(do (declare r8-unbound) (try (r8-unbound 1) (catch java.lang.IllegalStateException e :ise) (catch Throwable e :other)))" :expected ":ise"}
+  ;; reader low batch (jolt-ox7c.32): a further ':' in a keyword token is invalid;
+  ;; a bad \\u escape is a proper reader error (ExceptionInfo), not a raw condition.
+  {:suite "r8-reader" :expr "(try (read-string \":::foo\") (catch Throwable e :threw))" :expected ":threw"}
+  {:suite "r8-reader" :expr "[(read-string \":foo:bar\") (read-string \":ns/foo\") (read-string \":ns//\")]" :expected "[:foo:bar :ns/foo :ns//]"}
+  {:suite "r8-reader" :expr "(try (read-string \"\\\\uABCG\") (catch clojure.lang.ExceptionInfo e :ex) (catch Throwable e :other))" :expected ":ex"}
+  {:suite "r8-reader" :expr "(try (read-string \"\\\"\\\\u041\\\"\") (catch clojure.lang.ExceptionInfo e :ex) (catch Throwable e :other))" :expected ":ex"}
+  {:suite "r8-reader" :expr "[(int (read-string \"\\\\u0041\")) (count (read-string \"\\\"\\\\u0041\\\"\"))]" :expected "[65 1]"}
   {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (lazy-seq (do (swap! a inc) [1]))] (doall (map deref (for [_ (range 8)] (future (doall s))))) @a)" :expected "1"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) >= 2 <= 4)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) > 1 < 5)" :expected "(4 3 2)"}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -26,7 +26,7 @@
   :permissive
   "jolt succeeds where the JVM throws, on operations with one reasonable meaning: ex-info accepts nil data, count works on eduction, keys on a vector of pairs, (empty MapEntry) => []. A superset: portable JVM code behaves identically.",
   :namespace-model
-  "jolt's namespace layer is permissive: clojure.core always resolves (a :refer-clojure :exclude/:only affects syntax-quote qualification but not resolve/ns-resolve), var privacy is not enforced across namespaces, and ns-resolve/ns-unmap on a missing ns return nil rather than throwing. A superset — code that resolves on the JVM resolves on jolt."},
+  "jolt's namespace layer is permissive: clojure.core always resolves (a :refer-clojure :exclude/:only affects syntax-quote qualification but not resolve/ns-resolve) and var privacy is not enforced across namespaces. A superset — code that resolves on the JVM resolves on jolt."},
  :documented
  [;; Deliberate/tracked divergences that are NOT corpus rows, so they live here (not in
   ;; :entries, which certify.clj gates for staleness against the corpus).
@@ -64,12 +64,8 @@
    :jvm "throws (var is not public)"
    :jolt "returns the value"
    :note "Var privacy is not enforced across namespaces; ns-publics still filters privates out."}
-  ;; ns-resolve/ns-unmap/alias on a missing namespace are permissive.
-  {:category :namespace-model
-   :behavior "ns-resolve / ns-unmap / alias on a missing namespace"
-   :jvm "throws"
-   :jolt "returns nil (or no-ops)"
-   :note "Permissive; intern/the-ns do throw. Consistency deferred."}
+  ;; (ns-resolve / ns-unmap / alias on a missing namespace now throw like the JVM —
+  ;;  jolt-ox7c.33 — so that divergence is gone.)
   ;; an unregistered reader tag reads as an inert tagged literal rather than throwing.
   {:category :reader-model
    :behavior "(read-string \"#foo/bar 5\") with no reader for foo/bar"
@@ -82,6 +78,12 @@
    :jvm "throws (EOF while reading)"
    :jolt "nil"
    :note "Permissive."}
+  ;; auto-gensym suffix differs by a trailing "__".
+  {:category :reader-model
+   :behavior "an auto-gensym x# expands to a symbol named"
+   :jvm "x__N__auto__"
+   :jolt "x__N__auto"
+   :note "Cosmetic; each x# in a syntax-quote is still consistently renamed. Only string comparison of gensym names would see it."}
   ;; #?(...) reader conditionals are read by default (JVM requires {:read-cond :allow}).
   {:category :reader-model
    :behavior "read-string of a #?(...) reader conditional"


### PR DESCRIPTION
Epic jolt-ox7c.32. Runtime only (reader.ss), selfcheck holds, no remint. make ci green, 0 new divergences.

- A keyword token that **starts** with a colon (`:::foo`) is now an invalid token like the JVM. (A colon mid-name — `:foo:bar` — stays valid; the first attempt over-rejected that and broke clojure.edn-test, caught by cts.)
- A bad `\u` escape (`\uABCG`, `"\u041"`) raises a proper reader `ExceptionInfo` with a real message instead of leaking a raw Chez condition (class `:object`, nil message).

Documented, not fixed (deliberate): empty `read-string` => nil, `#?()` read by default, backquoted class name qualifies to clojure.core (already in known-divergences from R9), and the auto-gensym suffix (`__auto` vs `__auto__`, cosmetic — new entry). Also removed the now-stale "ns-resolve/ns-unmap permissive" divergence entry, since jolt-ox7c.33 made them throw.

Closes jolt-ox7c.32.