### PR TITLE
AOT the CLI entry closure into joltc for ~4x faster startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.11] - 2026-07-20
+### Changed
+
+- joltc startup is about 4x faster. The CLI entry namespaces (`jolt.main`,
+  `jolt.deps`, and their on-demand Clojure closure) were baked into the binary as
+  `(load-namespace …)` boot forms, which re-analyzed and re-emitted them from
+  Clojure source on every process start because a Chez boot file re-runs its
+  top-level forms each `Sbuild_heap`. That was roughly 380ms, about 70% of the
+  startup floor, paid by every invocation. They are now emitted to Scheme at build
+  time via the same path an app build uses and marked loaded, so at boot the vars
+  are installed by running compiled code like the rest of the runtime image. A
+  trivial `joltc prog.clj` drops from ~0.51s to ~0.12s. This is the base floor the
+  per-namespace AOT cache (0.4.10) could not touch, since install-owned namespaces
+  are never cached.
 
 A base java.time API in core that works with no dependency, as a single
 implementation rather than two (RFC 0008). Core previously registered a partial

--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -173,6 +173,66 @@
     (exit 0)))
 ")))
 
+;; --- AOT the CLI entry closure ----------------------------------------------
+;; jolt.main + jolt.deps and their on-demand Clojure require closure (clojure.string,
+;; clojure.edn, jolt.mvn-http, …) used to be baked as top-level (load-namespace …)
+;; forms. flat.so is a Chez boot file whose top-level forms re-execute at every
+;; Sbuild_heap (every process start), so those load-namespace calls re-analyzed and
+;; re-emitted the whole graph from Clojure source on EVERY invocation — ~380ms, about
+;; 70% of joltc's startup floor. Instead we emit their Scheme HERE, at build time,
+;; via the same emit-image path an app build uses, so at boot the vars are defined by
+;; running compiled Scheme (a few ms) exactly like the rest of the runtime image.
+;;
+;; The runtime + compiler image + clojure.core are already emitted above (bld-emit-
+;; runtime). We load jolt.main in THIS build process to populate the compiler's
+;; registries, capturing the on-demand load order via the loader's ns-loaded-hook —
+;; which fires only for namespaces NOT already in the image, i.e. exactly the CLI's
+;; on-demand closure. Each ns is emitted var-routed (prelude mode, direct-link OFF)
+;; so its runtime behavior is identical to the interpreted load it replaces. A form
+;; that fails to emit fails the build (bld-emit-ns is strict), same as an app build.
+;; jolt.deps's lazy in-fn (require 'clojure.data.json) is not on the load path here,
+;; so it stays load-on-demand at runtime — unchanged.
+(define (jb-emit-cli-ns out)
+  (let ((order '()))
+    (set-ns-loaded-hook! (lambda (name file) (set! order (cons (cons name file) order))))
+    (load-namespace "jolt.main")
+    (load-namespace "jolt.deps")
+    (set-ns-loaded-hook! (lambda (name file) #f))
+    (let ((ordered (reverse order)))   ; deps complete loading before requirers -> deps-first
+      (when (null? ordered)
+        (error 'build-joltc "no CLI namespace captured for jolt.main — is jolt-core on the source roots?"))
+      (dynamic-wind
+        (lambda ()
+          (ei-fresh-unit!)
+          ((var-deref "jolt.backend-scheme" "set-prelude-mode!") #t)
+          (set-optimize! #t)
+          (set-release! #t)
+          ((var-deref "jolt.backend-scheme" "set-var-cache!") #t))
+        (lambda ()
+          (for-each
+            (lambda (nf)
+              (let ((name (car nf)) (src (ldr-read-source (cdr nf))))
+                (put-string out (string-append "\n;; --- AOT " name " ---\n"))
+                (parameterize ((rdr-source-file (cdr nf)))
+                  (put-string out "(jolt-ns-load-vars-push!)\n")
+                  (for-each (lambda (s) (put-string out s) (put-string out "\n"))
+                            (bld-ns-prelude name src))
+                  (for-each (lambda (s) (put-string out s) (put-string out "\n"))
+                            (bld-emit-ns name src))
+                  (put-string out "(jolt-ns-load-vars-pop!)\n")
+                  ;; Record the ns as loaded so the runtime dispatch's
+                  ;; (load-namespace "jolt.main") in cli-core.ss is a no-op — the
+                  ;; defines above already installed every var. Without this the
+                  ;; loader sees an unmarked ns and recompiles it from source on the
+                  ;; first command that enters jolt.main/-main (run/build/version).
+                  (put-string out (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n")))))
+            ordered))
+        (lambda ()
+          (set-optimize! #f)
+          (set-release! #f)
+          ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
+          (ei-clear-cached!))))))
+
 (display "build-joltc: emitting flat source\n")
 (let ((out (open-output-file jb-flat-ss 'replace)))
   ;; Bake the version FIRST: rt.ss's jolt-version-string probes this binding via
@@ -188,11 +248,12 @@
   (jb-emit-runtime-embeds out)
   (put-string out "\n;; === embedded jolt-core + stdlib source ===\n")
   (jb-emit-source-embeds out)
-  ;; Preload jolt.main + jolt.deps into the image so CLI dispatch (every
-  ;; run/build/path/repl command) skips the ~0.14s source-load.
-  (put-string out "\n;; === AOT jolt.main + jolt.deps ===\n")
-  (put-string out "(load-namespace \"jolt.main\")\n")
-  (put-string out "(load-namespace \"jolt.deps\")\n")
+  ;; AOT jolt.main + jolt.deps (and their on-demand Clojure closure) as emitted
+  ;; Scheme so CLI dispatch never recompiles them from source at startup. See
+  ;; jb-emit-cli-ns — this replaces the old (load-namespace …) calls that paid the
+  ;; ~380ms analyze/emit cost on EVERY process start.
+  (put-string out "\n;; === AOT jolt.main + jolt.deps (emitted Scheme) ===\n")
+  (jb-emit-cli-ns out)
   (put-string out "\n;; === joltc launcher ===\n")
   (jb-emit-launcher out)
   (close-port out))


### PR DESCRIPTION
## The problem

joltc startup is slow even for trivial programs. A `joltc prog.clj` that just prints a value takes about 0.51s, and the same floor is paid by `-e`, `--version`, and every real program. This is what makes ys-style workloads (many small `jolt prog.clj` invocations) feel sluggish. The per-namespace AOT cache from #429 sped up library recompilation, but it could not touch this floor: it only caches library namespaces, and install-owned namespaces are never cached.

## Root cause

`build-joltc.ss` baked the CLI entry namespaces into the binary as top-level `(load-namespace "jolt.main")` / `(load-namespace "jolt.deps")` forms. `flat.so` is a Chez boot file, and a boot file re-executes its top-level forms at every `Sbuild_heap`, which is every process start. So those two calls re-ran the full analyze then emit then eval of jolt.main plus its on-demand Clojure closure (jolt.deps, clojure.string, clojure.edn, jolt.mvn-http, and so on) from source on every single invocation.

Instrumenting the baked `flat.so` phase by phase:

| phase | cumulative | delta |
|---|---|---|
| runtime + compiler image defines | 114ms | 114ms |
| build driver | 131ms | 17ms |
| embed .ss/.clj resources | 163ms | 32ms |
| load-namespace jolt.main + jolt.deps | 545ms | **382ms** |

That last row was about 70% of the floor.

## The fix

Emit the CLI closure to Scheme at build time, the same way an app build emits its own namespaces (emit-image path, prelude mode, var-routed with direct-link off so runtime behavior is identical to the interpreted load it replaces), and bake that into `flat.ss`. Each namespace is also marked loaded so the runtime dispatch in `cli-core.ss` (which calls `load-namespace "jolt.main"`) finds it already present instead of recompiling. At boot the vars are now installed by running compiled code, like the rest of the runtime image.

The load order is captured with the loader's `ns-loaded-hook` while loading jolt.main in the build process, so only the on-demand closure is emitted; the runtime and clojure.core are already in the image. jolt.deps's lazy in-function `(require 'clojure.data.json)` is not on this load path, so it stays load-on-demand at runtime, unchanged.

## Results

Measured on the built `target/release/joltc`:

| invocation | before | after |
|---|---|---|
| `joltc prog.clj` (trivial) | 0.51s | 0.12s |
| `joltc --version` | 0.50s | 0.13s |
| `joltc -e '1'` | 0.56s | 0.12s |

About 4x faster startup on every path. The 10001th-prime program from the original report drops from ~1.3s to ~0.6s locally (the remaining time is real compile plus compute, not startup).

Not fully at babashka parity (~0.04s here): bb is a GraalVM native image with a snapshotted heap, whereas jolt-on-Chez re-runs its runtime+compiler image defines each boot (~0.11s), since Chez has no heap snapshot. Closing that last gap is a runtime-architecture question tracked separately.

## Verification

- `make smoke` — 75/75
- `make buildsmoke` — all variants pass (release, optimized, direct-link, tree-shake, data-reader, natives, cljc, vendored fs/process, declare-only-var)
- `make aotcachesmoke` — 10/10, the #429 cache still behaves
- Manual: repl, `jolt build` producing a working binary, and running the built binary all check out.