### PR TITLE
process: spawn children in the user's cwd; JVM-style program resolution

### DIFF
--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -437,14 +437,17 @@
           ((string=? k "line.separator") "\n")
           ((string=? k "file.separator") "/")
           ((string=? k "path.separator") ":")
-          ((string=? k "user.dir") (or (getenv "PWD") "."))
+          ;; user.dir is the user's cwd (JVM: the process cwd). jolt's launcher
+          ;; cd's to the repo root and resets PWD, but preserves the user's cwd in
+          ;; JOLT_PWD — prefer it so user.dir and spawned-child cwds agree.
+          ((string=? k "user.dir") (or (getenv "JOLT_PWD") (getenv "PWD") "."))
           ((string=? k "user.home") (or (getenv "HOME") ""))
           ((string=? k "java.io.tmpdir") (or (getenv "TMPDIR") "/tmp"))
           ((pair? dflt) (car dflt))
           (else jolt-nil))))
 (define (sys-properties-map)
   (let ((base (jolt-hash-map "os.name" sys-os-name "line.separator" "\n" "file.separator" "/"
-                             "user.dir" (or (getenv "PWD") ".") "user.home" (or (getenv "HOME") "")
+                             "user.dir" (or (getenv "JOLT_PWD") (getenv "PWD") ".") "user.home" (or (getenv "HOME") "")
                              "java.io.tmpdir" (or (getenv "TMPDIR") "/tmp"))))
     (for-each
       (lambda (kv)

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -86,14 +86,23 @@
             (map (lambda (p) (proc-sh-quote (string-append (car p) "=" (cdr p)))) pairs))
           " "))))
 
