### PR TITLE
Guard cseq tail-force against concurrent realization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a latent concurrency bug in lazy sequence realization. A `cseq` seq cell
+  memoizes its tail under mutable `tail`/`forced?` fields with no synchronization,
+  so once a lazy-seq node was realized its underlying cell chain was shared across
+  threads (every future/agent walking the same seq reads the *same* cells) and two
+  threads could both force a cell's tail and publish the fields non-atomically — a
+  third reader could then observe `forced?` set with `tail` still the thunk,
+  leaking a closure out as a seq and crashing. The cell's tail force (`seq-more`)
+  is now guarded by a lazily-created per-cell mutex under the same `jolt-mt?` flag
+  the lazy-seq node uses, so it stays lock-free in single-threaded programs and
+  takes double-checked locking once a second thread is spawned. This was exposed
+  by the new concurrent-realization unit guard and is otherwise unchanged in
+  behavior; the minted seed is unaffected (host-runtime change only).
+
 - Lazy sequences are noticeably faster in single-threaded programs, which is the
   common case. Every lazy-seq node used to allocate an OS mutex when it was created
   and acquire it on first realization, so that concurrent futures or agents could

--- a/host/chez/natives-meta.ss
+++ b/host/chez/natives-meta.ss
@@ -59,7 +59,7 @@
     ;; original mutated it, so (with-meta xs {:k xs}) built a self-referential
     ;; cycle that loops *print-meta* printing.
     ((cseq? x) (make-cseq (cseq-head x) (cseq-tail x) (cseq-forced? x)
-                          (cseq-list? x) (cseq-cvec x) (cseq-ci x) (cseq-crest x)))
+                          (cseq-list? x) (cseq-cvec x) (cseq-ci x) (cseq-crest x) (cseq-lock x)))
     ((jolt-lazyseq? x) (make-jolt-lazyseq (jolt-lazyseq-thunk x) (jolt-lazyseq-val x)
                                           (jolt-lazyseq-realized? x) (jolt-lazyseq-error? x)
                                           (make-mutex)))

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -37,11 +37,11 @@
 ;; so their result is itself a chunked-seq (chained chunked transforms each batch
 ;; by 32, like the JVM). crest is #f for a plain vector-backed seq (whose "rest"
 ;; is the next 32-block of the SAME cvec) and for every non-chunked cell.
