### PR TITLE
Give transducer rf's fixed arities via case-lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before. On its own this is in the noise on `bench/seqs.clj` because the per-chunk
   lazy-seq node cost dominated; stacked with the lazy-seq mutex change it accounts
   for roughly another 4% (about 30ms) on that benchmark.
+- Transducers are faster and no longer slower than the equivalent lazy pipeline.
+  Each transducer stage's reducing fn was a variadic `(lambda a (case (length a)
+  …))`, so calling it with two arguments allocated a rest list and walked
+  `(length a)` on every element, then forwarded through the general variadic
+  invoke. Each stage is now a `case-lambda` with the exact transducer arities
+  (init, complete, step), so there is no rest list and no length check, and the
+  step calls the downstream reducing fn and the mapping/predicate fn through the
+  fixed-arity fast paths. The map transducer keeps a trailing variadic clause for
+  its multi-input arity, so the single-input hot path stays allocation-free. On a
+  2,000,000-element pipeline `transduce` drops about 23% and `into` with an xform
+  about 22%; a transducer pipeline is now faster than the lazy-seq equivalent, as
+  it should be, where before it was slower.
 
 ## [0.4.12] - 2026-07-21
 

--- a/host/chez/natives-seq.ss
+++ b/host/chez/natives-seq.ss
@@ -17,79 +17,81 @@
 ;; call routes through jolt-invoke. A `reduced` step stops the fold — reduce-seq
 ;; (seq.ss) already short-circuits on a jolt-reduced.
 ;; ============================================================================
-;; The map transducer's step fn supports multiple inputs ([result input & inputs]),
-;; so a multi-collection sequence/transduce — or medley's sequence-padded, which
-;; calls (f acc i1 i2 …) — applies f across all of them: (rf result (apply f inputs)).
+;; Each stage rf is a case-lambda with the exact transducer arities — []=init,
+;; [acc]=complete, [acc x]=step — instead of a variadic (lambda a (case (length a)
+;; …)). The variadic form allocated a rest-list and walked (length a) on EVERY
+;; element, then forwarded through general jolt-invoke; case-lambda dispatches on
+;; arity with no rest-list, and the step calls the downstream rf via jolt-invoke2
+;; and the mapping/predicate fn via jolt-invoke1 (fixed-arity fast paths). A
+;; `reduced` step stops the fold — reduce-seq (seq.ss) short-circuits on it.
+;; The map transducer additionally supports multiple inputs ([result input &
+;; inputs]) — a multi-collection sequence/transduce, or medley's sequence-padded
+;; calling (f acc i1 i2 …) — via a trailing variadic clause, so the single-input
+;; hot path stays allocation-free while (rf result (apply f inputs)) still works.
 (define (td-map f)
   (lambda (rf)
-    (lambda a
-      (case (length a)
-        ((0) (jolt-invoke rf))
-        ((1) (jolt-invoke rf (car a)))
-        (else (jolt-invoke rf (car a) (apply jolt-invoke f (cdr a))))))))
+    (case-lambda
+      (() (jolt-invoke rf))
+      ((acc) (jolt-invoke1 rf acc))
+      ((acc x) (jolt-invoke2 rf acc (jolt-invoke1 f x)))
+      ((acc . xs) (jolt-invoke2 rf acc (apply jolt-invoke f xs))))))
 (define (td-filter pred)
   (lambda (rf)
-    (lambda a
-      (case (length a)
-        ((0) (jolt-invoke rf))
-        ((1) (jolt-invoke rf (car a)))
-        (else (if (jolt-truthy? (jolt-invoke pred (cadr a)))
-                  (jolt-invoke rf (car a) (cadr a))
-                  (car a)))))))
-(define (td-remove pred) (td-filter (lambda (x) (jolt-not (jolt-invoke pred x)))))
+    (case-lambda
+      (() (jolt-invoke rf))
+      ((acc) (jolt-invoke1 rf acc))
+      ((acc x) (if (jolt-truthy? (jolt-invoke1 pred x))
+                   (jolt-invoke2 rf acc x)
+                   acc)))))
+(define (td-remove pred) (td-filter (lambda (x) (jolt-not (jolt-invoke1 pred x)))))
 (define (td-take n)
   (lambda (rf)
     (let ((left n))
-      (lambda a
-        (case (length a)
-          ((0) (jolt-invoke rf))
-          ((1) (jolt-invoke rf (car a)))
-          (else (if (<= left 0)
-                    (make-jolt-reduced (car a))
-                    (let ((r (jolt-invoke rf (car a) (cadr a))))
-                      (set! left (- left 1))
-                      (if (<= left 0) (ensure-reduced r) r)))))))))
+      (case-lambda
+        (() (jolt-invoke rf))
+        ((acc) (jolt-invoke1 rf acc))
+        ((acc x) (if (<= left 0)
+                     (make-jolt-reduced acc)
+                     (let ((r (jolt-invoke2 rf acc x)))
+                       (set! left (- left 1))
+                       (if (<= left 0) (ensure-reduced r) r))))))))
 (define (td-drop n)
   (lambda (rf)
     (let ((left n))
-      (lambda a
-        (case (length a)
-          ((0) (jolt-invoke rf))
-          ((1) (jolt-invoke rf (car a)))
-          (else (if (> left 0) (begin (set! left (- left 1)) (car a))
-                    (jolt-invoke rf (car a) (cadr a)))))))))
+      (case-lambda
+        (() (jolt-invoke rf))
+        ((acc) (jolt-invoke1 rf acc))
+        ((acc x) (if (> left 0) (begin (set! left (- left 1)) acc)
+                     (jolt-invoke2 rf acc x)))))))
 (define (td-take-while pred)
   (lambda (rf)
-    (lambda a
-      (case (length a)
-        ((0) (jolt-invoke rf))
-        ((1) (jolt-invoke rf (car a)))
-        (else (if (jolt-truthy? (jolt-invoke pred (cadr a)))
-                  (jolt-invoke rf (car a) (cadr a))
-                  (make-jolt-reduced (car a))))))))
+    (case-lambda
+      (() (jolt-invoke rf))
+      ((acc) (jolt-invoke1 rf acc))
+      ((acc x) (if (jolt-truthy? (jolt-invoke1 pred x))
+                   (jolt-invoke2 rf acc x)
+                   (make-jolt-reduced acc))))))
 (define (td-drop-while pred)
   (lambda (rf)
     (let ((dropping #t))
-      (lambda a
-        (case (length a)
-          ((0) (jolt-invoke rf))
-          ((1) (jolt-invoke rf (car a)))
-          (else (begin
-                  (when (and dropping (not (jolt-truthy? (jolt-invoke pred (cadr a)))))
-                    (set! dropping #f))
-                  (if dropping (car a) (jolt-invoke rf (car a) (cadr a))))))))))
+      (case-lambda
+        (() (jolt-invoke rf))
+        ((acc) (jolt-invoke1 rf acc))
+        ((acc x) (begin
+                   (when (and dropping (not (jolt-truthy? (jolt-invoke1 pred x))))
+                     (set! dropping #f))
+                   (if dropping acc (jolt-invoke2 rf acc x))))))))
 ;; (mapcat f) transducer: map f, then splice (cat) f's result into rf, honoring a
 ;; mid-splice `reduced`.
 (define (td-mapcat f)
   (lambda (rf)
-    (lambda a
-      (case (length a)
-        ((0) (jolt-invoke rf))
-        ((1) (jolt-invoke rf (car a)))
-        (else (let loop ((acc (car a))
-                         (xs (seq->list (jolt-seq (jolt-invoke f (cadr a))))))
-                (if (or (null? xs) (jolt-reduced? acc)) acc
-                    (loop (jolt-invoke rf acc (car xs)) (cdr xs)))))))))
+    (case-lambda
+      (() (jolt-invoke rf))
+      ((acc) (jolt-invoke1 rf acc))
+      ((acc x) (let loop ((acc acc)
+                          (xs (seq->list (jolt-seq (jolt-invoke1 f x)))))
+                 (if (or (null? xs) (jolt-reduced? acc)) acc
+                     (loop (jolt-invoke2 rf acc (car xs)) (cdr xs))))))))
 
 ;; (into to xform from): transduce `from` through `xform` with conj as the rf.
 (define (into-xform to xform from)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1161,6 +1161,16 @@
   {:suite "r2-chunk" :expr "(seq (filter (fn [x] (> x 1000)) (range 100)))" :expected ""}
   {:suite "r2-chunk" :expr "(reduce + (filter odd? (vec (range 64))))" :expected "1024"}
   {:suite "r2-chunk" :expr "[(nth (map inc (range)) 40) (first (filter (fn [x] (> x 100)) (range)))]" :expected "[41 101]"}
+  ;; transducer rf arities exercised directly (guards the case-lambda rewrite):
+  ;; 0-arg init, 1-arg completion, 2-arg step, the map transducer's multi-input
+  ;; arity, comp composition, and reduced short-circuit via take.
+  {:suite "r4-transducer" :expr "(((map inc) conj) [] 5)" :expected "[6]"}
+  {:suite "r4-transducer" :expr "(((map +) conj) [] 1 2 3)" :expected "[6]"}
+  {:suite "r4-transducer" :expr "(((comp (map inc) (filter even?)) conj))" :expected "[]"}
+  {:suite "r4-transducer" :expr "(transduce (map inc) conj [] [1 2 3])" :expected "[2 3 4]"}
+  {:suite "r4-transducer" :expr "(into [] (comp (map inc) (take 2)) (range 100))" :expected "[1 2]"}
+  {:suite "r4-transducer" :expr "(transduce (comp (filter odd?) (map (fn [x] (* x x)))) + 0 [1 2 3 4 5])" :expected "35"}
+  {:suite "r4-transducer" :expr "(transduce (take 3) + 0 (range))" :expected "3"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) >= 2 <= 4)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-set 1 2 3 4 5) > 1 < 5)" :expected "(4 3 2)"}
   {:suite "r7-rsubseq" :expr "(rsubseq (sorted-map 1 :a 2 :b 3 :c 4 :d 5 :e) >= 2 <= 4)" :expected "([4 :d] [3 :c] [2 :b])"}


### PR DESCRIPTION
## What

Each transducer stage's reducing fn was a variadic `(lambda a (case (length a) …))`. Calling it with two arguments allocated a rest list and walked `(length a)` on every element, then forwarded through the general variadic `jolt-invoke`. A multi-stage transducer paid several rest-list allocations and general dispatches per element, which is why on jolt a transducer pipeline was actually *slower* than the equivalent lazy pipeline, the opposite of Clojure/babashka where transducers fuse and win.

## How

Each stage is now a `case-lambda` with the exact transducer arities:

```scheme
(define (td-filter pred)
  (lambda (rf)
    (case-lambda
      (() (jolt-invoke rf))
      ((acc) (jolt-invoke1 rf acc))
      ((acc x) (if (jolt-truthy? (jolt-invoke1 pred x))
                   (jolt-invoke2 rf acc x)
                   acc)))))
