### PR TITLE
R8: java-layer dedup + stale overlay comments (.54, .56)

### DIFF
--- a/host/chez/emit-image.ss
+++ b/host/chez/emit-image.ss
@@ -209,6 +209,9 @@
 ;; The clojure.core tiers + stdlib namespaces, in load order.
 ;; Re-emitting these on Chez is the
 ;; prelude half of the fixpoint (the whole emitted system reproducing itself).
+;; This list IS the load order — the numeric filename prefixes are only a hint and
+;; don't disambiguate a tie: 00-syntax loads BEFORE 00-kernel (it provides the
+;; when/and/or/cond macros the kernel-adjacent tiers lean on).
 (define ei-prelude-ns-files
   (append
     (map (lambda (tf) (cons "clojure.core" (string-append "jolt-core/clojure/core/" tf ".clj")))

--- a/host/chez/java/dot-forms.ss
+++ b/host/chez/java/dot-forms.ss
@@ -90,7 +90,7 @@
     ((string=? name "equals")    (list (if (jolt= obj (car args)) #t #f)))
     (else #f)))
 
-(register-method-arm! 30
+(register-method-arm! arm-priority-dotform
   (lambda (obj method-name rest-args)
     (let* ((rest (if (jolt-nil? rest-args) '() (seq->list rest-args)))
            (field? (and (> (string-length method-name) 0)

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -834,7 +834,7 @@
 ;; record-method-dispatch already routes string? -> jolt-string-method. Add a
 ;; regex-t arm (Pattern .split / .matcher-less surface used by corpus) by wrapping
 ;; once more — a regex-t isn't a jhost.
-(register-method-arm! 42
+(register-method-arm! arm-priority-regex
   (lambda (obj method-name rest-args)
     (let ((rest (if (jolt-nil? rest-args) '() (seq->list rest-args))))
       (cond
@@ -909,7 +909,7 @@
 
 ;; htable arm: dispatch (.method obj a*) through the table's tag method registry;
 ;; an unregistered method falls through (sorted colls are htables too).
-(register-method-arm! 43
+(register-method-arm! arm-priority-htable
   (lambda (obj method-name rest-args)
     (let ((tag (and (htable? obj) (hashtable-ref (htable-h obj) "jolt/type" #f))))
       (let* ((mh (and tag (hashtable-ref tagged-methods-tbl (tag->method-key tag) #f)))
@@ -1373,19 +1373,12 @@
               'pass))
         'pass)))
 ;; count over the mutable collection shims, like RT.count over a java.util
-;; Collection/Map on the JVM.
-(define %shim-count jolt-count)
-(set! jolt-count
-  (lambda (x)
-    (if (jhost? x)
-        (let ((tag (jhost-tag x)))
-          (cond ((or (string=? tag "arraylist") (string=? tag "linkedlist")
-                     (string=? tag "arraydeque"))
-                 (al-cnt x))
-                ((or (string=? tag "hashmap") (string=? tag "hashset"))
-                 (hashtable-size (hm-tbl x)))
-                (else (%shim-count x))))
-        (%shim-count x))))
+;; Collection/Map on the JVM. Each shim registers a count arm (the hashmap arm
+;; is registered with its get/contains arms above); jolt-count walks the arms
+;; newest-first for jhost values, so these replace an earlier set!-wrap of
+;; jolt-count that duplicated the hashmap arm.
+(register-count-arm! al-family? (lambda (c) (al-cnt c)))
+(register-count-arm! hs-hashset? (lambda (c) (hashtable-size (hm-tbl c))))
 ;; IEditableCollection / ITransient* answer from the representation: the
 ;; transient-able persistent collections are editable; a transient reports its
 ;; kind's interfaces. Widening only — anything else passes to the other arms.
@@ -1462,6 +1455,13 @@
                       (and (procedure? x) (hashtable-ref chez-deftype-ctor-tag x #f) #t))
                   #t #f)))
 ;; nth over the java.util List shims, like RT.nth on a java.util.List.
+;; This stays a set!-wrap of jolt-nth rather than a registered arm: unlike
+;; jolt-count (which has a register-count-arm! registry), jolt-nth is an inline
+;; case-lambda with no nth-arm registry, so there is no arm mechanism to move
+;; this into. Converting an al-family List to a cseq here and delegating to the
+;; base jolt-nth is the only way nth reaches these shims. See the note by
+;; register-count-arm! in collections.ss — jolt-nth's migration to an arm
+;; registry is deferred until it gets its own bench guard.
 (define %shim-nth jolt-nth)
 (set! jolt-nth
   (case-lambda

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -123,7 +123,7 @@
        (list->cseq (if asc keep (reverse keep)))))
     (else (throw-jvm (quote IllegalArgumentException) (string-append "No matching method " method " on sorted collection")))))
 
-(register-method-arm! 44
+(register-method-arm! arm-priority-host-type
   (lambda (obj method-name rest-args)
     (cond
       ((jhost? obj)

--- a/host/chez/java/inst-time.ss
+++ b/host/chez/java/inst-time.ss
@@ -614,7 +614,7 @@
         (cons "format" (lambda (self d) (format-ms (vector-ref (jhost-state self) 0) (ms-of d))))))
 
 ;; a jinst's java.util.Date method surface (record-method-dispatch arm).
-(register-method-arm! 40
+(register-method-arm! arm-priority-date
   (lambda (obj method-name rest-args)
     (cond
       ((jinst? obj)

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -279,7 +279,7 @@
                (else (loop (- i 1))))))
       (else #f))))
 
-(register-method-arm! 41
+(register-method-arm! arm-priority-file
   (lambda (obj method-name rest-args)
     (if (jfile? obj)
         (let* ((rest (if (jolt-nil? rest-args) '() (seq->list rest-args)))

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -233,8 +233,8 @@
   (register-class-statics! "FileSystems" fs-statics)
   (register-class-statics! "java.nio.file.FileSystems" fs-statics))
 
-;; nio-path method dispatch (priority above the jfile arm's 41).
-(register-method-arm! 42
+;; nio-path method dispatch (priority above the jfile arm).
+(register-method-arm! arm-priority-nio-path
   (lambda (obj method-name rest-args)
     (if (nio-path? obj)
         (let* ((rest (if (jolt-nil? rest-args) '() (seq->list rest-args)))

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -1399,6 +1399,19 @@
       (cond ((null? as) (list (cons priority arm)))
             ((< priority (caar as)) (cons (cons priority arm) as))
             (else (cons (car as) (ins (cdr as))))))))
+;; Named priorities for register-method-arm!, in ascending dispatch order
+;; (lowest is tried first — see record-method-dispatch). Each name mirrors its
+;; arm's role; two disjoint-type arms may share a tier (regex-t and nio-path
+;; both sit just above jfile at 42). Values are unchanged from the prior magic
+;; numbers — this is a readability rename only.
+(define arm-priority-getclass 5)      ; .getClass — universal Object method, first
+(define arm-priority-dotform 30)      ; -field accessor + dot-form method dispatch
+(define arm-priority-date 40)         ; java.util.Date (jinst) method surface
+(define arm-priority-file 41)         ; java.io.File (jfile) methods
+(define arm-priority-regex 42)        ; regex-t (Pattern) .split/.matcher surface
+(define arm-priority-nio-path 42)     ; java.nio.file.Path methods (above jfile)
+(define arm-priority-htable 43)       ; tagged htable method registry
+(define arm-priority-host-type 44)    ; jhost/number/string per-type dispatch
 (define (record-method-dispatch obj method-name rest-args)
   (let loop ((as method-dispatch-arms))
     (if (null? as)
@@ -1410,7 +1423,7 @@
 ;; per-type arm — the class token for the value (jolt has no Class objects; the
 ;; token is the canonical name string, on which .getName/.getSimpleName work).
 ;; One arm, so a type arm that only whitelists its own methods can't steal it.
-(register-method-arm! 5
+(register-method-arm! arm-priority-getclass
   (lambda (obj method-name rest-args)
     (if (string=? method-name "getClass") (jolt-class obj) 'pass)))
 

--- a/jolt-core/clojure/core/21-coll.clj
+++ b/jolt-core/clojure/core/21-coll.clj
@@ -1,6 +1,7 @@
-;; clojure.core — collection tier, part 2 (rand/sort host seams, the
-;; clojure.test runner, fn combinators). Continues 20-coll.clj; same constraints
-;; (pure, eager, no macros), loaded in the 20 slot before 25-sorted.
+;; clojure.core — collection tier, part 2 (rand/shuffle/sort host seams, uuid,
+;; seq builders tree-seq/file-seq/xml-seq, fn combinators comparator/reductions).
+;; Continues 20-coll.clj; same constraints (pure, eager, no macros), loaded in the
+;; 20 slot before 25-sorted. (clojure.test lives in stdlib/clojure/test.clj.)
 
 ;; --- leaves over the rand / sort host seams ----------------------------------
 

--- a/jolt-core/clojure/core/22-coll.clj
+++ b/jolt-core/clojure/core/22-coll.clj
@@ -1,13 +1,10 @@
-;; clojure.core — collection tier, part 3 (canonical Clojure ports: key/val/find,
-;; merge-with, memoize, group-by, frequencies, transduce/into/eduction, and the
-;; JVM-shape stubs). Continues 21-coll.clj; same constraints.
+;; clojure.core — collection tier, part 3 (canonical Clojure ports: find,
+;; merge-with, memoize, get-in/assoc-in/update-in, comp, transduce/into/eduction,
+;; and the JVM-shape stubs). Continues 21-coll.clj; same constraints.
+;; (key/val/group-by/frequencies live in 20-coll.clj.)
 
 ;; --- canonical Clojure ports -------------------------------------------------
-;; key/val/find first — merge-with and memoize below use them.
-
-;; Strict, as in Clojure: an entry is what (seq m) yields (a host tuple), NOT
-;; a plain vector — (key [1 2]) throws.
-;; key/val moved above the hierarchies section (underive uses them).
+;; find first — merge-with and memoize below use it.
 
 ;; find was previously missing from jolt entirely. Presence (contains?), not
 ;; value, decides — so (find {:a nil} :a) is [:a nil]. Works on vectors by
@@ -315,8 +312,6 @@
 ;; into stays a host primitive: it's perf-wall hot (the into-vec bench pays ~11%
 ;; through the overlay call layers — same lesson as even?/odd?).
 
-;; eduction is EAGER on jolt (documented divergence): the composed
-;; xforms applied to coll, realized into a vector.
 ;; A lazy application of the composed xforms to coll (sequence is lazy now), so an
 ;; infinite or expensive source isn't realized up front. Not a re-iterable Eduction
 ;; object, but reduce / into / seq / first over it all work.

--- a/jolt-core/clojure/core/30-macros.clj
+++ b/jolt-core/clojure/core/30-macros.clj
@@ -3,9 +3,9 @@
 ;; fn/macro.
 ;;
 ;; IMPORTANT — only macros NOT used by the self-hosted compiler (jolt-core/jolt/*)
-;; or by the earlier overlay tiers belong here; those (and/or/when/when-not/
-;; when-let/cond/case/doseq/declare/cond->/->) must stay available before this
-;; tier loads, so they remain host primitives for now. Everything here is user-facing.
+;; or by the earlier overlay tiers belong here. Those needed earlier
+;; (and/or/when/when-not/when-let/cond/case/doseq/declare/cond->/->) are defmacros
+;; in 00-syntax.clj, which loads first. Everything here is user-facing.
 ;;
 ;; Migration: remove the host core-X macro fn AND its core-macro-names entry when
 ;; moving a macro here (defmacro installs the :macro flag itself).
@@ -283,10 +283,9 @@
 
 ;; Build the fn* form via a template (a reader-list array): cons/list in a macro
 ;; body produce a plist the evaluator can't call as a form.
-;; letfn is a primitive special form (analyze-letfn -> letrec*), not a macro: its
-;; fns are mutually recursive, which a (let* …) expansion cannot express. Defining
-;; it as a macro would shadow the special once macroexpansion runs first (the
-;; canonical order), so it is intentionally NOT a macro here.
+;; letfn itself is a macro in 00-syntax.clj expanding to the letfn* special form
+;; (mutual recursion, which a plain (let* …) can't express); it lives there
+;; because earlier tiers use it.
 
 ;; Dynamic binding: install a thread-binding frame of var->value (array-map keeps
 ;; var-get happy, unlike a phm), restore on exit.

--- a/jolt-core/clojure/core/40-lazy.clj
+++ b/jolt-core/clojure/core/40-lazy.clj
@@ -184,8 +184,9 @@
 ;; --- pmap family: parallel map over real-thread futures ----------------------
 ;; Each element's work runs on its own OS thread with SNAPSHOT semantics
 ;; (futures marshal captured state — pure fns only, mutations don't propagate
-;; back). Semi-lazy: spawns (+ 2 procs) futures ahead of consumption so the
-;; realization window is bounded, like Clojure's pmap. Does not force the
+;; back). Semi-lazy: spawns a fixed look-ahead of 4 futures ahead of consumption
+;; so the realization window is bounded (Clojure sizes it 2 + availableProcessors;
+;; jolt has no processor-count seam, so a fixed window). Does not force the
 ;; entire input collection — (first (take 2 (pmap inc (range)))) terminates.
 ;; All futures are spawned up front (doall), then derefed in order:
 ;; coarse-grained work only, as with Clojure's pmap.


### PR DESCRIPTION
Two low-risk R8 cleanups, batched (neither needs a remint — .54 is runtime-only,
.56 is comment-only so the seed rebuilds byte-identical).

## .54 — java-layer dedup (count arms, named priorities)
- `count` over the mutable-collection shims (ArrayList/LinkedList/ArrayDeque,
  HashSet) was a hand `set!`-wrap of `jolt-count` that re-implemented the arm
  registry and double-covered the hashmap case. Replaced with
  `register-count-arm!` entries beside the existing hashmap arm (disjoint tag
  sets, no double-count). `jolt-nth` stays a `set!`-wrap (no nth-arm registry;
  noted in a comment).
- Method-arm priorities (5/30/40-44, 42 shared by regex + nio-path) are now named
  constants — values unchanged, readability only.
- records.ss's internal last-segment duplicate now uses the one `last-dot`.
  `short-class-name` / `hsc-last-segment` stay separate — they handle a nested-
  class `$` differently from the `.`-only helpers, so folding them would change
  behavior.

(Deferred from .54: the full 5-way last-segment dedup — the `$`-handling
difference the bead itself flagged makes it a behavior risk, not a clean dedup.)

## .56 — stale overlay/stdlib comments
Fixed comments that had drifted from the code: the 22-coll header (key/val/
group-by/frequencies live in 20-coll now) + a stale "eduction is EAGER" line above
a lazy impl; the 21-coll header's phantom clojure.test runner (it's in
stdlib/clojure/test.clj); 30-macros claiming and/or/when "remain host primitives"
(they're defmacros in 00-syntax) and its letfn "intentionally NOT a macro" note
(letfn IS a macro in 00-syntax); the pmap `(+ 2 procs)` doc (it's a fixed 4 — no
processor-count seam); and a note on the emit-image prelude load list that it IS
the load order.

(Deferred from .56: making the non-JVM helper publics private — the destructuring
and with-in-str macros expand to unqualified references to them, so privacy could
break user-namespace resolution; needs the expansions qualified first.)

Gate: `make test` green — selfcheck holds (no seed change), cts matches baseline,
all CI gates passed. Smokes confirm count over ArrayList/HashSet/hashmap,
.getSimpleName, .split.

Closes jolt-ox7c.54, jolt-ox7c.56.