### PR TITLE
Compile stdin/-e forms in the current ns, not a hardcoded "user"

### DIFF
--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -105,9 +105,15 @@
                           (if (> j i)
                               (loop j (if (rdr-eof? form)
                                           result
+                                          ;; Compile each form in the CURRENT ns, re-read
+                                          ;; per form (like load-jolt-file) — an (ns …) form
+                                          ;; switches it, so a later (refer …)/def and its
+                                          ;; use land in the same namespace. Hardcoding
+                                          ;; "user" lost mappings a runtime refer added to
+                                          ;; the switched-to ns (jolt#… stdin ns-switch bug).
                                           (jolt-compile-eval-form
                                             (maybe-quote-require-args form)
-                                            "user")))
+                                            (chez-current-ns))))
                               result))))))
       (jolt-pop-thread-bindings)
       (let ((s (jolt-final-str result)))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -176,6 +176,15 @@ printf '(ns mcmd) (defn -main [& a] (prn *command-line-args*))\n' > "$mp/src/mcm
 cla_check "JOLT_PWD=\"$mp\" $joltc -m mcmd -- a b" '("a" "b")'
 rm -rf "$mp"
 
+# stdin `-`: an (ns …) switch is honored for later forms, so a runtime refer
+# into the switched-to ns is visible to a following form's analysis — the same
+# as loading a file. Was lost when `-`/-e compiled every form in a hardcoded
+# "user" ns (broke `ys -T jolt prog.ys | jolt -`).
+ns_dir="$(mktemp -d)"; ns_prog="$ns_dir/p.clj"
+printf "(intern (create-ns 'aux) 'AAA 42)\n(ns main)\n(refer 'aux :only '[AAA])\n(println AAA)\n" > "$ns_prog"
+cla_check "$joltc - < \"$ns_prog\"" '42'
+rm -rf "$ns_dir"
+
 # help prints usage (bare `help` and --help/-h are synonyms) and lists the
 # nREPL server as a bare command.
 help_out="$($joltc help 2>/dev/null)"


### PR DESCRIPTION
Fixes the stdin ns-switch bug reported by the YS (YAMLScript) project — `ys -T jolt prog.ys | jolt -` failing with "Unable to resolve symbol: ARGS".

## Root cause

`jolt -` (and `-e`) ran each top-level form through `jolt-compile-eval-form` with the namespace **pinned to `"user"`** (`cli-core.ss`). Loading a *file* instead re-reads `(chez-current-ns)` per form (`loader.ss`), so an `(ns …)` form switches it and later forms compile in the switched-to namespace.

The mismatch: a compiled YS program does `(ns main)` then a runtime `(refer …)` to pull the YS stdlib in. The `refer` lands in `main` (the runtime `*ns*`), while the *following* form compiled in `"user"` — so the referred symbol (`ARGS`, etc.) didn't resolve. Process substitution `jolt <(ys …)` already worked because it loads a file.

## Fix

Compile each stdin/`-e` form in `(chez-current-ns)`, re-read per form — exactly what the file loader does.

## Self-contained repro (no ys needed), now a smoke.sh regression

```clojure
(intern (create-ns 'aux) 'AAA 42)
(ns main)
(refer 'aux :only '[AAA])
(println AAA)
```
`jolt repro.clj` → 42; `jolt - < repro.clj` → was "Unable to resolve symbol: AAA", now 42.

`make smoke` 69/0 (adds the regression check). `-e`, `*command-line-args*`, and no-ns-switch stdin all still pass.