### PR TITLE
bench: add arrays + mathfns numeric benchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -22,6 +22,8 @@ absolute reference.
 | `mono-dispatch` | **monomorphic** protocol dispatch (devirt/inline-cache *can* fire) | devirt, inline-cache | AWFY-style |
 | `collections` | persistent map/vector churn (HAMT / 32-way tries) + map/filter/take/reduce over the built vector | persistent structures, transients | CLBG k-nucleotide-style |
 | `mandelbrot` | pure float compute (tight arith loops, no alloc/dispatch) | native arith, loop codegen | CLBG |
+| `arrays` | primitive `double-array` throughput (unboxed `aget`/`aset`, no boxing/collections) | unboxed primitive-array codegen (flvector read/write) | CLBG-style |
+| `mathfns` | transcendental math (`java.lang.Math` sqrt/sin/cos/log/pow/atan2 over doubles) | native `Math` op lowering (`flsqrt`/`flsin`/… vs generic host-static dispatch) | CLBG-style |
 | `fib` | recursion: function-call + integer-arith overhead | native arith, small-fn inlining | CLBG |
 | `tak` | deep three-way self-recursion (denser call overhead than `fib`) | native arith, small-fn inlining, self-call direct-link | Gabriel |
 | `loop-recur` | tight loop/recur iteration, no seq/collection alloc (single, nested, branchy) | native arith, loop codegen | AWFY-style |

--- a/bench/arrays.clj
+++ b/bench/arrays.clj
@@ -1,0 +1,52 @@
+;; arrays — primitive double-array throughput: fill an array with aset and read
+;; it back with aget in tight loops, no boxing, no collections, no dispatch. This
+;; isolates the unboxed primitive-array path (a ^doubles array is a Chez flvector;
+;; aget/aset lower to flvector-ref/-set! and the surrounding arith to fl+/fl*), so
+;; it tracks that codegen directly and guards it against regression. mandelbrot
+;; covers scalar double arith; this covers indexed array reads/writes.
+;;
+;; Portable Clojure (jolt + JVM Clojure) — ^doubles/aget/aset hit primitive arrays
+;; on both.
+;;   bench/run.sh arrays 40000
+(ns arrays)
+
+(defn fill! [^doubles a ^long n]
+  (loop [i 0]
+    (when (< i n)
+      (aset a i (double (+ (* i 0.5) 1.0)))
+      (recur (inc i))))
+  a)
+
+(defn dot ^double [^doubles a ^doubles b ^long n]
+  (loop [i 0 acc 0.0]
+    (if (< i n)
+      (recur (inc i) (+ acc (* (aget a i) (aget b i))))
+      acc)))
+
+;; `passes` dot products over two n-element arrays; each pass reads 2n elements
+;; unboxed and does n fused multiply-adds. The arrays are filled once (the aset
+;; path) then read every pass (the aget path).
+(defn run ^double [^long passes]
+  (let [n 1000
+        a (fill! (double-array n) n)
+        b (fill! (double-array n) n)]
+    (loop [p 0 acc 0.0]
+      (if (< p passes)
+        (recur (inc p) (+ acc (dot a b n)))
+        acc))))
+
+(defn -main [& args]
+  (let [passes (if (seq args) (Integer/parseInt (first args)) 40000)]
+    (dotimes [_ 2] (run (quot passes 2)))                ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run passes)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "arrays passes" passes "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/mathfns.clj
+++ b/bench/mathfns.clj
@@ -1,0 +1,43 @@
+;; mathfns — transcendental math throughput: a tight loop over doubles that calls
+;; java.lang.Math (sqrt/sin/cos/log/pow/atan2) and accumulates. When the operands
+;; are proven flonums, each call lowers to the native Chez op (flsqrt/flsin/…) and
+;; types double, so the whole accumulator stays unboxed. This isolates the native
+;; Math path and guards it against falling back to the generic string-keyed
+;; host-static dispatch (which boxes and re-dispatches per call).
+;;
+;; Portable Clojure (jolt + JVM Clojure) — the JVM turns these into intrinsics, so
+;; it's an honest reference.
+;;   bench/run.sh mathfns 1000000
+(ns mathfns)
+
+(defn kernel ^double [^long n]
+  (loop [i 1 acc 0.0]
+    (if (<= i n)
+      (let [x (* i 1.0e-6)]
+        (recur (inc i)
+               (+ acc
+                  (Math/sqrt x)
+                  (Math/sin x)
+                  (Math/cos x)
+                  (Math/log (+ x 1.0))
+                  (Math/pow x 2.0)
+                  (Math/atan2 x 1.0))))
+      acc)))
+
+(defn run ^double [^long n] (kernel n))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 1000000)]
+    (dotimes [_ 2] (run (quot n 2)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "mathfns n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -46,7 +46,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 collections:30000 seqs:20000 transducers:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 seqs:20000 transducers:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"


### PR DESCRIPTION
The bench suite covered scalar double arithmetic (`mandelbrot`) but nothing exercised the two numeric fast paths added in 0.4.15 (#448/#449), so a regression in either would be invisible to the scorecard. Adds two portable benchmarks:

- **`arrays`** — primitive `double-array` fill (`aset`) + dot-product (`aget`) in tight loops. A `^doubles` array is a Chez flvector; `aget`/`aset` lower to `flvector-ref`/`-set!` and the surrounding arithmetic to `fl+`/`fl*`. Guards the unboxed primitive-array codegen.
- **`mathfns`** — a loop calling `java.lang.Math` (`sqrt`/`sin`/`cos`/`log`/`pow`/`atan2`) over proven doubles, which lowers to the native Chez op (`flsqrt`/`flsin`/…) typed `double`. Guards against falling back to the generic string-keyed host-static dispatch.

Both are portable Clojure (verified on jolt optimized builds and JVM Clojure), wired into `run.sh`'s `BENCHES` and the README benchmark table.

Local optimized runs (M-series): `arrays` ~690ms, `mathfns` ~382ms at the default sizes.