### PR TITLE
bench: add lazy-seq/HOF and startup-latency benchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -23,6 +23,7 @@ absolute reference.
 | `collections` | persistent map/vector churn (HAMT / 32-way tries) | persistent structures, transients | CLBG k-nucleotide-style |
 | `mandelbrot` | pure float compute (tight arith loops, no alloc/dispatch) | native arith, loop codegen | CLBG |
 | `fib` | recursion: function-call + integer-arith overhead | native arith, small-fn inlining | CLBG |
+| `seqs` | **lazy-seq + HOF pipelines** (range/map/filter/reduce, every?, iterate/take, mapcat) | lazy-seq allocation, per-element call overhead | AWFY-style |
 
 What the ray tracer does **not** capture and these do: allocation as the
 bottleneck (~7% there), megamorphic *and* monomorphic dispatch (its dispatch is
@@ -51,6 +52,18 @@ plain `jolt build` (`MODE_A=1` adds this column):
 | `mandelbrot` | ~2.0× | ~6.5× | pure float compute (fl-unboxing needs `--opt`) |
 | `mono-dispatch` | ~2.6× | ~4.0× | monomorphic protocol dispatch |
 | `binary-trees` | ~7.0× | ~7.0× | escaping short-lived records (allocation/GC) |
+| `seqs` | ~10.9× | ~10.9× | lazy-seq + HOF pipelines (allocation + per-element calls) |
+
+`seqs` is the widest gap in the suite and the one idiomatic Clojure hits most:
+range/map/filter/reduce chains, short-circuiting `every?`, `iterate`/`take`, and
+`mapcat` all build lazy-seq cells and call a closure per element. jolt is at or
+ahead of the JVM on tight arithmetic loops (`fib`, `mandelbrot --opt`) but a lazy
+seq is a chain of allocated thunks with a var-routed HOF call at each stage, none
+of which the optimizer's arithmetic/dispatch/alloc passes target, so the ratio
+barely moves between `opt` and `release`. This axis dominates script-style
+workloads (e.g. ys-compiled programs) far more than the record/dispatch axes do.
+For reference this bench is ~2.7× babashka, versus jolt being *faster* than bb on
+the tight-loop `fib`/`mandelbrot` shapes.
 
 - **Parity (~1.1–1.3×, both modes)**: integer recursion and megamorphic
   protocol dispatch. A megamorphic site runs a per-site polymorphic inline
@@ -128,6 +141,30 @@ it's on demand.
 
 Needs Chez's kernel dev files (`libkernel.a` + `scheme.h`) and `cc` for the build,
 like `jolt build`; set `JOLT_CHEZ_CSV` to override the detected csv dir.
+
+## Startup / small-program latency
+
+`bench/run.sh` builds each benchmark to a binary and times the compute *inside*
+it, so it deliberately excludes `joltc`'s own startup. That fixed floor — boot the
+runtime + compiler image, then compile the program — is what dominates ys-style
+workloads: many short `joltc prog.clj` runs where the program itself runs for
+milliseconds. `bench/startup.sh` measures it, whole-process wall clock (best of N)
+for a built joltc against babashka on the same sources:
+
+```sh
+bench/startup.sh                          # default 7 reps
+REPS=15 bench/startup.sh                   # more reps
+JOLT_BIN=/path/to/joltc bench/startup.sh   # pick the binary
+```
+
+Three sizes: `version` (pure boot floor, no program), `trivial` (boot + compile +
+run a one-liner), `script` (a small lazy-seq pipeline). Use a BUILT joltc
+(`target/release/joltc` or an installed one), not the dev `bin/joltc` source
+launcher — the dev script boots from source and opts out of the AOT cache, so it
+is not representative. Indicative (M-series): ~130ms vs babashka ~20ms (~6.5×).
+The floor is runtime + compiler image instantiation that re-runs each boot (Chez
+has no heap snapshot); see the CLI-closure AOT work that removed the per-boot
+recompile of `jolt.main`.
 
 ## A/B against a change
 

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -46,7 +46,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 mandelbrot:200 collections:30000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
+BENCHES="fib:30 mandelbrot:200 collections:30000 seqs:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/bench/seqs.clj
+++ b/bench/seqs.clj
@@ -1,0 +1,65 @@
+;; seqs — LAZY-SEQ + higher-order-function pipelines: the cost of idiomatic
+;; Clojure seq code (range -> map -> filter -> reduce, short-circuiting every?,
+;; unbounded iterate/take, mapcat realization). Isolates lazy-seq allocation and
+;; per-element HOF call overhead, an axis distinct from the persistent-collection
+;; churn `collections` measures and the tight-loop arithmetic `fib`/`mandelbrot`
+;; measure. jolt is at or ahead of the JVM on tight loops but pays on lazy seqs,
+;; so this is the axis idiomatic pipelines (and ys-style programs) actually hit.
+;;
+;; All arithmetic is kept inside fixnum range with `mod MOD`, so the checksum is
+;; identical on jolt, JVM Clojure, and babashka (no long-overflow divergence) and
+;; the time is seq machinery, not bignum promotion.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh seqs 20000
+(ns seqs)
+
+(def MOD 1000000007)
+
+;; range -> map -> filter -> map -> reduce: a classic lazy pipeline, every stage
+;; a fresh lazy seq with a per-element closure call.
+(defn pipeline [n]
+  (reduce (fn [a x] (mod (+ a x) MOD)) 0
+          (map (fn [x] (mod (* x 7) MOD))
+               (filter odd?
+                       (map inc (range n))))))
+
+;; short-circuiting every? over many small ranges — the `prime?` shape, where
+;; every?'s lazy scan and early exit dominate.
+(defn scan [n]
+  (reduce (fn [a k]
+            (if (every? (fn [d] (not (zero? (rem k d)))) (range 2 (min k 40)))
+              (mod (+ a k) MOD) a))
+          0 (range 2 n)))
+
+;; unbounded lazy seq realized with take — iterate builds cells on demand.
+(defn realize [n]
+  (reduce (fn [a x] (mod (+ a x) MOD)) 0
+          (take n (iterate (fn [x] (mod (+ x 3) MOD)) 1))))
+
+;; mapcat expansion realized into a vector — flattening + collection build.
+(defn expand [n]
+  (count (into [] (mapcat (fn [x] (list x (inc x))) (range n)))))
+
+(defn run [n]
+  (mod (+ (pipeline (* n 40))
+          (scan n)
+          (realize (* n 40))
+          (expand (* n 20)))
+       MOD))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 20000)]
+    (dotimes [_ 2] (run (quot n 4)))                        ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "seqs n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/startup.sh
+++ b/bench/startup.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Startup / small-program latency — the axis run.sh does NOT measure. run.sh
+# builds each benchmark to an optimized binary and times the compute inside it;
+# it says nothing about how long `joltc` itself takes to get from exec to first
+# result. That fixed floor (runtime + compiler image boot, then compile the
+# program) is what dominates ys-style workloads: many short `joltc prog.clj`
+# invocations where the program runs for milliseconds.
+#
+# This times whole-process wall clock (best of N, to shed scheduler noise) for a
+# built joltc against babashka on the same sources, across three sizes:
+#   - version : pure boot floor, no user program
+#   - trivial : boot + compile + run of a one-liner
+#   - script  : boot + compile + run of a small real program (a seq pipeline)
+#
+#   bench/startup.sh              # default 7 reps
+#   REPS=15 bench/startup.sh      # more reps
+#   JOLT_BIN=/path/to/joltc bench/startup.sh
+#
+# joltc must be a BUILT binary (target/release/joltc or an installed joltc), not
+# the dev bin/joltc source launcher — the dev script opts out of the AOT cache and
+# boots from source, so it is not representative of what users run.
+set -e
+cd "$(dirname "$0")"
+root="$(cd .. && pwd)"
+
+joltc="${JOLT_BIN:-$root/target/release/joltc}"
+[ -x "$joltc" ] || joltc="$(command -v joltc || true)"
+if [ -z "$joltc" ] || [ ! -x "$joltc" ]; then
+  echo "error: no built joltc found. Build one (make joltc-release) or set JOLT_BIN." >&2
+  exit 1
+fi
+have_bb=""; command -v bb >/dev/null 2>&1 && have_bb=1
+
+REPS="${REPS:-7}"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+printf '(println (reduce + (map inc (filter odd? (range 1000)))))\n' > "$work/trivial.clj"
+# a small lazy-seq pipeline — representative of idiomatic script code
+cat > "$work/script.clj" <<'EOF'
+(println
+  (reduce (fn [a x] (+ a x)) 0
+          (take 5000 (map (fn [x] (* x x))
+                          (filter even? (iterate inc 1))))))
+EOF
+
+# best-of-N wall-clock in milliseconds for a command.
+best_ms() {
+  best=""
+  i=0
+  while [ "$i" -lt "$REPS" ]; do
+    t0=$(perl -MTime::HiRes=time -e 'printf "%d", time()*1000')
+    "$@" >/dev/null 2>&1 || true
+    t1=$(perl -MTime::HiRes=time -e 'printf "%d", time()*1000')
+    ms=$((t1 - t0))
+    if [ -z "$best" ] || [ "$ms" -lt "$best" ]; then best="$ms"; fi
+    i=$((i + 1))
+  done
+  echo "$best"
+}
+
+row() {
+  label="$1"; shift
+  jbin="$1"; shift
+  jms=$(best_ms "$joltc" $jbin)
+  if [ -n "$have_bb" ]; then
+    bms=$(best_ms bb "$@")
+    ratio=$(awk "BEGIN{ if ($bms>0) printf \"%.1fx\", $jms/$bms; else printf \"-\" }")
+    printf '%-10s jolt %5s ms   bb %5s ms   %s\n' "$label" "$jms" "$bms" "$ratio"
+  else
+    printf '%-10s jolt %5s ms\n' "$label" "$jms"
+  fi
+}
+
+echo "startup / small-program latency — best of $REPS  ($(basename "$joltc")${have_bb:+ vs bb})"
+row "version" "--version" "--version"
+row "trivial" "$work/trivial.clj" "$work/trivial.clj"
+row "script"  "$work/script.clj"  "$work/script.clj"


