### PR TITLE
Read the source leaf directly in chunked map/filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is unchanged because its `every?` component is a small slice of the total; the win
   shows up in code that leans on these predicates. `every?` lives in the kernel tier
   so it is expressed with `fn*`, and both functions are part of the minted seed.
+- Chunked `map` and `filter` allocate less per chunk. Both realized a chunk by
+  copying the source vector's 32-element trie leaf into an intermediate pvec and
+  then re-reading that copy to build the output, and `filter` additionally built a
+  Scheme list, reversed it, and converted it to a vector. They now read the source
+  leaf directly into the output chunk, skipping the intermediate copy (and, for
+  `filter`, the list round trip). The leaf resolution is identical to the previous
+  code, so chunk boundaries and the rare non-leaf-aligned window behave exactly as
+  before. On its own this is in the noise on `bench/seqs.clj` because the per-chunk
+  lazy-seq node cost dominated; stacked with the lazy-seq mutex change it accounts
+  for roughly another 4% (about 30ms) on that benchmark.
 
 ## [0.4.12] - 2026-07-21
 

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -632,6 +632,43 @@
        (if (fx>=? (cdr vb) (pvec-count (car vb))) jolt-nil (vec->seq (car vb) (cdr vb)))))
     (else (jolt-next s))))
 
+;; na-chunk-map-first / na-chunk-filter-first: transform a chunked seq's current
+;; block straight out of the source pvec leaf into a fresh chunk pvec, without the
+;; intermediate copy na-chunk-first makes (map/filter used to na-chunk-first into a
+;; buffer and then re-read it element by element — one wasted pvec alloc + copy per
+;; stage per chunk, and for filter also a Scheme list + reverse + list->vector).
+;; Leaf resolution mirrors na-chunk-first exactly: one contiguous leaf when the
+;; block is 32-aligned, per-index reads for the rare window crossing a leaf.
+(define (na-chunk-map-first s g)
+  (let* ((vb (na-vblock s)) (pv (car vb)) (i (cseq-ci s)) (end (cdr vb))
+         (len (fx- end i)) (out (make-vector len))
+         (node (pv-chunk-for pv i)) (off (fxand i pv-mask)))
+    (if (fx<=? (fx+ off len) (vector-length node))
+        (let loop ((j 0))
+          (if (fx<? j len)
+              (begin (vector-set! out j (g (vector-ref node (fx+ off j)))) (loop (fx+ j 1)))
+              (make-pvec out)))
+        (let loop ((j 0))
+          (if (fx<? j len)
+              (begin (vector-set! out j (g (pvec-nth-d pv (fx+ i j) jolt-nil))) (loop (fx+ j 1)))
+              (make-pvec out))))))
+;; Returns the kept-elements chunk pvec, or #f when the whole block is rejected
+;; (so the caller recurses straight into chunk-rest, emitting no empty cell).
+(define (na-chunk-filter-first s tp keep)
+  (let* ((vb (na-vblock s)) (pv (car vb)) (i (cseq-ci s)) (end (cdr vb))
+         (len (fx- end i)) (out (make-vector len))
+         (node (pv-chunk-for pv i)) (off (fxand i pv-mask))
+         (aligned? (fx<=? (fx+ off len) (vector-length node))))
+    (let loop ((j 0) (w 0))
+      (if (fx<? j len)
+          (let ((x (if aligned? (vector-ref node (fx+ off j)) (pvec-nth-d pv (fx+ i j) jolt-nil))))
+            (if (eq? keep (tp x))
+                (begin (vector-set! out w x) (loop (fx+ j 1) (fx+ w 1)))
+                (loop (fx+ j 1) w)))
+          (cond ((fx=? w 0) #f)
+                ((fx=? w len) (make-pvec out))
+                (else (make-pvec (vec-copy-range out 0 w))))))))
+
 ;; ============================================================================
 ;; map / filter / reduce / into / remove + range / take / concat / apply
 ;; ============================================================================
@@ -653,12 +690,8 @@
     (cond
       ((jolt-nil? s) jolt-empty-list)
       ((na-chunked-seq? s)
-       (let* ((c (na-chunk-first s)) (n (pvec-count c)) (out (make-vector n)))
-         (let loop ((i 0))
-           (if (fx<? i n)
-               (begin (vector-set! out i (g (pvec-nth-d c i jolt-nil))) (loop (fx+ i 1)))
-               (cseq-chunked (make-pvec out) 0
-                             (jolt-make-lazy-seq (lambda () (jolt-seq (map-seq f (jolt-seq (na-chunk-rest s)))))))))))
+       (cseq-chunked (na-chunk-map-first s g) 0
+                     (jolt-make-lazy-seq (lambda () (jolt-seq (map-seq f (jolt-seq (na-chunk-rest s))))))))
       (else
        (cseq-lazy (g (seq-first s)) (lambda () (map-seq f (jolt-seq (seq-more s)))))))))
 (define (map-seq* f seqs)              ; multi-collection map; stops at the shortest
@@ -691,17 +724,14 @@
     (cond
       ((jolt-nil? s) jolt-empty-list)         ; empty result is () (see map-seq)
       ((na-chunked-seq? s)
-       (let* ((c (na-chunk-first s)) (n (pvec-count c)))
-         (let loop ((i 0) (acc '()))
-           (if (fx<? i n)
-               (let ((x (pvec-nth-d c i jolt-nil)))
-                 (loop (fx+ i 1) (if (eq? keep (tp x)) (cons x acc) acc)))
-               (let ((kept (reverse acc)))
-                 (if (null? kept)
-                     (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)
-                     (cseq-chunked (make-pvec (list->vector kept)) 0
-                                   (jolt-make-lazy-seq
-                                    (lambda () (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)))))))))))
+       (let ((c (na-chunk-filter-first s tp keep)))
+         (if (not c)
+             (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)
+             (cseq-chunked
+              c 0
+              (jolt-make-lazy-seq
+               (lambda ()
+                 (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) keep))))))))
       (else
        (let walk ((s s))
          (cond ((jolt-nil? s) jolt-empty-list)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1150,6 +1150,17 @@
   {:suite "r3-every-some" :expr "(some (fn [_] false) [1 2 3])" :expected ""}
   {:suite "r3-every-some" :expr "[(some pos? []) (some pos? nil) (every? pos? []) (every? pos? nil)]" :expected "[nil nil true true]"}
   {:suite "r3-every-some" :expr "[(not-any? even? [1 3 5]) (not-any? even? [1 2 3]) (not-every? even? [2 4 5]) (not-every? even? [2 4 6])]" :expected "[true false true false]"}
+  ;; chunked map/filter across 32-element chunk boundaries (guards reading the
+  ;; source leaf directly instead of via an intermediate copy): exact values,
+  ;; partial last chunk, an all-rejected chunk, vector sources, and laziness.
+  {:suite "r2-chunk" :expr "(reduce + (map inc (range 100)))" :expected "5050"}
+  {:suite "r2-chunk" :expr "(= (mapv (fn [x] (* x x)) (range 65)) (vec (map (fn [x] (* x x)) (range 65))))" :expected "true"}
+  {:suite "r2-chunk" :expr "[(count (map inc (range 32))) (count (map inc (range 33))) (last (map inc (range 33)))]" :expected "[32 33 33]"}
+  {:suite "r2-chunk" :expr "[(count (filter even? (range 70))) (last (filter even? (range 70)))]" :expected "[35 68]"}
+  {:suite "r2-chunk" :expr "(vec (take 3 (filter (fn [x] (> x 50)) (range 100))))" :expected "[51 52 53]"}
+  {:suite "r2-chunk" :expr "(seq (filter (fn [x] (> x 1000)) (range 100)))" :expected ""}
+  {:suite "r2-chunk" :expr "(reduce + (filter odd? (vec (range 64))))" :expected "1024"}
+  {:suite "r2-chunk" :expr "[(nth (map inc (range)) 40) (first (filter (fn [x] (> x 100)) (range)))]" :expected "[41 101]"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) >= 2 <= 4)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) > 1 < 5)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-map 1 :a 2 :b 3 :c 4 :d 5 :e) >= 2 <= 4)" :expected "([4 :d] [3 :c] [2 :b])"}


