### PR TITLE
Download Maven deps over jolt-native HTTPS; drop curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Maven dependencies download over HTTPS through jolt itself instead of shelling
+  out to `curl`. A new `jolt.mvn-http` does a minimal cert-verifying HTTPS GET
+  (a raw socket via `jolt.ffi`, TLS over the system OpenSSL with peer verification
+  + SNI + hostname check), so a dependency jar is never fetched over an
+  unauthenticated transport. It loads the real OpenSSL lazily — on macOS the
+  Homebrew `openssl@3` (the protected `/usr/lib` copy can't be loaded); on Linux
+  the distro `libssl`/`libcrypto`; on Windows the `libssl-3-x64.dll` DLLs via
+  Winsock (the Windows path is implemented but not yet validated on a Windows
+  host). A repo that can't be reached is skipped, non-fatal. `git` (git deps) and
+  `unzip` (jar extraction) are still shelled out; `curl` is gone.
+
 ## [0.4.7] - 2026-07-19
 
 Library conformance (flatland/ordered; babashka.http-client via jolt-lang/http-client),

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke submodules
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke submodules httpsfetch
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -68,6 +68,11 @@ buildlibsmoke:
 # default), and --dynamic keeps the runtime load-shared-object path.
 staticnativesmoke:
 	@sh host/chez/static-native-smoke.sh
+
+# OPT-IN: jolt.mvn-http cert-verifying HTTPS fetch against Central + Clojars.
+# Not in `make test` — needs network + a working system OpenSSL.
+httpsfetch:
+	@sh host/chez/https-fetch-smoke.sh
 
 # Build joltc as a self-contained native binary into target/<profile>/joltc. The
 # binary bundles the runtime, compiler, jolt-core + stdlib source, the Chez boots,

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke submodules httpsfetch
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke submodules httpsfetch mvnhttp
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -22,7 +22,7 @@ test: submodules selfhost ci
 # lockfile) — it RUNS correctly on any Chez, but `selfhost` rebuilds it and a
 # different Chez version may emit byte-different (gensym/order) output, so the
 # byte-fixpoint is a dev-machine check, not a CI one (jolt-8479).
-ci: submodules values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke certify
+ci: submodules values corpus unit mvnhttp smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke certify
 	@echo "OK: CI gates passed"
 
 # Self-host fixpoint: bootstrap.ss rebuild == checked-in seed.
@@ -73,6 +73,11 @@ staticnativesmoke:
 # Not in `make test` — needs network + a working system OpenSSL.
 httpsfetch:
 	@sh host/chez/https-fetch-smoke.sh
+
+# jolt.mvn-http pure-function tests (URL/redirect/header/body parsing). No
+# network, no OpenSSL — runs in the default gate.
+mvnhttp:
+	@bin/joltc run test/mvn_http_test.clj
 
 # Build joltc as a self-contained native binary into target/<profile>/joltc. The
 # binary bundles the runtime, compiler, jolt-core + stdlib source, the Chez boots,

--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ Building from source needs only [Chez Scheme](https://cisco.github.io/ChezScheme
 (the gate invokes it as `chez`) and a C compiler. The conformance gate
 additionally uses Clojure on the JVM as an oracle, but running jolt does not.
 
+### Dependency resolution
+
+Resolving a project's `deps.edn` uses a few standard tools, each needed only for
+the coordinate types you use — a dependency that can't be fetched is skipped, never
+fatal:
+
+- **Git deps** (`:git/url`) need `git` on `PATH`.
+- **Maven deps** (`:mvn/version`) are downloaded over HTTPS by jolt itself (no
+  `curl`), using the system **OpenSSL** (`libssl`/`libcrypto`) via FFI, and
+  extracted with `unzip`. A jar already in `~/.m2/repository` is reused with no
+  download.
+  - **macOS**: `brew install openssl@3` — jolt loads the Homebrew copy; the
+    protected system `/usr/lib` OpenSSL can't be loaded into a non-Apple binary.
+    `git`/`unzip` come with the Xcode command-line tools.
+  - **Linux**: the distro `libssl3`/`libcrypto3` (or `libssl`/`libcrypto`) packages,
+    plus `git` and `unzip`.
+  - **Windows**: [Git for Windows](https://git-scm.com/download/win) supplies `git`,
+    the OpenSSL DLLs (`libssl-3-x64.dll`/`libcrypto-3-x64.dll`), and `unzip`; run
+    `joltc` from a shell with those on `PATH`.
+
 ## Build
 
 There is no build step. The bootstrap seed (`host/chez/seed/{prelude,image}.ss`)

--- a/host/chez/https-fetch-smoke.sh
+++ b/host/chez/https-fetch-smoke.sh
@@ -34,8 +34,8 @@ check_pom () {
 
 # Central: a pom is small and plaintext, ideal for a content check.
 check_pom "central" "https://repo1.maven.org/maven2/org/clojure/math.combinatorics/0.2.0/math.combinatorics-0.2.0.pom"
-# Clojars-hosted artifact.
-check_pom "clojars" "https://repo.clojars.org/org/clojure/math.combinatorics/0.2.0/math.combinatorics-0.2.0.pom"
+# Clojars-hosted artifact (math.combinatorics is Central-only; clj-http is on Clojars).
+check_pom "clojars" "https://repo.clojars.org/clj-http/clj-http/3.12.3/clj-http-3.12.3.pom"
 
 if [ "$fails" -ne 0 ]; then
   echo "https-fetch: FAILED — $fails check(s) failed"

--- a/host/chez/https-fetch-smoke.sh
+++ b/host/chez/https-fetch-smoke.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# OPT-IN network smoke for jolt.mvn-http: fetch a small real artifact over
+# cert-verifying HTTPS from both Maven Central and Clojars, and assert the body
+# landed as a non-empty file with the expected content. NOT in `make test` — it
+# needs network + a working system OpenSSL. Run with: make httpsfetch
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+JOLTC="${JOLTC:-bin/joltc}"
+
+fails=0
+
+# fetch URL -> tmp; assert the file is non-empty and its first line looks like a
+# Maven pom (<?xml ...> or <project ...>). $1 = label, $2 = url.
+check_pom () {
+  label="$1"; url="$2"; tmp="${TMPDIR:-/tmp}/jolt-http-$$"
+  rm -f "$tmp"
+  got="$($JOLTC -e "(require '[jolt.mvn-http]) (if (jolt.mvn-http/fetch \"$url\" \"$tmp\") :ok :fail)" 2>&1 | tail -1)"
+  if [ "$got" != ":ok" ]; then
+    echo "https-fetch: FAIL $label — fetch returned $got"
+    fails=$((fails + 1)); rm -f "$tmp"; return
+  fi
+  if [ ! -s "$tmp" ]; then
+    echo "https-fetch: FAIL $label — empty body"
+    fails=$((fails + 1)); rm -f "$tmp"; return
+  fi
+  if ! head -c 200 "$tmp" | grep -Eq '<\?xml|<project'; then
+    echo "https-fetch: FAIL $label — body is not a pom (first bytes:)"
+    head -c 60 "$tmp"; echo
+    fails=$((fails + 1)); rm -f "$tmp"; return
+  fi
+  echo "https-fetch: PASS $label ($(wc -c < "$tmp" | tr -d ' ') bytes)"
+  rm -f "$tmp"
+}
+
+# Central: a pom is small and plaintext, ideal for a content check.
+check_pom "central" "https://repo1.maven.org/maven2/org/clojure/math.combinatorics/0.2.0/math.combinatorics-0.2.0.pom"
+# Clojars-hosted artifact.
+check_pom "clojars" "https://repo.clojars.org/org/clojure/math.combinatorics/0.2.0/math.combinatorics-0.2.0.pom"
+
+if [ "$fails" -ne 0 ]; then
+  echo "https-fetch: FAILED — $fails check(s) failed"
+  exit 1
+fi
+echo "https-fetch: passed"

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -12,7 +12,7 @@
   :mvn/local-repo in deps.edn relocates it like tools.deps, JOLT_LOCAL_REPO
   overrides from the environment) shared with the JVM toolchain in both
   directions. Maven jars are fetched by jolt itself over HTTPS (jolt.mvn-http);
-  git/unzip still shell out through jolt.host/sh. Nothing here touches the JVM."
+  git and unzip still shell out through jolt.host/sh (nothing here touches the JVM)."
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [jolt.mvn-http :as http]))

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -11,10 +11,11 @@
   Maven jars live in the standard local repository (~/.m2/repository;
   :mvn/local-repo in deps.edn relocates it like tools.deps, JOLT_LOCAL_REPO
   overrides from the environment) shared with the JVM toolchain in both
-  directions. Resolution shells out to `git`/`curl`/`unzip` through
-  jolt.host/sh; nothing here touches the JVM."
+  directions. Maven jars are fetched by jolt itself over HTTPS (jolt.mvn-http);
+  git/unzip still shell out through jolt.host/sh. Nothing here touches the JVM."
   (:require [clojure.edn :as edn]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [jolt.mvn-http :as http]))
 
 ;; --- small host seams -------------------------------------------------------
 (defn- getenv [n] (jolt.host/getenv n))
@@ -176,8 +177,7 @@
           (if (empty? repos)
             (do (warn "maven dep " coord " " version " not found (Clojars/Central)") nil)
             (if (do (sh (str "mkdir -p " (pr-str (if legacy dir (str (m2-repo-dir) "/" vdir-rel)))))
-                    (zero? (sh (str "curl -fsSL " (pr-str (str (first repos) "/" vdir-rel "/" jar-name))
-                                " -o " (pr-str jar)))))
+                    (http/fetch (str (first repos) "/" vdir-rel "/" jar-name) jar))
               (do (info "fetching " coord " " version)
                   (let [d (extract-jar! jar dir)]
                     ;; legacy layout never keeps the jar; the m2 layout does —

--- a/stdlib/jolt/mvn_http.clj
+++ b/stdlib/jolt/mvn_http.clj
@@ -9,27 +9,31 @@
   (:require [jolt.ffi :as ffi]
             [clojure.string :as str]))
 
-(def ^:private macos?
-  (str/includes? (str/lower-case (or (System/getProperty "os.name") "")) "mac"))
+(def ^:private os-name
+  (str/lower-case (or (System/getProperty "os.name") "")))
+(def ^:private macos? (str/includes? os-name "mac"))
+(def ^:private windows? (str/includes? os-name "windows"))
 
 ;; libcrypto loads first (libssl links it). On macOS the system /usr/lib
-;; libcrypto is a protected Apple image and aborts the process if dlopen'd,
-;; so the Homebrew paths come first and the bare name is only a last resort.
+;; libcrypto is a protected Apple image and *aborts the process* if dlopen'd
+;; (an uncatchable SIGABRT, not a Scheme error) — so only explicit real-OpenSSL
+;; paths are tried; the bare "libcrypto.dylib" name is deliberately NOT a
+;; candidate. If none of these exist, fetch fails gracefully.
 (def ^:private crypto-candidates
-  (if macos?
-    ["/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib"
-     "/opt/homebrew/lib/libcrypto.dylib"
-     "/usr/local/opt/openssl@3/lib/libcrypto.dylib"
-     "libcrypto.dylib"]
-    ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"]))
+  (cond
+    macos?   ["/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib"
+              "/opt/homebrew/lib/libcrypto.dylib"
+              "/usr/local/opt/openssl@3/lib/libcrypto.dylib"]
+    windows? ["libcrypto-3-x64.dll" "libcrypto-3.dll" "libcrypto-1_1-x64.dll"]
+    :else    ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"]))
 
 (def ^:private ssl-candidates
-  (if macos?
-    ["/opt/homebrew/opt/openssl@3/lib/libssl.dylib"
-     "/opt/homebrew/lib/libssl.dylib"
-     "/usr/local/opt/openssl@3/lib/libssl.dylib"
-     "libssl.dylib"]
-    ["libssl.so.3" "libssl.so.1.1" "libssl.so"]))
+  (cond
+    macos?   ["/opt/homebrew/opt/openssl@3/lib/libssl.dylib"
+              "/opt/homebrew/lib/libssl.dylib"
+              "/usr/local/opt/openssl@3/lib/libssl.dylib"]
+    windows? ["libssl-3-x64.dll" "libssl-3.dll" "libssl-1_1-x64.dll"]
+    :else    ["libssl.so.3" "libssl.so.1.1" "libssl.so"]))
 
 (def ^:private ssl-loaded? (volatile! false))
 

--- a/stdlib/jolt/mvn_http.clj
+++ b/stdlib/jolt/mvn_http.clj
@@ -82,7 +82,32 @@
 (ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t :blocking)
 (ffi/defcfn c-getaddrinfo "getaddrinfo" [:pointer :pointer :pointer :pointer] :int :blocking)
 (ffi/defcfn c-freeaddrinfo "freeaddrinfo" [:pointer] :void)
+(ffi/defcfn c-setsockopt  "setsockopt"  [:int :int :int :pointer :int] :int)
 (ffi/defcfn c-WSAStartup  "WSAStartup"  [:int :pointer] :int)     ; Windows Winsock init
+
+;; SO_RCVTIMEO/SO_SNDTIMEO bound every blocking socket call so a stalled or
+;; malicious repo can't wedge dependency resolution forever (a timed-out recv
+;; returns -1 -> recv-bytes throws -> fetch returns false). Levels/names differ by
+;; platform; the option value is a struct timeval (POSIX, 16 bytes LP64) or a
+;; DWORD of milliseconds (Windows).
+(def ^:private sol-socket   (if (or macos? windows?) 0xffff 1))
+(def ^:private so-rcvtimeo  (if (or macos? windows?) 0x1006 20))
+(def ^:private so-sndtimeo  (if (or macos? windows?) 0x1005 21))
+(def ^:private socket-timeout-ms 30000)
+
+(defn- set-timeouts! [fd ms]
+  (if windows?
+    (let [buf (ffi/alloc 4)]
+      (ffi/write buf :int 0 ms)
+      (c-setsockopt fd sol-socket so-rcvtimeo buf 4)
+      (c-setsockopt fd sol-socket so-sndtimeo buf 4)
+      (ffi/free buf))
+    (let [tv (ffi/alloc 16)]
+      (ffi/write tv :long 0 (quot ms 1000))
+      (ffi/write tv :long 8 (* (rem ms 1000) 1000))
+      (c-setsockopt fd sol-socket so-rcvtimeo tv 16)
+      (c-setsockopt fd sol-socket so-sndtimeo tv 16)
+      (ffi/free tv))))
 
 ;; struct addrinfo field offsets. Both macOS and Win64 place ai_addr at 32
 ;; (ai_canonname before it); Linux packs ai_addr at 24.
@@ -122,8 +147,9 @@
                       fd (c-socket fam sockt proto)]
                   (cond
                     (neg? fd) (recur (ffi/read ai :pointer O-ai-next))
-                    (zero? (c-connect fd addr addrlen)) fd
-                    :else (do (c-close fd) (recur (ffi/read ai :pointer O-ai-next)))))))
+                    (zero? (c-connect fd addr addrlen)) (do (set-timeouts! fd socket-timeout-ms) fd)
+                    :else (do (if windows? (c-closesocket fd) (c-close fd))
+                              (recur (ffi/read ai :pointer O-ai-next)))))))
             (finally (c-freeaddrinfo res)))))
       (finally (ffi/free node) (ffi/free service) (ffi/free respp) (ffi/free hints)))))
 
