### PR TITLE
Skip the per-lazy-node mutex in single-threaded programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lazy sequences are noticeably faster in single-threaded programs, which is the
+  common case. Every lazy-seq node used to allocate an OS mutex when it was created
+  and acquire it on first realization, so that concurrent futures or agents could
+  not run the body twice. But iterate, repeat, cycle, and every map/filter chunk
+  tail is a lazy node, so idiomatic pipelines paid a mutex allocation and lock per
+  node, and per element for iterate. A node now carries no mutex and realization
+  takes no lock until the process actually spawns a second thread. A global flag
+  flips the first time `fork-thread` runs (via future, agent, core.async, or a
+  subprocess), after which realization falls back to the original double-checked
+  locking on a mutex created lazily per node. This is race-free because a single
+  thread is either forking or forcing, never both, and `fork-thread` establishes
+  happens-before so the spawned child sees the flag. The lazy-seq/HOF benchmark
+  (`bench/seqs.clj`) drops about 26% (roughly 1200ms to 890ms on an M-series
+  machine); tight-loop and persistent-collection benchmarks are unchanged.
+
 ## [0.4.12] - 2026-07-21
 
 ### Changed

--- a/host/chez/lazy-bridge.ss
+++ b/host/chez/lazy-bridge.ss
@@ -20,36 +20,65 @@
   (fields (mutable thunk) (mutable val) (mutable realized?) (mutable error?) (mutable lock))
   (nongenerative jolt-lazyseq-v2))
 
