### PR TITLE
Defer the joltc build subsystem off the startup hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trivial `joltc prog.clj` drops from ~0.51s to ~0.12s. This is the base floor the
   per-namespace AOT cache (0.4.10) could not touch, since install-owned namespaces
   are never cached.
+- joltc startup drops a further ~15% (~130ms to ~110ms on an M-series machine).
+  The build subsystem (`build.ss` plus the `emit-image.ss`/`dce.ss` it inlines) and
+  the runtime `.ss` source embeds it reads are used only by `jolt build`, but they
+  ran their defines and registered their bytes at every startup. They are now baked
+  as source and loaded lazily on the first `jolt build`, so `run`, `-e`, and every
+  other command skip them. No behavior change to `jolt build`; the standalone binary
+  is also slightly smaller.
 
 A base java.time API in core that works with no dependency, as a single
 implementation rather than two (RFC 0008). Core previously registered a partial

--- a/host/chez/build-joltc.ss
+++ b/host/chez/build-joltc.ss
@@ -169,7 +169,7 @@
     ;; shared dispatch (cli-core.ss, inlined via the runtime manifest): the -e
     ;; arm, end-of-options, and uncaught reporting are the same code the script
     ;; driver runs — the launcher once carried a stale fork of the -e arm.
-    (jolt-cli-run args (lambda () (jolt-materialize-bundles!)))
+    (jolt-cli-run args (lambda () (jolt-materialize-bundles!) (jb-load-build-subsystem!)))
     (exit 0)))
 ")))
 
@@ -242,10 +242,42 @@
                                  (ei-str-lit jb-version) ")\n"))
   ;; full runtime + compiler image: keep the compiler (joltc evals at runtime).
   (bld-emit-runtime out #f #f)
-  (put-string out "\n;; === build driver (inlined for self-contained `jolt build`) ===\n")
-  (bld-inline-line "(load \"host/chez/build.ss\")" out 0)
-  (put-string out "\n;; === embedded runtime source (self-contained `build` reads these) ===\n")
+  ;; The build subsystem (build.ss + emit-image.ss + dce.ss, fully inlined) and the
+  ;; runtime .ss source embeds it reads are needed ONLY by `jolt build`. As eager
+  ;; top-level forms they cost ~45ms at EVERY startup (build.ss defines ~18ms, the
+  ;; .ss embed registration ~27ms) — dead weight for run / -e / every non-build
+  ;; command. Bake the subsystem as source and the embeds as a thunk, loaded lazily
+  ;; on the first `build` (prepare-build! in the launcher). Safe because no boot-path
+  ;; code references bld-*/ei-*/dce-*: the runtime eval path uses jolt-compile-eval-
+  ;; form, not the emit-image cross-compiler, and .clj namespace loads read the
+  ;; embedded-resources table directly (not via build.ss's bld-source-string).
+  (put-string out "\n;; === build subsystem (deferred: loaded on first `jolt build`) ===\n")
+  (let ((build-src (let ((sp (open-output-string)))
+                     (bld-inline-line "(load \"host/chez/build.ss\")" sp 0)
+                     (get-output-string sp))))
+    (put-string out (string-append "(define jb-build-subsystem-src " (ei-str-lit build-src) ")\n")))
+  ;; Register the .ss embeds inside a thunk: the string literals stay compiled into
+  ;; the heap but the utf8 allocation + hashtable insert only run when called.
+  (put-string out "(define (jb-register-build-embeds!)\n")
   (jb-emit-runtime-embeds out)
+  (put-string out "  (if #f #f))\n")
+  (put-string out "(define jb-build-subsystem-loaded #f)\n")
+  (put-string out
+    (string-append
+      "(define (jb-load-build-subsystem!)\n"
+      "  (unless jb-build-subsystem-loaded\n"
+      "    (set! jb-build-subsystem-loaded #t)\n"
+      ;; eval the inlined subsystem source form-by-form into the top-level env, so
+      ;; build.ss's defines (bld-*, ei-*, dce-*) and its def-var! of jolt.host/
+      ;; build-binary land exactly as an eager (load) would have. It has no (load)
+      ;; forms left — bld-inline-line already spliced emit-image.ss and dce.ss in.
+      "    (let ((p (open-input-string jb-build-subsystem-src)))\n"
+      "      (let loop ()\n"
+      "        (let ((form (read p)))\n"
+      "          (unless (eof-object? form)\n"
+      "            (eval form (interaction-environment))\n"
+      "            (loop)))))\n"
+      "    (jb-register-build-embeds!)))\n"))
   (put-string out "\n;; === embedded jolt-core + stdlib source ===\n")
   (jb-emit-source-embeds out)
   ;; AOT jolt.main + jolt.deps (and their on-demand Clojure closure) as emitted


### PR DESCRIPTION
Follow-up to #433. That PR removed the per-boot recompile of `jolt.main` (~380ms). This one trims the next layer: work baked into the boot image that only `jolt build` ever uses.

## What ran at every startup for no reason

`build.ss` (plus the `emit-image.ss` and `dce.ss` it inlines) was emitted as eager top-level forms in the boot image, so it ran its ~100 defines on every process start. The runtime `.ss` source embeds it reads during a build were likewise registered into the resource table at every start. Together that is about 20ms on every invocation, and none of it is touched by `run`, `-e`, `repl`, `version`, or any non-build command.

## The change

Bake the fully-inlined build subsystem as a source string and `eval` it into the top-level environment on the first `jolt build`. Move the `.ss` embed registration into a thunk called at the same point. Both fire from the launcher's `prepare-build!`, which `cli-core` invokes only for the `build` command, the sole path that reaches `build-binary`/`build-library` (verified: `jolt.main`'s dispatch routes only `build` to `cmd-build`).

This is safe because no boot-path code references `bld-*`/`ei-*`/`dce-*`. The runtime eval path uses `jolt-compile-eval-form`, not the emit-image cross-compiler, and `.clj` namespace loading reads the `embedded-resources` table directly rather than through `build.ss`'s `bld-source-string`.

## Results

Clean A/B, min of 25 runs on an M-series machine:

| invocation | before | after |
|---|---|---|
| `-e '1'` | 130ms | 109ms |
| file run | 130ms | 110ms |
| `--version` | 130ms | 110ms |

About a 15% floor cut on every non-build command, and the standalone binary is ~200KB smaller because `build.ss` is stored as source instead of compiled into the boot. This came in below the ~45ms an earlier instrumented-flat prototype suggested; that harness (`chez --script` loading the object file) overstated the section costs relative to the real boot file, and the honest number is ~20ms.

The remaining ~110ms floor is the runtime + clojure.core + compiler-image defines that must re-run each boot (Chez has no heap snapshot), plus a per-class-deferrable Java host-interop layer. Those are tracked separately.

## Verification

- `make buildsmoke` — all variants pass (release, optimized, direct-link, tree-shake, compiler+core shake, data-reader, natives, cljc, vendored fs/process, declare-only-var), and a built binary runs correctly.
- `make smoke` — 75/75.
- `make aotcachesmoke` — 10/10.