### PR TITLE
Lock the lazy-realization fast path once multi-threaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Closed the reader-side half of the lazy-realization race. The tail force
+  (`seq-more`) and lazy-node force (`force-lazyseq`) kept an unlocked fast-path
+  read of the realized flag and value as their first case, taken even in
+  multi-threaded programs. Because the writer stores the value and the flag with no
+  barrier between them, on a weak memory model like ARM64 a lock-free reader could
+  observe the flag set while the value was still the thunk, the same leaked-closure
+  crash the earlier writer-side fix described. Once a second thread exists, every
+  access now goes through the per-node and per-cell mutex, reads included, so the
+  reader synchronizes against the writer's release. Single-threaded programs keep
+  the fully lock-free fast path. Host-runtime change only; the minted seed is
+  unaffected.
+
 - Fixed a latent concurrency bug in lazy sequence realization. A `cseq` seq cell
   memoizes its tail under mutable `tail`/`forced?` fields with no synchronization,
   so once a lazy-seq node was realized its underlying cell chain was shared across

--- a/host/chez/lazy-bridge.ss
+++ b/host/chez/lazy-bridge.ss
@@ -67,10 +67,15 @@
         (jolt-lazyseq-realized?-set! x #t)
         (jolt-lazyseq-thunk-set! x #f)
         r)))
+  ;; Single-threaded: no lock, and the fast realized? read is safe. Once a second
+  ;; thread exists, the fast read is NOT safe: run! stores val then realized? with
+  ;; no barrier between them, so on a weak memory model (ARM64) a lock-free reader
+  ;; can see realized?#t while val is still the thunk and leak a closure out as a
+  ;; seq. So on the multi-threaded path every access — reads included — goes through
+  ;; the per-node mutex, whose acquire/release order the writer and reader against.
   (cond
-    ((jolt-lazyseq-realized? x) (deliver))
-    ((not jolt-mt?) (run!))                       ; single-threaded: no lock/mutex
-    (else                                          ; multi-threaded: double-checked
+    ((not jolt-mt?) (if (jolt-lazyseq-realized? x) (deliver) (run!)))
+    (else                                          ; multi-threaded: always lock
      (with-mutex (jolt-lazyseq-ensure-lock! x)     ; locking on a lazily-made mutex
        (if (jolt-lazyseq-realized? x) (deliver) (run!))))))
 

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -68,10 +68,15 @@
     (or (cseq-lock s)
         (let ((m (make-mutex))) (cseq-lock-set! s m) m))))
 (define (seq-more s)                  ; force the tail; returns a seq (cseq | jolt-nil)
+  ;; Single-threaded: the fast forced? read is safe. Multi-threaded: it is NOT — the
+  ;; tail/forced? stores below are unordered, so a lock-free reader on ARM64 can see
+  ;; forced?#t with tail still the thunk-procedure. So once jolt-mt? flips, every
+  ;; access goes through the per-cell mutex, reads included (mirrors force-lazyseq).
   (cond
-    ((cseq-forced? s) (cseq-tail s))
-    ((not jolt-mt?) (let ((t ((cseq-tail s)))) (cseq-tail-set! s t) (cseq-forced?-set! s #t) t))
-    (else (with-mutex (cseq-ensure-lock! s)     ; multi-threaded: double-checked
+    ((not jolt-mt?)
+     (if (cseq-forced? s) (cseq-tail s)
+         (let ((t ((cseq-tail s)))) (cseq-tail-set! s t) (cseq-forced?-set! s #t) t)))
+    (else (with-mutex (cseq-ensure-lock! s)     ; multi-threaded: always lock
             (if (cseq-forced? s) (cseq-tail s)
                 (let ((t ((cseq-tail s)))) (cseq-tail-set! s t) (cseq-forced?-set! s #t) t))))))
 

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1138,6 +1138,12 @@
   ;; concurrent realization across MANY chunked nodes still runs each element's
   ;; body exactly once (guards the multi-threaded locked path across chunk tails).
   {:suite "r7-lazyseq" :expr "(let [a (atom 0) s (map (fn [x] (swap! a inc) x) (range 100))] (doall (map deref (for [_ (range 8)] (future (doall s))))) @a)" :expected "100"}
+  ;; reader-side: 16 futures each reduce+sum the SAME shared lazy map, forcing its
+  ;; cseq cells concurrently. A torn read (forced?/realized? seen set before the
+  ;; value store lands) would leak a thunk out as a seq and crash or give a wrong
+  ;; sum. Every future must observe the exact value (guards seq-more/force-lazyseq
+  ;; going through the per-cell mutex on reads once multi-threaded).
+  {:suite "r7-lazyseq" :expr "(let [s (map inc (range 200)) rs (doall (map deref (for [_ (range 16)] (future (reduce + s)))))] [(count rs) (every? (fn [x] (= x 20100)) rs)])" :expected "[16 true]"}
   ;; every?/some short-circuit and laziness (guards the reduce+reduced rewrites):
   ;; the pred runs exactly up to the decisive element, both terminate on infinite
   ;; seqs, some returns the pred's truthy value (not the element) and nil (not


### PR DESCRIPTION
## What

Closes the reader-side half of the lazy-sequence realization race that #441 addressed on the writer side.

Both `force-lazyseq` (`host/chez/lazy-bridge.ss`) and `seq-more` (`host/chez/seq.ss`) kept an unlocked read of the realized/forced flag plus the memoized value as their first `cond` clause, and that clause ran even after `jolt-mt?` flipped. The writer stores the value and then the flag with no barrier between them, so on a weak memory model like ARM64 a lock-free reader can observe the flag set while the value is still the tail thunk, and leak a closure out as a seq. That is the same crash mode #441 describes. #441 stopped two threads from both running the thunk, but a third thread reading on the fast path could still see a torn publish.

## How

Both sites now gate the fast flag-check under `(not jolt-mt?)`. Single-threaded programs keep exactly the lock-free path they had. Once a second OS thread is spawned, every access including reads goes through the per-node/per-cell mutex, so a reader acquires against the writer's release and cannot observe a half-published cell.

This is a host-runtime-only change, so the minted seed is unchanged and the self-host fixpoint holds.

## Why this is worth doing

It is a latent, low-probability race, and it was not seen in #441's stress run, but it is real on ARM64 (Apple Silicon), it lives in the concurrency path we just fixed a bug in, and closing it costs nothing on the single-threaded hot path.

## Verification

- New `r7-lazyseq` guard: 16 futures each `reduce +` the same shared lazy map, forcing its cells concurrently; every future must observe the exact sum.
- unit 1043/1043, run x4 for concurrency stability
- values 37/37
- corpus 0 new divergence (9 known allowlisted)
- selfhost fixpoint holds (rebuild == checked-in seed)

Follow-up to #441. Closes jolt-l0z.