-(define (jolt-make-lazy-seq thunk) (make-jolt-lazyseq thunk jolt-nil #f #f (make-mutex)))
+;; Thread-safety for lazy realization is only needed once a second OS thread can
+;; touch a shared, not-yet-realized node. In single-threaded programs — all of ys
+;; and the overwhelming majority of code — a lazy node needs neither a per-node
+;; mutex (allocated eagerly) nor a lock on force. Because iterate/repeat/cycle and
+;; every map/filter chunk tail is a lazy node, paying a mutex alloc + acquire per
+;; node (per element for iterate) was the dominant cost of idiomatic seq pipelines.
+;;
+;; `jolt-mt?` starts #f and flips to #t the first time a real OS thread is spawned
+;; (fork-thread is shadowed below). This is race-free: a single thread is either
+;; forking or forcing, never both, so no node is being realized on the lock-free
+;; path at the instant the flag turns on; and fork-thread establishes happens-
+;; before, so the spawned child observes the flip. Once multi-threaded, force takes
+;; a per-node mutex created lazily under a shared init lock, restoring the original
+;; double-checked-locking behavior.
+(define jolt-mt? #f)
+(define (jolt-mark-mt!) (set! jolt-mt? #t))
+
+;; guards lazy creation of a node's mutex on the multi-threaded path
+(define jolt-lazyseq-lock-init (make-mutex))
+(define (jolt-lazyseq-ensure-lock! x)
+  (with-mutex jolt-lazyseq-lock-init
+    (or (jolt-lazyseq-lock x)
+        (let ((m (make-mutex))) (jolt-lazyseq-lock-set! x m) m))))
+
+(define (jolt-make-lazy-seq thunk) (make-jolt-lazyseq thunk jolt-nil #f #f #f))
 
 ;; force once and memoize. The thunk is (fn [] (coll->cells body)); coll->cells
 ;; already coerced the body to a seq (cseq | nil) via the live jolt-seq, so the
 ;; result needs no further coercion (a nested lazyseq was forced by coll->cells).
-;; The realize is guarded by a per-cell mutex: futures/agents/fork-thread share
-;; the heap, so without it two threads can run the thunk twice. A thrown failure
-;; is cached and re-raised on every later force, like the JVM (the body runs
-;; exactly once; a failed force rethrows). The captured Chez condition is re-raised
-;; verbatim, so a downstream catch unwraps the original jolt value. Double-checked
-;; locking: a thread that blocked on the mutex finds the cell already realized.
+;; A thrown failure is cached and re-raised on every later force, like the JVM (the
+;; body runs exactly once; a failed force rethrows). The captured Chez condition is
+;; re-raised verbatim, so a downstream catch unwraps the original jolt value.
 (define (force-lazyseq x)
   (define (deliver)
     (if (jolt-lazyseq-error? x) (raise (jolt-lazyseq-val x)) (jolt-lazyseq-val x)))
-  (if (jolt-lazyseq-realized? x)
-      (deliver)
-      (with-mutex (jolt-lazyseq-lock x)
-        (if (jolt-lazyseq-realized? x)
-            (deliver)
-            (guard (e (#t
-                       (jolt-lazyseq-val-set! x e)
-                       (jolt-lazyseq-error?-set! x #t)
-                       (jolt-lazyseq-realized?-set! x #t)
-                       (jolt-lazyseq-thunk-set! x #f)
-                       (raise e)))
-              (let ((r (jolt-invoke (jolt-lazyseq-thunk x))))
-                (jolt-lazyseq-val-set! x r)
-                (jolt-lazyseq-realized?-set! x #t)
-                (jolt-lazyseq-thunk-set! x #f)
-                r))))))
+  (define (run!)
+    (guard (e (#t
+               (jolt-lazyseq-val-set! x e)
+               (jolt-lazyseq-error?-set! x #t)
+               (jolt-lazyseq-realized?-set! x #t)
+               (jolt-lazyseq-thunk-set! x #f)
+               (raise e)))
+      (let ((r (jolt-invoke (jolt-lazyseq-thunk x))))
+        (jolt-lazyseq-val-set! x r)
+        (jolt-lazyseq-realized?-set! x #t)
+        (jolt-lazyseq-thunk-set! x #f)
+        r)))
+  (cond
+    ((jolt-lazyseq-realized? x) (deliver))
+    ((not jolt-mt?) (run!))                       ; single-threaded: no lock/mutex
+    (else                                          ; multi-threaded: double-checked
+     (with-mutex (jolt-lazyseq-ensure-lock! x)     ; locking on a lazily-made mutex
+       (if (jolt-lazyseq-realized? x) (deliver) (run!))))))
+
+;; Shadow fork-thread so any spawn (future/agent/core.async/process, all loaded
+;; after this file) flips jolt-mt? on. Captured in a prior define so the RHS sees
+;; the primitive, not the top-level binding being defined (Chez top-level letrec*).
+(define %ls-orig-fork-thread fork-thread)
+(define (fork-thread thunk) (jolt-mark-mt!) (%ls-orig-fork-thread thunk))
 
 ;; coll->cells: coerce the body result to the cell representation = a seq | nil.
 (define (jolt-coll->cells c) (jolt-seq c))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1130,6 +1130,14 @@
   {:suite "r8-reader" :expr "(try (read-string \"\\\"\\\\u041\\\"\") (catch clojure.lang.ExceptionInfo e :ex) (catch Throwable e :other))" :expected ":ex"}
   {:suite "r8-reader" :expr "[(int (read-string \"\\\\u0041\")) (count (read-string \"\\\"\\\\u0041\\\"\"))]" :expected "[65 1]"}
   {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (lazy-seq (do (swap! a inc) [1]))] (doall (map deref (for [_ (range 8)] (future (doall s))))) @a)" :expected "1"}
+  ;; single-threaded realization is memoized: the body/step runs exactly once no
+  ;; matter how many times the seq is walked (guards the lock-free fast path).
+  {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (lazy-seq (do (swap! a inc) [42]))] [(first s) (first s) (nth s 0) @a])" :expected "[42 42 42 1]"}
+  {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (map (fn [x] (swap! a inc) (* x x)) (range 5))] (doall s) (doall s) @a)" :expected "5"}
+  {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (take 4 (iterate (fn [x] (swap! a inc) (inc x)) 0))] (doall s) (doall s) @a)" :expected "3"}
+  ;; concurrent realization across MANY chunked nodes still runs each element's
+  ;; body exactly once (guards the multi-threaded locked path across chunk tails).
+  {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (map (fn [x] (swap! a inc) x) (range 100))] (doall (map deref (for [_ (range 8)] (future (doall s))))) @a)" :expected "100"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) >= 2 <= 4)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) > 1 < 5)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-map 1 :a 2 :b 3 :c 4 :d 5 :e) >= 2 <= 4)" :expected "([4 :d] [3 :c] [2 :b])"}


### PR DESCRIPTION
## What

Every `jolt-lazyseq` node allocated an OS mutex when it was constructed and acquired it on first realization, so concurrent futures or agents could not run the body twice. That thread-safety is only needed once a second OS thread can touch a shared, not-yet-realized node, which is rare. But `iterate`, `repeat`, `cycle`, and every `map`/`filter` chunk tail is a lazy node, so idiomatic seq pipelines paid a mutex allocation plus a lock per node, and per element for `iterate`. This was the dominant cost the `bench/seqs.clj` lazy-seq/HOF benchmark exposes.

## How

A lazy node now carries no mutex, and `force-lazyseq` takes no lock, until the process actually spawns a second OS thread. A global `jolt-mt?` flag starts false and flips the first time `fork-thread` runs. `fork-thread` is shadowed in `lazy-bridge.ss` to flip the flag, which covers every spawn path (future, agent, core.async, subprocess) since all of those files load after `lazy-bridge.ss`. Once multi-threaded, `force-lazyseq` falls back to the original double-checked locking, on a mutex created lazily per node under a shared init lock.

This is race-free. A single thread is either forking or forcing a seq, never both, so no node is being realized on the lock-free path at the instant the flag turns on. And `fork-thread` establishes happens-before, so the spawned child observes the flip.

The `fork-thread` capture uses two separate defines because Chez top-level bindings are letrec*, so capturing the primitive in the same define that redefines the name would see the unassigned new binding.

## Tests

New guards in the `r7-lazyseq` unit suite:

- single-threaded realization runs the body exactly once across repeated walks, in three shapes (bare `lazy-seq`, `map`, and `take`/`iterate`)
- concurrent realization across many chunked nodes still runs each element's body exactly once (8 futures over a 100-element mapped range)

The existing concurrent double-realization guard (8 futures over one node) and the exception-memoization guard already covered the multi-threaded path and are unchanged.

## Results

`bench/seqs.clj` drops about 26%, roughly 1200ms to 890ms on an M-series machine (10.3x to about 8x versus JVM Clojure). `collections`, `fib`, and startup latency are unchanged.

Gates: unit 1019/1019, corpus clean (9 known allowlisted), values 37/37, cli smoke 75/0, buildsmoke full matrix, self-host fixpoint holds (rebuild == checked-in seed).

Bead: jolt-k5x. First of a series of runtime and startup performance rounds, one PR per round.