### PR TITLE
Move java.time.* out of core into jolt-lang/time (RFC 0008)

### DIFF
--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -192,6 +192,23 @@
 (vector-set! (mutable-static-cell "clojure.lang.RT" "checkSpecAsserts" #t) 0 #f)
 
 ;; ---- emit entry points ------------------------------------------------------
+;; An unresolved java.time.* class (fully qualified, or a distinctive short name)
+;; almost always means the jolt-lang/time library isn't loaded: java.time lives
+;; there, not in core (RFC 0008). Name the dependency so the fix is obvious,
+;; rather than leaving a bare "Unknown class".
+(define jt-short-names
+  '("Instant" "LocalDate" "LocalTime" "LocalDateTime" "ZonedDateTime"
+    "OffsetDateTime" "OffsetTime" "ZoneId" "ZoneOffset" "Duration" "Period"
+    "YearMonth" "MonthDay" "DateTimeFormatter" "FormatStyle"))
+(define (java-time-class? class)
+  (or (and (>= (string-length class) 10) (string=? (substring class 0 10) "java.time."))
+      (and (member class jt-short-names) #t)))
+(define (unknown-class-message class)
+  (if (java-time-class? class)
+      (string-append class " requires the jolt-lang/time library — java.time is not in "
+                     "core (add io.github.jolt-lang/time to deps.edn)")
+      (string-append "Unknown class " class)))
+
 (define (host-static-ref class member)
   (let ((cell (mutable-static-cell class member #f)))
     (if cell
@@ -200,7 +217,7 @@
           (if h
               (let ((v (hashtable-ref h member #f)))
                 (if v v (throw-jvm (quote IllegalArgumentException) (string-append "No matching field or method: " class "/" member))))
-              (throw-jvm (quote IllegalArgumentException) (string-append "Unknown class " class)))))))
+              (throw-jvm (quote IllegalArgumentException) (unknown-class-message class)))))))
 
 (define (host-static-call class member . args)
   (apply (host-static-ref class member) args))

--- a/host/chez/java/inst-time.ss
+++ b/host/chez/java/inst-time.ss
@@ -6,10 +6,13 @@
 ;; INSTANT (offset-normalized). The overlay inst?/inst-ms read (get x :jolt/type)/(get x :ms),
 ;; so jolt-get answers those off a jinst — the overlay fns then work unchanged.
 ;;
-;; The java.time surface (DateTimeFormatter/Instant/ZoneId/LocalDateTime/
-;; FormatStyle/Locale + the .format/.atZone/.toInstant/… methods) is
-;; registered through host-static.ss's class-statics / host-
-;; methods registries — so this loads LAST in rt.ss, after host-static.ss and io.ss.
+;; The full java.time.* surface lives in the jolt-lang/time library, not here
+;; (RFC 0008). Core keeps only the #inst literal and the java.util / java.text
+;; date layer (Date / Calendar / TimeZone / SimpleDateFormat / Locale). The
+;; Date/FileTime `.toInstant` bridge routes through the library's Instant
+;; constructor when the library is loaded (set-instant-ctor!), and throws
+;; otherwise — core defines no java.time value of its own. This loads LAST in
+;; rt.ss, after host-static.ss and io.ss.
 
 ;; --- civil <-> days since the Unix epoch (Howard Hinnant's algorithms) -------
 ;; No portable UTC mktime on Chez, so compute epoch days directly from y/m/d.
@@ -314,22 +317,12 @@
 ;; :jolt/inst tag (which print-method still dispatches on via __type-tag).
 (register-class-arm! jinst? (lambda (x) "java.util.Date"))
 
-;; java.time.Instant is nano-precise: two Instants are = when their epoch-nanos
-;; match (so an Instant and one shifted by a single nanosecond differ).
-(define (jt-instant-tag? x) (and (jhost? x) (string=? (jhost-tag x) "instant")))
-(register-eq-arm! (lambda (a b) (or (jt-instant-tag? a) (jt-instant-tag? b)))
-                  (lambda (a b) (and (jt-instant-tag? a) (jt-instant-tag? b)
-                                     (= (inst-nanos a) (inst-nanos b)))))
-(register-hash-arm! jt-instant-tag? (lambda (x) (jolt-hash (inst-nanos x))))
-
-;; ZonedDateTime / java.sql.Date shim values (mk-zoned/mk-sql-date jhosts) are
-;; equal when same kind + same epoch-ms.
-(define (time-jhost? x) (and (jhost? x) (member (jhost-tag x) '("zoned-dt" "sql-date")) #t))
-(register-eq-arm! (lambda (a b) (or (time-jhost? a) (time-jhost? b)))
-                  (lambda (a b) (and (time-jhost? a) (time-jhost? b)
-                                     (string=? (jhost-tag a) (jhost-tag b))
+;; java.sql.Date shim values (mk-sql-date jhosts) are equal by epoch-ms.
+(define (sql-date-jhost? x) (and (jhost? x) (string=? (jhost-tag x) "sql-date")))
+(register-eq-arm! (lambda (a b) (or (sql-date-jhost? a) (sql-date-jhost? b)))
+                  (lambda (a b) (and (sql-date-jhost? a) (sql-date-jhost? b)
                                      (= (ms-of a) (ms-of b)))))
-(register-hash-arm! time-jhost? (lambda (x) (jolt-hash (ms-of x))))
+(register-hash-arm! sql-date-jhost? (lambda (x) (jolt-hash (ms-of x))))
 
 (define (inst-pr i) (string-append "#inst \"" (inst-rfc3339 i) "\""))
 (register-pr-arm! jinst? inst-pr)
@@ -350,7 +343,6 @@
         ((jinst? val) (cond ((string=? tn "Date") #t)
                             ((string=? tn "Timestamp") #f)
                             (else 'pass)))
-        ((and (jhost? val) (string=? (jhost-tag val) "instant")) (if (string=? tn "Instant") #t 'pass))
         ;; java.sql.Date is a java.util.Date subclass (but not a Timestamp).
         ((and (jhost? val) (string=? (jhost-tag val) "sql-date"))
          (cond ((or (string=? tn "Date")) #t) ((string=? tn "Timestamp") #f) (else 'pass)))
@@ -359,125 +351,36 @@
 ;; inst-ms* is a seed native (the overlay inst-ms reads (get x :ms), now answered).
 (def-var! "clojure.core" "inst-ms*" (lambda (i) (jinst-ms i)))
 
-;; --- java.time shim values (jhost objects over host-static.ss registries) -----
-;; "local-date" stores an epoch-day (java-time.ss owns the type); ms-of projects it
-;; to UTC midnight so existing date math keeps working. "local-dt" stores epoch-day +
-;; nano-of-day; the others store epoch-ms.
+;; epoch-ms of a core date value (a number, a #inst/Date jinst, or a
+;; java.util.Calendar / java.sql.Date jhost). The java.time values live in the
+;; jolt-lang/time library and carry their own epoch accessors.
 (define (ms-of d)
   (cond ((number? d) d)
         ((jinst? d) (jinst-ms d))
-        ((and (jhost? d) (string=? (jhost-tag d) "local-date"))
-         (* (vector-ref (jhost-state d) 0) 86400000))
-        ((and (jhost? d) (string=? (jhost-tag d) "local-date-time"))
-         (+ (* (vector-ref (jhost-state d) 0) 86400000)
-            (quotient (vector-ref (jhost-state d) 1) 1000000)))
-        ;; "instant" stores epoch-nanos; project to ms (floor) for ms-based callers.
-        ((and (jhost? d) (string=? (jhost-tag d) "instant"))
-         (inst-floor-div (vector-ref (jhost-state d) 0) 1000000))
-        ((and (jhost? d) (member (jhost-tag d) '("zoned-dt" "calendar" "sql-date")))
+        ((and (jhost? d) (member (jhost-tag d) '("calendar" "sql-date")))
          (vector-ref (jhost-state d) 0))
         (else (throw-jvm (quote IllegalArgumentException) (string-append "not a date value: " (jolt-final-str d))))))
-;; A java.time.Instant stores epoch-nanos (exact integer). mk-instant takes ms,
-;; for the many ms-based call sites; mk-instant-nanos is the nano-precise ctor and
-;; inst-nanos the nano accessor (java-time.ss owns the nano-aware arithmetic).
-(define (mk-instant-nanos n) (make-jhost "instant" (vector (exact (truncate n)))))
-(define (inst-nanos x) (vector-ref (jhost-state x) 0))
-;; The jolt-lang/time library owns java.time.Instant; when it is loaded it sets
-;; this hook so Date/Calendar/#-derived .toInstant yields ITS instant, not a second
-;; representation. Unset by default (java.time comes from java-time.ss in core).
-(define jt-instant-hook #f)
-(define (mk-instant ms)
-  (let ((nanos (* (ms->exact ms) 1000000)))
-    (if jt-instant-hook (jt-instant-hook nanos) (mk-instant-nanos nanos))))
-(def-var! "jolt.host" "set-instant-ctor!"
-  (lambda (f) (set! jt-instant-hook (lambda (nanos) (jolt-invoke f nanos))) jolt-nil))
-(define (mk-zoned ms) (make-jhost "zoned-dt" (vector ms)))
-;; LocalDateTime from epoch-ms (UTC): the java-time.ss "local-date-time" jhost,
-;; state [epoch-day nano-of-day].
-(define (mk-local ms)
-  (let* ((ems (exact (truncate ms)))
-         (ed (inst-floor-div ems 86400000))
-         (mod (inst-floor-mod ems 86400000)))
-    (make-jhost "local-date-time" (vector ed (* mod 1000000)))))
-;; local-date from epoch-ms: the epoch-day of the UTC day containing ms.
-(define (mk-local-date ms) (make-jhost "local-date" (vector (inst-floor-div (exact (truncate ms)) 86400000))))
-;; a formatter carries its pattern and a locale id (default "en"); the locale
-;; selects month/day names in the java-time.ss format engine.
-(define (mk-formatter pat . loc) (make-jhost "dt-formatter" (vector pat (if (null? loc) "en" (car loc)))))
-(define (fmt-pat f) (vector-ref (jhost-state f) 0))
-(define (fmt-locale f) (let ((s (jhost-state f))) (if (> (vector-length s) 1) (vector-ref s 1) "en")))
-(define (locale-id l) (if (and (jhost? l) (string=? (jhost-tag l) "locale")) (vector-ref (jhost-state l) 0) "en"))
-(define (now-ms) (now-millis))   ; exact ms (= JVM long); now-millis from host-static.ss
 ;; coerce a user-supplied ms (exact or flonum) to an exact integer for storage.
 (define (ms->exact ms) (exact (round ms)))
+;; The jolt-lang/time library owns java.time.Instant (RFC 0008). When loaded it
+;; sets this hook so the Date/FileTime `.toInstant` bridge yields ITS instant, so
+;; a Date and a library instant are one representation. With no library loaded
+;; there is no Instant to build, so the bridge throws, naming the dependency.
+(define jt-instant-hook #f)
+(define (mk-instant ms)
+  (if jt-instant-hook
+      (jt-instant-hook (* (ms->exact ms) 1000000))
+      (throw-jvm (quote RuntimeException)
+                 "java.time.Instant requires the jolt-lang/time library (add io.github.jolt-lang/time to deps.edn)")))
+(def-var! "jolt.host" "set-instant-ctor!"
+  (lambda (f) (set! jt-instant-hook (lambda (nanos) (jolt-invoke f nanos))) jolt-nil))
+(define (now-ms) (now-millis))   ; exact ms (= JVM long); now-millis from host-static.ss
 
-(register-host-methods! "instant"
-  (list (cons "atZone" (lambda (self zone) (mk-zoned (ms-of self))))
-        (cons "toEpochMilli" (lambda (self) (ms-of self)))
-        (cons "toString" (lambda (self) (inst-rfc3339 (make-jinst (ms-of self)))))))
-(register-host-methods! "zoned-dt"
-  (list (cons "toLocalDateTime" (lambda (self) (mk-local (ms-of self))))
-        (cons "toInstant" (lambda (self) (mk-instant (ms-of self))))))
-;; LocalDate.atZone(zone): the UTC layer treats it as a zoned value at midnight.
-;; (java-time.ss registers atStartOfDay and the rest of the local-date surface.)
-(register-host-methods! "local-date"
-  (list (cons "atZone" (lambda (self zone) (mk-zoned (ms-of self))))))
-(register-host-methods! "dt-formatter"
-  (list (cons "withLocale" (lambda (self locale) (mk-formatter (fmt-pat self) (locale-id locale))))
-        (cons "withZone" (lambda (self zone) (mk-formatter (fmt-pat self) (fmt-locale self))))
-        (cons "format" (lambda (self d) (format-ms (fmt-pat self) (ms-of d))))
-        ;; parse a string per the pattern -> an instant value; Instant/from / the
-        ;; LocalDateTime/parse static read its ms back out.
-        (cons "parse" (lambda (self s) (mk-instant (jinst-ms (parse-ms (fmt-pat self) (jolt-str-render-one s))))))))
+;; java.time.Instant / ZoneId / LocalDateTime / DateTimeFormatter / FormatStyle
+;; and their methods are NOT registered here — they belong to the jolt-lang/time
+;; library (RFC 0008). Core exposes only the Date/FileTime `.toInstant` bridge
+;; (via mk-instant above) and the java.util / java.text layer below.
 
-;; FormatStyle approximations (no locale DB on this host).
-(define style-patterns
-  '((date . ((short . "M/d/yy") (medium . "MMM d, yyyy") (long . "MMMM d, yyyy") (full . "EEEE, MMMM d, yyyy")))
-    (time . ((short . "h:mm a") (medium . "h:mm:ss a") (long . "h:mm:ss a") (full . "h:mm:ss a")))
-    (datetime . ((short . "M/d/yy, h:mm a") (medium . "MMM d, yyyy, h:mm:ss a")
-                 (long . "MMMM d, yyyy, h:mm:ss a") (full . "EEEE, MMMM d, yyyy, h:mm:ss a")))))
-(define (style-of fs) (vector-ref (jhost-state fs) 0))       ; a symbol: short/medium/long/full
-(define (style-fmt kind fs)
-  (mk-formatter (or (let ((row (assq kind style-patterns))) (and row (let ((e (assq (style-of fs) (cdr row)))) (and e (cdr e)))))
-                    "yyyy-MM-dd HH:mm:ss")))
-
-(register-class-statics! "FormatStyle"
-  (list (cons "SHORT" (make-jhost "format-style" (vector 'short)))
-        (cons "MEDIUM" (make-jhost "format-style" (vector 'medium)))
-        (cons "LONG" (make-jhost "format-style" (vector 'long)))
-        (cons "FULL" (make-jhost "format-style" (vector 'full)))))
-(register-class-statics! "DateTimeFormatter"
-  (list (cons "ofPattern" (lambda (p . _) (mk-formatter p)))
-        (cons "ISO_LOCAL_DATE" (mk-formatter "yyyy-MM-dd"))
-        (cons "ISO_LOCAL_DATE_TIME" (mk-formatter "yyyy-MM-dd'T'HH:mm:ss"))
-        ;; ISO_INSTANT always renders in UTC with a trailing Z (format-ms is UTC; X -> "Z").
-        (cons "ISO_INSTANT" (mk-formatter "yyyy-MM-dd'T'HH:mm:ssX"))
-        ;; ISO_ZONED_DATE_TIME: the UTC layer renders/parses it like ISO_INSTANT.
-        (cons "ISO_ZONED_DATE_TIME" (mk-formatter "yyyy-MM-dd'T'HH:mm:ssX"))
-        (cons "ofLocalizedDate" (lambda (fs) (style-fmt 'date fs)))
-        (cons "ofLocalizedTime" (lambda (fs) (style-fmt 'time fs)))
-        (cons "ofLocalizedDateTime" (lambda (fs) (style-fmt 'datetime fs)))))
-(register-class-statics! "Instant"
-  (list (cons "ofEpochMilli" (lambda (ms) (mk-instant (ms->exact ms))))
-        (cons "now" (lambda () (mk-instant (now-ms))))
-        ;; Instant/parse an ISO-8601 instant ("…T…Z") -> an instant value.
-        (cons "parse" (lambda (s) (mk-instant (jinst-ms (jolt-inst-from-string
-                                                          (if (string? s) s (jolt-str-render-one s)))))))
-        ;; Instant/from a temporal accessor -> an instant at the same epoch-ms.
-        (cons "from" (lambda (t) (mk-instant (ms-of t))))))
-(register-class-statics! "ZoneId"
-  (list (cons "systemDefault" (lambda () (make-jhost "zone-id" (vector "system"))))
-        (cons "of" (lambda (id) (make-jhost "zone-id" (vector id))))))
-(register-class-statics! "LocalDateTime"
-  (list (cons "ofInstant" (lambda (inst zone) (mk-local (ms-of inst))))
-        (cons "now" (lambda () (mk-local (now-ms))))
-        ;; LocalDateTime/parse text, or text + a formatter (the UTC layer ignores
-        ;; the parsed offset) -> a local-dt at the parsed instant.
-        (cons "parse" (lambda (s . fmt)
-                        (let ((str (if (string? s) s (jolt-str-render-one s))))
-                          (mk-local (jinst-ms (if (null? fmt)
-                                                  (jolt-inst-from-string str)
-                                                  (parse-ms (fmt-pat (car fmt)) str)))))))))
 (let ((locale-ctor (lambda (id . _) (make-jhost "locale" (vector (if (string? id) id (jolt-str-render-one id)))))))
   (register-class-ctor! "Locale" locale-ctor)
   (register-class-ctor! "java.util.Locale" locale-ctor))
@@ -547,7 +450,6 @@
 (register-host-methods! "sql-date"
   (list (cons "getTime" (lambda (self) (ms-of self)))
         (cons "toInstant" (lambda (self) (mk-instant (ms-of self))))
-        (cons "toLocalDate" (lambda (self) (mk-local-date (ms-of self))))
         (cons "toString" (lambda (self) (inst-rfc3339 (make-jinst (ms-of self)))))))
 
 ;; java.util.Calendar: a mutable broken-down UTC time over an epoch-ms. setTime/
@@ -628,8 +530,6 @@
              ((string=? method-name "getSeconds") (list-ref (inst-fields (jinst-ms obj)) 5))
              ((string=? method-name "getDay") (list-ref (inst-fields (jinst-ms obj)) 7))
              ((string=? method-name "toInstant") (mk-instant (jinst-ms obj)))
-             ((string=? method-name "toLocalDate") (mk-local-date (jinst-ms obj)))
-             ((string=? method-name "toLocalDateTime") (mk-local (jinst-ms obj)))
              ((string=? method-name "toString") (inst-rfc3339 obj))
              ((string=? method-name "equals") (and (pair? (if (jolt-nil? rest-args) '() (seq->list rest-args)))
                                                    (jinst? (car (seq->list rest-args)))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -187,15 +187,11 @@
   {:suite "insttime" :expr "(.getTime #inst \"1970-01-01T00:00:00Z\")" :expected "0"}
   {:suite "insttime" :expr "(instance? java.util.Date #inst \"2020-01-01T00:00:00Z\")" :expected "true"}
   {:suite "insttime" :expr "(instance? java.sql.Timestamp #inst \"2020-01-01T00:00:00Z\")" :expected "false"}
-  {:suite "insttime" :expr "(.toEpochMilli (Instant/ofEpochMilli 1234))" :expected "1234"}
-  {:suite "insttime" :expr "(instance? java.time.Instant (Instant/ofEpochMilli 0))" :expected "true"}
-  {:suite "insttime" :expr "(> (.toEpochMilli (Instant/now)) 1500000000000)" :expected "true"}
-  {:suite "insttime" :expr "(instance? LocalDateTime (-> #inst \"2020-03-05T13:45:30Z\" (.toInstant) (.atZone (ZoneId/systemDefault)) (.toLocalDateTime)))" :expected "true"}
-  {:suite "insttime" :expr "(.format (DateTimeFormatter/ofPattern \"yyyy-MM-dd\") #inst \"2020-03-05T13:45:30Z\")" :expected "2020-03-05"}
-  {:suite "insttime" :expr "(boolean (re-matches #\"[A-Z][a-z]{2} \\d{1,2}, 2020 \\d{1,2}:\\d{2} [AP]M\" (.format (DateTimeFormatter/ofPattern \"MMM d, yyyy h:mm a\") #inst \"2020-03-05T13:45:30Z\")))" :expected "true"}
-  {:suite "insttime" :expr "(boolean (re-matches #\"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\" (.format DateTimeFormatter/ISO_LOCAL_DATE_TIME #inst \"2020-03-05T13:45:30Z\")))" :expected "true"}
-  {:suite "insttime" :expr "(string? (.format (DateTimeFormatter/ofLocalizedDate FormatStyle/MEDIUM) #inst \"2020-03-05T13:45:30Z\"))" :expected "true"}
-  {:suite "insttime" :expr "(string? (.format (.withLocale (DateTimeFormatter/ofPattern \"yyyy\") (java.util.Locale. \"en\")) #inst \"2020-01-01T00:00:00Z\"))" :expected "true"}
+  ;; java.time.* is the jolt-lang/time library, not core (RFC 0008). Its
+  ;; conformance lives in that library's suite. Core keeps only the #inst /
+  ;; java.util.Date layer; the Date `.toInstant` bridge needs the library, so with
+  ;; none loaded it throws rather than returning a core-owned Instant.
+  {:suite "insttime" :expr "(.toInstant #inst \"2020-01-01T00:00:00Z\")" :expected :throws}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (str (io/file \"/a/b\")))" :expected "/a/b"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (str (io/file \"/a\" \"b\")))" :expected "/a/b"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (.getName (io/file \"/a/b/c.txt\")))" :expected "c.txt"}


### PR DESCRIPTION
Implements [RFC 0008](https://github.com/jolt-lang/jolt-lang.github.io/blob/main/resources/md/rfc/0008-time-core-library-split.md).

## The problem

Core registered a partial `java.time` surface next to the `#inst` literal, so some `java.time` calls worked with no dependency and some didn't, with no rule a user could predict:

```clojure
(java.time.Instant/now)        ; worked  — core registered it
(java.time.LocalDateTime/now)  ; worked  — core registered it
(java.time.LocalDate/now)      ; failed  — library only
(java.time.ZonedDateTime/now)  ; failed  — library only
```

This is the confusion reported in the field. The two that worked were the anomaly.

## The change

Core now keeps only what the language itself needs: the `#inst` reader literal and the `java.util` / `java.text` date layer it round-trips and formats (`Date`, `sql.Date`/`Timestamp`, `Calendar`, `TimeZone`, `SimpleDateFormat`, `Locale`). The whole `java.time.*` namespace is the jolt-lang/time library.

The library already registers the full `java.time` surface through the same host seams and overrides core, so there is nothing new to write on the library side. Removing core's copies also ends the duplicate-registration drift between the two (the warnings that showed up under `JOLT_DEBUG`).

Core produces no `java.time` value of its own now. The `Date`/`FileTime` `.toInstant` bridge routes through the library's `Instant` constructor via the existing `set-instant-ctor!` hook; with no library loaded it throws a message naming the dependency. An unresolved `java.time.*` class now reports that it lives in jolt-lang/time rather than a bare "Unknown class", so the fix travels with the error.

```
$ joltc -e '(java.time.Instant/now)'
java.time.Instant requires the jolt-lang/time library — java.time is not in core (add io.github.jolt-lang/time to deps.edn)
```

The non-standard `Date.toLocalDate` / `toLocalDateTime` that core had invented (a `java.util.Date` has no such methods on the JVM) are dropped.

## Verification

All against the modified core:

- `make unit` 994/994 (insttime 26/26, including a new row asserting the bridge requires the library)
- `make selfhost` fixpoint holds
- `make smoke` 75/75, `make ffi` 10/10 (the HTTP date path uses `SimpleDateFormat`, which stays)
- `make corpus` (only the pre-existing allowlisted failures)
- the jolt-lang/time gate: 97 tests, 1020 assertions, 0 failures

`host/chez/*.ss` load at runtime rather than baking into the seed, so there is no re-mint and the checked-in seed is unchanged.

## Compatibility

A program that called `java.time.Instant/now` (or formatted with `DateTimeFormatter`) with no dependency now needs jolt-lang/time. That is the point: the boundary is consistent. The library provides a strict superset, and a program formatting a `Date` without `java.time` can use `java.text.SimpleDateFormat`, which stays in core.