### PR TITLE
R6: unify the syntax-quote symbol resolver (jolt-iklz)

### DIFF
--- a/host/chez/host-contract.ss
+++ b/host/chez/host-contract.ss
@@ -345,12 +345,8 @@
 ;; __sqset/__sq1 + quote — that the analyzer re-analyzes, so a backtick compiles
 ;; with zero runtime cost (read -> macroexpand -> compile). Symbols resolve to
 ;; clojure.core / the compile ns; a foo# auto-gensym is stable within one `.
-(define hc-special-symbols
-  '("quote" "syntax-quote" "unquote" "unquote-splicing" "do" "if" "def"
-    "fn*" "let*" "loop*" "recur" "throw" "try" "set!" "var" "new" "."
-    "&" "catch" "finally" "case*" "letfn*" "monitor-enter" "monitor-exit"
-    "reify*" "deftype*"))
-(define (hc-special-symbol? nm) (and (member nm hc-special-symbols) #t))
+;; the syntax-quote specials + resolver live in reader.ss (jsq-specials /
+;; jsq-resolve-symbol), shared with the read-string data path.
 
 (define hc-sq-gensym-counter 0)
 (define (hc-sq-gensym base)
@@ -374,48 +370,11 @@
                 (or (jolt-nil? ns) (and (string? ns) (string=? ns "clojure.core"))))))))
 (define (hc-second x) (seq-first (jolt-seq (seq-more x))))
 
