### PR TITLE
Run the GUI main loop on the nREPL primordial thread

### DIFF
--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -883,15 +883,19 @@
 
 ;; --- main-thread executor ---------------------------------------------------
 ;; Lets a worker thread (e.g. an nREPL eval future) run a thunk on the thread
-;; that owns the GUI main loop. On macOS GTK quartz, g_application_run must run
-;; on the process main thread or AppKit aborts (setMainMenu off-main → SIGABRT).
+;; that owns the process's main loop. This is for main-thread-affine work: many
+;; native UI toolkits require their event loop and widget mutation to run on the
+;; process main thread (on macOS, AppKit aborts if the main menu is set off the
+;; main thread), so a library that runs such a loop cannot just start it on
+;; whatever thread happened to call it.
+;;
 ;; Under `joltc nrepl-server` the accept loop is backgrounded in a future and the
 ;; primordial thread parks in jolt-park-until-interrupt, which doubles as the main
-;; pump (see below); glimmer's run marshals its startup through
-;; jolt-call-on-main-thread-async so the boot lands there and the eval returns.
+;; pump (see below). A library that must run on the main thread marshals its work
+;; through jolt-call-on-main-thread(-async) so it lands there.
 ;;
-;; - With no pump running (`joltc -M:run` calls run directly on the main thread),
-;;   call-on-main-thread(-async) runs the thunk INLINE — unchanged behaviour.
+;; - With no pump running (e.g. `joltc -M:run` calls straight through on the main
+;;   thread), call-on-main-thread(-async) runs the thunk INLINE — unchanged.
 ;; - A call from a thunk already executing on the pump runs inline too, so the
 ;;   pump can't deadlock on itself.
 ;; - Otherwise the thunk is enqueued; call-on-main-thread blocks for the result,
@@ -944,13 +948,12 @@
                   (raise (jolt-main-job-val job))))))))
 
 ;; Fire-and-forget variant: schedule `thunk` on the pump and return immediately,
-;; without waiting for it to finish. This is what glimmer's run wants under nREPL —
-;; boot g_application_run on the main thread (which then blocks for the GUI's whole
-;; lifetime) WITHOUT blocking the eval that called run, so the REPL session stays
-;; live for reactive edits. Errors in the thunk are the caller's problem to observe
-;; via the GUI; there is no waiter to re-raise into. With no pump active it runs
-;; inline (like -M:run, where run is already on the main thread). A reentrant call
-;; (already on the pump) also runs inline.
+;; without waiting for it to finish. This suits a main-thread event loop started
+;; from nREPL — the thunk blocks the pump for the loop's whole lifetime, but the
+;; eval that started it returns, so the REPL session stays live. Errors in the
+;; thunk have no waiter to re-raise into (the caller has already returned). With no
+;; pump active it runs inline (like -M:run, where the caller is already on the main
+;; thread). A reentrant call (already on the pump) also runs inline.
 (define (jolt-call-on-main-thread-async thunk)
   (if (jolt-in-main-pump?)
       (begin (jolt-invoke thunk) jolt-nil)
@@ -971,11 +974,12 @@
     (exit 0)))
 
 ;; Park the calling thread until a keyboard interrupt (^C), running the shutdown
