### PR TITLE
.49: strict mint — fail remint on silently-dropped overlay forms

### DIFF
--- a/host/chez/bootstrap.ss
+++ b/host/chez/bootstrap.ss
@@ -33,9 +33,14 @@
 (load "host/chez/compile-eval.ss")
 (load "host/chez/emit-image.ss")
 
-;; Rebuild both artifacts from source ON CHEZ and write them out.
+;; Rebuild both artifacts from source ON CHEZ and write them out. Any overlay/
+;; compiler form that fails to compile is skipped (guarded) so a partial build
+;; still boots; ei-skipped-count records how many, and the summary line lets
+;; remint.sh fail the fixpoint pass on a nonzero count.
+(ei-reset-skipped!)
 (let ((p (open-output-file bs-out-prelude 'replace)))
   (put-string p (jolt-emit-prelude)) (close-port p))
 (let ((p (open-output-file bs-out-image 'replace)))
   (put-string p (jolt-emit-image)) (close-port p))
+(fprintf (current-error-port) "mint: ~a form(s) skipped\n" ei-skipped-count)
 (display "bootstrap: rebuilt prelude + compiler image on Chez\n")

--- a/host/chez/emit-image.ss
+++ b/host/chez/emit-image.ss
@@ -127,6 +127,14 @@
              (proc ns-name 'form #f f)
              (loop (cdr forms)))))))))
 
+;; Count of forms silently dropped during a guarded emit (a source form that
+;; fails to compile is skipped so a partial overlay still boots). remint.sh reads
+;; this after the fixpoint pass and fails on a nonzero count — a regression that
+;; makes an overlay defn uncompilable would otherwise just delete the var while
+;; the byte-fixpoint still converges. Reset at the start of each full emit.
+(define ei-skipped-count 0)
+(define (ei-reset-skipped!) (set! ei-skipped-count 0))
+
 (define (ei-emit-ns* ns-name src optimize? guard?)
   (let ((acc '()))
     (ei-for-each-form ns-name src
@@ -134,12 +142,17 @@
         (let ((scm (if guard?
                        (guard (e (#t #f)) (ei-compile-form (make-analyze-ctx ns) f optimize?))
                        (ei-compile-form (make-analyze-ctx ns) f optimize?))))
-          (unless (and guard? (not scm))
-            (set! acc
-                  (cons (if (eq? kind 'macro)
-                            (ei-macro-string ns nm scm guard?)
-                            (if guard? (string-append "(guard (e (#t #f))\n  " scm ")") scm))
-                        acc))))))
+          (if (and guard? (not scm))
+              ;; a form the guard swallowed — report it so the drop isn't silent
+              (begin
+                (set! ei-skipped-count (+ ei-skipped-count 1))
+                (fprintf (current-error-port) "mint: skipped ~a/~a (failed to compile)\n"
+                         ns (or nm "<top-level-form>")))
+              (set! acc
+                    (cons (if (eq? kind 'macro)
+                              (ei-macro-string ns nm scm guard?)
+                              (if guard? (string-append "(guard (e (#t #f))\n  " scm ")") scm))
+                          acc))))))
     (reverse acc)))
 
 (define (ei-emit-ns ns-name src) (ei-emit-ns* ns-name src #f #t))

--- a/host/chez/remint.sh
+++ b/host/chez/remint.sh
@@ -15,10 +15,19 @@ cp host/chez/seed/image.ss   "$tmp/cur-i.ss"
 i=0
 while [ "$i" -lt 8 ]; do
   i=$((i + 1))
+  # capture stderr so the fixpoint pass can be checked for skipped forms; the
+  # skip count is only trustworthy once converged (an earlier pass compiling off
+  # an older seed may skip a form that a later pass, off the rebuilt seed, emits).
   "$CHEZ" --script host/chez/bootstrap.ss \
-    "$tmp/cur-p.ss" "$tmp/cur-i.ss" "$tmp/new-p.ss" "$tmp/new-i.ss" >/dev/null
+    "$tmp/cur-p.ss" "$tmp/cur-i.ss" "$tmp/new-p.ss" "$tmp/new-i.ss" >/dev/null 2>"$tmp/err"
   if diff -q "$tmp/cur-p.ss" "$tmp/new-p.ss" >/dev/null \
      && diff -q "$tmp/cur-i.ss" "$tmp/new-i.ss" >/dev/null; then
+    skipped=$(sed -n 's/^mint: \([0-9][0-9]*\) form(s) skipped$/\1/p' "$tmp/err" | tail -1)
+    if [ -n "$skipped" ] && [ "$skipped" -ne 0 ]; then
+      echo "re-mint: $skipped form(s) failed to compile in the fixpoint pass:" >&2
+      grep '^mint: skipped ' "$tmp/err" >&2
+      exit 1
+    fi
     cp "$tmp/new-p.ss" host/chez/seed/prelude.ss
     cp "$tmp/new-i.ss" host/chez/seed/image.ss
     echo "re-minted seed (converged after $i pass(es))"


### PR DESCRIPTION
Epic jolt-ox7c.49. Build tooling only — emitted seed byte-identical, no runtime effect. make ci green.

The minter guards each emitted form so a partial overlay still boots; emit-image.ss swallowed any form that failed to compile, so a regression making an overlay defn uncompilable would silently delete the var while the byte-fixpoint still converged and selfhost stayed green.

ei-emit-ns* now counts + reports skipped forms to stderr, bootstrap.ss prints the total, and remint.sh fails when the **converged** pass has a nonzero skip count. Verified: a broken `(if)` form makes remint exit 1 with the skip list; a clean tree reports 0 and converges.

Closes jolt-ox7c.49.