### PR DESCRIPTION
## What

Chunked `map` and `filter` realized each chunk by calling `na-chunk-first`, which copies the source vector's 32-element trie leaf into a fresh intermediate pvec, and then re-read that copy element by element to build the output chunk. `filter` also accumulated the kept elements as a Scheme list, reversed it, and ran `list->vector`. The intermediate copy and the list round trip are pure waste; the source leaf can be read directly.

## How

Two helpers, `na-chunk-map-first` and `na-chunk-filter-first`, transform the source block straight out of the leaf into the output chunk pvec. The leaf resolution is copied verbatim from `na-chunk-first` (one contiguous leaf when the block is 32-aligned, per-index reads for the rare window that crosses a leaf), so chunk boundaries and the non-aligned fallback behave exactly as before. `filter` packs kept elements into a right-sized output vector and returns `#f` when the whole block is rejected, so the caller still recurses straight into chunk-rest without emitting an empty cell.

This is a runtime-only change (`seq.ss`), so the minted seed is unchanged and the self-host fixpoint holds.

## Results

I want to be straight about the measurement. On its own, on top of current main, this is within the noise on `bench/seqs.clj` (~1180ms vs ~1206ms), because the per-chunk lazy-seq node cost dominates the pipeline and hides the copy savings. Measured on top of the lazy-seq mutex change (the R1 PR), it accounts for about another 4%, roughly 30ms, taking that benchmark from ~893ms to ~860ms. So the value is real but only visible once the mutex cost is gone; the two changes compound. It also stands on its own as a simplification: fewer allocations and the removal of the list/reverse/list->vector step in filter.

## Tests

New `r2-chunk` unit guards: `map`/`filter` across 32-element chunk boundaries (sizes 32/33/65/70/100), a partial last chunk, an all-rejected chunk that must skip to the next, vector sources, and laziness over infinite seqs (`nth` of a mapped range, `first` of a filtered infinite range). The existing corpus seq coverage is unchanged.

Gates: unit 1023/1023, corpus 0 new divergence (9 known allowlisted), values 37/37, cli smoke 75/0, buildsmoke full matrix, self-host fixpoint holds (rebuild == checked-in seed).

Bead: jolt-9b6. Round 3 of the runtime performance series. Best measured stacked on the R1 PR (#436).