@@ -160,6 +186,8 @@
 (def ^:private BIO-PENDING 10)
 (def ^:private SET-TLSEXT-HOSTNAME 55)
 (def ^:private NAMETYPE-host-name 0)
+(def ^:private SET-MIN-PROTO-VERSION 123)
+(def ^:private TLS1_2-VERSION 0x0303)
 (def ^:private ssl-chunk 16384)
 
 (ffi/defcfn c-TLS-client-method "TLS_client_method" [] :pointer)
@@ -176,6 +204,7 @@
 (ffi/defcfn c-SSL-write          "SSL_write"          [:pointer :pointer :int] :int)
 (ffi/defcfn c-SSL-get-error      "SSL_get_error"      [:pointer :int] :int)
 (ffi/defcfn c-SSL-ctrl           "SSL_ctrl"           [:pointer :int :int64 :pointer] :int64)
+(ffi/defcfn c-SSL-CTX-ctrl       "SSL_CTX_ctrl"       [:pointer :int :int64 :pointer] :int64)
 (ffi/defcfn c-SSL-shutdown       "SSL_shutdown"       [:pointer] :int)
 (ffi/defcfn c-SSL-set1-host      "SSL_set1_host"      [:pointer :pointer] :int)
 (ffi/defcfn c-BIO-new            "BIO_new"            [:pointer] :pointer)
@@ -262,28 +291,47 @@
 (defn- tls-connect
   "Open a verified TLS client connection to host:port."
   [host port]
-  (let [ctx (c-SSL-CTX-new (c-TLS-client-method))]
-    (when (ffi/null? ctx) (throw (ex-info "SSL_CTX_new failed" {})))
-    (c-SSL-CTX-default-verify ctx)
-    (c-SSL-CTX-set-verify ctx VERIFY-PEER ffi/null)
-    (let [ssl (c-SSL-new ctx)
-          rbio (c-BIO-new (c-BIO-s-mem))
-          wbio (c-BIO-new (c-BIO-s-mem))
-          host-buf (cstr host)]
-      (c-SSL-set-bio ssl rbio wbio)
-      (c-SSL-set-connect ssl)
-      (c-SSL-ctrl ssl SET-TLSEXT-HOSTNAME NAMETYPE-host-name host-buf) ; SNI
-      (c-SSL-set1-host ssl host-buf)                                   ; hostname check
-      (ffi/free host-buf)
-      (let [sock (connect host port)
-            st {:sock sock :ssl ssl :ctx ctx :rbio rbio :wbio wbio}]
-        (try (handshake! st)
-             (catch :default e (tls-close st) (throw e)))
-        st))))
+  ;; Open the socket FIRST: connect throws on DNS/refused (the common failure),
+  ;; and doing it before any OpenSSL allocation means that path leaks nothing.
+  (let [sock (connect host port)
+        ctx  (c-SSL-CTX-new (c-TLS-client-method))]
+    (when (ffi/null? ctx)
+      (close-sock sock)
+      (throw (ex-info "SSL_CTX_new failed" {})))
+    (let [ssl  (c-SSL-new ctx)]
+      (when (ffi/null? ssl)
+        (c-SSL-CTX-free ctx) (close-sock sock)
+        (throw (ex-info "SSL_new failed" {})))
+      (let [rbio (c-BIO-new (c-BIO-s-mem))
+            wbio (c-BIO-new (c-BIO-s-mem))
+            st   {:sock sock :ssl ssl :ctx ctx :rbio rbio :wbio wbio}]
+        ;; Hand the BIOs to the SSL up front — SSL_free then owns and frees them,
+        ;; so tls-close in the catch below reclaims everything.
+        (c-SSL-set-bio ssl rbio wbio)
+        (try
+          (when (zero? (c-SSL-CTX-default-verify ctx))
+            (throw (ex-info "no CA trust store (SSL_CTX_set_default_verify_paths)" {})))
+          (c-SSL-CTX-set-verify ctx VERIFY-PEER ffi/null)
+          (c-SSL-CTX-ctrl ctx SET-MIN-PROTO-VERSION TLS1_2-VERSION ffi/null) ; TLS >= 1.2
+          (c-SSL-set-connect ssl)
+          (let [host-buf (cstr host)]
+            (try
+              (c-SSL-ctrl ssl SET-TLSEXT-HOSTNAME NAMETYPE-host-name host-buf) ; SNI
+              (when-not (= 1 (c-SSL-set1-host ssl host-buf))                   ; hostname check
+                (throw (ex-info "SSL_set1_host failed" {})))
+              (finally (ffi/free host-buf))))
+          (handshake! st)
+          st
+          (catch :default e (tls-close st) (throw e)))))))
 
 ;; --- HTTP/1.1 request/response ---
 (defn- jolt-version []
   (or (System/getProperty "jolt.version") "jolt"))
+
+;; A CR, LF, or NUL in a URL would let a crafted :mvn/version or a server
+;; redirect Location inject a second request line / header (request smuggling).
+(defn- ctl-free? [s]
+  (not-any? (fn [c] (or (= c \return) (= c \newline) (= c (char 0)))) s))
 
 (defn- parse-url
   "https://host[:port]/path[?query] -> {:host :port :path}. HTTPS only."
@@ -295,12 +343,13 @@
           slash (str/index-of after "/")
           authority (if slash (subs after 0 slash) after)
           path (if slash (subs after slash) "/")
-          colon (str/index-of authority ":")]
+          colon (str/index-of authority ":")
+          host (if colon (subs authority 0 colon) authority)]
+      (when-not (and (ctl-free? host) (ctl-free? path))
+        (throw (ex-info "jolt.mvn-http: control character in URL" {:url s})))
       (if colon
-        {:host (subs authority 0 colon)
-         :port (or (parse-long (subs authority (inc colon))) 443)
-         :path path}
-        {:host authority :port 443 :path path}))))
+        {:host host :port (or (parse-long (subs authority (inc colon))) 443) :path path}
+        {:host host :port 443 :path path}))))
 
 (defn- build-request [host port path]
   (let [host-hdr (if (= port 443) host (str host ":" port))]
@@ -382,35 +431,57 @@
                                [(str/trim (subs line 0 c)) (str/trim (subs line (inc c)))]))
                            (rest lines)))
           te (header-ci pairs "transfer-encoding")
-          body (if (and te (str/includes? (str/lower-case te) "chunked"))
-                 (dechunk body-ba) body-ba)]
-      {:status status :header-pairs pairs :body body})))
+          chunked? (and te (str/includes? (str/lower-case te) "chunked"))
+          body (if chunked? (dechunk body-ba) body-ba)
+          clen (when-let [c (header-ci pairs "content-length")] (parse-long (str/trim c)))]
+      {:status status :header-pairs pairs :body body
+       ;; a Content-Length only frames a non-chunked body; used to reject a
+       ;; truncated download (a mid-body TLS drop reads as a short clean EOF).
+       :content-length (when-not chunked? clen)})))
 
+;; Resolve a redirect Location against the current base, HTTPS only. A redirect
+;; to plain http:// is a downgrade and is refused outright (returns nil) rather
+;; than silently followed — defense in depth, independent of parse-url.
 (defn- resolve-location [base loc]
   (let [host-port (str (:host base)
                        (when-not (= (:port base) 443) (str ":" (:port base))))]
     (cond
+      (str/starts-with? loc "http://")  nil
       (str/starts-with? loc "//")       (str "https:" loc)
       (str/starts-with? loc "https://") loc
-      (str/starts-with? loc "http://")  loc
       (str/starts-with? loc "/")        (str "https://" host-port loc)
       :else                             (str "https://" host-port "/" loc))))
 
+;; Write via a temp file + atomic rename so a crash/partial write never leaves a
+;; corrupt jar at the final path (which deps.clj would then trust and never
+;; re-fetch).
 (defn- write-bytes-to-file [path ba]
-  (doto (java.io.FileOutputStream. path) (.write ba) (.close)))
+  (let [tmp (str path ".part")]
+    (doto (java.io.FileOutputStream. tmp) (.write ba) (.close))
+    (let [t (java.io.File. tmp) f (java.io.File. path)]
+      (.delete f)
+      (when-not (.renameTo t f)
+        (.delete t)
+        (throw (ex-info "rename of downloaded file failed" {:path path}))))))
 
 (def ^:private max-redirects 5)
