### PR TITLE
tools: cross-compilation POC — three host→target directions verified (#375)

### DIFF
--- a/.github/workflows/cross-smoke.yml
+++ b/.github/workflows/cross-smoke.yml
@@ -1,0 +1,87 @@
+# cross-smoke — pin the invariant the cross-compilation design rests on:
+# `jolt build`'s flat.ss is machine-neutral, and step 4 (compile-file ->
+# make-boot-file -> cc link) retargets cleanly under Chez's xpatch.
+#
+# Runs the tools/cross-compile POC end to end on one runner:
+#   ta6le (x86_64 Linux) host  ->  tarm64le (aarch64 Linux) target,
+# verified under qemu with a byte-identical-output diff against the native
+# build. A change that bakes host state into the Scheme emission (an absolute
+# path, a compile-time machine-type constant) fails this job.
+#
+# Manual-dispatch only: it is a guard for cross-compile work, not a per-push
+# gate. ~25 min cold, ~8 min with a warm Chez cache. (jolt-lang/jolt#375)
+name: cross-smoke
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  cross-smoke:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive   # vendor/irregex etc. — bin/joltc refuses to run without them
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential git liblz4-dev zlib1g-dev \
+            libncurses-dev uuid-dev gcc-aarch64-linux-gnu qemu-user-static
+
+      # One cache holds all three Chez artifacts: the ta6le host compiler,
+      # the tarm64le boot files + xpatch (bootquick), and the tarm64le cross
+      # kernel. Same pinned version as tests.yml/release.yml.
+      - name: Cache Chez Scheme (host + cross)
+        id: cache-chez
+        uses: actions/cache@v4
+        with:
+          path: ~/chez
+          key: chez-cross-v10.4.1-ta6le-tarm64le-v1
+
+      - name: Build Chez host + tarm64le boot files + cross kernel
+        if: steps.cache-chez.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v10.4.1 --recurse-submodules \
+            https://github.com/cisco/ChezScheme ~/chez
+          cd ~/chez
+          ./configure -m=ta6le --disable-x11
+          make -j"$(nproc)"
+          make bootquick XM=tarm64le
+          # --disable-curses/--disable-x11: the aarch64 cross sysroot has no
+          # ncurses or X11 headers (same reason the other workflows build x11off).
+          ./configure --cross --force -m=tarm64le \
+            --toolprefix=aarch64-linux-gnu- --disable-curses --disable-x11 \
+            CC_FOR_BUILD=cc
+          make -j"$(nproc)"
+
+      # bin/joltc wants a `chez` on PATH; the workarea scheme needs its boot
+      # dir. jolt build's legacy cc path reads the kernel/boots via JOLT_CHEZ_CSV.
+      - name: Wire up chez wrapper
+        run: |
+          mkdir -p ~/bin
+          printf '#!/bin/sh\nSCHEMEHEAPDIRS=%s exec %s "$@"\n' \
+            "$HOME/chez/ta6le/boot/ta6le" "$HOME/chez/ta6le/bin/ta6le/scheme" > ~/bin/chez
+          chmod +x ~/bin/chez
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          echo "JOLT_CHEZ_CSV=$HOME/chez/ta6le/boot/ta6le" >> "$GITHUB_ENV"
+          echo "JOLT_QUIET=1" >> "$GITHUB_ENV"
+
+      - name: Native baseline (ta6le)
+        run: |
+          cd tools/cross-compile/hello
+          ../../../bin/joltc build -m hello.core -o hello-host
+          ./hello-host | tee native.out
+          grep -q "fib(30) = 832040" native.out
+
+      - name: Cross build (tarm64le) + qemu verification
+        run: |
+          cd tools/cross-compile/hello
+          HOST_M=ta6le TARGET_M=tarm64le ARCH_FLAG="" CC=aarch64-linux-gnu-gcc \
+            CHEZ_SRC="$HOME/chez" ../cross-build-poc.sh hello-host.build hello-arm64
+          file hello-arm64 | grep -q "ARM aarch64"
+          qemu-aarch64-static -L /usr/aarch64-linux-gnu ./hello-arm64 | tee cross.out
+          # the load-bearing assertion: cross output is byte-identical to native
+          diff native.out cross.out
+          echo "cross-smoke OK: tarm64le output byte-identical to ta6le"

--- a/tools/cross-compile/README.md
+++ b/tools/cross-compile/README.md
@@ -15,6 +15,7 @@ under Rosetta 2:
 | tarm64osx → ta6osx | `hello/` (pure fns, loop/recur, reduce) | `Mach-O 64-bit executable x86_64`; output byte-identical to the native arm64 build (Rosetta 2) |
 | tarm64osx → ta6osx | `examples/hiccup-app` (real git dep, macros) | same — byte-identical HTML output |
 | ta6le → tarm64le | `hello/` (Arch Linux x86_64 host) | `ELF 64-bit LSB pie executable, ARM aarch64`; identical output, exit 0 under `qemu-aarch64-static` |
+| tarm64osx → ta6le | `hello/` (**cross-OS**: built on the arm64 Mac with `zig cc`) | `ELF 64-bit LSB executable, x86-64`; sha-matched transfer to a physical x86_64 Arch Linux machine, identical output, exit 0 — **native, no emulation** |
 
 Additionally verified on **physical Intel hardware**: the cross-built
 `hello-x86` was transferred (sha256-matched) to an Intel MacBook Pro
@@ -127,8 +128,45 @@ The POC hand-drives step 4; productizing it in build.ss is modest:
 
 Caveats: `:jolt/native` archives must be provided per target arch; app
 macros that inspect the build host at compile time would bake host facts
-(none of the stdlib does); untested here: Windows targets and cross-OS
-(mac→linux) link, which needs the zig/mingw toolchain from item 4.
+(none of the stdlib does); Windows (`ta6nt` via mingw-w64) remains the one
+untested target family — buildable from any host, but verification needs a
+Windows machine or wine.
+
+## Cross-OS: macOS → Linux with `zig cc` (verified)
+
+The macOS arm64 host built a `ta6le` (x86_64 Linux) binary that ran
+natively on a physical Arch Linux machine — no emulation. `zig cc` supplies
+the Linux libc/sysroot; three extra wrinkles beyond the same-OS flow:
+
+```sh
+cd ~/dev/ChezScheme
+printf '#!/bin/sh\nexec zig cc -target x86_64-linux-gnu -I<zlibdir> -I<lz4dir>/lib "$@"\n' > zig-cc-ta6le
+chmod +x zig-cc-ta6le
+bin/zuo tarm64osx bootquick ta6le          # target boots + xc-ta6le/s/xpatch
+
+# 1) In-tree zlib's configure sniffs the *host* (Darwin) and builds a broken
+#    Mach-O-flavored archive from ELF objects. Build zlib + lz4 out of tree
+#    with zig and archive with `zig ar` (macOS ar/ranlib silently produce an
+#    EMPTY archive from ELF objects — the empty-libz.a failure mode):
+(cp -r zlib /tmp/zl && cd /tmp/zl && CC=$PWD/../zig-cc-ta6le CHOST=x86_64-linux-gnu ./configure --static && make libz.a && zig ar rcs libz.a <the 15 obj files>)
+(cp -r lz4 /tmp/l4 && make -C /tmp/l4/lib liblz4.a CC=... AR="zig ar" BUILD_SHARED=no)
+
+# 2) Hand them to configure via ZLIB=/LZ4= (include dirs ride in the wrapper),
+#    with the same curses/X11 disables as any Linux cross kernel:
+./configure --cross --force -m=ta6le --disable-curses --disable-x11 \
+  CC="$PWD/zig-cc-ta6le" AR="zig ar" CC_FOR_BUILD=cc ZLIB=/tmp/zl/libz.a LZ4=/tmp/l4/lib/liblz4.a
+make
+# 3) Stage the archives where the POC script expects them:
+mkdir -p ta6le/lz4/lib ta6le/zlib && cp /tmp/l4/lib/liblz4.a ta6le/lz4/lib/ && cp /tmp/zl/libz.a ta6le/zlib/
+
+# then, as usual:
+HOST_M=tarm64osx TARGET_M=ta6le ARCH_FLAG="" CC=~/dev/ChezScheme/zig-cc-ta6le \
+  CHEZ_SRC=~/dev/ChezScheme tools/cross-compile/cross-build-poc.sh app.build app-linux
+```
+
+This also means CI could build **every Linux artifact from any runner** —
+and, with mingw-w64, plausibly the Windows one too — without per-target
+runner hardware.
 
 ## Why bother (beyond the issue)
 

--- a/tools/cross-compile/README.md
+++ b/tools/cross-compile/README.md
@@ -10,10 +10,11 @@ On an ARM64 Mac (`tarm64osx`, Chez 10.4.1), `jolt build` output was
 cross-compiled into an **x86_64 macOS** (`ta6osx`) executable and verified
 under Rosetta 2:
 
-| app | result |
-|---|---|
-| `hello/` (this dir — pure fns, loop/recur, reduce) | `Mach-O 64-bit executable x86_64`; output byte-identical to the native arm64 build |
-| `examples/hiccup-app` (real git dep, macros) | same — byte-identical HTML output |
+| host → target | app | result |
+|---|---|---|
+| tarm64osx → ta6osx | `hello/` (pure fns, loop/recur, reduce) | `Mach-O 64-bit executable x86_64`; output byte-identical to the native arm64 build (Rosetta 2) |
+| tarm64osx → ta6osx | `examples/hiccup-app` (real git dep, macros) | same — byte-identical HTML output |
+| ta6le → tarm64le | `hello/` (Arch Linux x86_64 host) | `ELF 64-bit LSB pie executable, ARM aarch64`; identical output, exit 0 under `qemu-aarch64-static` |
 
 Additionally verified on **physical Intel hardware**: the cross-built
 `hello-x86` was transferred (sha256-matched) to an Intel MacBook Pro
@@ -72,23 +73,28 @@ arch -x86_64 ./hello-x86       # runs under Rosetta; same output as ./hello-host
 ## Trying it from a Linux host
 
 The same flow works with Linux machine types (`ta6le` = x86_64, `tarm64le` =
-aarch64). On an x86_64 Linux box the natural POC is ta6le → tarm64le:
+aarch64) — **verified 2026-07-19 on Arch Linux** (packages:
+`aarch64-linux-gnu-gcc`, `qemu-user-static`):
 
 ```sh
 cd ~/dev/ChezScheme
 ./configure -m=ta6le && make
 make bootquick XM=tarm64le
-./configure --cross --force -m=tarm64le --toolprefix=aarch64-linux-gnu- CC_FOR_BUILD=cc
-make                                      # needs gcc-aarch64-linux-gnu + target ncurses/uuid dev libs
+# --disable-curses --disable-x11: a cross sysroot has no ncurses or X11
+# headers, and the expeditor otherwise needs both (same reason jolt's CI
+# builds Chez with X11 off).
+./configure --cross --force -m=tarm64le --toolprefix=aarch64-linux-gnu- \
+  --disable-curses --disable-x11 CC_FOR_BUILD=cc
+make
 
-HOST_M=ta6le TARGET_M=tarm64le ARCH_FLAG= CC=aarch64-linux-gnu-gcc \
+HOST_M=ta6le TARGET_M=tarm64le ARCH_FLAG="" CC=aarch64-linux-gnu-gcc \
   CHEZ_SRC=~/dev/ChezScheme tools/cross-compile/cross-build-poc.sh app.build app-arm64
-qemu-aarch64 ./app-arm64                  # or run on a real ARM box
+qemu-aarch64-static -L /usr/aarch64-linux-gnu ./app-arm64   # or a real ARM box
 ```
 
