### PR TITLE
bench: add loop-recur, tak, transducers; broaden collections coverage

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -20,10 +20,13 @@ absolute reference.
 | `binary-trees` | allocation / GC pressure (escaping short-lived records) | scalar-replace, escape analysis | CLBG |
 | `dispatch` | polymorphic (**megamorphic**) protocol dispatch | devirt, inline-cache | AWFY-style |
 | `mono-dispatch` | **monomorphic** protocol dispatch (devirt/inline-cache *can* fire) | devirt, inline-cache | AWFY-style |
-| `collections` | persistent map/vector churn (HAMT / 32-way tries) | persistent structures, transients | CLBG k-nucleotide-style |
+| `collections` | persistent map/vector churn (HAMT / 32-way tries) + map/filter/take/reduce over the built vector | persistent structures, transients | CLBG k-nucleotide-style |
 | `mandelbrot` | pure float compute (tight arith loops, no alloc/dispatch) | native arith, loop codegen | CLBG |
 | `fib` | recursion: function-call + integer-arith overhead | native arith, small-fn inlining | CLBG |
+| `tak` | deep three-way self-recursion (denser call overhead than `fib`) | native arith, small-fn inlining, self-call direct-link | Gabriel |
+| `loop-recur` | tight loop/recur iteration, no seq/collection alloc (single, nested, branchy) | native arith, loop codegen | AWFY-style |
 | `seqs` | **lazy-seq + HOF pipelines** (range/map/filter/reduce, every?, iterate/take, mapcat) | lazy-seq allocation, per-element call overhead | AWFY-style |
+| `transducers` | transducer pipelines (comp of map/filter/take via transduce/into/eduction) | reducing-fn composition, no lazy-seq cells | AWFY-style |
 
 What the ray tracer does **not** capture and these do: allocation as the
 bottleneck (~7% there), megamorphic *and* monomorphic dispatch (its dispatch is

--- a/bench/collections.clj
+++ b/bench/collections.clj
@@ -1,8 +1,9 @@
 ;; collections — PERSISTENT-COLLECTION churn. Builds and reads persistent maps
 ;; and vectors (32-way hash/array tries) under heavy assoc/update/conj/lookup, a
-;; word-count-style workload (cf. CLBG k-nucleotide). Exercises jolt's persistent
-;; data structures and (eventually) transients — an axis the ray tracer (fixed
-;; records, no collections in the hot loop) doesn't touch.
+;; word-count-style workload (cf. CLBG k-nucleotide), then consumes the built
+;; vector with a map/filter/take + reduce pipeline. Covers persistent map,
+;; reduce, and map/filter/take over materialized collections — an axis the ray
+;; tracer (fixed records, no collections in the hot loop) doesn't touch.
 ;;
 ;; Portable Clojure (jolt + JVM Clojure).
 ;;   bench/run.sh collections 200000
@@ -17,17 +18,29 @@
                (assoc m k (+ 1 (get m k 0)))))
       m)))
 
+;; reduce over a persistent map: sum the values by looking each key back up.
 (defn sum-vals [m]
   (reduce (fn [acc k] (+ acc (get m k))) 0 (keys m)))
 