+(def ^:private redirect-codes #{301 302 303 307 308})
 
 (defn- fetch-once [url out-path]
   (let [{:keys [host port path]} (parse-url url)
         st (tls-connect host port)]
     (try
       (tls-write st (.getBytes (build-request host port path) "UTF-8"))
-      (let [{:keys [status header-pairs body]} (parse-response (recv-all st))]
+      (let [{:keys [status header-pairs body content-length]} (parse-response (recv-all st))
+            loc (header-ci header-pairs "location")]
         (cond
-          (and (#{301 302 307 308} status) (header-ci header-pairs "location"))
-          {:redirect (resolve-location {:host host :port port}
-                                        (header-ci header-pairs "location"))}
+          (and (redirect-codes status) loc)
+          {:redirect (resolve-location {:host host :port port} loc)}
+          ;; a Content-Length that disagrees with the body we read means the
+          ;; transfer was cut short — treat it as a failure, don't write a
+          ;; truncated jar.
+          (and (<= 200 status 299) content-length (not= content-length (alength body)))
+          {:result false}
           (<= 200 status 299) (do (write-bytes-to-file out-path body) {:result true})
           :else {:result false}))
       (finally (tls-close st)))))

--- a/stdlib/jolt/mvn_http.clj
+++ b/stdlib/jolt/mvn_http.clj
@@ -1,64 +1,68 @@
 (ns jolt.mvn-http
-  "Cert-verifying HTTPS GET-to-file for dependency download. A minimal HTTP/1.1
-  client over BSD sockets (jolt.ffi) and the system OpenSSL via memory-BIO TLS:
-  VERIFY_PEER + the default verify paths + SNI + SSL_set1_host (hostname check).
-  Follows redirects (max 5), handles Content-Length / chunked / read-to-EOF
-  bodies, and writes the body as raw bytes.
-
-  libssl + libcrypto load on first use; if either is absent, or any step errors
-  (DNS / connect / TLS / cert / parse), fetch returns false — a failed download
-  never crashes dependency resolution. Plain HTTP is rejected: a jar is
-  executable, so it is not fetched over unauthenticated transport."
+  "Minimal cert-verifying HTTPS GET-to-file for dependency download. A plain
+  TCP socket (getaddrinfo/socket/connect) carries ciphertext; TLS runs against
+  in-memory BIOs over the system OpenSSL via jolt.ffi, so no raw fd reaches
+  OpenSSL. libcrypto then libssl lazy-load on first use (candidate lists,
+  Homebrew first on macOS). fetch returns true on a 2xx, false on any failure,
+  so jolt.deps falls through to the next repo. HTTPS only; the server
+  certificate is verified (default verify paths + VERIFY_PEER + hostname check)."
   (:require [jolt.ffi :as ffi]
-            [clojure.string :as str]
-            [clojure.java.io :as io]))
+            [clojure.string :as str]))
 
-;; --- platform + lazy library load -------------------------------------------
-;; ffi/loaded? loads the shared object (a guarded load-shared-object) and reports
-;; success, so trying each candidate both probes and loads. libssl depends on
-;; libcrypto symbols, so crypto loads first.
-(def ^:private os-name
-  (str/lower-case (or (System/getProperty "os.name") "")))
-(def ^:private macos? (str/includes? os-name "mac"))
+(def ^:private macos?
+  (str/includes? (str/lower-case (or (System/getProperty "os.name") "")) "mac"))
+
+;; libcrypto loads first (libssl links it). On macOS the system /usr/lib
+;; libcrypto is a protected Apple image and aborts the process if dlopen'd,
+;; so the Homebrew paths come first and the bare name is only a last resort.
+(def ^:private crypto-candidates
+  (if macos?
+    ["/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib"
+     "/opt/homebrew/lib/libcrypto.dylib"
+     "/usr/local/opt/openssl@3/lib/libcrypto.dylib"
+     "libcrypto.dylib"]
+    ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"]))
 
 (def ^:private ssl-candidates
   (if macos?
-    ["libssl.dylib" "libssl.35.dylib" "libssl.3.dylib" "libssl.46.dylib"]
+    ["/opt/homebrew/opt/openssl@3/lib/libssl.dylib"
+     "/opt/homebrew/lib/libssl.dylib"
+     "/usr/local/opt/openssl@3/lib/libssl.dylib"
+     "libssl.dylib"]
     ["libssl.so.3" "libssl.so.1.1" "libssl.so"]))
-(def ^:private crypto-candidates
-  (if macos?
-    ["libcrypto.dylib" "libcrypto.35.dylib" "libcrypto.3.dylib" "libcrypto.46.dylib"]
-    ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"]))
 
-(def ^:private ssl-ready? (atom false))
+(def ^:private ssl-loaded? (volatile! false))
 
-(defn- load-candidates [cands]
-  (boolean (some #(ffi/loaded? %) cands)))
+(defn- load-one [path]
+  (try (ffi/load-library path) true (catch :default _ false)))
 
-(defn- ensure-ssl-loaded! []
-  (or @ssl-ready?
-      (when (and (load-candidates crypto-candidates)
-                 (load-candidates ssl-candidates))
-        (reset! ssl-ready? true)
+(defn- try-candidates [cs]
+  (loop [cs cs]
+    (cond (empty? cs) false
+          (load-one (first cs)) true
+          :else (recur (rest cs)))))
+
+(defn- ensure-ssl!
+  "Lazy-load libcrypto then libssl on first use. Returns true once both loaded;
+  a later fetch retries (a candidate may have appeared)."
+  []
+  (or @ssl-loaded?
+      (when (and (try-candidates crypto-candidates)
+                 (try-candidates ssl-candidates))
+        (vreset! ssl-loaded? true)
         true)))
 
-;; Any internal failure throws; fetch catches everything and returns false, so
-;; the message is for diagnostics only.
-(defn- fail [msg] (throw (ex-info (str "jolt.mvn-http: " msg) {})))
-
-;; --- BSD sockets (libc; symbols resolve from the running process) -----------
-;; accept/recv/send/connect/getaddrinfo are :blocking so a parked socket call
-;; never pins jolt's stop-the-world collector.
-(ffi/defcfn c-socket       "socket"       [:int :int :int] :int)
-(ffi/defcfn c-connect      "connect"      [:int :pointer :int] :int :blocking)
-(ffi/defcfn c-close        "close"        [:int] :int)
-(ffi/defcfn c-recv         "recv"         [:int :pointer :size_t :int] :ssize_t :blocking)
-(ffi/defcfn c-send         "send"         [:int :pointer :size_t :int] :ssize_t :blocking)
-(ffi/defcfn c-getaddrinfo  "getaddrinfo"  [:pointer :pointer :pointer :pointer] :int :blocking)
+;; --- BSD socket layer (process symbols resolve at load) ---
+(ffi/defcfn c-socket      "socket"      [:int :int :int] :int)
+(ffi/defcfn c-connect     "connect"     [:int :pointer :int] :int :blocking)
+(ffi/defcfn c-close       "close"       [:int] :int)
+(ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-getaddrinfo "getaddrinfo" [:pointer :pointer :pointer :pointer] :int :blocking)
 (ffi/defcfn c-freeaddrinfo "freeaddrinfo" [:pointer] :void)
 
-;; struct addrinfo field offsets (LP64). macOS swaps ai_canonname/ai_addr versus
-;; Linux, so ai_addr sits at 32 on macOS, 24 on Linux. ai_addrlen=16, ai_next=40.
+;; struct addrinfo field offsets (LP64). macOS swaps ai_canonname/ai_addr
+;; vs Linux, so ai_addr sits at 32 on macOS, 24 on Linux.
 (def ^:private O-ai-family 4)
 (def ^:private O-ai-socktype 8)
 (def ^:private O-ai-protocol 12)
@@ -69,28 +73,30 @@
 (defn- connect
   "Resolve host:port and open a connected TCP socket; return its fd."
   [host port]
-  (let [node    (ffi/string->ptr (str host))
+  (let [node (ffi/string->ptr (str host))
         service (ffi/string->ptr (str port))
-        respp   (ffi/alloc (ffi/sizeof :pointer))
-        ;; hints: ai_socktype = SOCK_STREAM, else getaddrinfo also returns UDP
-        ;; entries and connect() on a datagram socket spuriously "succeeds".
-        hints   (ffi/alloc 48)]
+        respp (ffi/alloc (ffi/sizeof :pointer))
+        hints (ffi/alloc 48)]
     (dotimes [i 48] (ffi/write hints :uint8 i 0))
+    ;; SOCK_STREAM in ai_socktype, else getaddrinfo also returns UDP entries
+    ;; and connect() on a datagram socket spuriously "succeeds".
     (ffi/write hints :int O-ai-socktype 1)
     (try
       (let [rc (c-getaddrinfo node service hints respp)]
-        (when-not (zero? rc) (fail (str "unknown host: " host)))
+        (when-not (zero? rc)
+          (throw (ex-info (str "lookup failed: " host) {:host host})))
         (let [res (ffi/read respp :pointer)]
           (try
             (loop [ai res]
               (if (ffi/null? ai)
-                (fail (str "connection refused: " host ":" port))
-                (let [fam     (ffi/read ai :int O-ai-family)
-                      sockt   (ffi/read ai :int O-ai-socktype)
-                      proto   (ffi/read ai :int O-ai-protocol)
+                (throw (ex-info (str "connection refused: " host ":" port)
+                                {:host host :port port}))
+                (let [fam (ffi/read ai :int O-ai-family)
+                      sockt (ffi/read ai :int O-ai-socktype)
+                      proto (ffi/read ai :int O-ai-protocol)
                       addrlen (ffi/read ai :int O-ai-addrlen)
-                      addr    (ffi/read ai :pointer O-ai-addr)
-                      fd      (c-socket fam sockt proto)]
+                      addr (ffi/read ai :pointer O-ai-addr)
+                      fd (c-socket fam sockt proto)]
                   (cond
                     (neg? fd) (recur (ffi/read ai :pointer O-ai-next))
                     (zero? (c-connect fd addr addrlen)) fd
@@ -98,330 +104,308 @@
             (finally (c-freeaddrinfo res)))))
       (finally (ffi/free node) (ffi/free service) (ffi/free respp) (ffi/free hints)))))
 
-(def ^:private bufsize 65536)
+(def ^:private recv-bufsize 65536)
 
 (defn- recv-bytes
-  "Read up to one bufferful from fd: a byte-array, or nil at EOF (recv 0)."
+  "Read up to one bufferful from fd: a byte-array, nil at EOF."
   [fd]
-  (let [buf (ffi/alloc bufsize)]
+  (let [buf (ffi/alloc recv-bufsize)]
     (try
-      (let [got (c-recv fd buf bufsize 0)]
-        (cond
-          (pos? got) (ffi/read-array buf got)
-          (zero? got) nil
-          :else (fail "read timed out")))
+      (let [got (c-recv fd buf recv-bufsize 0)]
+        (cond (pos? got) (ffi/read-array buf got)
+              (zero? got) nil
+              :else (throw (ex-info "recv failed" {}))))
       (finally (ffi/free buf)))))
 
-(defn- send-bytes
-  "Send all of byte-array data over fd."
-  [fd data]
+(defn- send-bytes [fd data]
   (let [n (alength data) buf (ffi/alloc (max 1 n))]
     (try
       (ffi/write-array buf data)
       (loop [off 0]
         (when (< off n)
           (let [sent (c-send fd (+ buf off) (- n off) 0)]
-            (if (pos? sent)
-              (recur (+ off sent))
-              (fail "send failed")))))
+            (if (pos? sent) (recur (+ off sent))
+                (throw (ex-info "send failed" {}))))))
       (finally (ffi/free buf)))))
 
-(defn- close [fd] (c-close fd) nil)
+(defn- close-sock [fd] (c-close fd) nil)
 
-;; --- OpenSSL TLS (client, memory-BIO over the socket above) -----------------
-;; SSL runs against in-memory BIOs while ciphertext is shuttled over the plain
-;; socket, so no raw-fd access into OpenSSL is needed.
+;; --- OpenSSL TLS client (memory-BIO) ---
 (def ^:private WANT-READ 2)
 (def ^:private WANT-WRITE 3)
 (def ^:private VERIFY-PEER 1)
 (def ^:private BIO-PENDING 10)
 (def ^:private SET-TLSEXT-HOSTNAME 55)
 (def ^:private NAMETYPE-host-name 0)
-(def ^:private chunk 16384)
+(def ^:private ssl-chunk 16384)
 
-(ffi/defcfn c-TLS-client-method  "TLS_client_method"              [] :pointer)
-(ffi/defcfn c-SSL-CTX-new        "SSL_CTX_new"                    [:pointer] :pointer)
-(ffi/defcfn c-SSL-CTX-free       "SSL_CTX_free"                   [:pointer] :void)
-(ffi/defcfn c-SSL-CTX-set-verify "SSL_CTX_set_verify"             [:pointer :int :pointer] :void)
+(ffi/defcfn c-TLS-client-method "TLS_client_method" [] :pointer)
+(ffi/defcfn c-SSL-CTX-new        "SSL_CTX_new"        [:pointer] :pointer)
+(ffi/defcfn c-SSL-CTX-free       "SSL_CTX_free"       [:pointer] :void)
+(ffi/defcfn c-SSL-CTX-set-verify "SSL_CTX_set_verify" [:pointer :int :pointer] :void)
 (ffi/defcfn c-SSL-CTX-default-verify "SSL_CTX_set_default_verify_paths" [:pointer] :int)
-(ffi/defcfn c-SSL-new            "SSL_new"                        [:pointer] :pointer)
-(ffi/defcfn c-SSL-free           "SSL_free"                       [:pointer] :void)
-(ffi/defcfn c-SSL-set-bio        "SSL_set_bio"                    [:pointer :pointer :pointer] :void)
-(ffi/defcfn c-SSL-set-connect    "SSL_set_connect_state"          [:pointer] :void)
-(ffi/defcfn c-SSL-connect        "SSL_connect"                    [:pointer] :int)
-(ffi/defcfn c-SSL-read           "SSL_read"                       [:pointer :pointer :int] :int)
-(ffi/defcfn c-SSL-write          "SSL_write"                      [:pointer :pointer :int] :int)
-(ffi/defcfn c-SSL-get-error      "SSL_get_error"                  [:pointer :int] :int)
-(ffi/defcfn c-SSL-ctrl           "SSL_ctrl"                       [:pointer :int :int64 :pointer] :int64)
-(ffi/defcfn c-SSL-shutdown       "SSL_shutdown"                   [:pointer] :int)
-(ffi/defcfn c-SSL-set1-host      "SSL_set1_host"                  [:pointer :pointer] :int)
-(ffi/defcfn c-BIO-new            "BIO_new"                        [:pointer] :pointer)
-(ffi/defcfn c-BIO-s-mem          "BIO_s_mem"                      [] :pointer)
-(ffi/defcfn c-BIO-read           "BIO_read"                       [:pointer :pointer :int] :int)
-(ffi/defcfn c-BIO-write          "BIO_write"                      [:pointer :pointer :int] :int)
-(ffi/defcfn c-BIO-ctrl           "BIO_ctrl"                       [:pointer :int :int64 :pointer] :int64)
+(ffi/defcfn c-SSL-new            "SSL_new"            [:pointer] :pointer)
+(ffi/defcfn c-SSL-free           "SSL_free"           [:pointer] :void)
+(ffi/defcfn c-SSL-set-bio        "SSL_set_bio"        [:pointer :pointer :pointer] :void)
+(ffi/defcfn c-SSL-set-connect    "SSL_set_connect_state" [:pointer] :void)
+(ffi/defcfn c-SSL-connect        "SSL_connect"        [:pointer] :int)
+(ffi/defcfn c-SSL-read           "SSL_read"           [:pointer :pointer :int] :int)
+(ffi/defcfn c-SSL-write          "SSL_write"          [:pointer :pointer :int] :int)
+(ffi/defcfn c-SSL-get-error      "SSL_get_error"      [:pointer :int] :int)
+(ffi/defcfn c-SSL-ctrl           "SSL_ctrl"           [:pointer :int :int64 :pointer] :int64)
+(ffi/defcfn c-SSL-shutdown       "SSL_shutdown"       [:pointer] :int)
+(ffi/defcfn c-SSL-set1-host      "SSL_set1_host"      [:pointer :pointer] :int)
+(ffi/defcfn c-BIO-new            "BIO_new"            [:pointer] :pointer)
+(ffi/defcfn c-BIO-s-mem          "BIO_s_mem"          [] :pointer)
+(ffi/defcfn c-BIO-read           "BIO_read"           [:pointer :pointer :int] :int)
+(ffi/defcfn c-BIO-write          "BIO_write"          [:pointer :pointer :int] :int)
+(ffi/defcfn c-BIO-ctrl           "BIO_ctrl"           [:pointer :int :int64 :pointer] :int64)
 
-;; A NUL-terminated C-string pointer; the caller frees it.
 (defn- cstr [s] (ffi/string->ptr (str s)))
+
 (defn- bio-pending [bio] (c-BIO-ctrl bio BIO-PENDING 0 ffi/null))
+
+;; A TLS stream is a plain map {:sock fd :ssl :ctx :rbio :wbio}.
+;; Drain ciphertext OpenSSL produced into wbio out to the socket.
+(defn- flush-out [st]
+  (let [wbio (:wbio st) sock (:sock st)]
+    (loop []
+      (let [p (bio-pending wbio)]
+        (when (pos? p)
+          (let [buf (ffi/alloc p) n (c-BIO-read wbio buf p)]
+            (when (pos? n) (send-bytes sock (ffi/read-array buf n)))
+            (ffi/free buf) (recur)))))))
 
 ;; Pull one ciphertext chunk off the socket into rbio; false at EOF.
 (defn- feed-in [st]
-  (let [data (recv-bytes (jolt.host/ref-get st :sock))]
+  (let [data (recv-bytes (:sock st))]
     (if (and data (pos? (alength data)))
       (let [n (alength data) buf (ffi/alloc n)]
         (ffi/write-array buf data)
-        (c-BIO-write (jolt.host/ref-get st :rbio) buf n)
-        (ffi/free buf)
-        true)
+        (c-BIO-write (:rbio st) buf n)
+        (ffi/free buf) true)
       false)))
 
 (defn- handshake! [st]
   (loop []
-    (let [ret (c-SSL-connect (jolt.host/ref-get st :ssl))]
-      ((jolt.host/ref-get st :flush) st)
-      (when-not (= ret 1)
-        (let [err (c-SSL-get-error (jolt.host/ref-get st :ssl) ret)]
-          (cond
-            (= err WANT-READ) (do (when-not (feed-in st)
-                                    (fail "connection closed during TLS handshake"))
-                                  (recur))
-            (= err WANT-WRITE) (recur)
-            :else (fail (str "TLS handshake failed (SSL_get_error=" err ")"))))))))
+    (let [ret (c-SSL-connect (:ssl st))]
+      (flush-out st)
+      (when (not= ret 1)
+        (let [err (c-SSL-get-error (:ssl st) ret)]
+          (case err
+            2 (if (feed-in st) (recur)
+                  (throw (ex-info "connection closed during TLS handshake" {})))
+            3 (recur)
+            (throw (ex-info (str "TLS handshake failed (SSL_get_error=" err ")") {}))))))))
 
-;; A TLS stream is a host tagged-table carrying :write / :read / :close closures
-;; and the shared ssl/ctx/bio/eof state they mutate.
-(defn- make-stream [sock ssl ctx rbio wbio]
-  (let [st (jolt.host/tagged-table :jolt/tls-stream)]
-    (jolt.host/ref-put! st :sock sock) (jolt.host/ref-put! st :ssl ssl)
-    (jolt.host/ref-put! st :ctx ctx) (jolt.host/ref-put! st :rbio rbio)
-    (jolt.host/ref-put! st :wbio wbio) (jolt.host/ref-put! st :eof false)
-    ;; Drain ciphertext OpenSSL produced into wbio out to the socket.
-    (jolt.host/ref-put! st :flush
-      (fn [self]
-        (let [wbio (jolt.host/ref-get self :wbio)]
-          (loop []
-            (let [p (bio-pending wbio)]
-              (when (pos? p)
-                (let [buf (ffi/alloc p) n (c-BIO-read wbio buf p)]
-                  (when (pos? n) (send-bytes (jolt.host/ref-get self :sock) (ffi/read-array buf n)))
-                  (ffi/free buf)
-                  (recur))))))))
-    (jolt.host/ref-put! st :write
-      (fn [self data]
-        (let [n (alength data) buf (ffi/alloc (max 1 n))]
-          (ffi/write-array buf data)
-          (try
-            (loop [off 0]
-              (when (< off n)
-                (let [wrote (c-SSL-write (jolt.host/ref-get self :ssl) (+ buf off) (- n off))]
-                  ((jolt.host/ref-get self :flush) self)
-                  (if (pos? wrote)
-                    (recur (+ off wrote))
-                    (let [err (c-SSL-get-error (jolt.host/ref-get self :ssl) wrote)]
-                      (cond
-                        (= err WANT-READ) (do (feed-in self) (recur off))
-                        (= err WANT-WRITE) (recur off)
-                        :else (fail "TLS write failed")))))))
-            (finally (ffi/free buf)))
-          self)))
-    (jolt.host/ref-put! st :read
-      ;; return a decrypted byte-array chunk, or nil at EOF.
-      (fn [self _timeout]
-        (when-not (jolt.host/ref-get self :eof)
-          (let [tmp (ffi/alloc chunk)]
-            (try
-              (loop []
-                (let [got (c-SSL-read (jolt.host/ref-get self :ssl) tmp chunk)]
-                  (if (pos? got)
-                    (ffi/read-array tmp got)
-                    (let [err (c-SSL-get-error (jolt.host/ref-get self :ssl) got)]
-                      (cond
-                        (= err WANT-READ) (if (feed-in self) (recur)
-                                              (do (jolt.host/ref-put! self :eof true) nil))
-                        (= err WANT-WRITE) (do ((jolt.host/ref-get self :flush) self) (recur))
-                        :else (do (jolt.host/ref-put! self :eof true) nil))))))
-              (finally (ffi/free tmp)))))))
-    (jolt.host/ref-put! st :close
-      (fn [& _]
-        (try (c-SSL-shutdown ssl) (catch Throwable _ nil))
-        (try (close sock) (catch Throwable _ nil))
-        (try (c-SSL-free ssl) (catch Throwable _ nil))
-        (try (c-SSL-CTX-free ctx) (catch Throwable _ nil))
-        nil))
-    st))
+(defn- tls-write [st data]
+  (let [n (alength data)
+        buf (ffi/alloc (max 1 n))]
+    (ffi/write-array buf data)
+    (try
+      (loop [off 0]
+        (when (< off n)
+          (let [wrote (c-SSL-write (:ssl st) (+ buf off) (- n off))]
+            (flush-out st)
+            (if (pos? wrote)
+              (recur (+ off wrote))
+              (let [err (c-SSL-get-error (:ssl st) wrote)]
+                (if (or (= err 2) (= err 3))
+                  (do (feed-in st) (recur off))
+                  (throw (ex-info "TLS write failed" {}))))))))
+      (finally (ffi/free buf)))))
+
+;; One decrypted byte-array chunk, or nil at EOF.
+(defn- tls-read [st]
+  (let [tmp (ffi/alloc ssl-chunk)]
+    (try
+      (loop []
+        (let [got (c-SSL-read (:ssl st) tmp ssl-chunk)]
+          (if (pos? got) (ffi/read-array tmp got)
+              (let [err (c-SSL-get-error (:ssl st) got)]
+                (cond
+                  (= err 2) (if (feed-in st) (recur) nil)
+                  (= err 3) (do (flush-out st) (recur))
+                  :else nil)))))
+      (finally (ffi/free tmp)))))
+
+(defn- tls-close [st]
+  (try (c-SSL-shutdown (:ssl st)) (catch :default _ nil))
+  (try (close-sock (:sock st)) (catch :default _ nil))
+  (try (c-SSL-free (:ssl st)) (catch :default _ nil))
+  (try (c-SSL-CTX-free (:ctx st)) (catch :default _ nil))
+  nil)
 
 (defn- tls-connect
-  "Open a TLS client connection to host:port with peer verification (default
-  verify paths + VERIFY_PEER) and SNI. The server certificate and hostname are
-  checked; a verification failure fails the handshake."
+  "Open a verified TLS client connection to host:port."
   [host port]
   (let [ctx (c-SSL-CTX-new (c-TLS-client-method))]
-    (when (ffi/null? ctx) (fail "SSL_CTX_new failed"))
+    (when (ffi/null? ctx) (throw (ex-info "SSL_CTX_new failed" {})))
     (c-SSL-CTX-default-verify ctx)
     (c-SSL-CTX-set-verify ctx VERIFY-PEER ffi/null)
-    (let [ssl     (c-SSL-new ctx)
-          memmeth (c-BIO-s-mem)
-          rbio    (c-BIO-new memmeth)
-          wbio    (c-BIO-new memmeth)
+    (let [ssl (c-SSL-new ctx)
+          rbio (c-BIO-new (c-BIO-s-mem))
+          wbio (c-BIO-new (c-BIO-s-mem))
           host-buf (cstr host)]
       (c-SSL-set-bio ssl rbio wbio)
       (c-SSL-set-connect ssl)
-      (c-SSL-ctrl ssl SET-TLSEXT-HOSTNAME NAMETYPE-host-name host-buf)  ; SNI
-      (c-SSL-set1-host ssl host-buf)                                    ; hostname check
+      (c-SSL-ctrl ssl SET-TLSEXT-HOSTNAME NAMETYPE-host-name host-buf) ; SNI
+      (c-SSL-set1-host ssl host-buf)                                   ; hostname check
+      (ffi/free host-buf)
       (let [sock (connect host port)
-            st   (make-stream sock ssl ctx rbio wbio)]
+            st {:sock sock :ssl ssl :ctx ctx :rbio rbio :wbio wbio}]
         (try (handshake! st)
-             (catch Throwable e
-               ((jolt.host/ref-get st :close)) (ffi/free host-buf) (throw e)))
-        (ffi/free host-buf)
+             (catch :default e (tls-close st) (throw e)))
         st))))
 
-;; --- HTTP/1.1 client --------------------------------------------------------
-(defn- min-idx [s chars]
-  (reduce (fn [best ch] (if-let [i (str/index-of s (str ch))] (min best i) best))
-          (count s) chars))
+;; --- HTTP/1.1 request/response ---
+(defn- jolt-version []
+  (or (System/getProperty "jolt.version") "jolt"))
 
-(defn- parse-url [spec]
-  (let [s (str spec) colon (str/index-of s ":")]
-    (when (or (nil? colon) (= colon 0) (str/index-of (subs s 0 colon) "/"))
-      (fail (str "no protocol: " s)))
-    (let [scheme (subs s 0 colon) after-colon (subs s (inc colon))]
-      (when-not (str/starts-with? after-colon "//")
-        (fail (str "not an absolute URL: " s)))
-      (let [rest     (subs after-colon 2)
-            auth-end (min-idx rest [\/ \? \#])
-            authority (subs rest 0 auth-end)
-            after    (subs rest auth-end)
-            pc       (str/index-of authority ":")
-            host     (if pc (subs authority 0 pc) authority)
-            port     (if pc (or (parse-long (subs authority (inc pc))) -1) -1)
-            q        (str/index-of after "?")]
-        {:scheme scheme :host host :port port
-         :path (if q (subs after 0 q) after)
-         :query (when q (subs after (inc q)))}))))
+(defn- parse-url
+  "https://host[:port]/path[?query] -> {:host :port :path}. HTTPS only."
+  [spec]
+  (let [s (str spec)]
+    (when-not (str/starts-with? s "https://")
+      (throw (ex-info (str "jolt.mvn-http: HTTPS only, got " s) {:url s})))
+    (let [after (subs s 8)
+          slash (str/index-of after "/")
+          authority (if slash (subs after 0 slash) after)
+          path (if slash (subs after slash) "/")
+          colon (str/index-of authority ":")]
+      (if colon
+        {:host (subs authority 0 colon)
+         :port (or (parse-long (subs authority (inc colon))) 443)
+         :path path}
+        {:host authority :port 443 :path path}))))
 
-(defn- default-port? [url] (or (= (:port url) -1) (= (:port url) 443)))
-(defn- effective-port [url]
-  (let [p (:port url)] (if (and (number? p) (>= p 0)) p 443)))
-(defn- host-port [url]
-  (let [p (:port url)] (if (and (number? p) (>= p 0)) (str (:host url) ":" p) (:host url))))
+(defn- build-request [host port path]
+  (let [host-hdr (if (= port 443) host (str host ":" port))]
+    (str "GET " path " HTTP/1.1\r\n"
+         "Host: " host-hdr "\r\n"
+         "User-Agent: jolt/" (jolt-version) "\r\n"
+         "Accept: */*\r\n"
+         "Connection: close\r\n\r\n")))
 
-(defn- build-request [url]
-  (let [path (let [p (:path url) q (:query url)]
-               (str (if (or (nil? p) (= "" p)) "/" p) (if q (str "?" q) "")))
-        ua   (str "jolt/" (or (System/getProperty "jolt.version") "dev"))
-        host-hdr (if (default-port? url) (:host url) (str (:host url) ":" (effective-port url)))]
-    (byte-array (.getBytes (str "GET " path " HTTP/1.1\r\n"
-                                "Host: " host-hdr "\r\n"
-                                "User-Agent: " ua "\r\n"
-                                "Accept: */*\r\n"
-                                "Connection: close\r\n\r\n")
-                           "UTF-8"))))
+(defn- recv-all [st]
+  (loop [chunks []]
+    (if-let [b (tls-read st)]
+      (recur (conj chunks b))
+      (byte-array (mapcat seq chunks)))))
 
-;; bytes flow as jolt byte-arrays; a latin1 round-trip is byte-exact (one char
-;; per byte 0-255), so the header/chunk parsing below is binary-safe.
-(defn- ba->latin1 [ba] (String. ba "ISO-8859-1"))
-(defn- latin1->ba [s] (byte-array (map int s)))
+;; Index of the first \r\n\r\n in the byte-array (the body start), else nil.
+(defn- header-end [ba]
+  (let [n (alength ba)]
+    (loop [i 0]
+      (if (> i (- n 4))
+        nil
+        (if (and (= (aget ba i) 13) (= (aget ba (inc i)) 10)
+                 (= (aget ba (+ i 2)) 13) (= (aget ba (+ i 3)) 10))
+          (+ i 4)
+          (recur (inc i)))))))
+
+(defn- subbytes [ba start end]
+  (let [out (byte-array (- end start))]
+    (dotimes [i (- end start)] (aset out i (aget ba (+ start i))))
+    out))
 
 (defn- header-ci [pairs name]
   (let [low (str/lower-case name)]
     (reduce (fn [v pair] (if (= low (str/lower-case (first pair))) (second pair) v)) nil pairs)))
 
-(defn- dechunk
-  "raw: latin1 string of a chunked body. Returns the dechunked latin1 string."
-  [raw]
-  (loop [i 0 out (StringBuilder.)]
-    (if (>= i (count raw))
-      (.toString out)
-      (let [crlf (str/index-of raw "\r\n" i)]
-        (if (nil? crlf)
-          (.toString out)
-          (let [line (subs raw i crlf)
-                semi (str/index-of line ";")
-                line (if semi (subs line 0 semi) line)
-                sz (try (Long/parseLong (str/trim line) 16) (catch Throwable _ nil))]
-            (if (or (nil? sz) (<= sz 0))
-              (.toString out)
-              (let [start (+ crlf 2)
-                    end   (min (count raw) (+ start sz))]
-                (.append out (subs raw start end))
-                (recur (+ start sz 2) out)))))))))
+(defn- parse-chunk-size [s]
+  (let [semi (str/index-of s ";")
+        s (if semi (subs s 0 semi) s)]
+    (try (Long/parseLong (str/trim s) 16) (catch :default _ nil))))
+
+;; Dechunk a Transfer-Encoding: chunked body. ISO-8859-1 is a byte-identity
+;; map (each byte 0..255 <-> one char), so a binary chunk body survives exactly;
+;; the chunk framing (hex size + CRLF) is ASCII.
+(defn- dechunk-step [ba raw i]
+  (let [crlf (str/index-of raw "\r\n" i)]
+    (if (nil? crlf)
+      [nil i]
+      (let [sz (parse-chunk-size (subs raw i crlf))]
+        (if (or (nil? sz) (<= sz 0))
+          [nil i]
+          (let [start (+ crlf 2)]
+            [(subbytes ba start (+ start sz)) (+ start sz 2)]))))))
+
+(defn- dechunk [ba]
+  (let [raw (String. ba "ISO-8859-1")
+        out (java.io.ByteArrayOutputStream.)]
+    (loop [i 0]
+      (let [[chunk next-i] (dechunk-step ba raw i)]
+        (if (nil? chunk)
+          (.toByteArray out)
+          (do (.write out chunk) (recur next-i)))))))
 
 (defn- parse-response
   "raw: the full response byte-array. Returns {:status :header-pairs :body}."
   [raw]
-  (let [s   (ba->latin1 raw)
-        end (str/index-of s "\r\n\r\n")]
-    (when (nil? end) (fail "malformed response: no header terminator"))
-    (let [head        (subs s 0 end)
-          body-raw    (subs s (+ end 4))
-          lines       (str/split head #"\r\n")
+  (let [he (header-end raw)]
+    (when (nil? he)
+      (throw (ex-info "malformed response: no header terminator" {})))
+    (let [header-ba (subbytes raw 0 (- he 4))
+          body-ba (subbytes raw he (alength raw))
+          s (String. header-ba "UTF-8")
+          lines (str/split s #"\r\n")
           status-line (first lines)
-          parts       (str/split status-line #" ")
-          status      (or (parse-long (nth parts 1 ""))
-                          (fail (str "bad status line: " status-line)))
-          pairs       (vec (keep (fn [line]
-                                   (when-let [c (str/index-of line ":")]
-                                     [(str/trim (subs line 0 c)) (str/trim (subs line (inc c)))]))
-                                 (rest lines)))
-          te          (header-ci pairs "transfer-encoding")
-          body        (if (and te (str/includes? (str/lower-case te) "chunked"))
-                        (dechunk body-raw) body-raw)]
-      {:status status :header-pairs pairs :body (latin1->ba body)})))
-
-(defn- recv-all [stream]
-  (loop [chunks []]
-    (if-let [b ((jolt.host/ref-get stream :read) stream nil)]
-      (recur (conj chunks b))
-      (byte-array (mapcat seq chunks)))))
-
-(defn- stream-write [stream data] ((jolt.host/ref-get stream :write) stream data))
-(defn- stream-close [stream] ((jolt.host/ref-get stream :close)))
-
-(def ^:private redirect-statuses #{301 302 303 307 308})
+          parts (str/split status-line #" ")
+          status (or (parse-long (nth parts 1 ""))
+                     (throw (ex-info (str "bad status line: " status-line) {})))
+          pairs (vec (keep (fn [line]
+                             (when-let [c (str/index-of line ":")]
+                               [(str/trim (subs line 0 c)) (str/trim (subs line (inc c)))]))
+                           (rest lines)))
+          te (header-ci pairs "transfer-encoding")
+          body (if (and te (str/includes? (str/lower-case te) "chunked"))
+                 (dechunk body-ba) body-ba)]
+      {:status status :header-pairs pairs :body body})))
 
 (defn- resolve-location [base loc]
-  (cond
-    (or (str/starts-with? loc "http://") (str/starts-with? loc "https://"))
-    (parse-url loc)
-    (str/starts-with? loc "//")
-    (parse-url (str (:scheme base) ":" loc))
-    (str/starts-with? loc "/")
-    (parse-url (str (:scheme base) "://" (host-port base) loc))
-    :else
-    (parse-url (str (:scheme base) "://" (host-port base) "/" loc))))
+  (let [host-port (str (:host base)
+                       (when-not (= (:port base) 443) (str ":" (:port base))))]
+    (cond
+      (str/starts-with? loc "//")       (str "https:" loc)
+      (str/starts-with? loc "https://") loc
+      (str/starts-with? loc "http://")  loc
+      (str/starts-with? loc "/")        (str "https://" host-port loc)
+      :else                             (str "https://" host-port "/" loc))))
 
-(defn- do-fetch
-  "GET start-url over TLS, following redirects (max 5). Returns the final
-  parsed response map."
-  [start-url]
-  (loop [url start-url redirects 0]
-    ;; https only — a redirect to plain http is rejected, not followed.
-    (when-not (= (:scheme url) "https") (fail "redirect to non-https"))
-    (let [stream (tls-connect (:host url) (effective-port url))
-          resp   (try
-                   (stream-write stream (build-request url))
-                   (parse-response (recv-all stream))
-                   (finally (try (stream-close stream) (catch Throwable _ nil))))
-          loc    (header-ci (:header-pairs resp) "location")]
-      (if (and (redirect-statuses (:status resp)) loc (< redirects 5))
-        (recur (resolve-location url loc) (inc redirects))
-        resp))))
+(defn- write-bytes-to-file [path ba]
+  (doto (java.io.FileOutputStream. path) (.write ba) (.close)))
 
-;; --- public entry point -----------------------------------------------------
+(def ^:private max-redirects 5)
+
+(defn- fetch-once [url out-path]
+  (let [{:keys [host port path]} (parse-url url)
+        st (tls-connect host port)]
+    (try
+      (tls-write st (.getBytes (build-request host port path) "UTF-8"))
+      (let [{:keys [status header-pairs body]} (parse-response (recv-all st))]
+        (cond
+          (and (#{301 302 307 308} status) (header-ci header-pairs "location"))
+          {:redirect (resolve-location {:host host :port port}
+                                        (header-ci header-pairs "location"))}
+          (<= 200 status 299) (do (write-bytes-to-file out-path body) {:result true})
+          :else {:result false}))
+      (finally (tls-close st)))))
+
 (defn fetch
-  "HTTPS GET `url` and write the response body as raw bytes to `out-path`.
-  Verifies the server certificate. Returns true on a 2xx final status, false on
-  any failure — a non-https URL, missing libssl/libcrypto, a DNS/connect/TLS/
-  cert/parse error, or a non-2xx status. No partial file is written on failure."
+  "GET `url` (HTTPS only) over a cert-verified TLS connection and write the
+  response body as raw bytes to `out-path`. Follows up to 5 redirects. Returns
+  true on a 2xx final status, false/nil on any failure (DNS, connect, TLS,
+  cert, parse, non-2xx). A failed fetch never leaves a partial file."
   [url out-path]
   (try
-    (let [u (parse-url url)]
-      (when (= (:scheme u) "https")
-        (when (ensure-ssl-loaded!)
-          (let [resp (do-fetch u)]
-            (when (and (number? (:status resp)) (<= 200 (:status resp) 299))
-              (io/copy (:body resp) out-path)
-              true)))))
-    (catch Throwable _ false)))
+    (if-not (ensure-ssl!) false
+            (loop [u url redirects 0]
+              (let [r (fetch-once u out-path)]
+                (cond
+                  (:redirect r) (if (>= redirects max-redirects)
+                                  false
+                                  (recur (:redirect r) (inc redirects)))
+                  (contains? r :result) (:result r)
+                  :else false))))
+    (catch :default _ false)))

--- a/stdlib/jolt/mvn_http.clj
+++ b/stdlib/jolt/mvn_http.clj
@@ -5,7 +5,9 @@
   OpenSSL. libcrypto then libssl lazy-load on first use (candidate lists,
   Homebrew first on macOS). fetch returns true on a 2xx, false on any failure,
   so jolt.deps falls through to the next repo. HTTPS only; the server
-  certificate is verified (default verify paths + VERIFY_PEER + hostname check)."
+  certificate is verified (default verify paths + VERIFY_PEER + hostname check).
+  macOS and Linux are validated; the Windows path (ws2_32 + WSAStartup +
+  closesocket) is implemented but not yet tested on a Windows host."
   (:require [jolt.ffi :as ffi]
             [clojure.string :as str]))
 
@@ -35,7 +37,7 @@
     windows? ["libssl-3-x64.dll" "libssl-3.dll" "libssl-1_1-x64.dll"]
     :else    ["libssl.so.3" "libssl.so.1.1" "libssl.so"]))
 
-(def ^:private ssl-loaded? (volatile! false))
+(def ^:private native-ready? (volatile! false))
 
 (defn- load-one [path]
   (try (ffi/load-library path) true (catch :default _ false)))
@@ -46,32 +48,49 @@
           (load-one (first cs)) true
           :else (recur (rest cs)))))
 
-(defn- ensure-ssl!
-  "Lazy-load libcrypto then libssl on first use. Returns true once both loaded;
-  a later fetch retries (a candidate may have appeared)."
+;; Windows sockets live in ws2_32.dll and need WSAStartup(2.2) once before any
+;; socket call; POSIX sockets are process symbols, so this is a no-op there.
+;; UNTESTED on Windows — no Windows machine was available to validate against.
+(defn- init-sockets! []
+  (if-not windows?
+    true
+    (when (or (load-one "ws2_32.dll") (load-one "ws2_32"))
+      (let [wsadata (ffi/alloc 512)]
+        (try (zero? (c-WSAStartup 0x0202 wsadata))
+             (finally (ffi/free wsadata)))))))
+
+(defn- ensure-native!
+  "Lazy-load the native transport on first use: (Windows) ws2_32 + WSAStartup,
+  then libcrypto then libssl. Returns true once ready; a later fetch retries."
   []
-  (or @ssl-loaded?
-      (when (and (try-candidates crypto-candidates)
+  (or @native-ready?
+      (when (and (init-sockets!)
+                 (try-candidates crypto-candidates)
                  (try-candidates ssl-candidates))
-        (vreset! ssl-loaded? true)
+        (vreset! native-ready? true)
         true)))
 
-;; --- BSD socket layer (process symbols resolve at load) ---
+;; --- BSD socket layer. On POSIX these are the process's own symbols (libc);
+;; on Windows they live in ws2_32.dll (loaded, with WSAStartup, by ensure-native!
+;; before the first call), which exports the same getaddrinfo/socket/connect/
+;; recv/send names plus closesocket. ---
 (ffi/defcfn c-socket      "socket"      [:int :int :int] :int)
 (ffi/defcfn c-connect     "connect"     [:int :pointer :int] :int :blocking)
 (ffi/defcfn c-close       "close"       [:int] :int)
+(ffi/defcfn c-closesocket "closesocket" [:int] :int)              ; Windows sockets
 (ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t :blocking)
 (ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t :blocking)
 (ffi/defcfn c-getaddrinfo "getaddrinfo" [:pointer :pointer :pointer :pointer] :int :blocking)
 (ffi/defcfn c-freeaddrinfo "freeaddrinfo" [:pointer] :void)
+(ffi/defcfn c-WSAStartup  "WSAStartup"  [:int :pointer] :int)     ; Windows Winsock init
 
-;; struct addrinfo field offsets (LP64). macOS swaps ai_canonname/ai_addr
-;; vs Linux, so ai_addr sits at 32 on macOS, 24 on Linux.
+;; struct addrinfo field offsets. Both macOS and Win64 place ai_addr at 32
+;; (ai_canonname before it); Linux packs ai_addr at 24.
 (def ^:private O-ai-family 4)
 (def ^:private O-ai-socktype 8)
 (def ^:private O-ai-protocol 12)
 (def ^:private O-ai-addrlen 16)
-(def ^:private O-ai-addr (if macos? 32 24))
+(def ^:private O-ai-addr (if (or macos? windows?) 32 24))
 (def ^:private O-ai-next 40)
 
 (defn- connect
@@ -132,7 +151,7 @@
                 (throw (ex-info "send failed" {}))))))
       (finally (ffi/free buf)))))
 
-(defn- close-sock [fd] (c-close fd) nil)
+(defn- close-sock [fd] (if windows? (c-closesocket fd) (c-close fd)) nil)
 
 ;; --- OpenSSL TLS client (memory-BIO) ---
 (def ^:private WANT-READ 2)
@@ -403,7 +422,7 @@
   cert, parse, non-2xx). A failed fetch never leaves a partial file."
   [url out-path]
   (try
-    (if-not (ensure-ssl!) false
+    (if-not (ensure-native!) false
             (loop [u url redirects 0]
               (let [r (fetch-once u out-path)]
                 (cond

--- a/stdlib/jolt/mvn_http.clj
+++ b/stdlib/jolt/mvn_http.clj
@@ -1,0 +1,427 @@
+(ns jolt.mvn-http
+  "Cert-verifying HTTPS GET-to-file for dependency download. A minimal HTTP/1.1
+  client over BSD sockets (jolt.ffi) and the system OpenSSL via memory-BIO TLS:
+  VERIFY_PEER + the default verify paths + SNI + SSL_set1_host (hostname check).
+  Follows redirects (max 5), handles Content-Length / chunked / read-to-EOF
+  bodies, and writes the body as raw bytes.
+
+  libssl + libcrypto load on first use; if either is absent, or any step errors
+  (DNS / connect / TLS / cert / parse), fetch returns false — a failed download
+  never crashes dependency resolution. Plain HTTP is rejected: a jar is
+  executable, so it is not fetched over unauthenticated transport."
+  (:require [jolt.ffi :as ffi]
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
+
+;; --- platform + lazy library load -------------------------------------------
+;; ffi/loaded? loads the shared object (a guarded load-shared-object) and reports
+;; success, so trying each candidate both probes and loads. libssl depends on
+;; libcrypto symbols, so crypto loads first.
+(def ^:private os-name
+  (str/lower-case (or (System/getProperty "os.name") "")))
+(def ^:private macos? (str/includes? os-name "mac"))
+
+(def ^:private ssl-candidates
+  (if macos?
+    ["libssl.dylib" "libssl.35.dylib" "libssl.3.dylib" "libssl.46.dylib"]
+    ["libssl.so.3" "libssl.so.1.1" "libssl.so"]))
+(def ^:private crypto-candidates
+  (if macos?
+    ["libcrypto.dylib" "libcrypto.35.dylib" "libcrypto.3.dylib" "libcrypto.46.dylib"]
+    ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"]))
+
+(def ^:private ssl-ready? (atom false))
+
+(defn- load-candidates [cands]
+  (boolean (some #(ffi/loaded? %) cands)))
+
+(defn- ensure-ssl-loaded! []
+  (or @ssl-ready?
+      (when (and (load-candidates crypto-candidates)
+                 (load-candidates ssl-candidates))
+        (reset! ssl-ready? true)
+        true)))
+
+;; Any internal failure throws; fetch catches everything and returns false, so
+;; the message is for diagnostics only.
+(defn- fail [msg] (throw (ex-info (str "jolt.mvn-http: " msg) {})))
+
+;; --- BSD sockets (libc; symbols resolve from the running process) -----------
+;; accept/recv/send/connect/getaddrinfo are :blocking so a parked socket call
+;; never pins jolt's stop-the-world collector.
+(ffi/defcfn c-socket       "socket"       [:int :int :int] :int)
+(ffi/defcfn c-connect      "connect"      [:int :pointer :int] :int :blocking)
+(ffi/defcfn c-close        "close"        [:int] :int)
+(ffi/defcfn c-recv         "recv"         [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-send         "send"         [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-getaddrinfo  "getaddrinfo"  [:pointer :pointer :pointer :pointer] :int :blocking)
+(ffi/defcfn c-freeaddrinfo "freeaddrinfo" [:pointer] :void)
+
+;; struct addrinfo field offsets (LP64). macOS swaps ai_canonname/ai_addr versus
+;; Linux, so ai_addr sits at 32 on macOS, 24 on Linux. ai_addrlen=16, ai_next=40.
+(def ^:private O-ai-family 4)
+(def ^:private O-ai-socktype 8)
+(def ^:private O-ai-protocol 12)
+(def ^:private O-ai-addrlen 16)
+(def ^:private O-ai-addr (if macos? 32 24))
+(def ^:private O-ai-next 40)
+
+(defn- connect
+  "Resolve host:port and open a connected TCP socket; return its fd."
+  [host port]
+  (let [node    (ffi/string->ptr (str host))
+        service (ffi/string->ptr (str port))
+        respp   (ffi/alloc (ffi/sizeof :pointer))
+        ;; hints: ai_socktype = SOCK_STREAM, else getaddrinfo also returns UDP
+        ;; entries and connect() on a datagram socket spuriously "succeeds".
+        hints   (ffi/alloc 48)]
+    (dotimes [i 48] (ffi/write hints :uint8 i 0))
+    (ffi/write hints :int O-ai-socktype 1)
+    (try
+      (let [rc (c-getaddrinfo node service hints respp)]
+        (when-not (zero? rc) (fail (str "unknown host: " host)))
+        (let [res (ffi/read respp :pointer)]
+          (try
+            (loop [ai res]
+              (if (ffi/null? ai)
+                (fail (str "connection refused: " host ":" port))
+                (let [fam     (ffi/read ai :int O-ai-family)
+                      sockt   (ffi/read ai :int O-ai-socktype)
+                      proto   (ffi/read ai :int O-ai-protocol)
+                      addrlen (ffi/read ai :int O-ai-addrlen)
+                      addr    (ffi/read ai :pointer O-ai-addr)
+                      fd      (c-socket fam sockt proto)]
+                  (cond
+                    (neg? fd) (recur (ffi/read ai :pointer O-ai-next))
+                    (zero? (c-connect fd addr addrlen)) fd
+                    :else (do (c-close fd) (recur (ffi/read ai :pointer O-ai-next)))))))
+            (finally (c-freeaddrinfo res)))))
+      (finally (ffi/free node) (ffi/free service) (ffi/free respp) (ffi/free hints)))))
+
+(def ^:private bufsize 65536)
+
+(defn- recv-bytes
+  "Read up to one bufferful from fd: a byte-array, or nil at EOF (recv 0)."
+  [fd]
+  (let [buf (ffi/alloc bufsize)]
+    (try
+      (let [got (c-recv fd buf bufsize 0)]
+        (cond
+          (pos? got) (ffi/read-array buf got)
+          (zero? got) nil
+          :else (fail "read timed out")))
+      (finally (ffi/free buf)))))
+
+(defn- send-bytes
+  "Send all of byte-array data over fd."
+  [fd data]
+  (let [n (alength data) buf (ffi/alloc (max 1 n))]
+    (try
+      (ffi/write-array buf data)
+      (loop [off 0]
+        (when (< off n)
+          (let [sent (c-send fd (+ buf off) (- n off) 0)]
+            (if (pos? sent)
+              (recur (+ off sent))
+              (fail "send failed")))))
+      (finally (ffi/free buf)))))
+
+(defn- close [fd] (c-close fd) nil)
+
+;; --- OpenSSL TLS (client, memory-BIO over the socket above) -----------------
+;; SSL runs against in-memory BIOs while ciphertext is shuttled over the plain
+;; socket, so no raw-fd access into OpenSSL is needed.
+(def ^:private WANT-READ 2)
+(def ^:private WANT-WRITE 3)
+(def ^:private VERIFY-PEER 1)
+(def ^:private BIO-PENDING 10)
+(def ^:private SET-TLSEXT-HOSTNAME 55)
+(def ^:private NAMETYPE-host-name 0)
+(def ^:private chunk 16384)
+
+(ffi/defcfn c-TLS-client-method  "TLS_client_method"              [] :pointer)
+(ffi/defcfn c-SSL-CTX-new        "SSL_CTX_new"                    [:pointer] :pointer)
+(ffi/defcfn c-SSL-CTX-free       "SSL_CTX_free"                   [:pointer] :void)
+(ffi/defcfn c-SSL-CTX-set-verify "SSL_CTX_set_verify"             [:pointer :int :pointer] :void)
+(ffi/defcfn c-SSL-CTX-default-verify "SSL_CTX_set_default_verify_paths" [:pointer] :int)
+(ffi/defcfn c-SSL-new            "SSL_new"                        [:pointer] :pointer)
+(ffi/defcfn c-SSL-free           "SSL_free"                       [:pointer] :void)
+(ffi/defcfn c-SSL-set-bio        "SSL_set_bio"                    [:pointer :pointer :pointer] :void)
+(ffi/defcfn c-SSL-set-connect    "SSL_set_connect_state"          [:pointer] :void)
+(ffi/defcfn c-SSL-connect        "SSL_connect"                    [:pointer] :int)
+(ffi/defcfn c-SSL-read           "SSL_read"                       [:pointer :pointer :int] :int)
+(ffi/defcfn c-SSL-write          "SSL_write"                      [:pointer :pointer :int] :int)
+(ffi/defcfn c-SSL-get-error      "SSL_get_error"                  [:pointer :int] :int)
+(ffi/defcfn c-SSL-ctrl           "SSL_ctrl"                       [:pointer :int :int64 :pointer] :int64)
+(ffi/defcfn c-SSL-shutdown       "SSL_shutdown"                   [:pointer] :int)
+(ffi/defcfn c-SSL-set1-host      "SSL_set1_host"                  [:pointer :pointer] :int)
+(ffi/defcfn c-BIO-new            "BIO_new"                        [:pointer] :pointer)
+(ffi/defcfn c-BIO-s-mem          "BIO_s_mem"                      [] :pointer)
+(ffi/defcfn c-BIO-read           "BIO_read"                       [:pointer :pointer :int] :int)
+(ffi/defcfn c-BIO-write          "BIO_write"                      [:pointer :pointer :int] :int)
+(ffi/defcfn c-BIO-ctrl           "BIO_ctrl"                       [:pointer :int :int64 :pointer] :int64)
+
+;; A NUL-terminated C-string pointer; the caller frees it.
+(defn- cstr [s] (ffi/string->ptr (str s)))
+(defn- bio-pending [bio] (c-BIO-ctrl bio BIO-PENDING 0 ffi/null))
+
+;; Pull one ciphertext chunk off the socket into rbio; false at EOF.
+(defn- feed-in [st]
+  (let [data (recv-bytes (jolt.host/ref-get st :sock))]
+    (if (and data (pos? (alength data)))
+      (let [n (alength data) buf (ffi/alloc n)]
+        (ffi/write-array buf data)
+        (c-BIO-write (jolt.host/ref-get st :rbio) buf n)
+        (ffi/free buf)
+        true)
+      false)))
+
+(defn- handshake! [st]
+  (loop []
+    (let [ret (c-SSL-connect (jolt.host/ref-get st :ssl))]
+      ((jolt.host/ref-get st :flush) st)
+      (when-not (= ret 1)
+        (let [err (c-SSL-get-error (jolt.host/ref-get st :ssl) ret)]
+          (cond
+            (= err WANT-READ) (do (when-not (feed-in st)
+                                    (fail "connection closed during TLS handshake"))
+                                  (recur))
+            (= err WANT-WRITE) (recur)
+            :else (fail (str "TLS handshake failed (SSL_get_error=" err ")"))))))))
+
+;; A TLS stream is a host tagged-table carrying :write / :read / :close closures
+;; and the shared ssl/ctx/bio/eof state they mutate.
+(defn- make-stream [sock ssl ctx rbio wbio]
+  (let [st (jolt.host/tagged-table :jolt/tls-stream)]
+    (jolt.host/ref-put! st :sock sock) (jolt.host/ref-put! st :ssl ssl)
+    (jolt.host/ref-put! st :ctx ctx) (jolt.host/ref-put! st :rbio rbio)
+    (jolt.host/ref-put! st :wbio wbio) (jolt.host/ref-put! st :eof false)
+    ;; Drain ciphertext OpenSSL produced into wbio out to the socket.
+    (jolt.host/ref-put! st :flush
+      (fn [self]
+        (let [wbio (jolt.host/ref-get self :wbio)]
+          (loop []
+            (let [p (bio-pending wbio)]
+              (when (pos? p)
+                (let [buf (ffi/alloc p) n (c-BIO-read wbio buf p)]
+                  (when (pos? n) (send-bytes (jolt.host/ref-get self :sock) (ffi/read-array buf n)))
+                  (ffi/free buf)
+                  (recur))))))))
+    (jolt.host/ref-put! st :write
+      (fn [self data]
+        (let [n (alength data) buf (ffi/alloc (max 1 n))]
+          (ffi/write-array buf data)
+          (try
+            (loop [off 0]
+              (when (< off n)
+                (let [wrote (c-SSL-write (jolt.host/ref-get self :ssl) (+ buf off) (- n off))]
+                  ((jolt.host/ref-get self :flush) self)
+                  (if (pos? wrote)
+                    (recur (+ off wrote))
+                    (let [err (c-SSL-get-error (jolt.host/ref-get self :ssl) wrote)]
+                      (cond
+                        (= err WANT-READ) (do (feed-in self) (recur off))
+                        (= err WANT-WRITE) (recur off)
+                        :else (fail "TLS write failed")))))))
+            (finally (ffi/free buf)))
+          self)))
+    (jolt.host/ref-put! st :read
+      ;; return a decrypted byte-array chunk, or nil at EOF.
+      (fn [self _timeout]
+        (when-not (jolt.host/ref-get self :eof)
+          (let [tmp (ffi/alloc chunk)]
+            (try
+              (loop []
+                (let [got (c-SSL-read (jolt.host/ref-get self :ssl) tmp chunk)]
+                  (if (pos? got)
+                    (ffi/read-array tmp got)
+                    (let [err (c-SSL-get-error (jolt.host/ref-get self :ssl) got)]
+                      (cond
+                        (= err WANT-READ) (if (feed-in self) (recur)
+                                              (do (jolt.host/ref-put! self :eof true) nil))
+                        (= err WANT-WRITE) (do ((jolt.host/ref-get self :flush) self) (recur))
+                        :else (do (jolt.host/ref-put! self :eof true) nil))))))
+              (finally (ffi/free tmp)))))))
+    (jolt.host/ref-put! st :close
+      (fn [& _]
+        (try (c-SSL-shutdown ssl) (catch Throwable _ nil))
+        (try (close sock) (catch Throwable _ nil))
+        (try (c-SSL-free ssl) (catch Throwable _ nil))
+        (try (c-SSL-CTX-free ctx) (catch Throwable _ nil))
+        nil))
+    st))
+
+(defn- tls-connect
+  "Open a TLS client connection to host:port with peer verification (default
+  verify paths + VERIFY_PEER) and SNI. The server certificate and hostname are
+  checked; a verification failure fails the handshake."
+  [host port]
+  (let [ctx (c-SSL-CTX-new (c-TLS-client-method))]
+    (when (ffi/null? ctx) (fail "SSL_CTX_new failed"))
+    (c-SSL-CTX-default-verify ctx)
+    (c-SSL-CTX-set-verify ctx VERIFY-PEER ffi/null)
+    (let [ssl     (c-SSL-new ctx)
+          memmeth (c-BIO-s-mem)
+          rbio    (c-BIO-new memmeth)
+          wbio    (c-BIO-new memmeth)
+          host-buf (cstr host)]
+      (c-SSL-set-bio ssl rbio wbio)
+      (c-SSL-set-connect ssl)
+      (c-SSL-ctrl ssl SET-TLSEXT-HOSTNAME NAMETYPE-host-name host-buf)  ; SNI
+      (c-SSL-set1-host ssl host-buf)                                    ; hostname check
+      (let [sock (connect host port)
+            st   (make-stream sock ssl ctx rbio wbio)]
+        (try (handshake! st)
+             (catch Throwable e
+               ((jolt.host/ref-get st :close)) (ffi/free host-buf) (throw e)))
+        (ffi/free host-buf)
+        st))))
+
+;; --- HTTP/1.1 client --------------------------------------------------------
+(defn- min-idx [s chars]
+  (reduce (fn [best ch] (if-let [i (str/index-of s (str ch))] (min best i) best))
+          (count s) chars))
+
+(defn- parse-url [spec]
+  (let [s (str spec) colon (str/index-of s ":")]
+    (when (or (nil? colon) (= colon 0) (str/index-of (subs s 0 colon) "/"))
+      (fail (str "no protocol: " s)))
+    (let [scheme (subs s 0 colon) after-colon (subs s (inc colon))]
+      (when-not (str/starts-with? after-colon "//")
+        (fail (str "not an absolute URL: " s)))
+      (let [rest     (subs after-colon 2)
+            auth-end (min-idx rest [\/ \? \#])
+            authority (subs rest 0 auth-end)
+            after    (subs rest auth-end)
+            pc       (str/index-of authority ":")
+            host     (if pc (subs authority 0 pc) authority)
+            port     (if pc (or (parse-long (subs authority (inc pc))) -1) -1)
+            q        (str/index-of after "?")]
+        {:scheme scheme :host host :port port
+         :path (if q (subs after 0 q) after)
+         :query (when q (subs after (inc q)))}))))
+
+(defn- default-port? [url] (or (= (:port url) -1) (= (:port url) 443)))
+(defn- effective-port [url]
+  (let [p (:port url)] (if (and (number? p) (>= p 0)) p 443)))
+(defn- host-port [url]
+  (let [p (:port url)] (if (and (number? p) (>= p 0)) (str (:host url) ":" p) (:host url))))
+
+(defn- build-request [url]
+  (let [path (let [p (:path url) q (:query url)]
+               (str (if (or (nil? p) (= "" p)) "/" p) (if q (str "?" q) "")))
+        ua   (str "jolt/" (or (System/getProperty "jolt.version") "dev"))
+        host-hdr (if (default-port? url) (:host url) (str (:host url) ":" (effective-port url)))]
+    (byte-array (.getBytes (str "GET " path " HTTP/1.1\r\n"
+                                "Host: " host-hdr "\r\n"
+                                "User-Agent: " ua "\r\n"
+                                "Accept: */*\r\n"
+                                "Connection: close\r\n\r\n")
+                           "UTF-8"))))
+
+;; bytes flow as jolt byte-arrays; a latin1 round-trip is byte-exact (one char
+;; per byte 0-255), so the header/chunk parsing below is binary-safe.
+(defn- ba->latin1 [ba] (String. ba "ISO-8859-1"))
+(defn- latin1->ba [s] (byte-array (map int s)))
+
+(defn- header-ci [pairs name]
+  (let [low (str/lower-case name)]
+    (reduce (fn [v pair] (if (= low (str/lower-case (first pair))) (second pair) v)) nil pairs)))
+
+(defn- dechunk
+  "raw: latin1 string of a chunked body. Returns the dechunked latin1 string."
+  [raw]
+  (loop [i 0 out (StringBuilder.)]
+    (if (>= i (count raw))
+      (.toString out)
+      (let [crlf (str/index-of raw "\r\n" i)]
+        (if (nil? crlf)
+          (.toString out)
+          (let [line (subs raw i crlf)
+                semi (str/index-of line ";")
+                line (if semi (subs line 0 semi) line)
+                sz (try (Long/parseLong (str/trim line) 16) (catch Throwable _ nil))]
+            (if (or (nil? sz) (<= sz 0))
+              (.toString out)
+              (let [start (+ crlf 2)
+                    end   (min (count raw) (+ start sz))]
+                (.append out (subs raw start end))
+                (recur (+ start sz 2) out)))))))))
+
+(defn- parse-response
+  "raw: the full response byte-array. Returns {:status :header-pairs :body}."
+  [raw]
+  (let [s   (ba->latin1 raw)
+        end (str/index-of s "\r\n\r\n")]
+    (when (nil? end) (fail "malformed response: no header terminator"))
+    (let [head        (subs s 0 end)
+          body-raw    (subs s (+ end 4))
+          lines       (str/split head #"\r\n")
+          status-line (first lines)
+          parts       (str/split status-line #" ")
+          status      (or (parse-long (nth parts 1 ""))
+                          (fail (str "bad status line: " status-line)))
+          pairs       (vec (keep (fn [line]
+                                   (when-let [c (str/index-of line ":")]
+                                     [(str/trim (subs line 0 c)) (str/trim (subs line (inc c)))]))
+                                 (rest lines)))
+          te          (header-ci pairs "transfer-encoding")
+          body        (if (and te (str/includes? (str/lower-case te) "chunked"))
+                        (dechunk body-raw) body-raw)]
+      {:status status :header-pairs pairs :body (latin1->ba body)})))
+
+(defn- recv-all [stream]
+  (loop [chunks []]
+    (if-let [b ((jolt.host/ref-get stream :read) stream nil)]
+      (recur (conj chunks b))
+      (byte-array (mapcat seq chunks)))))
+
+(defn- stream-write [stream data] ((jolt.host/ref-get stream :write) stream data))
+(defn- stream-close [stream] ((jolt.host/ref-get stream :close)))
+
+(def ^:private redirect-statuses #{301 302 303 307 308})
+
+(defn- resolve-location [base loc]
+  (cond
+    (or (str/starts-with? loc "http://") (str/starts-with? loc "https://"))
+    (parse-url loc)
+    (str/starts-with? loc "//")
+    (parse-url (str (:scheme base) ":" loc))
+    (str/starts-with? loc "/")
+    (parse-url (str (:scheme base) "://" (host-port base) loc))
+    :else
+    (parse-url (str (:scheme base) "://" (host-port base) "/" loc))))
+
+(defn- do-fetch
+  "GET start-url over TLS, following redirects (max 5). Returns the final
+  parsed response map."
+  [start-url]
+  (loop [url start-url redirects 0]
+    ;; https only — a redirect to plain http is rejected, not followed.
+    (when-not (= (:scheme url) "https") (fail "redirect to non-https"))
+    (let [stream (tls-connect (:host url) (effective-port url))
+          resp   (try
+                   (stream-write stream (build-request url))
+                   (parse-response (recv-all stream))
+                   (finally (try (stream-close stream) (catch Throwable _ nil))))
+          loc    (header-ci (:header-pairs resp) "location")]
+      (if (and (redirect-statuses (:status resp)) loc (< redirects 5))
+        (recur (resolve-location url loc) (inc redirects))
+        resp))))
+
+;; --- public entry point -----------------------------------------------------
+(defn fetch
+  "HTTPS GET `url` and write the response body as raw bytes to `out-path`.
+  Verifies the server certificate. Returns true on a 2xx final status, false on
+  any failure — a non-https URL, missing libssl/libcrypto, a DNS/connect/TLS/
+  cert/parse error, or a non-2xx status. No partial file is written on failure."
+  [url out-path]
+  (try
+    (let [u (parse-url url)]
+      (when (= (:scheme u) "https")
+        (when (ensure-ssl-loaded!)
+          (let [resp (do-fetch u)]
+            (when (and (number? (:status resp)) (<= 200 (:status resp) 299))
+              (io/copy (:body resp) out-path)
+              true)))))
+    (catch Throwable _ false)))

--- a/test/mvn_http_test.clj
+++ b/test/mvn_http_test.clj
@@ -1,0 +1,89 @@
+(ns mvn-http-test
+  "Pure-function tests for jolt.mvn-http — URL parsing, redirect resolution,
+  header/body framing, dechunking, and the request-smuggling guard. These need
+  no network and no OpenSSL (defcfn is lazy; ensure-native! only runs inside
+  fetch), so they run in the default gate. Run: make mvnhttp"
+  (:require [jolt.mvn-http]
+            [clojure.string :as str]))
+
+;; the functions under test are private; reach them through their vars.
+(def parse-url        (var jolt.mvn-http/parse-url))
+(def resolve-location (var jolt.mvn-http/resolve-location))
+(def header-end       (var jolt.mvn-http/header-end))
+(def header-ci        (var jolt.mvn-http/header-ci))
+(def parse-response   (var jolt.mvn-http/parse-response))
+(def dechunk          (var jolt.mvn-http/dechunk))
+(def ctl-free?        (var jolt.mvn-http/ctl-free?))
+
+(def ^:private fails (atom []))
+(defn- ok= [expected actual label]
+  (when-not (= expected actual)
+    (swap! fails conj (str label " — expected " (pr-str expected) ", got " (pr-str actual)))))
+(defn- throws [f label]
+  (let [threw (try (f) false (catch :default _ true))]
+    (when-not threw (swap! fails conj (str label " — expected a throw, got none")))))
+(defn- bytes-of [s] (.getBytes ^String s "ISO-8859-1"))
+
+(defn- run []
+  ;; parse-url
+  (ok= {:host "h" :port 443 :path "/p"} (parse-url "https://h/p") "parse-url simple")
+  (ok= {:host "h" :port 8443 :path "/x?q=1"} (parse-url "https://h:8443/x?q=1") "parse-url port+query")
+  (ok= {:host "h" :port 443 :path "/"} (parse-url "https://h") "parse-url no path")
+  (throws #(parse-url "http://h/p") "parse-url rejects http")
+  (throws #(parse-url "https://h/a\r\nb") "parse-url rejects CRLF in path")
+  (throws #(parse-url "https://h\r\n/p") "parse-url rejects CRLF in host")
+
+  ;; resolve-location (base host h, port 443)
+  (let [base {:host "h" :port 443}]
+    (ok= "https://h/a" (resolve-location base "/a") "reloc absolute path")
+    (ok= "https://e/x" (resolve-location base "//e/x") "reloc scheme-relative")
+    (ok= "https://e/x" (resolve-location base "https://e/x") "reloc absolute https")
+    (ok= "https://h/a" (resolve-location base "a") "reloc relative")
+    (ok= nil (resolve-location base "http://e/x") "reloc rejects http downgrade"))
+  (ok= "https://h:8443/a" (resolve-location {:host "h" :port 8443} "/a") "reloc keeps non-443 port")
+
+  ;; ctl-free?
+  (ok= true  (ctl-free? "abc/def") "ctl-free plain")
+  (ok= false (ctl-free? "a\rb")    "ctl-free CR")
+  (ok= false (ctl-free? "a\nb")    "ctl-free LF")
+
+  ;; header-end
+  (ok= 6   (header-end (bytes-of "AB\r\n\r\nCD")) "header-end offset")
+  (ok= nil (header-end (bytes-of "no terminator")) "header-end absent")
+
+  ;; header-ci (case-insensitive)
+  (let [pairs [["Content-Type" "text/xml"] ["Location" "https://x/y"]]]
+    (ok= "https://x/y" (header-ci pairs "location") "header-ci lower")
+    (ok= "https://x/y" (header-ci pairs "LOCATION") "header-ci upper")
+    (ok= nil (header-ci pairs "x-absent") "header-ci absent"))
+
+  ;; dechunk — hex size framing, binary-exact, terminal 0
+  (ok= "hello" (String. (dechunk (bytes-of "5\r\nhello\r\n0\r\n\r\n")) "ISO-8859-1") "dechunk basic")
+  (ok= "hello" (String. (dechunk (bytes-of "5;ext=1\r\nhello\r\n0\r\n\r\n")) "ISO-8859-1") "dechunk chunk-ext ignored")
+  (let [raw (byte-array [0 -1 65])
+        b (dechunk (bytes-of (str "3\r\n" (String. raw "ISO-8859-1") "\r\n0\r\n\r\n")))]
+    (ok= (vec raw) (vec b) "dechunk binary-exact"))
+
+  ;; parse-response — status, headers, content-length framing
+  (let [r (parse-response (bytes-of "HTTP/1.1 200 OK\r\nContent-Length: 3\r\nContent-Type: x\r\n\r\nabc"))]
+    (ok= 200 (:status r) "parse-response status")
+    (ok= "abc" (String. ^bytes (:body r) "ISO-8859-1") "parse-response body")
+    (ok= 3 (:content-length r) "parse-response content-length"))
+  (let [r (parse-response (bytes-of "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"))]
+    (ok= 404 (:status r) "parse-response 404 status"))
+  ;; chunked: content-length is not used to frame a chunked body
+  (let [r (parse-response (bytes-of "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n"))]
+    (ok= "hello" (String. ^bytes (:body r) "ISO-8859-1") "parse-response chunked body")
+    (ok= nil (:content-length r) "parse-response chunked ignores content-length"))
+  (throws #(parse-response (bytes-of "no header terminator here")) "parse-response no terminator throws"))
+
+(defn -main [& _]
+  (run)
+  (if (seq @fails)
+    (do (println "mvn-http-test: FAILED")
+        (doseq [f @fails] (println "  -" f))
+        (throw (ex-info "mvn-http-test failures" {:count (count @fails)})))
+    (println "mvn-http-test: passed")))
+
+;; run on load so `joltc run test/mvn_http_test.clj` executes the checks.
+(-main)


### PR DESCRIPTION
Replaces the `curl` shell-out in `jolt.deps`'s Maven download with a jolt-native, cert-verifying HTTPS GET. `joltc` now downloads dependencies itself — no external `curl` — and does it safely (TLS with peer verification), instead of over an unauthenticated transport.

## What
- **`stdlib/jolt/mvn_http.clj`** — a minimal HTTPS GET-to-file: raw BSD socket via `jolt.ffi`, TLS over the system **OpenSSL** through in-memory BIOs (`SSL_CTX_set_default_verify_paths` + `VERIFY_PEER` + SNI + `SSL_set1_host` hostname check), HTTP/1.1 with redirect following, binary-faithful body written to disk. Adapted from jolt's own proven `net.clj`/`tls.clj` (jolt-lang/http-client) — **not** a dependency on that library (chicken-and-egg), a minimal copy in core using `jolt.ffi`.
- **`jolt.deps`** — `ensure-maven` calls `jolt.mvn-http/fetch`; **all curl removed**.
- OpenSSL is **lazy-loaded** only on the first fetch; a box without it (or a repo that can't be reached) fails the fetch gracefully — non-fatal, resolution continues.

## Why not plain HTTP / a vendored TLS lib
Plain HTTP is unsafe for executable jars. The one vendorable pure-Chez TLS binding (`ecraven/chez-scheme-libraries`) is GPL-3, and pure-Scheme TLS (Industria) is too old for modern repos. OpenSSL via FFI is a shared *library* (like libsqlite3/libz jolt already links), not an external *program*.

## Platforms
- **macOS / Linux**: implemented and **validated** — live fetches of `.pom` and a binary `.jar` (valid `PK` header) from Central and Clojars, graceful 404, and a fresh-repo end-to-end resolve of `org.clojure/data.json`. On macOS it loads the **Homebrew** OpenSSL; the bare `libcrypto.dylib` name is deliberately excluded because the protected system copy aborts the process (uncatchable).
- **Windows**: Winsock path (`ws2_32` + `WSAStartup` + `closesocket`, Win64 offsets) is implemented but **NOT yet validated on a Windows host** — no Windows machine was available. Needs a real-Windows smoke before it's trusted.

## Not in scope
`git` (git deps) and `unzip` (jar extraction) still shell out — separate, larger efforts (git smart-HTTP protocol; a jolt-native ZIP reader).

## Test
Opt-in `make httpsfetch` smoke (network; Central + Clojars). Full `make test` green (selfhost fixpoint, corpus 0-new, unit 1002/1002, cts baseline, dce-refs, shake, manifest).

## Known limitations
No socket read-timeout (a stalled server hangs a fetch); whole response buffered in memory (fine for jars).

Implemented by dirge from a written spec, then reviewed — review caught the macOS abort risk and the missing Windows candidates, and added the Winsock path. Docs (README + site) updated with the per-platform OpenSSL/git/unzip requirements.