-;; hooks and exiting when it arrives — AND own the GUI main-thread pump while
-;; parked. The nREPL server parks the primordial thread here: it must both be
-;; interruptible for ^C and be the thread call-on-main-thread(-async) marshals
-;; onto, so a worker's glimmer run boots g_application_run on THIS (main) thread
-;; instead of inline off-main (a macOS AppKit setMainMenu abort).
+;; hooks and exiting when it arrives — AND own the main-thread pump while parked.
+;; The nREPL server parks the primordial thread here: it must both be interruptible
+;; for ^C and be the thread call-on-main-thread(-async) marshals onto, so a worker
+;; that must run on the main thread (e.g. a UI toolkit's event loop) runs on THIS
+;; (main) thread instead of inline off-main (on macOS an off-main native UI call
+;; can abort the process).
 ;;
 ;; Interruptibility is subtle. A keyboard interrupt raised while a thread blocks
 ;; in condition-wait is only *delivered* at the next Scheme safe point OUTSIDE the
@@ -986,14 +990,14 @@
 ;; not own mutex" hazard). This loop idles in (sleep …) instead: sleep is a
 ;; syscall Chez interrupt-checks around, so a pending ^C fires jolt-pump-kih there
 ;; (shutdown hooks -> exit) within one poll interval. jolt-park-poll-ms is short
-;; enough that GUI-boot latency after an nREPL eval is imperceptible.
+;; enough that the latency to pick up a job after an nREPL eval is imperceptible.
 ;;
 ;; SIGINT is unblocked in this thread first (it was masked by jolt-block-sigint so
 ;; the accept loop inherited a blocked mask and couldn't absorb ^C in its foreign
 ;; accept() call). pump-active is set so call-on-main-thread(-async) enqueues onto
-;; us rather than running inline. While a job runs (glimmer's g_application_run
-;; blocks for the GUI's lifetime) the mutex is NOT held, so other threads keep
-;; enqueueing; ^C during that foreign call is uninterruptible, exactly as -M:run.
+;; us rather than running inline. While a job runs (e.g. an event loop that blocks
+;; for its lifetime) the mutex is NOT held, so other threads keep enqueueing; ^C
+;; during that foreign call is uninterruptible, exactly as under -M:run.
 (define jolt-park-poll-ms 50)
 (define (jolt-park-until-interrupt)
   (keyboard-interrupt-handler jolt-pump-kih)
@@ -1009,10 +1013,10 @@
                             (set! jolt-main-queue (cdr jolt-main-queue))
                             j)))))
           (if job
-              ;; run the job on THIS (main) thread — glimmer's g_application_run
-              ;; blocks here for the GUI's lifetime; the mutex is released so other
-              ;; threads keep enqueueing. jolt-in-main-pump? makes a reentrant
-              ;; call-on-main-thread run inline instead of self-deadlocking.
+              ;; run the job on THIS (main) thread — a UI event loop blocks here
+              ;; for its lifetime; the mutex is released so other threads keep
+              ;; enqueueing. jolt-in-main-pump? makes a reentrant call-on-main-thread
+              ;; run inline instead of self-deadlocking.
               (let ((r (dynamic-wind
                          (lambda () (jolt-in-main-pump? #t))
                          (lambda ()

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -885,23 +885,25 @@
 ;; Lets a worker thread (e.g. an nREPL eval future) run a thunk on the thread
 ;; that owns the GUI main loop. On macOS GTK quartz, g_application_run must run
 ;; on the process main thread or AppKit aborts (setMainMenu off-main → SIGABRT).
-;; Under `joltc nrepl` the accept loop is backgrounded in a future and the
-;; primordial thread enters jolt-run-main-pump; glimmer's run marshals its
-;; startup through jolt-call-on-main-thread.
+;; Under `joltc nrepl-server` the accept loop is backgrounded in a future and the
+;; primordial thread parks in jolt-park-until-interrupt, which doubles as the main
+;; pump (see below); glimmer's run marshals its startup through
+;; jolt-call-on-main-thread-async so the boot lands there and the eval returns.
 ;;
 ;; - With no pump running (`joltc -M:run` calls run directly on the main thread),
-;;   call-on-main-thread runs the thunk INLINE — unchanged behaviour.
+;;   call-on-main-thread(-async) runs the thunk INLINE — unchanged behaviour.
 ;; - A call from a thunk already executing on the pump runs inline too, so the
 ;;   pump can't deadlock on itself.
-;; - Otherwise the thunk is enqueued; the caller blocks until the pump runs it,
-;;   then receives the value, or the thrown condition is re-raised.
+;; - Otherwise the thunk is enqueued; call-on-main-thread blocks for the result,
+;;   call-on-main-thread-async returns right away (fire-and-forget).
 ;;
-;; stop-main-pump is the graceful-shutdown / external API: it tells the pump to
-;; drain whatever is queued and return. The pump-active flag is flipped to #f
-;; under jolt-main-queue-mu in the same critical section that decides to exit, and
-;; call-on-main-thread reads that flag and enqueues under the SAME mutex, so a job
-;; can never slip in after the pump has decided to leave — a call that loses the
-;; race simply runs inline instead of blocking forever on a pump that is gone.
+;; jolt-run-main-pump / stop-main-pump remain the external blocking-pump API (a
+;; pump that drains queued jobs and returns on stop). The nREPL server uses the
+;; interruptible park variant instead, since run-main-pump's bare condition-wait
+;; can't be broken by ^C. The pump-active flag is flipped under jolt-main-queue-mu
+;; in the same critical section that decides to exit, and call-on-main-thread reads
+;; that flag and enqueues under the SAME mutex, so a job can never slip in after
+;; the pump has left — a losing call runs inline instead of blocking on a dead pump.
 
 (define jolt-main-queue-mu (make-mutex))
 (define jolt-main-queue-cv (make-condition))
@@ -941,25 +943,92 @@
                   (jolt-main-job-val job)
                   (raise (jolt-main-job-val job))))))))
 
+;; Fire-and-forget variant: schedule `thunk` on the pump and return immediately,
+;; without waiting for it to finish. This is what glimmer's run wants under nREPL —
+;; boot g_application_run on the main thread (which then blocks for the GUI's whole
+;; lifetime) WITHOUT blocking the eval that called run, so the REPL session stays
+;; live for reactive edits. Errors in the thunk are the caller's problem to observe
+;; via the GUI; there is no waiter to re-raise into. With no pump active it runs
+;; inline (like -M:run, where run is already on the main thread). A reentrant call
+;; (already on the pump) also runs inline.
+(define (jolt-call-on-main-thread-async thunk)
+  (if (jolt-in-main-pump?)
+      (begin (jolt-invoke thunk) jolt-nil)
+      (let ((enq (with-mutex jolt-main-queue-mu
+                   (and (unbox jolt-main-pump-active)
+                        (let ((j (make-jolt-main-job thunk #f #f jolt-nil
+                                                     (make-mutex) (make-condition))))
+                          (set! jolt-main-queue (append jolt-main-queue (list j)))
+                          (condition-signal jolt-main-queue-cv)
+                          #t)))))
+        (unless enq (jolt-invoke thunk))
+        jolt-nil)))
+
 (define jolt-pump-kih
   (lambda ()
     (for-each (lambda (th) (guard (e (#t #f)) (th)))
               (reverse (unbox jolt-shutdown-hooks)))
     (exit 0)))
 
-;; Park the calling thread until a keyboard interrupt (^C), then run the shutdown
-;; hooks and exit. Unlike run-main-pump (whose tight recursive condition-wait
-;; loop elides Chez's interrupt poll points, so the handler never fires), this
-;; uses a single condition-wait — the form Chez reliably interrupts. The nREPL
-;; server parks here; SIGINT is unblocked in this thread first (it was masked by
-;; jolt-block-sigint so the accept loop inherited a blocked mask and couldn't
-;; absorb ^C in its foreign accept() call).
-(define jolt-park-mu (make-mutex))
-(define jolt-park-cv (make-condition))
+;; Park the calling thread until a keyboard interrupt (^C), running the shutdown
+;; hooks and exiting when it arrives — AND own the GUI main-thread pump while
+;; parked. The nREPL server parks the primordial thread here: it must both be
+;; interruptible for ^C and be the thread call-on-main-thread(-async) marshals
+;; onto, so a worker's glimmer run boots g_application_run on THIS (main) thread
+;; instead of inline off-main (a macOS AppKit setMainMenu abort).
+;;
+;; Interruptibility is subtle. A keyboard interrupt raised while a thread blocks
+;; in condition-wait is only *delivered* at the next Scheme safe point OUTSIDE the
+;; wait, and the ordinary dequeue primitives (with-mutex / null? / car) are NOT
+;; reliable interrupt-check points — only a real syscall is. run-main-pump idles
+;; in a bare condition-wait with no such safe point, so a pending ^C is never
+;; delivered (it also holds jolt-main-queue-mu across the wait — the "thread does
+;; not own mutex" hazard). This loop idles in (sleep …) instead: sleep is a
+;; syscall Chez interrupt-checks around, so a pending ^C fires jolt-pump-kih there
+;; (shutdown hooks -> exit) within one poll interval. jolt-park-poll-ms is short
+;; enough that GUI-boot latency after an nREPL eval is imperceptible.
+;;
+;; SIGINT is unblocked in this thread first (it was masked by jolt-block-sigint so
+;; the accept loop inherited a blocked mask and couldn't absorb ^C in its foreign
+;; accept() call). pump-active is set so call-on-main-thread(-async) enqueues onto
+;; us rather than running inline. While a job runs (glimmer's g_application_run
+;; blocks for the GUI's lifetime) the mutex is NOT held, so other threads keep
+;; enqueueing; ^C during that foreign call is uninterruptible, exactly as -M:run.
+(define jolt-park-poll-ms 50)
 (define (jolt-park-until-interrupt)
   (keyboard-interrupt-handler jolt-pump-kih)
   (jolt-set-sigint-blocked #f)
-  (with-mutex jolt-park-mu (condition-wait jolt-park-cv jolt-park-mu))
+  (with-mutex jolt-main-queue-mu (set-box! jolt-main-pump-active #t))
+  (dynamic-wind
+    (lambda () #f)
+    (lambda ()
+      (let loop ()
+        (let ((job (with-mutex jolt-main-queue-mu
+                     (and (not (null? jolt-main-queue))
+                          (let ((j (car jolt-main-queue)))
+                            (set! jolt-main-queue (cdr jolt-main-queue))
+                            j)))))
+          (if job
+              ;; run the job on THIS (main) thread — glimmer's g_application_run
+              ;; blocks here for the GUI's lifetime; the mutex is released so other
+              ;; threads keep enqueueing. jolt-in-main-pump? makes a reentrant
+              ;; call-on-main-thread run inline instead of self-deadlocking.
+              (let ((r (dynamic-wind
+                         (lambda () (jolt-in-main-pump? #t))
+                         (lambda ()
+                           (guard (e (#t (cons #f e)))
+                             (cons #t (jolt-invoke (jolt-main-job-thunk job)))))
+                         (lambda () (jolt-in-main-pump? #f)))))
+                (with-mutex (jolt-main-job-mu job)
+                  (jolt-main-job-ok?-set! job (car r))
+                  (jolt-main-job-val-set! job (cdr r))
+                  (jolt-main-job-done?-set! job #t)
+                  (condition-broadcast (jolt-main-job-cv job))))
+              ;; idle: sleep — an interrupt-checked syscall — so a pending ^C fires.
+              (sleep (ms->duration jolt-park-poll-ms)))
+          (loop))))
+    (lambda ()
+      (with-mutex jolt-main-queue-mu (set-box! jolt-main-pump-active #f))))
   jolt-nil)
 
 (define (jolt-run-main-pump)
@@ -1058,6 +1127,7 @@
   jolt-nil)
 
 (def-var! "jolt.host" "call-on-main-thread" jolt-call-on-main-thread)
+(def-var! "jolt.host" "call-on-main-thread-async" jolt-call-on-main-thread-async)
 (def-var! "jolt.host" "run-main-pump" jolt-run-main-pump)
 (def-var! "jolt.host" "stop-main-pump" jolt-stop-main-pump)
 (def-var! "jolt.host" "add-shutdown-hook" jolt-add-shutdown-hook)

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -14,6 +14,7 @@ block-sigint
 build-binary
 build-library
 call-on-main-thread
+call-on-main-thread-async
 callable-host?
 chez-number-literal
 class-ancestors

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -353,9 +353,10 @@
       ;; failure like the port already being in use surfaces here and exits rather
       ;; than being swallowed by a background thread. It then runs the accept loop
       ;; on a worker thread and returns a stop fn, leaving this thread free to own
-      ;; the GUI main loop: glimmer's run marshals its startup here via
-      ;; jolt.host/call-on-main-thread — on macOS GTK quartz, g_application_run
-      ;; must run on the main thread or AppKit aborts when it sets the main menu.
+      ;; the process main loop: main-thread-affine work an eval starts (e.g. a UI
+      ;; toolkit's event loop) marshals here via jolt.host/call-on-main-thread —
+      ;; on macOS a native UI event loop must run on the main thread or the
+      ;; process aborts (e.g. AppKit rejects setting the main menu off-main).
       ;; Block SIGINT in this (primordial) thread before starting the server so the
       ;; accept-loop future — and the conn-handler futures it spawns — inherit a
       ;; blocked SIGINT mask. Without this, ^C lands on the accept loop blocked in

--- a/jolt-core/jolt/nrepl.clj
+++ b/jolt-core/jolt/nrepl.clj
@@ -322,7 +322,8 @@
   accepts connections on a background thread and returns immediately. Writes
   .nrepl-port. Does NOT block — the caller keeps the process alive (jolt.main
   parks the main thread in jolt.host/park-until-interrupt, which also runs the
-  GUI main-thread pump so a client's glimmer run marshals onto the main thread).
+  main-thread pump, so main-thread-affine work an eval starts, such as a UI
+  toolkit's event loop, marshals onto the main thread via call-on-main-thread).
 
   Returns a zero-arg stop fn: it stops the accept loop, closes the listen socket
   (freeing the port), and removes .nrepl-port. Calling it more than once is a

--- a/jolt-core/jolt/nrepl.clj
+++ b/jolt-core/jolt/nrepl.clj
@@ -321,7 +321,8 @@
   in use) is thrown to the caller rather than swallowed by the accept thread, then
   accepts connections on a background thread and returns immediately. Writes
   .nrepl-port. Does NOT block — the caller keeps the process alive (jolt.main
-  parks the main thread in jolt.host/run-main-pump).
+  parks the main thread in jolt.host/park-until-interrupt, which also runs the
+  GUI main-thread pump so a client's glimmer run marshals onto the main thread).
 
   Returns a zero-arg stop fn: it stops the accept loop, closes the listen socket
   (freeing the port), and removes .nrepl-port. Calling it more than once is a


### PR DESCRIPTION
## Problem

Starting a glimmer app from an nREPL session (`joltc nrepl-server`, connect an editor, evaluate `-main`) aborted on macOS with:

```
API misuse: setting the main menu on a non-main thread.
```

glimmer's `run` marshals `g_application_run` onto the main thread through `jolt.host/call-on-main-thread`, which only hops when a main pump is active. That pump used to be `run-main-pump`, but the nREPL server was later changed to park in `park-until-interrupt` for clean `^C` shutdown, and that variant never activates the pump. So the hop fell through to running `g_application_run` inline on the nREPL worker thread, and GTK quartz aborted when it set the main menu off the main thread.

## Fix

`park-until-interrupt` now doubles as the main-thread pump. It activates the pump, drains queued jobs and runs each on the primordial thread, and idles otherwise.

The idle wait is a `sleep` poll rather than a `condition-wait`, on purpose. A keyboard interrupt is only delivered at a real-syscall safe point outside `condition-wait`, so `run-main-pump`'s bare `condition-wait` loop swallows `^C` (and holding the queue mutex across the wait risks the "thread does not own mutex" abort). `sleep` is interrupt-checked, so `^C` is delivered within one poll interval and still runs the shutdown hooks before exit. I confirmed this difference with isolation tests against the live server.

Also adds `jolt.host/call-on-main-thread-async`, a fire-and-forget hop so glimmer's `run` can schedule the GUI boot and return immediately, leaving the nREPL session live for reactive edits. `call-on-main-thread` (blocking) and `run-main-pump` stay as the external pump API; the nREPL server no longer uses `run-main-pump`.

## Verification

Against the repo source launcher (`bin/joltc`), from the glimmer-app example:

- nREPL boot of a glimmer app: no crash, the `run` eval returns in ~0.6s rather than blocking.
- `(swap! ...)` from later evals re-renders the running window and returns cleanly.
- `^C` shuts the server down cleanly.
- `-M:run` still blocks inline until the window closes, no crash.
- futures / promises / pmap unaffected.

Pairs with jolt-lang/glimmer#1 (glimmer's `run` switches to the async hop). glimmer resolves the seam at call time and falls back to the inline path, so it stays compatible with an older jolt.