+;; The child's cwd: a JVM child inherits user.dir (the user's cwd), but jolt's OS
+;; cwd is the repo root its launcher cd'd to — the user's logical cwd is JOLT_PWD.
+;; So default the child to JOLT_PWD and resolve a relative :dir against it (like
+;; io.ss project-relative), matching ProcessBuilder.directory semantics.
+(define (proc-effective-dir dir)
+  (if dir
+      (project-relative dir)
+      (let ((pwd (getenv "JOLT_PWD"))) (and pwd (> (string-length pwd) 0) pwd))))
+
 (define (proc-build-shell-command st)
-  (let ((cmd     (proc-pb-cmd st))
-        (env-map (proc-pb-env st))
-        (dir     (proc-pb-dir st))
-        (rin     (proc-pb-redir-in st))
-        (rout    (proc-pb-redir-out st))
-        (rerr    (proc-pb-redir-err st))
-        (merge?  (proc-pb-merge-err? st)))
+  (let* ((cmd     (proc-pb-cmd st))
+         (env-map (proc-pb-env st))
+         (dir     (proc-effective-dir (proc-pb-dir st)))
+         (rin     (proc-pb-redir-in st))
+         (rout    (proc-pb-redir-out st))
+         (rerr    (proc-pb-redir-err st))
+         (merge?  (proc-pb-merge-err? st)))
     (string-append
       (if dir (string-append "cd " (proc-sh-quote dir) " && ") "")
       "exec "
@@ -256,8 +265,46 @@
 (define (proc-p-inherit-latches st) (vector-ref (jhost-state st) 9))
 (define (proc-process? x) (and (jhost? x) (string=? (jhost-tag x) "process")))
 
+;; ProcessBuilder.start resolves the program before spawning and throws
+;; IOException("…No such file or directory") when it can't be found; our shell
+;; would otherwise fail at exec (127) with a different message. Mirror it:
+;;   - absolute program: the file must exist
+;;   - slash-bearing relative program: resolves against the child cwd, like exec
+;;   - bare name: an entry of that name must be on PATH
+(define (proc-path-join a b)
+  (if (or (= (string-length a) 0) (char=? (string-ref a (- (string-length a) 1)) #\/))
+      (string-append a b)
+      (string-append a "/" b)))
+(define (proc-has-slash? s)
+  (let loop ((i 0)) (cond ((= i (string-length s)) #f)
+                          ((char=? (string-ref s i) #\/) #t)
+                          (else (loop (+ i 1))))))
+(define (proc-on-path? prog)
+  (let ((path (getenv "PATH")))
+    (and path
+         (let loop ((dirs (str-literal-split path ":")))
+           (cond ((null? dirs) #f)
+                 ((and (> (string-length (car dirs)) 0)
+                       (file-exists? (proc-path-join (car dirs) prog))) #t)
+                 (else (loop (cdr dirs))))))))
+(define (proc-program-resolvable? prog effective-dir)
+  (let ((prog (if (string? prog) prog (jolt-str-render-one prog))))
+    (cond
+      ((= (string-length prog) 0) #f)
+      ((char=? (string-ref prog 0) #\/) (file-exists? prog))
+      ((proc-has-slash? prog)
+       (file-exists? (proc-path-join (or effective-dir (getenv "JOLT_PWD") ".") prog)))
+      (else (proc-on-path? prog)))))
+
 (define (proc-pb-start self)
-  (let ((st (jhost-state self)))
+  (let* ((st (jhost-state self))
+         (cmd (proc-pb-cmd self)))
+    (when (and (pair? cmd)
+               (not (proc-program-resolvable? (car cmd) (proc-effective-dir (proc-pb-dir self)))))
+      (throw-jvm (quote java.io.IOException)
+        (string-append "Cannot run program \""
+                       (if (string? (car cmd)) (car cmd) (jolt-str-render-one (car cmd)))
+                       "\": error=2, No such file or directory")))
     (call-with-values
       (lambda () (open-process-ports (proc-build-shell-command self) (buffer-mode block) #f))
       (lambda (child-stdin child-stdout child-stderr pid)

--- a/host/chez/process-suite.sh
+++ b/host/chez/process-suite.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# babashka/process upstream suite runner (manual conformance harness, like cts.sh
+# — the CI gate is test/chez/process-test.clj). Runs the vendored
+# babashka.process-test against joltc with the program-resolution fixtures staged
+# and bb isolated, so the portable (non-bb) tests run to a clean result.
+#
+# Two things the bare `bin/joltc -M:proc babashka.process-test` can't do on its own:
+#   1. The program-resolution tests copy test-resources/print-dirs.sh into
+#      target/test/{on-path,cwd,workdir} and resolve a bare name via PATH — so the
+#      fixtures must be present and the on-path dir must be on PATH.
+#   2. Most other tests shell out to `babashka` itself; with bb on PATH they run
+#      (and one can hang). We drop the dir holding bb from PATH so find-bb returns
+#      nil and those tests skip (BABASHKA_TEST_ENV=jvm) instead.
+#
+# Everything is staged in a temp dir (no writes into the repo). Baseline result:
+# 27 assertions pass, 0 fail, 0 errors; the bb-gated tests skip.
+set -u
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+vend="$root/vendor/process"
+joltc="${JOLT_BIN:-$root/bin/joltc}"
+
+if [ ! -f "$vend/test-resources/print-dirs.sh" ]; then
+  echo "process-suite: skipped (git submodule update --init vendor/process)"
+  exit 0
+fi
+
+chez="$(command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)"
+if [ -z "$chez" ]; then echo "process-suite: no chez on PATH"; exit 1; fi
+
+# Canonicalize the temp dir: on macOS mktemp returns /var/… (a symlink to
+# /private/var/…). The program-resolution tests compare a canonicalized expected
+# path against the program's reported real path, so the staging root must already
+# be symlink-free or those two disagree.
+work="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$work"' EXIT
+
+# A minimal tool PATH: chez (for joltc) + the standard system dirs, but NOT the
+# dir that holds bb (typically a homebrew/coursier dir) — so bb-dependent tests
+# skip rather than run/hang.
+toolbin="$work/bin"; mkdir -p "$toolbin"
+ln -s "$chez" "$toolbin/chez"
+
+# Staging: JOLT_PWD is a temp project whose deps.edn points (absolutely) at the
+# vendored source + this suite's runner. Under it, a process/ subdir holds the
+# fixtures (BABASHKA_TEST_ENV=jvm makes test-utils use the bb-submodule layout,
+# i.e. "process/…" paths), with the source fixtures symlinked and target/ writable.
+proj="$work/proj"
+mkdir -p "$proj/process/target/test/on-path" "$proj/process/target/test/workdir" "$proj/process/target/test/cwd"
+ln -s "$vend/test-resources" "$proj/process/test-resources"
+ln -s "$vend/script" "$proj/process/script"
+cat > "$proj/deps.edn" <<EOF
+{:paths ["$root/test/chez/process-suite/src" "$vend/test" "$vend/src" "$root/vendor/fs/src"]
+ :aliases {:proc {:main-opts ["-m" "process-run"]}}}
+EOF
+onpath="$(cd "$proj/process/target/test/on-path" && pwd -P)"
+
+# perl for a portable timeout (the coreutils `timeout` may not be on the tool PATH).
+out="$(JOLT_PWD="$proj" BABASHKA_TEST_ENV=jvm PATH="$onpath:$toolbin:/usr/bin:/bin" \
+       perl -e 'alarm shift; exec @ARGV' 300 "$joltc" -M:proc babashka.process-test 2>&1)"
+
+echo "$out" | grep -E 'PROC-RESULT|Ran '
+echo "$out" | grep -E 'FAIL:|ERROR:' | head -20
+res="$(echo "$out" | grep '^PROC-RESULT' | head -1)"
+fails="$(echo "$res" | awk '{print $4}')"
+errs="$(echo "$res" | awk '{print $5}')"
+if [ -n "$res" ] && [ "${fails:-1}" = "0" ] && [ "${errs:-1}" = "0" ]; then
+  echo "process-suite: clean ($(echo "$res" | awk '{print $3}') assertions passed; bb-gated tests skipped)"
+  exit 0
+fi
+echo "process-suite: FAILED (${fails:-?} failures / ${errs:-?} errors)"
+exit 1

--- a/test/chez/process-suite/README.md
+++ b/test/chez/process-suite/README.md
@@ -10,20 +10,33 @@ runner is a manual conformance harness, like `cts-app`.
 ## Running
 
 ```
+host/chez/process-suite.sh
+```
+
+The script stages what the suite needs and isolates babashka:
+
+- **Program-resolution fixtures.** The program-resolution tests copy
+  `test-resources/print-dirs.sh` into `target/test/{on-path,cwd,workdir}` and
+  resolve a bare name via `PATH`, so the script symlinks the fixtures into a temp
+  project and puts the `on-path` dir on `PATH`.
+- **bb isolation.** Most other tests shell out to `babashka` itself (one can
+  hang). The script runs joltc under a minimal tool `PATH` (just `chez` +
+  `/usr/bin:/bin`) that excludes the dir holding `bb`, so `find-bb` returns nil
+  and those tests skip (`BABASHKA_TEST_ENV=jvm`).
+
+Everything is staged in a temp dir — no writes into the repo.
+
+## Baseline
+
+`babashka.process-test`: **27 assertions pass, 0 fail, 0 errors.** The bb-gated
+tests skip.
+
+## Manual run
+
+For a quick run without the fixture staging (the program-resolution test will
+error on the missing fixtures, and bb-gated tests run if `bb` is on `PATH`):
+
+```
 JOLT_PWD="$PWD/test/chez/process-suite" BABASHKA_TEST_ENV=jvm \
   bin/joltc -M:proc babashka.process-test
 ```
-
-`BABASHKA_TEST_ENV=jvm` makes the many tests that shell out to `babashka` itself
-skip gracefully when `bb` is not on the `PATH` (they are neither pass nor fail).
-
-## Baseline (bb absent)
-
-`babashka.process-test`: **19 assertions pass, 0 failures.** The bb-dependent
-tests skip. The one remaining error is `resolve-program-macos-linux-test`, which
-tests babashka's own PATH/program resolution and needs staged executable fixtures
-under `process/test-resources/` plus a writable repo-root `target/` — it is
-environment-specific, not a `jolt.process` defect.
-
-If `bb` is installed the bb-gated tests also run and exercise real babashka
-sub-process interaction; those results are environment-dependent.

--- a/test/chez/process-test.clj
+++ b/test/chez/process-test.clj
@@ -2,7 +2,8 @@
 ;; Run: bin/joltc run test/chez/process-test.clj (smoke.sh greps for "PROCESS-TEST OK").
 (ns process-test
   (:require [jolt.process :as p :refer [process sh check pipeline]]
-            [jolt.fs :as fs]))
+            [jolt.fs :as fs]
+            [clojure.string :as str]))
 
 (def failures (atom []))
 (defn check-eq [label got want]
@@ -60,6 +61,23 @@
   (p/destroy proc)
   (check-eq "sigterm exit" (:exit @proc) 143)
   (check-eq "dead after destroy" (p/alive? proc) false))
+
+;; a spawned child inherits the user's cwd (user.dir / JOLT_PWD), not jolt's OS cwd
+;; (the launcher cd's to the repo root but preserves the user's cwd in JOLT_PWD)
+(check-eq "child cwd = user.dir"
+          (str (fs/canonicalize (str/trim (:out (sh ["pwd"])))))
+          (str (fs/canonicalize (System/getProperty "user.dir"))))
+;; an explicit :dir sets the child's cwd (pwd echoes the logical cd path)
+(let [sub (fs/create-temp-dir {:prefix "jp-dir-"})]
+  (check-eq "dir set" (str/trim (:out (sh ["pwd"] {:dir (str sub)}))) (str sub))
+  (fs/delete-tree sub))
+
+;; ProcessBuilder.start throws (like the JVM) when the program can't be resolved,
+;; with a "No such file" message — not a shell "not found" after spawning
+(check-eq "missing program throws"
+          (try (sh ["definitely-no-such-program-xyz"]) :no-throw
+               (catch Exception e (if (re-find #"No such file" (str (ex-message e))) :nosuch :other)))
+          :nosuch)
 
 ;; class / instance? derive from the central registry
 (check-eq "pb instance?" (instance? java.lang.ProcessBuilder (java.lang.ProcessBuilder. ["true"])) true)


### PR DESCRIPTION
Follow-up to #418, found while wiring up the babashka/process program-resolution test fixtures.

## Bugs fixed (subprocess working directory)

- **Child cwd.** A spawned child inherited jolt's OS cwd — the repo root its launcher `cd`s to — instead of the user's cwd. A JVM child inherits `user.dir`; jolt preserves the user's cwd in `JOLT_PWD`. The process shim now `cd`s the child to `JOLT_PWD` by default and resolves a relative `:dir` against it. Before, `(sh ["ls"])` listed the jolt repo, not the caller's dir.
- **user.dir.** `System/getProperty "user.dir"` returned `PWD` (the repo root after the launcher's `cd`), not the user's cwd. It now prefers `JOLT_PWD`, so `user.dir` and spawned-child cwds agree.

## Conformance

- **Program resolution.** `ProcessBuilder.start` now resolves the program before spawning and throws `IOException("...No such file or directory")` when it can't be found (absolute / slash-relative file must exist; a bare name must be on `PATH`) — matching the JVM instead of letting the shell fail at `exec` with a different message.

## Harness

`host/chez/process-suite.sh` runs the upstream `babashka.process-test` with the program-resolution fixtures staged (in a temp dir) and `bb` isolated (minimal tool PATH), so the portable subset runs clean: **27 assertions pass, 0 fail, 0 errors**; bb-gated tests skip. `process-test.clj` gains regression coverage for the child-cwd and missing-program behavior.

Local: `make smoke` 68/0.