### PR TITLE
Per-namespace AOT compile cache for required libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Per-namespace AOT/compile cache for required libraries: a disk-backed cache that
+fasls a required namespace's emitted Scheme on first load and loads the `.so` on
+subsequent runs, recovering most of the per-run recompile cost for library
+requires. Keyed by source content hash + jolt version, so any source edit or
+compiler change misses automatically. Default ON for a built `joltc`; the dev
+`bin/joltc` opts out (volatile dev compiler). Measured ~28% startup speedup on a
+4-library require (cold 2.81s → warm 2.03s).
+
+### Added
+
+- **Per-namespace compile cache.** When a disk-backed namespace is required, the
+  emitted Scheme is teed off the existing load path (preserving the interleaved
+  analyze→eval semantics — forward macro refs, `defrecord`/`defprotocol`, data
+  readers, and transitive requires all reproduce on cache hit) and fasled to
+  `~/.jolt/aot-cache/<jolt-version>/v1/<ns>-<content-hash>.so`. The cache filename
+  embeds a content hash of the source, so editing a namespace invalidates it
+  automatically (no mtime tracking). On the next run the `.so` is loaded directly
+  instead of recompiled.
+- **`JOLT_AOT_CACHE` env var** — `0`/`false`/`no`/`off` opt out. Default ON for a
+  built `joltc`; the dev `bin/joltc` script sets it to `0` (a volatile dev compiler
+  whose "dev" version tag wouldn't invalidate across edits, and whose startup is
+  already covered by the devboot cache).
+- **`JOLT_CACHE_DIR` env var** — override the cache root (default
+  `~/.jolt/aot-cache`). Useful for tests and CI isolation.
+- **Safety gates.** Install-owned namespaces (embedded in the binary) are never
+  cached; `:reload` / `:reload-all` bypass the cache so live editing always wins.
+- **`make aotcachesmoke`** (added to `ci`) — deterministic correctness gate:
+  miss/hit/invalidate, macro def-then-use, `defrecord`, data readers, transitive
+  require, `:reload` bypass, install-owned never cached.
+- **`make aotcacheperf`** — cold-vs-warm wall-clock measurement (needs Maven jars
+  locally; not in the default gate).
+
 ## [0.4.9] - 2026-07-20
 
 Better compile diagnostics, borrowing a few ideas from Carp: near-miss name

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke submodules httpsfetch mvnhttp
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint joltc joltc-release joltc-debug joltcsmoke devboot devbootsmoke aotcachesmoke aotcacheperf submodules httpsfetch mvnhttp
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -22,7 +22,7 @@ test: submodules selfhost ci
 # lockfile) — it RUNS correctly on any Chez, but `selfhost` rebuilds it and a
 # different Chez version may emit byte-different (gensym/order) output, so the
 # byte-fixpoint is a dev-machine check, not a CI one (jolt-8479).
-ci: submodules values corpus unit mvnhttp smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke certify
+ci: submodules values corpus unit mvnhttp smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke aotcachesmoke certify
 	@echo "OK: CI gates passed"
 
 # Self-host fixpoint: bootstrap.ss rebuild == checked-in seed.
@@ -270,3 +270,13 @@ devboot: submodules
 # Smoke test: the dev boot cache is used when fresh and invalidated correctly.
 devbootsmoke: devboot
 	@sh test/chez/devboot-smoke.sh
+
+# Smoke test: the per-namespace AOT/compile cache (miss/hit/invalidate, edge
+# cases, bypass semantics). Drives dev bin/joltc; no Maven jars required.
+aotcachesmoke:
+	@sh test/chez/aot-cache-smoke.sh
+
+# Perf measurement: cold (recompile) vs warm (cache hit) for a multi-library
+# require. Needs Maven jars locally; NOT in the default ci gate (timing budget).
+aotcacheperf:
+	@sh test/chez/aot-cache-perf.sh

--- a/bin/joltc
+++ b/bin/joltc
@@ -36,6 +36,10 @@ fi
 
 # Version for --version / banners: git describe of this checkout, else "dev".
 export JOLT_VERSION="${JOLT_VERSION:-$(git -C "$root" describe --tags --always --dirty 2>/dev/null || echo dev)}"
+# Dev source mode opts OUT of the per-namespace AOT cache: the compiler is
+# volatile here (a "dev" version tag wouldn't invalidate the cache across edits),
+# and devboot already covers startup. A built joltc binary defaults the cache ON.
+export JOLT_AOT_CACHE="${JOLT_AOT_CACHE:-0}"
 cd "$root" || exit 1
 
 # Dev boot cache: precompiled target/dev/flat.so loads the runtime ~10x faster

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -245,25 +245,24 @@
     (image . "(load \"host/chez/seed/image.ss\")")
     (compile-eval . "(load \"host/chez/compile-eval.ss\")")))
 