-(define-record-type cseq (fields head (mutable tail) (mutable forced?) list? cvec ci crest) (nongenerative chez-cseq-v4))
-(define (cseq-realized head tail) (make-cseq head tail #t #f #f 0 #f))   ; tail already a seq
-(define (cseq-lazy head tail-thunk) (make-cseq head tail-thunk #f #f #f 0 #f))
-(define (cseq-list head tail) (make-cseq head tail #t #t #f 0 #f))       ; a PersistentList node
-(define (cseq-vec head tail-thunk v i) (make-cseq head tail-thunk #f #f v i #f)) ; vector-backed
+(define-record-type cseq (fields head (mutable tail) (mutable forced?) list? cvec ci crest (mutable lock)) (nongenerative chez-cseq-v5))
+(define (cseq-realized head tail) (make-cseq head tail #t #f #f 0 #f #f))   ; tail already a seq
+(define (cseq-lazy head tail-thunk) (make-cseq head tail-thunk #f #f #f 0 #f #f))
+(define (cseq-list head tail) (make-cseq head tail #t #t #f 0 #f #f))       ; a PersistentList node
+(define (cseq-vec head tail-thunk v i) (make-cseq head tail-thunk #f #f v i #f #f)) ; vector-backed
 ;; A ChunkedCons cell over a standalone chunk pvec: head is chunk[i], walking
 ;; (seq-more) advances within the chunk and then continues into `rest`. `rest` is
 ;; the already-coerced after-chunk seq (cseq | jolt-nil | a jolt-lazyseq), held in
@@ -53,11 +53,27 @@
                           (if (fx<? i1 (pvec-count chunk))
                               (cseq-chunked chunk i1 rest)
                               (jolt-seq rest))))
-             #f #f chunk i rest))
+              #f #f chunk i rest #f))
 (define (seq-first s) (cseq-head s))
+;; guards lazy creation of a cell's tail mutex on the multi-threaded path (mirrors
+;; force-lazyseq's lock-init). A cseq cell is shared across threads once its owning
+;; lazyseq node is realized (every future/agent walking the same seq reads the SAME
+;; cell), so without serialization two threads can both see forced?#f, both run the
+;; tail thunk, and publish tail/forced? non-atomically — a third reader can then see
+;; forced?#t with tail still the thunk-procedure, leaking a closure out as a seq.
+;; Like force-lazyseq this stays lock-free until jolt-mt? flips (fork-thread shadow).
+(define cseq-lock-init (make-mutex))
+(define (cseq-ensure-lock! s)
+  (with-mutex cseq-lock-init
+    (or (cseq-lock s)
+        (let ((m (make-mutex))) (cseq-lock-set! s m) m))))
 (define (seq-more s)                  ; force the tail; returns a seq (cseq | jolt-nil)
-  (if (cseq-forced? s) (cseq-tail s)
-      (let ((t ((cseq-tail s)))) (cseq-tail-set! s t) (cseq-forced?-set! s #t) t)))
+  (cond
+    ((cseq-forced? s) (cseq-tail s))
+    ((not jolt-mt?) (let ((t ((cseq-tail s)))) (cseq-tail-set! s t) (cseq-forced?-set! s #t) t))
+    (else (with-mutex (cseq-ensure-lock! s)     ; multi-threaded: double-checked
+            (if (cseq-forced? s) (cseq-tail s)
+                (let ((t ((cseq-tail s)))) (cseq-tail-set! s t) (cseq-forced?-set! s #t) t))))))
 
 ;; The empty seq (Clojure's empty list ()), distinct from nil. The (unused) field
 ;; defeats Chez's interning of fieldless records, so an empty list carrying


### PR DESCRIPTION
## What

A latent concurrency bug in lazy sequence realization. A `cseq` seq cell memoizes its tail under mutable `tail`/`forced?` fields with no synchronization, so once a `lazy-seq` node was realized its underlying cell chain was shared across threads (every future/agent walking the same seq reads the *same* cells). Two threads could both see `forced?#f`, both run the tail thunk, and publish the fields non-atomically — a third reader could then observe `forced?#t` with `tail` still the thunk-procedure, leaking a closure out as a seq and crashing.

## How

`seq-more` now takes double-checked locking on a lazily-created per-cell mutex under the same `jolt-mt?` flag the `lazy-seq` node uses (`force-lazyseq`'s existing `jolt-lazyseq-lock-init` pattern), so it stays lock-free in single-threaded programs and only locks once a second thread is spawned.

This mirrors `force-lazyseq`: the node-level mutex added in #436 only serializes realization of the node itself, not the cells it publishes. Both layers need the guard.

The `cseq` record grows a mutable `lock` field (`chez-cseq-v4` → `chez-cseq-v5`). The only other `make-cseq` copy site (`with-meta` in `natives-meta.ss`) carries the field through. This is a host-runtime-only change, so the minted seed is unchanged and the self-host fixpoint holds.

## Why this surfaced now

The bug was always there (it reproduces on pre-#436 `main` too), but #436's new concurrent-realization unit guard — 8 futures walking a 100-element mapped range — made it fire reliably (~10% of runs) instead of vanishingly rarely. That guard now passes clean.

## Results / verification

- unit 1042/1042 **×2** (was an intermittent `1/1042` fail on `r7-lazyseq`)
- a 300-iteration ×3 concurrent stress over `lazy1` / `map100` / `filt70` — all clean (0 failures across 2700 realizations)
- `map100` value check (`(apply + (doall (map inc (range 100))))` == 5050) ×200 — exact every time
- values 37/37
- corpus 0 new divergence (9 known allowlisted)
- selfhost fixpoint holds (rebuild == checked-in seed)

Fixes the flaky failure introduced by #436.