-The script picks Linux link libs automatically for `*le` targets (mirroring
-build.ss's `bld-link-libs`). A machine that only *runs* a cross-built binary
-needs nothing installed — no Chez, no jolt.
+The script picks the matching Linux link libs automatically for `*le`
+targets. A machine that only *runs* a cross-built binary needs nothing
+installed — no Chez, no jolt.
 
 ## What a real `jolt build --target <machine>` needs
 

--- a/tools/cross-compile/README.md
+++ b/tools/cross-compile/README.md
@@ -15,6 +15,14 @@ under Rosetta 2:
 | `hello/` (this dir — pure fns, loop/recur, reduce) | `Mach-O 64-bit executable x86_64`; output byte-identical to the native arm64 build |
 | `examples/hiccup-app` (real git dep, macros) | same — byte-identical HTML output |
 
+Additionally verified on **physical Intel hardware**: the cross-built
+`hello-x86` was transferred (sha256-matched) to an Intel MacBook Pro
+(macOS 26.5.2, x86_64) and ran natively with identical output, exit 0.
+For binaries meant for other Macs, pass
+`ARCH_FLAG="-arch x86_64 -mmacosx-version-min=11.0"` (and build the target
+kernel with the same `-mmacosx-version-min` in `CFLAGS`) — clang otherwise
+stamps the build host's OS version as the binary's minimum.
+
 `otool -L` on the produced binaries shows only macOS system libraries
 (`libSystem`, `libncurses`, `libiconv`, `Foundation`) — lz4/zlib are linked
 statically, so the binary is as self-contained as a native `jolt build` one.

--- a/tools/cross-compile/README.md
+++ b/tools/cross-compile/README.md
@@ -175,6 +175,21 @@ retired the Intel runners ("Intel Macs build from source"). Item 1–3 above
 would restore that artifact by cross-building `ta6osx` on the existing
 `macos-14` arm64 runner, POC'd here end to end.
 
+## CI integration
+
+- [`.github/workflows/cross-smoke.yml`](../../.github/workflows/cross-smoke.yml)
+  — manual-dispatch job that runs this POC end to end on one ubuntu runner
+  (ta6le → tarm64le, qemu-verified, byte-identical-output diff). It pins the
+  machine-neutrality invariant: a change that bakes host state into the
+  Scheme emission fails the diff. Not a per-push gate.
+- [`release-macos-x86_64.draft.yml`](release-macos-x86_64.draft.yml) — the
+  release.yml matrix row that restores the dropped x86_64-macos artifact by
+  cross-building on the arm64 runner (smoke via Rosetta, which GitHub's
+  macos-14 runners ship). Deliberately a draft outside `.github/workflows/`:
+  it is blocked on cross-target support in `build-joltc.ss` (the artifact is
+  joltc itself, which embeds the target's boots/stub/kernel). Move it into
+  release.yml with the `--target` PR.
+
 ## Observed timings (M-series Mac)
 
 - host Chez build: ~6 min (one-time)

--- a/tools/cross-compile/README.md
+++ b/tools/cross-compile/README.md
@@ -1,0 +1,131 @@
+# Cross-compilation POC (issue #375)
+
+Answer to [jolt-lang/jolt#375](https://github.com/jolt-lang/jolt/issues/375):
+**yes — cross-compilation works today**, with no changes to jolt itself.
+This directory holds the proof-of-concept that built and verified it.
+
+## What was proven
+
+On an ARM64 Mac (`tarm64osx`, Chez 10.4.1), `jolt build` output was
+cross-compiled into an **x86_64 macOS** (`ta6osx`) executable and verified
+under Rosetta 2:
+
+| app | result |
+|---|---|
+| `hello/` (this dir — pure fns, loop/recur, reduce) | `Mach-O 64-bit executable x86_64`; output byte-identical to the native arm64 build |
+| `examples/hiccup-app` (real git dep, macros) | same — byte-identical HTML output |
+
+`otool -L` on the produced binaries shows only macOS system libraries
+(`libSystem`, `libncurses`, `libiconv`, `Foundation`) — lz4/zlib are linked
+statically, so the binary is as self-contained as a native `jolt build` one.
+
+## Why it works
+
+`jolt build` (host/chez/build.ss) splits exactly at the machine boundary:
+
+1. **Steps 1–3 are machine-neutral.** Loading the entry ns, re-emitting each
+   namespace to Scheme, and flattening runtime + app + launcher into
+   `<out>.build/flat.ss` produces plain Scheme *text*. Audited: no absolute
+   host paths, no host machine-type baked as data; every `(machine-type)`
+   in the image is a runtime call (so `os.name` etc. are correct on the
+   target at runtime).
+2. **Step 4 is machine-specific** — `compile-file` → `make-boot-file` →
+   cc link — and Chez Scheme ships cross-compilation for precisely those
+   two functions. `make bootquick XM=<target>` emits the target's boot
+   files **plus** `xc-<target>/s/xpatch`; loading that xpatch into the host
+   Chez retargets `compile-file`/`make-boot-file` to emit target-machine
+   code (ChezScheme/BUILDING, "CROSS COMPILING SCHEME PROGRAMS").
+   The target's C kernel (`libkernel.a`) comes from
+   `./configure --cross --force -m=<target>` — for macOS arm64→x86_64 that
+   is literally just `CFLAGS="-arch x86_64"`.
+
+`cross-build-poc.sh` is jolt build's step 4, retargeted. Everything else is
+stock `jolt build`.
+
+## Reproduction
+
+```sh
+# one-time: prepare Chez artifacts (~10 min total on an M-series Mac)
+git clone --recurse-submodules https://github.com/cisco/ChezScheme ~/dev/ChezScheme
+cd ~/dev/ChezScheme
+./configure -m=tarm64osx && make          # host compiler
+make bootquick XM=ta6osx                  # target boots + xpatch
+./configure --cross --force -m=ta6osx CFLAGS="-arch x86_64" CC_FOR_BUILD=cc
+make                                      # target kernel
+
+# per app (~1 min)
+cd tools/cross-compile/hello
+../../../bin/joltc build -m hello.core -o hello-host        # normal host build
+CHEZ_SRC=~/dev/ChezScheme ../cross-build-poc.sh hello-host.build hello-x86
+file hello-x86                 # Mach-O 64-bit executable x86_64
+arch -x86_64 ./hello-x86       # runs under Rosetta; same output as ./hello-host
+```
+
+## Trying it from a Linux host
+
+The same flow works with Linux machine types (`ta6le` = x86_64, `tarm64le` =
+aarch64). On an x86_64 Linux box the natural POC is ta6le → tarm64le:
+
+```sh
+cd ~/dev/ChezScheme
+./configure -m=ta6le && make
+make bootquick XM=tarm64le
+./configure --cross --force -m=tarm64le --toolprefix=aarch64-linux-gnu- CC_FOR_BUILD=cc
+make                                      # needs gcc-aarch64-linux-gnu + target ncurses/uuid dev libs
+
+HOST_M=ta6le TARGET_M=tarm64le ARCH_FLAG= CC=aarch64-linux-gnu-gcc \
+  CHEZ_SRC=~/dev/ChezScheme tools/cross-compile/cross-build-poc.sh app.build app-arm64
+qemu-aarch64 ./app-arm64                  # or run on a real ARM box
+```
+
+The script picks Linux link libs automatically for `*le` targets (mirroring
+build.ss's `bld-link-libs`). A machine that only *runs* a cross-built binary
+needs nothing installed — no Chez, no jolt.
+
+## What a real `jolt build --target <machine>` needs
+
+The POC hand-drives step 4; productizing it in build.ss is modest:
+
+1. **Spawn-path cross compile.** `build-with-cc` already spawns a fresh Chez
+   for `compile-file`/`make-boot-file`; a `--target` flag only needs to
+   prepend `(load ".../xc-<target>/s/xpatch")` to the generated compile.ss.
+   (The self-contained path compiles in-process and would keep using the
+   spawn path when cross-targeting.)
+2. **Key platform decisions off the target, not the host.** `bld-osx?` /
+   `bld-nt?` / `bld-link-libs` / the `.exe` suffix all read the *host*
+   `(machine-type)` today; under `--target` they must read the target
+   machine string.
+3. **Target packs.** `JOLT_CHEZ_CSV` already overrides where the boots +
+   kernel come from. A per-target bundle (petite/scheme.boot, libkernel.a,
+   scheme.h, static lz4/zlib, prebuilt launcher stub — ~10 MB, exactly what
+   the `csv<ver>/<machine>` install layout already contains, plus the
+   xpatch) could be published per release, Zig/Go style. With a prebuilt
+   *target* launcher stub, the append-payload path needs **no C compiler at
+   all** for pure-Clojure apps: the stub framing
+   (`[stub][boot][u64 len]["JOLTBOOT"]`) is arch-independent.
+4. **C cross-compilers only where unavoidable** (`:jolt/native` static
+   archives, `--library`): macOS↔macOS is `-arch`; Linux targets from any
+   host work with `zig cc -target x86_64-linux-gnu`; Windows needs
+   mingw-w64 (`--toolprefix=x86_64-w64-mingw32-`, same as Chez's own cross
+   build).
+5. **Version pinning.** Host compiler, xpatch, target boots, and target
+   kernel must come from one Chez tree (jolt already pins 10.4.1 in CI).
+
+Caveats: `:jolt/native` archives must be provided per target arch; app
+macros that inspect the build host at compile time would bake host facts
+(none of the stdlib does); untested here: Windows targets and cross-OS
+(mac→linux) link, which needs the zig/mingw toolchain from item 4.
+
+## Why bother (beyond the issue)
+
+`.github/workflows/release.yml` ships **no x86_64-macos binary** — GitHub
+retired the Intel runners ("Intel Macs build from source"). Item 1–3 above
+would restore that artifact by cross-building `ta6osx` on the existing
+`macos-14` arm64 runner, POC'd here end to end.
+
+## Observed timings (M-series Mac)
+
+- host Chez build: ~6 min (one-time)
+- `bootquick XM=ta6osx`: ~2 min (one-time)
+- cross kernel: ~1 min (one-time)
+- per-app cross step 4 (compile + boot + link): ~30 s

--- a/tools/cross-compile/cross-build-poc.sh
+++ b/tools/cross-compile/cross-build-poc.sh
@@ -33,14 +33,18 @@ set -e
 CHEZ_SRC="${CHEZ_SRC:?set CHEZ_SRC to a ChezScheme checkout prepared per the header comment}"
 HOST_M="${HOST_M:-tarm64osx}"
 TARGET_M="${TARGET_M:-ta6osx}"
-ARCH_FLAG="${ARCH_FLAG:--arch x86_64}"
+# "-" (not ":-") so an explicit ARCH_FLAG="" survives — Linux cross targets
+# select the arch via CC (aarch64-linux-gnu-gcc), not an -arch flag.
+ARCH_FLAG="${ARCH_FLAG--arch x86_64}"
 CC_BIN="${CC:-cc}"
 
-# link libs for the TARGET OS (mirrors build.ss bld-link-libs); *osx = macOS,
-# *le = Linux machine types. Override with LINK_LIBS for anything else.
+# link libs for the TARGET OS; *osx = macOS, *le = Linux machine types.
+# The Linux set matches a cross kernel configured with --disable-curses
+# --disable-x11 (a cross sysroot has no ncurses/X11); it mirrors Chez's own
+# scheme-executable link. Override with LINK_LIBS for anything else.
 case "$TARGET_M" in
   *osx) DEFAULT_LIBS="-lncurses -liconv -lm -framework Foundation" ;;
-  *le)  DEFAULT_LIBS="-lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt" ;;
+  *le)  DEFAULT_LIBS="-lm -ldl -lrt -lpthread" ;;
   *)    DEFAULT_LIBS="" ;;
 esac
 LINK_LIBS="${LINK_LIBS:-$DEFAULT_LIBS}"