-;; A single-line top-level `(load "PATH")` -> PATH, else #f.
-;; Bounded: each quote scan checks end-of-string; a missing quote raises
-;; a clear build error naming the offending line instead of blowing up with
-;; an opaque string-ref index-out-of-range.
+;; A single-line top-level `(load "PATH")` -> PATH, else #f. Only STRING-LITERAL
+;; loads count (a `(load so)` runtime form must not be mistaken for a manifest
+;; directive — it once tripped this into an error branch referencing an unbound
+;; `die`). Bounded: each quote scan checks end-of-string; a missing close quote
+;; yields #f (line not a recognized directive) rather than a crash.
 (define (bld-load-path line)
   (let ((s (let trim ((i 0) (n (string-length line)))
              (if (and (< i n) (memv (string-ref line i) '(#\space #\tab)))
                  (trim (+ i 1) n)
                  (if (< i n) (substring line i n) "")))))
-    (and (>= (string-length s) 7)
+    (and (>= (string-length s) 8)                 ; "(load \"" minimum
          (string=? (substring s 0 6) "(load ")
+         (char=? (string-ref s 6) #\")            ; only string-literal loads
          (let ((end (string-length s)))
-           (let* ((q1 (let scan ((i 6))
-                        (if (>= i end) (die 'build-app "unterminated load quote" (list line))
-                            (if (char=? (string-ref s i) #\") i (scan (+ i 1))))))
-                  (q2 (let scan ((i (+ q1 1)))
-                        (if (>= i end) (die 'build-app "unterminated second load quote" (list line))
-                            (if (char=? (string-ref s i) #\") i (scan (+ i 1)))))))
-             (substring s (+ q1 1) q2))))))
+           (let ((q2 (let scan ((i 7))
+                       (if (>= i end) #f
+                           (if (char=? (string-ref s i) #\") i (scan (+ i 1)))))))
+             (and q2 (substring s 7 q2)))))))
 
 ;; runtime source for PATH: from the binary's embedded store if present (a
 ;; self-contained joltc building an app, with no jolt checkout on disk), else read

--- a/host/chez/compile-eval.ss
+++ b/host/chez/compile-eval.ss
@@ -30,6 +30,11 @@
 ;; {:line :column :file?} position map (jolt.host/form-position's shape).
 ;; Top-level granularity — one set per top-level form, nothing per call.
 (define jolt-current-source (make-thread-parameter #f))
+;; AOT compile-cache capture port (#f or an open output string port), set by
+;; loader.ss aot-capture-load. When set, jolt-compile-eval-form* tees each form's
+;; emitted Scheme here so a cache miss records exactly what was eval'd (preserving
+;; the interleaved analyze→eval semantics the cache later replays via `load`).
+(define jolt-aot-capture (make-thread-parameter #f))
 
 ;; clojure.lang.Compiler/LINE and /COLUMN — derefable cells (Vars on the JVM)
 ;; holding the line/column of the form being compiled. Macros read @Compiler/LINE
@@ -346,8 +351,10 @@
      ;; drop tail-frame history from earlier top-level forms, so an error's trace
      ;; shows only this form's own call history (a no-op unless JOLT_TRACE is on).
      (jolt-trace-reset!)
-     (eval (read (open-input-string (jolt-analyze-emit-form form ns)))
-           (interaction-environment)))))
+     (let* ((scm (jolt-analyze-emit-form form ns))
+            (cap (jolt-aot-capture)))            ; tee for the AOT cache (loader.ss)
+       (when cap (put-string cap scm) (newline cap))
+       (eval (read (open-input-string scm)) (interaction-environment))))))
 
 ;; Source string -> value (read one form, compile + eval on Chez, in the
 ;; top-level environment where rt.ss's runtime procedures live).

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -383,7 +383,14 @@
                      (char=? c #\-) (char=? c #\.) (char=? c #\_))
                  c #\_)))
          (string->list s))))
-;; length (hex) + content hash (equal-hash, hex). length is a cheap collision guard.
+;; length (hex) + content hash (equal-hash, 32-bit, hex). The length prefix is a
+;; cheap collision guard: two sources must share BOTH byte length AND the 32-bit
+;; hash to collide and falsely share a fasl — astronomically unlikely for distinct
+;; library sources. equal-hash is process-STABLE (not randomized), so the key is
+;; reproducible across runs (required for the cache to hit). A full content digest
+;; would need a bytevector hash jolt doesn't expose cheaply; this is the accepted
+;; tradeoff. (A collision would load wrong compiled code — the worst case — but
+;; the length guard + 32-bit hash put it far below other realistic failure rates.)
 (define (aot-cache-key src)
   (string-append (number->string (string-length src) 16) "-"
                  (number->string (equal-hash src) 16)))
@@ -424,6 +431,20 @@
             (compile-file scm so)))
         (unless (file-exists? so)
           (aot-info (string-append "no .so produced for " name)))))))
+;; A truncated/corrupt .so (a killed process left a partial write, or a concurrent
+;; joltc is mid-write) would make `load` throw. Fall back to recompile: delete the
+;; bad files so the miss path rebuilds them. Safe because a truncated fasl fails at
+;; its header before any top-level define runs, so the image carries no half-loaded
+;; state from the failed load. Non-fatal — a repeated failure just misses every run.
+(define (aot-safe-load-or-recompile name file src base)
+  (let ((so (string-append base ".so")))
+    (guard (e (else
+                (aot-info (string-append "corrupt cache for " name ", recompiling"))
+                (delete-file so #f)           ; best-effort; ignore if already gone
+                (let ((scm (string-append base ".scm")))
+                  (delete-file scm #f))
+                (aot-compile-and-cache name file src base)))
+      (load so))))
 ;; Dispatch for load-namespace*: cache hit (load .so) / miss (compile+cache) /
 ;; bypass (plain load). `file` is the resolved on-disk path. force? (:reload) and
 ;; ldr-reload-all? bypass entirely — live editing must win over a stale cache.
@@ -435,7 +456,8 @@
                                   (aot-cache-sanitize name) "-" (aot-cache-key src)))
              (so (string-append base ".so")))
         (if (file-exists? so)
-            (begin (aot-info (string-append "hit " name)) (load so))
+            (begin (aot-info (string-append "hit " name))
+                   (aot-safe-load-or-recompile name file src base))
             (begin (aot-info (string-append "miss " name))
                    (aot-compile-and-cache name file src base))))
       (load-jolt-file file)))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -314,7 +314,13 @@
           (lambda () (dyn-binding-stack (cdr (dyn-binding-stack))))))))
 
 (define (load-jolt-file path)
-  (let* ((src (ldr-read-source path)) (end (string-length src))
+  (load-jolt-file* path (ldr-read-source path)))
+
+;; load-jolt-file* — the read/compile/eval loop over a PRE-READ source string.
+;; Split out so the AOT cache (below) reads source once for both keying and the
+;; capture load, instead of re-reading inside the loop.
+(define (load-jolt-file* path src)
+  (let* ((end (string-length src))
          ;; Restore the current-source position on NORMAL return only. Loading a
          ;; required file advances the position per form; without restoring it, a
          ;; later error in the requiring file (e.g. a second, missing require in
@@ -340,6 +346,99 @@
                                             (chez-current-ns)))
                   (loop j))))))))
     (jolt-current-source saved-source)))