-;; vector churn: conj many, then reduce
-(defn vec-sum [n]
-  (let [v (loop [i 0 v []] (if (< i n) (recur (inc i) (conj v (mod i 1000))) v))]
-    (reduce + 0 v)))
+;; vector churn: conj many into a persistent vector.
+(defn build-vec [n]
+  (loop [i 0 v []] (if (< i n) (recur (inc i) (conj v (mod i 1000))) v)))
+
+;; map/filter/take pipeline over the built vector, then reduce — the read-side
+;; consumption of a materialized persistent collection (distinct from `seqs`,
+;; whose source is an unbounded lazy range).
+(defn transform [v]
+  (reduce + 0
+          (take (quot (count v) 2)
+                (map (fn [x] (* x 3))
+                     (filter even? v)))))
 
 (defn run [n]
-  (let [m (freq-map n 4096)]
-    (+ (sum-vals m) (vec-sum (quot n 4)))))
+  (let [m (freq-map n 4096)
+        v (build-vec (quot n 4))]
+    (+ (sum-vals m)                                          ; persistent map + reduce
+       (reduce + 0 v)                                        ; vector reduce
+       (transform v))))                                      ; map/filter/take + reduce
 
 (defn -main [& args]
   (let [n (if (seq args) (Integer/parseInt (first args)) 200000)]

--- a/bench/loop_recur.clj
+++ b/bench/loop_recur.clj
@@ -1,0 +1,69 @@
+;; loop-recur — tight LOOP/RECUR iteration: jolt's core counted-loop construct
+;; with no seq or collection allocation in the hot path. Isolates the recur
+;; back-edge and fixnum arithmetic, including nested loops and a data-dependent
+;; branch in the body (the shape idiomatic imperative-style Clojure compiles to).
+;; Complements `fib`/`tak` (self-recursion via the call stack) and `seqs` (the
+;; lazy-seq alternative to an explicit loop) — this is the allocation-free loop.
+;;
+;; All arithmetic is kept in fixnum range with `mod MOD`, so the checksum is
+;; identical on jolt, JVM Clojure, and babashka and the time is loop machinery.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh loop-recur 20000
+(ns loop-recur)
+
+(def MOD 1000000007)
+
+;; single counted loop: accumulate i*i, the plain recur back-edge + fixnum arith.
+(defn sum-squares [n]
+  (loop [i 0 acc 0]
+    (if (< i n)
+      (recur (inc i) (mod (+ acc (* i i)) MOD))
+      acc)))
+
+;; nested loop/recur: an inner accumulate inside an outer counted loop.
+(defn nested [n]
+  (loop [i 0 acc 0]
+    (if (< i n)
+      (recur (inc i)
+             (loop [j 0 a acc]
+               (if (< j 64)
+                 (recur (inc j) (mod (+ a (bit-xor i j)) MOD))
+                 a)))
+      acc)))
+
+;; data-dependent branch in the loop body: Collatz step counts, where each
+;; iteration picks one of two recur arms. Trajectories stay well within fixnum.
+(defn collatz [n]
+  (loop [k 1 total 0]
+    (if (> k n)
+      total
+      (recur (inc k)
+             (+ total
+                (loop [x k steps 0]
+                  (if (== x 1)
+                    steps
+                    (recur (if (even? x) (quot x 2) (inc (* 3 x)))
+                           (inc steps)))))))))
+
+(defn run [n]
+  (mod (+ (sum-squares (* n 20))
+          (nested n)
+          (collatz n))
+       MOD))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 20000)]
+    (dotimes [_ 2] (run (quot n 4)))                        ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "loop-recur n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -46,7 +46,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 mandelbrot:200 collections:30000 seqs:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 collections:30000 seqs:20000 transducers:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/bench/tak.clj
+++ b/bench/tak.clj
@@ -1,0 +1,37 @@
+;; tak — the Takeuchi function: deeply recursive three-way self-recursion with
+;; only integer comparison and subtraction, no allocation. A denser call-overhead
+;; probe than `fib` (up to three recursive calls per non-base frame, nested as
+;; arguments to a fourth), the classic Gabriel/Larceny benchmark. Isolates
+;; function-call throughput and native integer arith, the target of small-fn
+;; inlining and self-call direct-linking.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh tak 24
+(ns tak)
+
+(defn tak [x y z]
+  (if (< y x)
+    (tak (tak (- x 1) y z)
+         (tak (- y 1) z x)
+         (tak (- z 1) x y))
+    z))
+
+;; scale the classic (tak n 2n/3 n/3); n=24 -> (tak 24 16 8), a few seconds.
+(defn run [n]
+  (tak n (quot (* n 2) 3) (quot n 3)))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 24)]
+    (dotimes [_ 2] (run (- n 6)))                           ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "tak n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/transducers.clj
+++ b/bench/transducers.clj
@@ -1,0 +1,59 @@
+;; transducers — TRANSDUCER pipelines: the same map/filter/take shapes as `seqs`,
+;; but composed as transducers (`comp`) and driven allocation-free through
+;; `transduce` / `into` / `eduction`. Isolates the transducer machinery (composed
+;; reducing functions, one accumulator, no per-stage lazy-seq cells) against the
+;; lazy pipeline `seqs` measures on the same source data — the read-side pattern
+;; idiomatic Clojure reaches for when it wants a pipeline without the thunk chain.
+;;
+;; All arithmetic is kept in fixnum range with `mod MOD`, so the checksum is
+;; identical on jolt, JVM Clojure, and babashka.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh transducers 20000
+(ns transducers)
+
+(def MOD 1000000007)
+
+(def xform
+  (comp (map inc)
+        (filter odd?)
+        (map (fn [x] (mod (* x 7) MOD)))))
+
+;; transduce: fold the composed xform straight into an accumulator, no seq built.
+(defn td [n]
+  (transduce xform
+             (fn ([a] a) ([a x] (mod (+ a x) MOD)))
+             0
+             (range n)))
+
+;; into with a transducer (incl. take): build a vector through the xform, which
+;; runs transient-backed, then reduce it.
+(defn into-xf [n]
+  (reduce + 0 (into [] (comp xform (take (quot n 2))) (range n))))
+
+;; eduction: a reducible/seqable view over the xform, realized by reduce.
+(defn edu [n]
+  (reduce (fn [a x] (mod (+ a x) MOD)) 0
+          (eduction xform (range n))))
+
+(defn run [n]
+  (mod (+ (td (* n 40))
+          (into-xf (* n 20))
+          (edu (* n 40)))
+       MOD))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 20000)]
+    (dotimes [_ 2] (run (quot n 4)))                        ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "transducers n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))


### PR DESCRIPTION
Adds three benchmarks under `bench` and extends the existing `collections` bench so the suite covers a few workload axes it was missing.

`loop-recur` isolates tight `loop`/`recur` iteration with no seq or collection allocation in the hot path: a single counted loop, a nested loop, and a branchy Collatz loop that picks between two recur arms. It is the allocation-free counterpart to the stack-recursive `fib`/`tak` and the lazy `seqs` pipeline.

`tak` is the Takeuchi function, deep three-way self-recursion over integer compare and subtract. It is a denser call-overhead probe than `fib` since a non-base frame makes up to three recursive calls nested as arguments to a fourth. `tak` grows explosively, so the size is kept small (default 24).

`transducers` runs the same map/filter/take shapes as `seqs` but composed with `comp` and driven through `transduce`, `into`, and `eduction`, so it isolates the transducer machinery against the lazy-seq pipeline on the same source data.

`collections` now also consumes the vector it builds with a map/filter/take plus reduce pipeline, so it explicitly covers persistent map, reduce, and map/filter/take over a materialized collection.

`run.sh` registers the three new benches and the README documents them.

All four were verified on JVM Clojure and as optimized AOT binaries via `run.sh`.