### PR DESCRIPTION
Adds the two workload axes the suite was missing, both of which dominate script-style use (including ys-compiled programs) more than the axes already covered.

## seqs — lazy-seq + HOF pipelines

`range` -> `map` -> `filter` -> `reduce`, short-circuiting `every?`, `iterate`/`take`, and `mapcat`. This isolates lazy-seq allocation and per-element higher-order-function call overhead, which is distinct from the persistent-collection churn `collections` measures and the tight-loop arithmetic `fib`/`mandelbrot` measure.

It is the widest gap in the suite: ~10.9x JVM Clojure, and the ratio does not move between `opt` and `release` because the optimizer's arithmetic/dispatch/allocation passes don't target lazy-seq machinery. jolt is at or ahead of the JVM on tight loops but pays here, which is what idiomatic Clojure hits most. For reference it's ~2.7x babashka, versus jolt being faster than bb on the `fib`/`mandelbrot` shapes.

All arithmetic is kept in fixnum range with `mod`, so the checksum is identical on jolt, JVM Clojure, and babashka (verified: all three print `800324130` at n=2000), and the measured time is seq machinery rather than bignum promotion.

Registered in `run.sh` as `seqs:20000`.

## startup.sh — startup / small-program latency

`run.sh` builds each benchmark to a binary and times the compute inside it, so it deliberately excludes joltc's own startup. That fixed floor (boot the runtime + compiler image, then compile the program) is what dominates many-short-invocation workloads. `startup.sh` measures it as whole-process wall clock, best of N, against babashka on the same sources, at three sizes: `version` (pure floor), `trivial` (one-liner), `script` (small lazy-seq pipeline). Indicative M-series: ~130ms vs bb ~20ms.

## Notes

Diagnostic context behind these (compile is cheap, execution and the boot floor dominate) is tracked in beads jolt-bcq and jolt-7yj. No shipped behavior changes, so CHANGELOG is untouched.

Verified: parity across jolt/JVM/bb, `bench/run.sh seqs` and `bench/startup.sh` both run clean.