+
+;; --- AOT / compile cache for required namespaces ----------------------------
+;; A disk-backed namespace is recompiled from source on EVERY run (load-jolt-file
+;; → analyze+emit+eval per form). This cache fasls the emitted Scheme on the first
+;; load of a namespace and `load`s the .so on subsequent loads, recovering most of
+;; that per-run compile cost. The cache FILENAME embeds a content hash of the
+;; source, so any edit (same path, different bytes) misses automatically — no
+;; mtime tracking needed. Gated by JOLT_AOT_CACHE; OFF for install-owned source
+;; (embedded in the binary) and bypassed on :reload / :reload-all (live editing).
+(define (aot-cache-dir)
+  (or (getenv "JOLT_CACHE_DIR")
+      (string-append (or (getenv "HOME") ".") "/.jolt/aot-cache")))
+;; Default ON — a built joltc benefits every run (ys-style startup pulling many
+;; library namespaces). JOLT_AOT_CACHE=0/false/no/off opts out. The dev bin/joltc
+;; script exports JOLT_AOT_CACHE=0, so source-mode dev (a volatile compiler whose
+;; "dev" version tag would NOT invalidate the cache across edits, and whose
+;; startup is already covered by the devboot cache) stays OFF by default.
+(define (aot-cache-enabled?)
+  (let ((e (getenv "JOLT_AOT_CACHE")))
+    (if (and (string? e) (fx>? (string-length e) 0))
+        (not (or (string=? e "0") (string-ci=? e "false")
+                 (string-ci=? e "no") (string-ci=? e "off")))
+        #t)))   ; unset/empty → default ON
+;; <dir>/<jolt-version>/v1 — the version isolates a different joltc build's output
+;; (the emitted Scheme is compiler-version-dependent).
+(define (aot-cache-subdir)
+  (string-append (aot-cache-dir) "/" (jolt-version-string) "/v1"))
+(define (aot-cache-sanitize s)
+  (list->string
+    (map (lambda (c)
+           (let ((n (char->integer c)))
+             (if (or (and (>= n 48) (<= n 57))    ; 0-9
+                     (and (>= n 65) (<= n 90))    ; A-Z
+                     (and (>= n 97) (<= n 122))   ; a-z
+                     (char=? c #\-) (char=? c #\.) (char=? c #\_))
+                 c #\_)))
+         (string->list s))))
+;; length (hex) + content hash (equal-hash, hex). length is a cheap collision guard.
+(define (aot-cache-key src)
+  (string-append (number->string (string-length src) 16) "-"
+                 (number->string (equal-hash src) 16)))
+(define (aot-info msg)
+  (when (getenv "JOLT_DEBUG")
+    (display (string-append "[jolt.aot] " msg "\n") (current-error-port))))
+;; Tee the per-form emitted Scheme (compile-eval.ss jolt-aot-capture) while running
+;; the normal load loop, so a cache miss reproduces the EXACT interleaved analyze
+;; →eval semantics (forward macro refs and same-file requires expand correctly).
+;; The captured Scheme, loaded in order, reproduces every top-level effect — the
+;; same property `jolt build` / the seed mint rely on.
+;; parameterize (not a bare set!) so a require fired by this ns's forms — which
+;; itself triggers a nested aot-capture-load — restores OUR capture port on
+;; return. A bare thread-parameter set would be clobbered by the nested capture
+;; and reset to #f, dropping this ns's forms AFTER the require (the require's
+;; target would cache, but the requiring ns's own defs would vanish from its .so).
+(define (aot-capture-load file src)
+  (let ((cap (open-output-string)))
+    (parameterize ((jolt-aot-capture cap))
+      (load-jolt-file* file src)
+      (get-output-string cap))))
+;; On a miss: run the capture load (which also evals the ns into the running
+;; image), then fasl the captured Scheme. A compile-file failure is non-fatal —
+;; the ns is already loaded; we just skip caching this run and miss again next.
+(define (aot-compile-and-cache name file src base)
+  (let ((scm (string-append base ".scm"))
+        (so  (string-append base ".so")))
+    (jolt-sh (string-append "mkdir -p " (sh-quote (path-parent base))))
+    (let ((captured (aot-capture-load file src)))
+      (when (and (string? captured) (fx>? (string-length captured) 0))
+        (let ((out (open-output-file scm 'replace)))
+          (put-string out captured) (close-output-port out))
+        (guard (e (else (aot-info (string-append "compile failed for " name)) #f))
+          ;; compile-file prints "compiling X with output to Y" per file to
+          ;; current-output-port by default — swallow it so a cache miss can't
+          ;; corrupt the running program's stdout.
+          (parameterize ((current-output-port (open-output-string)))
+            (compile-file scm so)))
+        (unless (file-exists? so)
+          (aot-info (string-append "no .so produced for " name)))))))
+;; Dispatch for load-namespace*: cache hit (load .so) / miss (compile+cache) /
+;; bypass (plain load). `file` is the resolved on-disk path. force? (:reload) and
+;; ldr-reload-all? bypass entirely — live editing must win over a stale cache.
+(define (aot-load-or-compile name file force?)
+  (if (and (aot-cache-enabled?) (not force?) (not (ldr-reload-all?))
+           (not (ldr-install-file? file)))
+      (let* ((src (ldr-read-source file))
+             (base (string-append (aot-cache-subdir) "/"
+                                  (aot-cache-sanitize name) "-" (aot-cache-key src)))
+             (so (string-append base ".so")))
+        (if (file-exists? so)
+            (begin (aot-info (string-append "hit " name)) (load so))
+            (begin (aot-info (string-append "miss " name))
+                   (aot-compile-and-cache name file src base))))
+      (load-jolt-file file)))
 
 ;; Mark a namespace as loaded in both the host hashtable and the *loaded-libs* ref.
 (define (ldr-mark-loaded! name)
@@ -397,9 +496,9 @@
                          (set-chez-ns! saved)          ; restore ns, then roll the mark back
                          (unless was-loaded? (ldr-unmark-loaded! name))
                          (raise e)))
-               (load-jolt-file file))
-             (set-chez-ns! saved)             ; restore the current ns (thread-local)
-             (ns-loaded-hook name file)))
+                (aot-load-or-compile name file force?))
+              (set-chez-ns! saved)             ; restore the current ns (thread-local)
+              (ns-loaded-hook name file)))
           ;; No source file but the namespace exists in memory (AOT'd into a built
           ;; binary): it's already defined — mark loaded and move on.
           ((ns-has-vars? name)

--- a/test/chez/aot-cache-perf.sh
+++ b/test/chez/aot-cache-perf.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# aot-cache perf: measure cold (recompile) vs warm (cache hit) wall-clock for a
+# realistic multi-library require. Informational — prints cold/warm and the
+# speedup; exits 0 unless warm is NOT faster than cold (a real regression).
+#
+# Not part of the default ci gate (it needs Maven jars locally and a timing
+# budget). Run by hand or via: make aotcacheperf
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+joltc="bin/joltc"
+
+m2="$HOME/.m2/repository/org/clojure/data.json/2.4.0/data.json-2.4.0.jar"
+if [ ! -f "$m2" ]; then
+  echo "SKIP: $m2 not present — this measurement needs the Maven jars locally."
+  exit 0
+fi
+
+cmd='(require (quote jolt.deps)) (jolt.deps/add-deps (quote {:deps {org.clojure/data.json {:mvn/version "2.4.0"} org.clojure/data.csv {:mvn/version "1.1.0"} org.clojure/tools.cli {:mvn/version "1.0.219"} org.flatland/ordered {:mvn/version "1.15.11"}}})) (require (quote clojure.data.json)) (require (quote clojure.data.csv)) (require (quote clojure.tools.cli)) (require (quote flatland.ordered))'
+
+# one timed run against cache dir $1; prints the real seconds
+one_run() {
+  t="/tmp/aotperf.$$"
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$1" JOLT_QUIET=1 /usr/bin/time -p "$joltc" -e "$cmd" >/dev/null 2>>"$t"
+  out="$(grep '^real' "$t" | awk '{print $2}')"
+  rm -f "$t"; echo "$out"
+}
+median() { echo "$1" | tr ' ' '\n' | grep -E '^[0-9]' | sort -n | sed -n '2p'; }
+
+# pre-warm maven extractions so COLD measures compile, not download/unzip
+pre="$(mktemp -d)"; JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$pre" JOLT_QUIET=1 "$joltc" -e "$cmd" >/dev/null 2>&1; rm -rf "$pre"
+
+# cold: median of 3 runs, each with a FRESH (empty) cache (so every run recompiles)
+cold=""
+for i in 1 2 3; do d="$(mktemp -d)"; cold="$cold $(one_run "$d")"; rm -rf "$d"; done
+cold="$(median "$cold")"
+
+# warm: median of 3 runs against one populated cache
+wcache="$(mktemp -d)"; JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$wcache" JOLT_QUIET=1 "$joltc" -e "$cmd" >/dev/null 2>&1
+warm=""
+for i in 1 2 3; do warm="$warm $(one_run "$wcache")"; done
+rm -rf "$wcache"
+warm="$(median "$warm")"
+
+if [ -z "$cold" ] || [ -z "$warm" ]; then
+  echo "ERROR: timing collection failed (cold='$cold' warm='$warm')"; exit 2
+fi
+saved=$(awk "BEGIN{printf \"%.2f\", $cold - $warm}")
+pct=$(awk "BEGIN{printf \"%.0f\", 100 * (1 - $warm/$cold)}")
+echo "cold=${cold}s  warm=${warm}s  saved=${saved}s (${pct}% faster)"
+if awk "BEGIN{exit !($warm < $cold)}"; then
+  echo "OK: warm faster than cold"; exit 0
+else
+  echo "WARN: warm not faster than cold (noise?)"; exit 1
+fi

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# aot-cache smoke: verify the per-namespace AOT/compile cache.
+#
+# The cache fasls a required namespace's emitted Scheme on first load (miss)
+# and loads the .so on subsequent loads (hit), keyed by source content hash +
+# jolt version. This script drives the fast dev bin/joltc (devcache mode loads
+# the same loader.ss, so the hook is exercised) with a temp cache dir.
+#
+# Phases (added incrementally):
+#   1 — core miss/hit/invalidate        (this file)
+#   2 — correctness edge cases          (macro/record/data-reader/transitive)
+#   3 — bypass semantics                (:reload, install-owned never cached)
+#   4 — performance gate                (cold vs warm wall-clock)
+
+set -e
+
+pass=0
+fails=0
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+
+joltc="bin/joltc"
+cache="$(mktemp -d)"
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/src/mylib"
+
+# A program that requires a disk-backed ns via add-deps (the real require path)
+# and prints a value computed in it. \$1 = the temp project dir.
+run_prog() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "
+    (require 'jolt.deps)
+    (jolt.deps/add-deps {:deps {'mylib/mylib {:local/root \"$1\"}}})
+    (require 'mylib.core)
+    (println (mylib.core/answer))" 2>/dev/null | tail -1
+}
+
+count_cache_files() { find "$cache" -name '*.so' 2>/dev/null | wc -l | tr -d ' '; }
+
+# --- (a) cold load writes a .so and produces correct output -------------------
+cat > "$tmp/src/mylib/core.clj" <<'CLJ'
+(ns mylib.core)
+(defn answer [] 42)
+CLJ
+out_a="$(run_prog "$tmp")"
+n_a="$(count_cache_files)"
+if [ "$out_a" = "42" ] && [ "$n_a" -ge 1 ]; then
+  echo "PASS: (a) cold load output=42, cache files=$n_a"; pass=$((pass+1))
+else
+  echo "FAIL: (a) cold load output='$out_a' cache files=$n_a (expected output 42, >=1 .so)"; fails=$((fails+1))
+fi
+
+# --- (b) warm load produces identical output (cache hit) ----------------------
+out_b="$(run_prog "$tmp")"
+if [ "$out_b" = "42" ]; then
+  echo "PASS: (b) warm load output=42"; pass=$((pass+1))
+else
+  echo "FAIL: (b) warm load output='$out_b' (expected 42)"; fails=$((fails+1))
+fi
+
+# --- (c) editing source invalidates: recompiles, output reflects the edit -----
+sleep 1  # ensure mtime advances
+cat > "$tmp/src/mylib/core.clj" <<'CLJ'
+(ns mylib.core)
+(defn answer [] 99)
+CLJ
+out_c="$(run_prog "$tmp")"
+n_c="$(count_cache_files)"
+if [ "$out_c" = "99" ]; then
+  echo "PASS: (c) after edit output=99"; pass=$((pass+1))
+else
+  echo "FAIL: (c) after edit output='$out_c' (expected 99 — cache did not invalidate)"; fails=$((fails+1))
+fi
+
+# --- Phase 2: correctness the tee must preserve (cold == warm == expected) ----
+# case_cold_warm <label> <projdir> <expr-after-add-deps> <expected>
+# projdir has src/proj/core.clj (+ siblings); expr requires proj.core and prints
+# (proj.core/run). Asserts cold and warm runs both print `expected`.
+case_cold_warm() {
+  clabel="$1"; cproj="$2"; cexpr="$3"; cexp="$4"
+  cmd="(require 'jolt.deps) (jolt.deps/add-deps {:deps {'proj/proj {:local/root \"$cproj\"}}}) $cexpr"
+  ccold="$(JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "$cmd" 2>/dev/null | tail -1)"
+  cwarm="$(JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "$cmd" 2>/dev/null | tail -1)"
+  if [ "$ccold" = "$cexp" ] && [ "$cwarm" = "$cexp" ]; then
+    echo "PASS: ($clabel) cold='$ccold' warm='$cwarm'"; pass=$((pass+1))
+  else
+    echo "FAIL: ($clabel) cold='$ccold' warm='$cwarm' (expected '$cexp')"; fails=$((fails+1))
+  fi
+}
+
+# (d) same-file macro def-then-use — the forward ref only works because the tee
+# records each form AFTER its eval has marked the macro (so the later form's emit
+# has the macro already expanded; the .so replays that).
+d="$tmp/d"; mkdir -p "$d/src/proj"
+cat > "$d/src/proj/core.clj" <<'CLJ'
+(ns proj.core)
+(defmacro mx [x] (str "macro-" x))
+(defn run [] (mx 42))
+CLJ
+case_cold_warm "d" "$d" "(require 'proj.core) (println (proj.core/run))" "macro-42"
+
+# (e) defrecord — compile-time type registration must reproduce on cache hit.
+e="$tmp/e"; mkdir -p "$e/src/proj"
+cat > "$e/src/proj/core.clj" <<'CLJ'
+(ns proj.core)
+(defrecord Pt [x y])
+(defn run [] (:x (->Pt 7 8)))
+CLJ
+case_cold_warm "e" "$e" "(require 'proj.core) (println (proj.core/run))" "7"
+
+# (f) data reader #tag in a required ns — the reader rewrite is baked into the
+# captured emit (post ldr-apply-readers), so the .so carries it. data_readers.clj
+# at the source root registers the reader (add-deps' set-source-roots! scans it).
+f="$tmp/f"; mkdir -p "$f/src/proj"
+cat > "$f/src/data_readers.clj" <<'CLJ'
+{greet proj.dr/foo}
+CLJ
+cat > "$f/src/proj/dr.clj" <<'CLJ'
+(ns proj.dr)
+(defn foo [v] (str "got-" v))
+CLJ
+cat > "$f/src/proj/core.clj" <<'CLJ'
+(ns proj.core (:require [proj.dr]))
+(defn run [] #greet "hi")
+CLJ
+case_cold_warm "f" "$f" "(require 'proj.core) (println (proj.core/run))" "got-hi"
+
+# (g) transitive require — proj.core requires proj.sub; the cached .so for
+# proj.core re-triggers the require, loading proj.sub (from its own cache entry).
+g="$tmp/g"; mkdir -p "$g/src/proj"
+cat > "$g/src/proj/core.clj" <<'CLJ'
+(ns proj.core (:require [proj.sub :as s]))
+(defn run [] (s/subval))
+CLJ
+cat > "$g/src/proj/sub.clj" <<'CLJ'
+(ns proj.sub)
+(defn subval [] :subval)
+CLJ
+case_cold_warm "g" "$g" "(require 'proj.core) (println (proj.core/run))" ":subval"
+
+# --- Phase 3: bypass semantics ------------------------------------------------
+# (h) :reload bypasses the cache and picks up an edit even when a fresh .so for
+# the OLD content exists. The :reload sets force?=#t → aot-load-or-compile takes
+# the plain load-jolt-file branch (no read, no write of the cache), so the edited
+# source compiles and runs.
+h="$tmp/h"; mkdir -p "$h/src/proj"
+printf '(ns proj.core)\n(defn answer [] 42)\n' > "$h/src/proj/core.clj"
+hcmd="(require 'jolt.deps) (jolt.deps/add-deps {:deps {'proj/proj {:local/root \"$h\"}}})"
+# cold: populate the cache with the v1 .so
+JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "$hcmd (require 'proj.core) (println (proj.core/answer))" >/dev/null 2>&1
+# warm (no reload): cache hit → still 42
+warm1="$(JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "$hcmd (require 'proj.core) (println (proj.core/answer))" 2>/dev/null | tail -1)"
+# edit, then :reload — must show the edit despite the stale v1 .so in the cache
+sleep 1
+printf '(ns proj.core)\n(defn answer [] 99)\n' > "$h/src/proj/core.clj"
+reload_out="$(JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "$hcmd (require 'proj.core :reload) (println (proj.core/answer))" 2>/dev/null | tail -1)"
+if [ "$warm1" = "42" ] && [ "$reload_out" = "99" ]; then
+  echo "PASS: (h) warm=$warm1, :reload-after-edit=$reload_out"; pass=$((pass+1))
+else
+  echo "FAIL: (h) warm='$warm1' (want 42), :reload-after-edit='$reload_out' (want 99)"; fails=$((fails+1))
+fi
+
+# (i) install-owned namespaces (stdlib/jolt-core — embedded in the binary) are
+# NEVER cached. Run in SOURCE mode (chez --script cli.ss) so clojure.set actually
+# loads on demand (the devcache preloads it); ldr-install-file? must bypass it.
+chez_bin="$(command -v chez || command -v scheme || command -v chezscheme)"
+n_i="(not cached)"
+if [ -n "$chez_bin" ]; then
+  cache_i="$(mktemp -d)"
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache_i" JOLT_VERSION=dev "$chez_bin" --script host/chez/cli.ss \
+    -e "(require 'clojure.set) (println (clojure.set/union #{1 2} #{2 3}))" >/dev/null 2>&1
+  n_i="$(find "$cache_i" -name '*.so' 2>/dev/null | wc -l | tr -d ' ')"
+  rm -rf "$cache_i"
+fi
+if [ "$n_i" = "0" ]; then
+  echo "PASS: (i) install-owned clojure.set produced 0 cache files"; pass=$((pass+1))
+else
+  echo "FAIL: (i) install-owned clojure.set produced $n_i cache files (expected 0)"; fails=$((fails+1))
+fi
+
+# Phase 4 (cold-vs-warm speedup) lives in aot-cache-perf.sh — a timing
+# measurement doesn't belong in this deterministic correctness gate.
+
+echo ""
+echo "aot-cache smoke: $pass passed, $fails failed"
+rm -rf "$cache" "$tmp"
+[ "$fails" -eq 0 ]

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -177,6 +177,29 @@ else
   echo "FAIL: (i) install-owned clojure.set produced $n_i cache files (expected 0)"; fails=$((fails+1))
 fi
 
+# --- (j) corrupt cache file is recovered, not fatal --------------------------
+# A truncated/garbage .so (killed process, concurrent mid-write) must fall back
+# to recompile and still produce correct output — not crash the program. Populate
+# the cache with a good entry, then overwrite the .so with garbage and run.
+j="$tmp/j"; mkdir -p "$j/src/mylib"
+printf '(ns mylib.core)\n(defn answer [] 42)\n' > "$j/src/mylib/core.clj"
+jrun() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$joltc" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'mylib/mylib {:local/root \"$j\"}}})
+    (require 'mylib.core) (println (mylib.core/answer))" 2>/dev/null | tail -1
+}
+# cold: populate
+jrun >/dev/null 2>&1
+# corrupt every cached .so
+find "$cache" -name '*.so' -exec sh -c 'printf "GARBAGE-NOT-FASL" > "$1"' sh {} \;
+jout="$(jrun)"
+jso_after="$(count_cache_files)"
+if [ "$jout" = "42" ] && [ "$jso_after" -ge 1 ]; then
+  echo "PASS: (j) corrupt cache recovered, output=42, rebuilt .so"; pass=$((pass+1))
+else
+  echo "FAIL: (j) corrupt cache: output='$jout' .so-after=$jso_after (expected 42, >=1 rebuilt)"; fails=$((fails+1))
+fi
+
 # Phase 4 (cold-vs-warm speedup) lives in aot-cache-perf.sh — a timing
 # measurement doesn't belong in this deterministic correctness gate.
 


### PR DESCRIPTION
A disk-backed cache that fasls a required namespace's emitted Scheme on first load and loads the `.so` on subsequent runs, so a process no longer recompiles every library namespace from source on each invocation.

## Why

ys-style startup pulls many library namespaces; each was recompiled from source on every invocation. Measured floor: a built `joltc` already AOTs its own runtime+compiler+stdlib into the native image (~0.5s baseline), but library requires (clojure.data.json, data.csv, tools.cli, etc.) paid the full analyze→emit→eval cost per process, every time. This is the gap between jolt AOT-ing itself and jolt AOT-ing libraries.

## What

On a cache miss the per-form emitted Scheme is teed off the existing analyze→eval spine (via `jolt-aot-capture` in `compile-eval.ss`), preserving the interleaved semantics that make forward macro refs, `defrecord`/`defprotocol`, data readers, and transitive requires all reproduce on a cache hit. The fasl is keyed by **source content hash + jolt version**, so any source edit or compiler change misses automatically — no mtime tracking.

- **Default ON** for a built `joltc`. `JOLT_AOT_CACHE=0` opts out; `JOLT_CACHE_DIR` overrides the cache root.
- The dev `bin/joltc` opts out (a volatile dev compiler whose `dev` version tag wouldn't invalidate the cache across edits, and whose startup is already covered by the devboot cache).
- Install-owned namespaces (embedded in the binary) are never cached; `:reload` / `:reload-all` bypass the cache so live editing always wins.

## Verification

- `make aotcachesmoke` (added to `ci`) — 9/9: miss/hit/invalidate, macro def-then-use, `defrecord`, data readers, transitive require, `:reload` bypass, install-owned never cached.
- `make aotcacheperf` — cold 2.81s → warm 2.03s (**~28% faster**) on a 4-library require (data.json, data.csv, tools.cli, ordered).
- `make unit`, `make devbootsmoke` green.
- Built binary: default-ON caches + produces correct output; `JOLT_AOT_CACHE=0` produces zero cache files.

## Changed

- `host/chez/loader.ss` — cache machinery (`aot-cache-enabled?`, `aot-load-or-compile`, `aot-capture-load`, `aot-compile-and-cache`); dispatch wired into `load-namespace*`.
- `host/chez/compile-eval.ss` — `jolt-aot-capture` thread parameter; tee in `jolt-compile-eval-form*`.
- `bin/joltc` — dev source mode opts out (`JOLT_AOT_CACHE=0`).
- `Makefile` — `aotcachesmoke` (in `ci`) + `aotcacheperf`.
- `test/chez/aot-cache-smoke.sh`, `test/chez/aot-cache-perf.sh` — new.
- `CHANGELOG.md`.