--- a/tools/cross-compile/cross-build-poc.sh
+++ b/tools/cross-compile/cross-build-poc.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# cross-build-poc.sh — proof of concept for jolt-lang/jolt#375: cross-compile
+# a jolt app on one platform into a native executable for another.
+#
+# `jolt build` splits cleanly at the machine boundary:
+#   steps 1-3: Clojure -> IR -> Scheme emission -> <out>.build/flat.ss
+#              (machine-neutral text: no host paths, no host machine-type
+#              literals; every (machine-type) call is a runtime call)
+#   step 4:    compile-file -> make-boot-file -> cc link   (machine-specific)
+#
+# This script re-runs ONLY step 4 under Chez's cross compiler. Chez's
+# `make bootquick XM=<target>` produces target boot files AND an "xpatch"
+# that retargets exactly the two functions step 4 calls: compile-file and
+# make-boot-file (see ChezScheme/BUILDING, "CROSS COMPILING SCHEME PROGRAMS").
+#
+# One-time prereqs, in a ChezScheme checkout (with submodules) at the version
+# jolt pins (v10.4.1):
+#   ./configure -m=<host>  && make        # host compiler        (~5-8 min)
+#   make bootquick XM=<target>            # target boots + xpatch (~2 min)
+#   ./configure --cross --force -m=<target> CFLAGS="<target cc flags>" CC_FOR_BUILD=cc
+#   make                                  # target libkernel.a    (~1 min)
+#
+# Defaults below are the macOS arm64 -> macOS x86_64 (tarm64osx -> ta6osx)
+# case, which is verifiable on one machine via Rosetta 2 — and is exactly the
+# release artifact jolt CI dropped when GitHub retired Intel runners.
+#
+# Usage:
+#   bin/joltc build -m app.core -o myapp        # host build; leaves myapp.build/
+#   CHEZ_SRC=~/dev/ChezScheme tools/cross-compile/cross-build-poc.sh myapp.build myapp-x86
+#   file myapp-x86        # => Mach-O 64-bit executable x86_64
+set -e
+
+CHEZ_SRC="${CHEZ_SRC:?set CHEZ_SRC to a ChezScheme checkout prepared per the header comment}"
+HOST_M="${HOST_M:-tarm64osx}"
+TARGET_M="${TARGET_M:-ta6osx}"
+ARCH_FLAG="${ARCH_FLAG:--arch x86_64}"
+CC_BIN="${CC:-cc}"
+
+# link libs for the TARGET OS (mirrors build.ss bld-link-libs); *osx = macOS,
+# *le = Linux machine types. Override with LINK_LIBS for anything else.
+case "$TARGET_M" in
+  *osx) DEFAULT_LIBS="-lncurses -liconv -lm -framework Foundation" ;;
+  *le)  DEFAULT_LIBS="-lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt" ;;
+  *)    DEFAULT_LIBS="" ;;
+esac
+LINK_LIBS="${LINK_LIBS:-$DEFAULT_LIBS}"
+
+FLAT_DIR="$1"; OUT="$2"
+[ -n "$OUT" ] || { echo "usage: cross-build-poc.sh <dir-with-flat.ss> <out-binary>"; exit 1; }
+[ -f "$FLAT_DIR/flat.ss" ] || { echo "no flat.ss in $FLAT_DIR (run jolt build first)"; exit 1; }
+
+HOST_SCHEME="$CHEZ_SRC/$HOST_M/bin/$HOST_M/scheme"
+HOST_BOOT="$CHEZ_SRC/$HOST_M/boot/$HOST_M"
+XPATCH="$CHEZ_SRC/xc-$TARGET_M/s/xpatch"
+TARGET_CSV="${TARGET_CSV:-$CHEZ_SRC/$TARGET_M/boot/$TARGET_M}"   # libkernel.a, scheme.h, *.boot
+TARGET_LZ4="$CHEZ_SRC/$TARGET_M/lz4/lib"                          # static lz4 built for target
+TARGET_ZLIB="$CHEZ_SRC/$TARGET_M/zlib"                            # static zlib built for target
+
+for f in "$HOST_SCHEME" "$XPATCH" "$TARGET_CSV/libkernel.a" "$TARGET_CSV/scheme.h" \
+         "$TARGET_CSV/petite.boot" "$TARGET_CSV/scheme.boot"; do
+  [ -e "$f" ] || { echo "missing prereq: $f"; exit 1; }
+done
+
+WORK="$OUT.build"
+mkdir -p "$WORK"
+
+# --- jolt build step 4a, retargeted: compile + boot under the xpatch --------
+# Same Chez parameters as build.ss's release mode (bld-chez-params).
+cat > "$WORK/cross-compile.ss" <<EOF
+(import (chezscheme))
+(load "$XPATCH")
+(optimize-level 2)
+(generate-inspector-information #t)
+(generate-procedure-source-information #t)
+(fasl-compressed #t)
+(compile-file "$FLAT_DIR/flat.ss" "$WORK/flat.so")
+(make-boot-file "$WORK/jolt.boot" (list)
+  "$TARGET_CSV/petite.boot"
+  "$TARGET_CSV/scheme.boot"
+  "$WORK/flat.so")
+EOF
+echo "cross-build: compile-file + make-boot-file under xpatch ($TARGET_M)"
+SCHEMEHEAPDIRS="$HOST_BOOT" "$HOST_SCHEME" --script "$WORK/cross-compile.ss"
+
+# --- jolt build step 4b, retargeted: link the target-arch launcher ----------
+# Same main.c + xxd embedding as build.ss's build-with-cc, but cc targets the
+# other architecture and links the target-arch kernel + static lz4/zlib.
+xxd -i "$WORK/jolt.boot" > "$WORK/boot_data.h"
+sed -i.bak -E 's/unsigned char [A-Za-z0-9_]+\[\]/unsigned char jolt_boot[]/; s/unsigned int [A-Za-z0-9_]+_len/unsigned int jolt_boot_len/' "$WORK/boot_data.h"
+cat > "$WORK/main.c" <<'EOF'
+#include "scheme.h"
+#include "boot_data.h"
+int main(int argc, char *argv[]) {
+  Sscheme_init(0);
+  Sregister_boot_file_bytes("jolt", jolt_boot, jolt_boot_len);
+  Sbuild_heap(0, 0);
+  int status = Sscheme_start(argc, (const char **)argv);
+  Sscheme_deinit();
+  return status;
+}
+EOF
+echo "cross-build: $CC_BIN $ARCH_FLAG link against $TARGET_CSV/libkernel.a"
+$CC_BIN $ARCH_FLAG -O2 -I"$TARGET_CSV" -I"$WORK" "$WORK/main.c" "$TARGET_CSV/libkernel.a" \
+   -o "$OUT" -L"$TARGET_LZ4" -L"$TARGET_ZLIB" -llz4 -lz $LINK_LIBS
+echo "cross-build: wrote $OUT"
+file "$OUT"

--- a/tools/cross-compile/hello/deps.edn
+++ b/tools/cross-compile/hello/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :tasks {run {:doc "hello cross-compile probe" :main-opts ["-m" "hello.core"]}}}

--- a/tools/cross-compile/hello/src/hello/core.clj
+++ b/tools/cross-compile/hello/src/hello/core.clj
@@ -1,0 +1,10 @@
+(ns hello.core)
+
+(defn fib [n]
+  (loop [a 0 b 1 i 0]
+    (if (= i n) a (recur b (+ a b) (inc i)))))
+
+(defn -main [& _]
+  (println "hello from jolt cross-compile POC")
+  (println "fib(30) =" (fib 30))
+  (println "sum =" (reduce + (range 1000))))

--- a/tools/cross-compile/release-macos-x86_64.draft.yml
+++ b/tools/cross-compile/release-macos-x86_64.draft.yml
@@ -1,0 +1,70 @@
+# DRAFT — intentionally NOT in .github/workflows/. (jolt-lang/jolt#375)
+#
+# Restores the x86_64-macos release artifact (dropped when GitHub retired the
+# Intel runners — see the "No x86_64-macos" note in release.yml) by
+# cross-building it on the existing macos-14 arm64 runner.
+#
+# BLOCKED ON: cross-target support in host/chez/build-joltc.ss. The release
+# artifact is joltc itself — a self-contained binary that embeds the TARGET's
+# petite/scheme boot files, launcher stub, and kernel resources (csv/*), and
+# whose final compile-file/make-boot-file/cc-link must run under the target
+# xpatch. That is the same step-4 retargeting tools/cross-compile/
+# cross-build-poc.sh proves for apps, applied inside build-joltc.ss (e.g. a
+# JOLT_CROSS_XPATCH/JOLT_TARGET env or --target arg). Until that lands, this
+# job cannot produce a working joltc; move it into release.yml's matrix when
+# it does.
+#
+# Everything below the joltc-build step is already de-risked:
+#   - Chez artifacts: verified 2026-07-19 (tarm64osx host -> ta6osx boots,
+#     xpatch, kernel via CFLAGS="-arch x86_64 -mmacosx-version-min=11.0").
+#   - Smoke on the arm64 runner: GitHub's macos-14 runners ship Rosetta 2, so
+#     the cross-built Intel joltc runs right there (same as the POC's local
+#     verification; also verified on a physical Intel MacBook Pro).
+#   - minos: pin -mmacosx-version-min=11.0 in BOTH the kernel CFLAGS and the
+#     final link, or the binary refuses to load on Macs older than the
+#     runner's OS (clang stamps the build host's version by default).
+
+# --- matrix row (add under jobs.build.strategy.matrix.include) --------------
+#   - os: macos-14
+#     target: x86_64-macos          # cross-built ta6osx on the arm64 runner
+#     shell: bash
+#     cross: ta6osx                 # gate the extra steps below on matrix.cross
+
+# --- extra steps for the cross row (before "build joltc") -------------------
+#   - name: Cache Chez Scheme (host + ta6osx cross)
+#     if: matrix.cross
+#     uses: actions/cache@v4
+#     with:
+#       path: ~/chez
+#       key: chez-cross-v10.4.1-tarm64osx-ta6osx-v1
+#
+#   - name: Build Chez host + ta6osx boots/xpatch + cross kernel
+#     if: matrix.cross && steps.cache-chez.outputs.cache-hit != 'true'
+#     run: |
+#       git clone --depth 1 --branch v10.4.1 --recurse-submodules \
+#         https://github.com/cisco/ChezScheme ~/chez
+#       cd ~/chez
+#       ./configure -m=tarm64osx && make -j"$(sysctl -n hw.ncpu)"
+#       make bootquick XM=ta6osx
+#       ./configure --cross --force -m=ta6osx \
+#         CFLAGS="-arch x86_64 -mmacosx-version-min=11.0" CC_FOR_BUILD=cc
+#       make -j"$(sysctl -n hw.ncpu)"
+#
+#   - name: Build joltc (cross ta6osx)          # <-- the blocked step
+#     if: matrix.cross
+#     run: |
+#       # strawman interface; final shape belongs to the --target PR:
+#       JOLT_TARGET=ta6osx \
+#       JOLT_CROSS_XPATCH="$HOME/chez/xc-ta6osx/s/xpatch" \
+#       JOLT_CHEZ_CSV="$HOME/chez/ta6osx/boot/ta6osx" \
+#       JOLT_CC_FLAGS="-arch x86_64 -mmacosx-version-min=11.0" \
+#         make joltc-release
+#
+#   - name: Smoke (Rosetta)
+#     if: matrix.cross
+#     run: |
+#       file target/release/joltc | grep -q x86_64
+#       arch -x86_64 target/release/joltc -e '(+ 1 2)' | grep -qx 3
+#
+# The existing package/upload steps then apply unchanged with
+# name="joltc-${ver}-x86_64-macos".


### PR DESCRIPTION
Proof of concept answering #375: **cross-compilation works with stock Chez cross-compilation and zero changes to jolt's build code.**

`jolt build`'s steps 1–3 emit a machine-neutral `flat.ss`; only step 4 (`compile-file` → `make-boot-file` → cc link) is machine-specific, and Chez's `make bootquick XM=<target>` produces target boot files plus an `xpatch` that retargets exactly those two functions. This PR adds:

- **`tools/cross-compile/cross-build-poc.sh`** — a ~90-line script that re-runs step 4 under the xpatch (jolt's release-mode Chez parameters, same `main.c`/xxd embedding as `build-with-cc`).
- **`tools/cross-compile/hello/`** — a zero-dep sample app used as the test fixture.
- **`tools/cross-compile/README.md`** — mechanics, reproduction commands (~10 min one-time Chez setup, ~30 s per app), verified-results table, gotcha notes, and a 5-point productization sketch for a real `jolt build --target <machine>`.
- **`.github/workflows/cross-smoke.yml`** — a manual-dispatch (not per-push) CI job that runs the POC end to end on one ubuntu runner and asserts the cross-built binary's output is **byte-identical** to the native build under qemu. It pins the invariant the design rests on: a change that bakes host state into the Scheme emission fails the diff.
- **`tools/cross-compile/release-macos-x86_64.draft.yml`** — a drafted release-matrix row (deliberately *outside* `.github/workflows/`) that would restore the dropped `x86_64-macos` artifact by cross-building on the arm64 runner; blocked on cross-target support in `build-joltc.ss` and annotated accordingly.

## Verified (all on real machines; details in the README)

| host → target | verified by |
|---|---|
| `tarm64osx` → `ta6osx` | Rosetta 2 **and** a physical Intel MacBook Pro — byte-identical output (hello + `examples/hiccup-app` with a git dep + macros) |
| `ta6le` → `tarm64le` | `qemu-aarch64` on Arch Linux, and green in CI (cross-smoke, ~6 min cold) |
| `tarm64osx` → `ta6le` (**cross-OS**, via `zig cc`) | native run on a physical x86_64 Arch Linux machine — no emulation |

CI on this branch: the full `tests.yml` gate passes, and `cross-smoke` passes (first execution, cold cache).

Not covered: Windows (`ta6nt`/mingw-w64) — buildable from any host in principle, unverified for lack of a Windows machine.

## Motivation beyond the issue

`release.yml` ships no `x86_64-macos` artifact since GitHub retired the Intel runners; the verified `tarm64osx → ta6osx` direction restores it from the existing `macos-14` arm64 runner (GitHub's arm64 macOS runners ship Rosetta 2, so the release smoke can run in-place). The zig path would similarly let one runner build every Linux artifact.

If maintainers prefer a `--target` implementation over a POC-tools PR, I'm happy to build that instead — every unknown in the README's 5-point plan has been de-risked empirically here.

Closes nothing on its own; discussion continues in #375 (see [my comment with the full findings](https://github.com/jolt-lang/jolt/issues/375#issuecomment-5015640561)).