```

No rest list, no `(length a)`. The step calls the downstream rf via `jolt-invoke2` and the mapping/predicate fn via `jolt-invoke1`, the fixed-arity fast paths that check the arity mask and call directly. The map transducer keeps a trailing `(acc . xs)` clause for its documented multi-input arity; `case-lambda` tries the fixed clauses first, so the single-input step stays allocation-free while `(rf result (apply f inputs))` still works for the multi-collection case.

This is a runtime-only change (`natives-seq.ss`), so the minted seed is unchanged and the self-host fixpoint holds.

## Results

On a 2,000,000-element pipeline (`(comp (map …) (filter odd?) (map …))`):

| path | before | after |
| --- | --- | --- |
| `transduce` | 523ms | ~401ms (about 23% faster) |
| `into []` with xform | 612ms | ~477ms (about 22% faster) |

The important qualitative change: a transducer pipeline is now faster than the lazy-seq equivalent, as it should be. Before this it was slower.

`bench/seqs.clj` is unaffected because it uses lazy `map`/`filter`, not transducers.

## Tests

New `r4-transducer` unit guards exercise the rf arities directly: 0-arg init, 1-arg completion, 2-arg step, the map multi-input arity (`(((map +) conj) [] 1 2 3)`), comp composition, and `reduced` short-circuit through `take`. The extensive existing transducer corpus suite (into/transduce/sequence/eduction across every xform, comp, halt-when, completing, short-circuit over infinite seqs, multi-input map) is unchanged and passes.

Gates: unit 1022/1022, corpus 0 new divergence (9 known allowlisted), values 37/37, cli smoke 75/0, buildsmoke full matrix, self-host fixpoint holds (rebuild == checked-in seed).

Bead: jolt-s1u. Round 4 of the runtime performance series.