### PR TITLE
fix(build): read the require scan in scan mode — accept ::alias/kw keywords

### DIFF
--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -612,7 +612,11 @@
                              (set! reqs (cons (car parsed) reqs)))))
                        (expand-spec unquoted))))
                   (cdr items)))))))
-      (map rdr-form->data (ei-read-all src)))
+      ;; scan mode: this read happens BEFORE any namespace is loaded, so
+      ;; alias-resolved auto keywords (::alias/kw) can't resolve yet — read
+      ;; them leniently; only require clauses are extracted from these forms.
+      (parameterize ((rdr-scan-mode #t))
+        (map rdr-form->data (ei-read-all src))))
     (reverse reqs)))
 
 ;; Post-order DFS from a list of root namespace names: for each name, find its

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -65,6 +65,12 @@
 ;; its tagged elements through :readers/:default like the JVM.
 (define rdr-edn-mode (make-parameter #f))
 (define rdr-discard-cb (make-parameter #f))
+;; Scan mode: reading source BEFORE any namespace is loaded (the build's
+;; require scanner). An auto keyword whose alias isn't registered yet can't
+;; resolve — in scan mode keep the alias text as the keyword's ns instead of
+;; erroring; the scanner only extracts require clauses and discards every
+;; other form, so the placeholder value is never observed.
+(define rdr-scan-mode (make-parameter #f))
 
 (define (rdr-skip-ws s i end)
   (let loop ((i i))
@@ -795,7 +801,9 @@
               (let* ((cur (chez-current-ns))
                      (rns (if (string? ns)
                               (let ((a (chez-resolve-alias cur ns)))
-                                (if a a (rdr-invalid-token (string-append "::" tok))))
+                                (cond (a a)
+                                      ((rdr-scan-mode) ns)
+                                      (else (rdr-invalid-token (string-append "::" tok)))))
                               cur)))
                 (values (keyword rns name) j))
               (values (keyword ns name) j)))))))


### PR DESCRIPTION
Fixes the `Invalid token: ::alias/kw` failure in `joltc build`'s require scanner (companion issue has the minimal repro and analysis).

Adds a reader parameter `rdr-scan-mode` (default `#f`): in scan mode an unresolvable `::alias/name` keeps the alias text as the keyword ns instead of erroring; `bld-ns-requires` parameterizes it around its read. The placeholder value is never observed — the scanner only extracts require clauses and discards every other form — and compiled output is correct because the emit-path reads happen after loading (aliases registered, `set-chez-ns!` in effect).

Verified:
- The repro project builds, and its binary prints the correctly-resolved keyword (`{:clojure.string/trim-mode :both}`) — the placeholder never leaks into compiled output.
- A genuinely invalid `::nosuch/kw` still errors under `run`/load (scan mode is scanner-scoped).
- `make unit` green; `make corpus` green (only the 9 pre-existing allowlisted failures).

Fixes #416.