+;; compile path: resolve against the compile ns, via the shared resolver
+;; (reader.ss jsq-resolve-symbol). Same resolution the data path uses, so a
+;; compiled ` and a read-string ` agree on every name.
 (define (hc-sq-symbol ctx form gsmap)
-  (let ((sns (hc-sym-ns form)) (nm (symbol-t-name form)))
-    (if (jolt-nil? sns)
-        (cond
-          ;; foo# -> a stable per-` auto-gensym
-          ((and (> (string-length nm) 0)
-                (char=? (string-ref nm (- (string-length nm) 1)) #\#))
-           (or (hashtable-ref gsmap nm #f)
-               (let ((g (hc-sq-gensym (substring nm 0 (- (string-length nm) 1)))))
-                 (hashtable-set! gsmap nm g) g)))
-          ((hc-special-symbol? nm) form)               ; special form: leave bare
-          ((hc-interop-head? nm) form)                 ; interop (.method / Class. / .-field): bare
-          ;; a fully-qualified class name (java.util.Map, clojure.lang.ILookup) is
-          ;; a class token, not a var to namespace-qualify — leave it bare, as
-          ;; Clojure's syntax-quote resolves it to the class.
-          ((hc-fq-class-name? nm) form)
-          ;; the compile ns's OWN def shadows clojure.core — a name the ns
-          ;; excluded and redefined (e.g. core.logic's `==` after
-          ;; (:refer-clojure :exclude [==])), or any ns-local redefinition.
-          ;; Referred names live in a separate table, so this only hits a real
-          ;; local intern, matching how the analyzer resolves the bare symbol.
-          ((var-cell-lookup (chez-actx-cns ctx) nm) (jolt-symbol (chez-actx-cns ctx) nm))
-          ;; a name the compile ns excluded from clojure.core (:refer-clojure
-          ;; :exclude) is not clojure.core/nm even before the ns defines its own —
-          ;; qualify to the compile ns, like Clojure (core.logic.fd's `==`).
-          ((chez-core-excluded? (chez-actx-cns ctx) nm) (jolt-symbol (chez-actx-cns ctx) nm))
-          ((var-cell-lookup "clojure.core" nm) (jolt-symbol "clojure.core" nm))
-          ;; a name referred into the compile ns (:require :refer / :use :only)
-          ;; qualifies to its SOURCE ns, not the compile ns — so a macro that
-          ;; syntax-quotes a referred var (e.g. clojure.tools.logging/spy using
-          ;; clojure.pprint's pprint) expands to the real var.
-          ((chez-resolve-refer (chez-actx-cns ctx) nm)
-           => (lambda (target) (jolt-symbol target nm)))
-          (else (jolt-symbol (chez-actx-cns ctx) nm)))  ; else: qualify to compile ns
-        ;; qualified: if the ns part is an :as alias in the compile ns, resolve it
-        ;; to the target namespace — Clojure resolves the alias part of a qualified
-        ;; symbol in syntax-quote, so a macro's `impl/foo` expands to its real
-        ;; (clojure.tools.logging.impl/foo) name and stays unambiguous even when
-        ;; another loaded ns shares the alias's short name. Otherwise
-        ;; leave it as written (a real ns or an interop class token).
-        (let ((target (chez-resolve-alias (chez-actx-cns ctx) sns)))
-          (if target (jolt-symbol target nm) form)))))
+  (jsq-resolve-symbol (chez-actx-cns ctx) form gsmap hc-sq-gensym))
 
 (define (hc-sq-lower ctx form gsmap)
   (cond

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -1028,11 +1028,48 @@
   (jolt-symbol #f (string-append base "__" (number->string rdr-sq-gensym-counter) "__auto")))
 
 ;; special forms / interop heads stay bare in backquote, like the JVM reader
-(define rdr-sq-specials
+;; The one list of names a syntax-quote leaves BARE (not namespace-qualified):
+;; the special-form heads plus the reader-macro markers. Shared by the data path
+;; (rdr-sq-symbol) and the compile path (host-contract.ss hc-sq-symbol), so a
+;; special added here is honored by both `read-string and a compiled `.
+(define jsq-specials
   '("quote" "syntax-quote" "unquote" "unquote-splicing" "do" "if" "def"
     "fn*" "let*" "loop*" "recur" "throw" "try" "set!" "var" "new" "."
     "&" "catch" "finally" "case*" "letfn*" "monitor-enter" "monitor-exit"
     "reify*" "deftype*"))
+
+;; The one syntax-quote symbol resolver, shared by both paths. `cns` is the
+;; namespace to resolve against (the compile ns / the current ns); `gensym-fn`
+;; makes a fresh auto-gensym for a trailing-# symbol (each path keeps its own
+;; counter, so a compiled ` and a read-string ` don't share gensym numbers).
+;; Resolution order (Clojure): a foo# auto-gensym; a bare special/interop/class
+;; token; the ns's own interned var; a :refer'd name (SOURCE ns) — BEFORE the
+;; implicit clojure.core, so an explicit :refer shadows core; then clojure.core
+;; unless the name is :refer-clojure-excluded or ns-unmapped; else qualify to cns.
+(define (jsq-resolve-symbol cns sym gsmap gensym-fn)
+  (let ((sns (symbol-t-ns sym)) (nm (symbol-t-name sym)))
+    (if (or (jolt-nil? sns) (null? sns) (not sns))
+        (cond
+          ((and (fx>? (string-length nm) 0)
+                (char=? (string-ref nm (fx- (string-length nm) 1)) #\#))
+           (or (hashtable-ref gsmap nm #f)
+               (let ((g (gensym-fn (substring nm 0 (fx- (string-length nm) 1)))))
+                 (hashtable-set! gsmap nm g) g)))
+          ((member nm jsq-specials) sym)
+          ((hc-interop-head? nm) sym)         ; interop (.method / Class. / .-field)
+          ((hc-fq-class-name? nm) sym)        ; a fully-qualified class token
+          ((var-cell-lookup cns nm) (jolt-symbol cns nm))          ; the ns's own var
+          ((chez-resolve-refer cns nm)                             ; a :refer'd name
+           => (lambda (target) (jolt-symbol target nm)))
+          ((and (not (chez-core-excluded? cns nm))                 ; else clojure.core,
+                (not (eq? (hashtable-ref ns-refer-table (cons cns nm) #f) 'unmapped))
+                (var-cell-lookup "clojure.core" nm))               ; unless excluded/unmapped
+           (jolt-symbol "clojure.core" nm))
+          (else (jolt-symbol cns nm)))                             ; else the ns itself
+        ;; qualified: resolve an :as alias in cns to the target ns, else leave as
+        ;; written (a real ns or an interop class token).
+        (let ((target (chez-resolve-alias cns sns)))
+          (if target (jolt-symbol target nm) sym)))))
 
 (define (rdr-sq-head-is? x nm)
   (and (cseq? x)
@@ -1045,36 +1082,9 @@
 (define (rdr-sq-literal? x)
   (or (jolt-nil? x) (boolean? x) (number? x) (string? x) (keyword? x) (char? x)))
 
-;; Resolve a bare or qualified symbol against the current ns, like Clojure's
-;; syntax-quote reader. A trailing # triggers auto-gensym (stable within one `).
+;; data path: resolve against the current ns, via the shared resolver.
 (define (rdr-sq-symbol sym gsmap)
-  (let ((sns (symbol-t-ns sym)) (nm (symbol-t-name sym)))
-    (if (or (jolt-nil? sns) (null? sns) (not sns))
-        (cond
-          ((and (fx>? (string-length nm) 0)
-                (char=? (string-ref nm (fx- (string-length nm) 1)) #\#))
-           (or (hashtable-ref gsmap nm #f)
-               (let ((g (rdr-sq-gensym (substring nm 0 (fx- (string-length nm) 1)))))
-                 (hashtable-set! gsmap nm g) g)))
-           ((member nm rdr-sq-specials) sym)
-           ((hc-interop-head? nm) sym)   ; interop (.method / Class. / .-field): bare
-           ;; a fully-qualified class name (java.util.Map) is a class token, not a
-           ;; var to namespace-qualify — leave it bare like the compile path.
-           ((hc-fq-class-name? nm) sym)
-           (else
-            ;; JVM syntax-quote resolution: the ns's own interned var wins, then
-            ;; refers/aliased refers, then the implicit clojure.core default,
-            ;; else qualify to the current ns.
-            (let* ((cns (chez-current-ns))
-                   (own (let ((c (var-cell-lookup cns nm))) (and c (var-cell-defined? c))))
-                   (resolved (and (not own) (chez-resolve-refer cns nm)))
-                   (core (and (not own) (not resolved)
-                              (not (eq? (hashtable-ref ns-refer-table (cons cns nm) #f) 'unmapped))
-                              (let ((c (var-cell-lookup "clojure.core" nm)))
-                                (and c (var-cell-defined? c))))))
-              (jolt-symbol (cond (own cns) (resolved resolved) (core "clojure.core") (else cns)) nm))))
-        (let ((target (chez-resolve-alias (chez-current-ns) sns)))
-          (if target (jolt-symbol target nm) sym)))))
+  (jsq-resolve-symbol (chez-current-ns) sym gsmap rdr-sq-gensym))
 
 (define (rdr-sq-lower form gsmap)
   (cond

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -334,6 +334,11 @@
   {:suite "reader" :expr "(= (quote (quote x)) (read-string \"'x\"))" :expected "true"}
   {:suite "reader" :expr "(= (quote (clojure.core/deref a)) (read-string \"@a\"))" :expected "true"}
    {:suite "reader" :expr "(= (quote (clojure.core/seq (clojure.core/concat (clojure.core/list (quote user/a)) (clojure.core/list b)))) (read-string \"`(a ~b)\"))" :expected "true"}
+   ;; shared syntax-quote resolver (jsq-resolve-symbol): a special stays bare, a
+   ;; core name qualifies to clojure.core, an unknown to the current ns.
+   {:suite "reader" :expr "(= (quote (quote if)) (read-string \"`if\"))" :expected "true"}
+   {:suite "reader" :expr "(= (quote (quote clojure.core/inc)) (read-string \"`inc\"))" :expected "true"}
+   {:suite "reader" :expr "(= (quote (quote user/undefined-xyz)) (read-string \"`undefined-xyz\"))" :expected "true"}
   {:suite "reader" :expr "(= (quote (clojure.core/unquote-splicing xs)) (read-string \"~@xs\"))" :expected "true"}
   {:suite "reader" :expr "(= 42 (read-string \"; comment\\n42\"))" :expected "true"}
   {:suite "reader" :expr "(= [1 2] (read-string \"[1 #_ 9 2]\"))" :expected "true"}


### PR DESCRIPTION
The compile path (`host-contract.ss` `hc-sq-symbol`) and the read-string data
path (`reader.ss` `rdr-sq-symbol`) each carried their own copy of the
syntax-quote specials list and their own symbol resolver, and the two had drifted
— the compile path checked clojure.core *before* a `:refer`'d name, the data path
checked the refer first. So a syntax-quote fix (like the R6 `.23` work) had to be
made twice, and the two paths could resolve the same symbol differently.

Collapse them to one shared `jsq-resolve-symbol` (in reader.ss, which loads
first), parameterized by the namespace to resolve against and the per-path
auto-gensym fn. `hc-sq-symbol` and `rdr-sq-symbol` are now thin wrappers; the
specials list is one `jsq-specials`.

- Resolution order is **refer-before-core** in both paths, matching Clojure (an
  explicit `:refer` shadows clojure.core).
- The core fallback is guarded by `:refer-clojure :exclude` and ns-unmap in both
  paths — the data path previously ignored an `:exclude`.
- The two lowerings (`hc-sq-lower`'s `__sqcat` IR vs `rdr-sq-lower`'s
  `seq`/`concat`) stay separate — a deliberate perf split, per the bead.

Seed byte-identical: the clojure.core overlay syntax-quotes no name that is both
a core var and `:refer`'d (or excluded), so the reorder is a no-op there — this
is a runtime `.ss` change with no remint.

Gate: `make test` green — selfcheck holds, **cts matches baseline** (core.logic
and the other macro-heavy conformance namespaces unaffected), sci/unit/shakesmoke
pass. 3 reader unit rows pin the shared resolver (special stays bare, core name
qualifies, unknown qualifies to the ns).

Closes jolt-iklz.