### PR TITLE
release: build the Linux binary in manylinux2014 (glibc 2.17 floor)

### DIFF
--- a/.github/workflows/glibc-floor.yml
+++ b/.github/workflows/glibc-floor.yml
@@ -34,9 +34,16 @@ jobs:
           - name: manylinux_2_28
             image: quay.io/pypa/manylinux_2_28_x86_64
           # glibc 2.17 (CentOS 7 base, gcc 10, maintained image — no dead-repo
-          # bit-rot) — the practical floor candidate.
+          # bit-rot) — the practical floor candidate. Its dynamic build links
+          # libncurses.so.5 (el7 ABI), dead on modern distros.
           - name: manylinux2014
             image: quay.io/pypa/manylinux2014_x86_64
+          # same base, but lz4/z/ncurses/tinfo/uuid linked STATICALLY (the .so
+          # linker symlinks are removed so -l picks the .a): floor 2.17 AND no
+          # runtime deps beyond glibc — the "runs everywhere" candidate.
+          - name: manylinux2014-static
+            image: quay.io/pypa/manylinux2014_x86_64
+            static: 1
     steps:
       - uses: actions/checkout@v5
         with:
@@ -66,6 +73,7 @@ jobs:
             -w /src \
             -e JOLT_VERSION=glibc-probe \
             -e GLIBC_FLOOR_IMAGE='${{ matrix.image }}' \
+            -e STATIC_DEPS='${{ matrix.static }}' \
             '${{ matrix.image }}' sh ci/glibc-floor-build.sh
 
       - name: Upload binary + report
@@ -83,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [ubuntu-20.04, manylinux_2_28, manylinux2014]
+        name: [ubuntu-20.04, manylinux_2_28, manylinux2014, manylinux2014-static]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/glibc-floor.yml
+++ b/.github/workflows/glibc-floor.yml
@@ -14,10 +14,6 @@ name: glibc-floor
 # (checkout/cache) can't run inside glibc-2.17-era images.
 on:
   workflow_dispatch: {}
-  # temporary self-trigger while the probe lives on its own branch
-  # (workflow_dispatch only resolves on the default branch); drop on merge.
-  push:
-    branches: [ci/glibc-floor]
 
 jobs:
   build:

--- a/.github/workflows/glibc-floor.yml
+++ b/.github/workflows/glibc-floor.yml
@@ -1,0 +1,117 @@
+name: glibc-floor
+
+# Issue #452: the released Linux binary demands GLIBC 2.35 because it is built
+# on ubuntu-22.04 — every >=2.33 symbol it needs is a build-host artifact (the
+# 2.34 libpthread/libdl merge, the 2.33 stat family, math symbol bumps), not a
+# real API requirement. This probe builds joltc inside progressively older
+# build images and smokes each result across a wide runtime matrix, to answer:
+#   1. the oldest environment that still builds Chez 10.4.1 + joltc,
+#   2. the glibc floor of each produced binary (readelf report),
+#   3. whether it runs OUT OF THE BOX (no packages installed) per distro.
+# The winner becomes the release.yml Linux build environment.
+#
+# Build images run via `docker run`, not `container:` — node-based actions
+# (checkout/cache) can't run inside glibc-2.17-era images.
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: build in ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # glibc 2.31 — the issue reporter's Ubuntu 20.04.
+          - name: ubuntu-20.04
+            image: ubuntu:20.04
+          # glibc 2.28 (AlmaLinux 8, gcc 12) — covers RHEL/Rocky 8+, Debian 10+.
+          - name: manylinux_2_28
+            image: quay.io/pypa/manylinux_2_28_x86_64
+          # glibc 2.17 (CentOS 7 base, gcc 10, maintained image — no dead-repo
+          # bit-rot) — the practical floor candidate.
+          - name: manylinux2014
+            image: quay.io/pypa/manylinux2014_x86_64
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      # Chez source on the HOST (with lz4/zlib submodules for the static
+      # fallback); mounted read-only into the build container.
+      - name: Clone Chez Scheme source
+        run: |
+          git clone --depth 1 --branch v10.4.1 --recurse-submodules \
+            https://github.com/cisco/ChezScheme.git "$HOME/chez-src"
+
+      - name: Cache Chez install
+        id: cache-chez
+        uses: actions/cache@v4
+        with:
+          path: ~/chez-opt
+          key: glibc-floor-chez-v10.4.1-${{ matrix.name }}-v1
+
+      - name: Build joltc in ${{ matrix.image }}
+        run: |
+          mkdir -p "$HOME/chez-opt"
+          docker run --rm \
+            -v "$PWD":/src \
+            -v "$HOME/chez-src":/chez-src:ro \
+            -v "$HOME/chez-opt":/opt/chez \
+            -w /src \
+            -e JOLT_VERSION=glibc-probe \
+            -e GLIBC_FLOOR_IMAGE='${{ matrix.image }}' \
+            '${{ matrix.image }}' sh ci/glibc-floor-build.sh
+
+      - name: Upload binary + report
+        uses: actions/upload-artifact@v4
+        with:
+          name: joltc-${{ matrix.name }}
+          path: |
+            target/release/joltc
+            target/release/glibc-report.txt
+
+  smoke:
+    name: smoke ${{ matrix.name }} binary
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ubuntu-20.04, manylinux_2_28, manylinux2014]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: joltc-${{ matrix.name }}
+          path: probe
+
+      - name: Smoke across runtime images
+        run: |
+          chmod +x probe/joltc
+          {
+            echo "## binary built in ${{ matrix.name }}"
+            echo
+            echo '```'
+            cat probe/glibc-report.txt
+            echo '```'
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          sh ci/glibc-floor-smoke.sh probe/joltc "$GITHUB_STEP_SUMMARY"
+
+      # The floor build must also still COMPILE apps (cc-link path) — run the
+      # self-contained build smoke on the oldest runtime that passes bare.
+      - name: Self-contained build smoke on ubuntu-20.04
+        run: |
+          docker run --rm -v "$PWD/probe":/probe:ro ubuntu:20.04 sh -c '
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update >/dev/null && apt-get install -y -qq gcc liblz4-1 zlib1g libtinfo6 >/dev/null
+            mkdir -p /app/src/app && cd /app
+            printf "{:paths [\"src\"]}\n" > deps.edn
+            printf "(ns app.core)\n(defn -main [& _] (println \"built:\" (reduce + (range 10))))\n" > src/app/core.clj
+            /probe/joltc build -m app.core -o app
+            out="$(./app)"
+            [ "$out" = "built: 45" ] || { echo "self-contained build ran: $out"; exit 1; }
+            echo "self-contained build: PASS"'

--- a/.github/workflows/glibc-floor.yml
+++ b/.github/workflows/glibc-floor.yml
@@ -14,6 +14,10 @@ name: glibc-floor
 # (checkout/cache) can't run inside glibc-2.17-era images.
 on:
   workflow_dispatch: {}
+  # temporary self-trigger while the probe lives on its own branch
+  # (workflow_dispatch only resolves on the default branch); drop on merge.
+  push:
+    branches: [ci/glibc-floor]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Oldest supported runner on purpose: the binary requires the glibc it
-          # was built against, so building on 22.04 (glibc 2.35) keeps the
-          # prebuilt runnable on Ubuntu 22.04+/Debian 12+/RHEL 9+. ubuntu-latest
-          # (24.04, glibc 2.39) shipped a binary older distros couldn't load.
-          - os: ubuntu-22.04
+          # The Linux binary is built inside a manylinux2014 container (glibc
+          # 2.17, gcc 10) with ncurses/tinfo/zlib linked statically, so the
+          # prebuilt runs on any glibc distro since ~2014 (CentOS 7+, Ubuntu
+          # 14.04+, Debian 8+, Amazon Linux 2+) — every >=2.33 symbol the old
+          # runner-built binary demanded was a build-host artifact, not a real
+          # API need (#452). Remaining dynamic deps: liblz4/libuuid + glibc.
+          - os: ubuntu-latest
             target: x86_64-linux
             shell: bash
+            container-build: quay.io/pypa/manylinux2014_x86_64
           - os: macos-14
             target: aarch64-macos
             shell: bash
@@ -53,42 +56,38 @@ jobs:
         with:
           submodules: recursive   # vendor/irregex, used by the Chez regex shim
 
-      # --- Linux: build Chez from source. The apt chezscheme ships petite+scheme
-      # only, with no kernel dev files (libkernel.a, scheme.h), which build-joltc
-      # needs to cc-link. Same setup as .github/workflows/tests.yml. ---
-      - name: Install build dependencies (Linux)
+      # --- Linux: the whole Chez + joltc build runs inside the old-glibc
+      # container (matrix.container-build) via ci/glibc-floor-build.sh — the
+      # same script the glibc-floor probe validated. docker run, not
+      # `container:`, because node-based actions can't run on a glibc-2.17
+      # image. The container writes target/release/joltc into the mounted
+      # workspace; every later step (smokes, package) runs on the host. ---
+      - name: Clone Chez Scheme source (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential git liblz4-dev zlib1g-dev libncurses-dev uuid-dev
+          git clone --depth 1 --branch v10.4.1 --recurse-submodules \
+            https://github.com/cisco/ChezScheme.git "$HOME/chez-src"
 
       - name: Cache Chez Scheme (Linux)
         if: runner.os == 'Linux'
         id: cache-chez
         uses: actions/cache@v4
         with:
-          path: /opt/chez
-          key: chez-${{ matrix.os }}-v10.4.1-x11off
+          path: ~/chez-opt
+          key: chez-manylinux2014-v10.4.1-static-v1
 
-      - name: Build Chez Scheme from source (Linux)
-        if: runner.os == 'Linux' && steps.cache-chez.outputs.cache-hit != 'true'
-        run: |
-          git clone --depth 1 --branch v10.4.1 https://github.com/cisco/ChezScheme.git /tmp/chez-src
-          cd /tmp/chez-src
-          ./configure --installprefix=/opt/chez --threads --disable-x11
-          make -j"$(nproc)"
-          sudo make install
-          sudo chown -R "$USER" /opt/chez
-
-      - name: Put chez on PATH (Linux)
+      - name: Build joltc in ${{ matrix.container-build }} (Linux)
         if: runner.os == 'Linux'
         run: |
-          # Installed as `scheme`; the build invokes `chez`. A wrapper that execs
-          # scheme keeps argv0 so Chez finds its boot files, and sits next to
-          # scheme so build.ss derives the csv dir (libkernel.a/scheme.h) from it.
-          printf '#!/bin/sh\nexec /opt/chez/bin/scheme "$@"\n' > /opt/chez/bin/chez
-          chmod +x /opt/chez/bin/chez
-          echo '/opt/chez/bin' >> "$GITHUB_PATH"
+          mkdir -p "$HOME/chez-opt"
+          docker run --rm \
+            -v "$PWD":/src \
+            -v "$HOME/chez-src":/chez-src:ro \
+            -v "$HOME/chez-opt":/opt/chez \
+            -w /src \
+            -e JOLT_VERSION="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}" \
+            -e STATIC_DEPS=1 \
+            '${{ matrix.container-build }}' sh ci/glibc-floor-build.sh
 
       # --- macOS: Homebrew chezscheme ships `chez` plus the csv kernel dev files
       # (libkernel.a, scheme.h, *.boot), which is all build-joltc needs. ---
@@ -156,6 +155,7 @@ jobs:
           chmod +x "$bindir/cc"
 
       - name: Show Chez version
+        if: runner.os != 'Linux'
         run: chez --version
 
       # --- x86_64-macos is cross-built on the arm64 runner (matrix.cross=ta6osx):
@@ -198,6 +198,7 @@ jobs:
       # JOLTC_TARGET is empty for native rows and the target machine for the cross
       # row (matrix.cross), which build-joltc.ss consumes with $JOLT_TARGET_PACK.
       - name: Build joltc (release)
+        if: runner.os != 'Linux'
         run: make joltc-release JOLTC_TARGET="${{ matrix.cross }}"
         env:
           # Bake the release tag into the binary (build-joltc falls back to

--- a/ci/glibc-floor-build.sh
+++ b/ci/glibc-floor-build.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Build joltc inside an old-glibc container to probe the lowest build
+# environment that still produces a working binary (issue #452). Run by
+# .github/workflows/glibc-floor.yml as:
+#
+#   docker run -v <workspace>:/src -v <chez-src>:/chez-src:ro -v <chez-cache>:/opt/chez \
+#     -w /src -e JOLT_VERSION=glibc-probe <image> sh ci/glibc-floor-build.sh
+#
+# The Chez source tree is cloned on the host and mounted at /chez-src. The
+# joltc link line (build.ss bld-link-libs) needs the shared dev libs:
+# -llz4 -lz -lncurses -ltinfo -luuid — so their dev packages are installed
+# here. glibc symbol versions are stamped from THIS image's glibc, which is
+# the whole point of building in an old one.
+set -eux
+
+# --- toolchain + link deps per distro family ---------------------------------
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    build-essential git ca-certificates file \
+    liblz4-dev zlib1g-dev libncurses-dev uuid-dev
+else
+  pkg="$(command -v dnf || command -v yum)"
+  # lz4-devel lives in EPEL on the centos7 family (manylinux2014); the pypa
+  # images ship a working epel repo. gcc: the manylinux images already carry a
+  # modern devtoolset gcc on PATH — only install one if none is present.
+  "$pkg" install -y epel-release || true
+  "$pkg" install -y make git file lz4-devel zlib-devel ncurses-devel libuuid-devel
+  command -v gcc >/dev/null 2>&1 || "$pkg" install -y gcc gcc-c++
+fi
+gcc --version | head -1
+ldd --version | head -1
+
+# --- Chez 10.4.1 (cached across runs via the mounted /opt/chez) --------------
+if [ ! -x /opt/chez/bin/scheme ]; then
+  # configure writes into the source tree; copy so the read-only host mount
+  # stays clean.
+  cp -a /chez-src /tmp/chez-build
+  cd /tmp/chez-build
+  ./configure --installprefix=/opt/chez --threads --disable-x11
+  make -j"$(nproc)"
+  make install
+fi
+# the jolt build invokes `chez`; keep argv0 = scheme so boot files resolve.
+printf '#!/bin/sh\nexec /opt/chez/bin/scheme "$@"\n' > /opt/chez/bin/chez
+chmod +x /opt/chez/bin/chez
+export PATH="/opt/chez/bin:$PATH"
+chez --version
+
+# --- joltc release build ------------------------------------------------------
+cd /src
+make joltc-release
+
+# --- report + in-container smoke ---------------------------------------------
+b=target/release/joltc
+{
+  echo "build image: ${GLIBC_FLOOR_IMAGE:-unknown}"
+  ldd --version | head -1
+  echo "NEEDED:"; readelf -d "$b" | grep NEEDED || true
+  echo "glibc versions:"; readelf -V "$b" | grep -o 'GLIBC_[0-9.]*' | sort -Vu
+} | tee target/release/glibc-report.txt
+file "$b"
+out="$("$b" -e '(reduce + (range 10))')"
+test "$out" = "45"
+echo "in-container smoke: PASS"

--- a/ci/glibc-floor-build.sh
+++ b/ci/glibc-floor-build.sh
@@ -18,7 +18,7 @@ if command -v apt-get >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
   apt-get install -y --no-install-recommends \
-    build-essential git ca-certificates file \
+    build-essential git ca-certificates file xxd \
     liblz4-dev zlib1g-dev libncurses-dev uuid-dev
 else
   pkg="$(command -v dnf || command -v yum)"
@@ -27,6 +27,8 @@ else
   # modern devtoolset gcc on PATH — only install one if none is present.
   "$pkg" install -y epel-release || true
   "$pkg" install -y make git file lz4-devel zlib-devel ncurses-devel libuuid-devel
+  # xxd (build-joltc embeds the boot as C bytes) ships in vim-common on el-family
+  command -v xxd >/dev/null 2>&1 || "$pkg" install -y vim-common
   command -v gcc >/dev/null 2>&1 || "$pkg" install -y gcc gcc-c++
 fi
 gcc --version | head -1

--- a/ci/glibc-floor-build.sh
+++ b/ci/glibc-floor-build.sh
@@ -30,6 +30,22 @@ else
   # xxd (build-joltc embeds the boot as C bytes) ships in vim-common on el-family
   command -v xxd >/dev/null 2>&1 || "$pkg" install -y vim-common
   command -v gcc >/dev/null 2>&1 || "$pkg" install -y gcc gcc-c++
+  [ -n "${STATIC_DEPS:-}" ] && { "$pkg" install -y ncurses-static zlib-static || true; \
+                                 "$pkg" install -y lz4-static libuuid-static || true; }
+fi
+
+# STATIC_DEPS=1: make -llz4/-lz/-lncurses/-ltinfo/-luuid resolve to the static
+# archives by removing the .so linker symlinks (only where a .a exists, so a
+# missing static package degrades to the shared lib instead of a link error).
+# The result should need nothing at runtime beyond glibc itself.
+if [ -n "${STATIC_DEPS:-}" ]; then
+  for lib in lz4 z ncurses tinfo uuid; do
+    for d in /usr/lib64 /usr/lib /usr/lib/x86_64-linux-gnu; do
+      if [ -f "$d/lib$lib.a" ] && [ -e "$d/lib$lib.so" ]; then
+        rm -f "$d/lib$lib.so"; echo "static-deps: lib$lib -> $d/lib$lib.a"
+      fi
+    done
+  done
 fi
 gcc --version | head -1
 ldd --version | head -1

--- a/ci/glibc-floor-build.sh
+++ b/ci/glibc-floor-build.sh
@@ -33,20 +33,6 @@ else
   [ -n "${STATIC_DEPS:-}" ] && { "$pkg" install -y ncurses-static zlib-static || true; \
                                  "$pkg" install -y lz4-static libuuid-static || true; }
 fi
-
-# STATIC_DEPS=1: make -llz4/-lz/-lncurses/-ltinfo/-luuid resolve to the static
-# archives by removing the .so linker symlinks (only where a .a exists, so a
-# missing static package degrades to the shared lib instead of a link error).
-# The result should need nothing at runtime beyond glibc itself.
-if [ -n "${STATIC_DEPS:-}" ]; then
-  for lib in lz4 z ncurses tinfo uuid; do
-    for d in /usr/lib64 /usr/lib /usr/lib/x86_64-linux-gnu; do
-      if [ -f "$d/lib$lib.a" ] && [ -e "$d/lib$lib.so" ]; then
-        rm -f "$d/lib$lib.so"; echo "static-deps: lib$lib -> $d/lib$lib.a"
-      fi
-    done
-  done
-fi
 gcc --version | head -1
 ldd --version | head -1
 
@@ -65,6 +51,23 @@ printf '#!/bin/sh\nexec /opt/chez/bin/scheme "$@"\n' > /opt/chez/bin/chez
 chmod +x /opt/chez/bin/chez
 export PATH="/opt/chez/bin:$PATH"
 chez --version
+
+# STATIC_DEPS=1: make -llz4/-lz/-lncurses/-ltinfo/-luuid resolve to the static
+# archives for the JOLTC link by removing the .so linker symlinks (only where a
+# .a exists, so a missing static package degrades to the shared lib instead of
+# a link error). Runs AFTER the Chez build — Chez's own scheme links -lncurses
+# without -ltinfo, which only resolves via the shared lib's transitive tinfo
+# dep; jolt's link line names both, so the static archives satisfy it. The
+# result should need nothing at runtime beyond glibc itself.
+if [ -n "${STATIC_DEPS:-}" ]; then
+  for lib in lz4 z ncurses tinfo uuid; do
+    for d in /usr/lib64 /usr/lib /usr/lib/x86_64-linux-gnu; do
+      if [ -f "$d/lib$lib.a" ] && [ -e "$d/lib$lib.so" ]; then
+        rm -f "$d/lib$lib.so"; echo "static-deps: lib$lib -> $d/lib$lib.a"
+      fi
+    done
+  done
+fi
 
 # --- joltc release build ------------------------------------------------------
 cd /src

--- a/ci/glibc-floor-smoke.sh
+++ b/ci/glibc-floor-smoke.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Smoke a built joltc across runtime containers, bare first (out-of-the-box)
+# and, when bare fails, again after installing the runtime shared libs
+# (liblz4/zlib/libtinfo) — so the summary distinguishes "glibc too old, will
+# never run" from "runs once the usual libs are present" (container images are
+# more minimal than real installs: on desktop/server distros systemd drags in
+# liblz4 and bash drags in libtinfo, so 'with deps' approximates a real box).
+# Usage: ci/glibc-floor-smoke.sh <path-to-joltc> <summary-md-out>
+# Runs ON THE HOST; drives `docker run` per runtime image.
+set -eu
+joltc="$1"; summary="$2"
+dir="$(cd "$(dirname "$joltc")" && pwd)"
+
+DEB='export DEBIAN_FRONTEND=noninteractive; apt-get update >/dev/null 2>&1; apt-get install -y -qq liblz4-1 zlib1g libtinfo6 >/dev/null 2>&1'
+RPM='( dnf install -y -q lz4-libs ncurses-libs zlib || dnf install -y -q lz4-libs ncurses-libs zlib-ng-compat || yum install -y -q lz4 ncurses-libs zlib ) >/dev/null 2>&1'
+
+# image | glibc note | dep install for the retry
+IMAGES="
+ubuntu:20.04|2.31|$DEB
+ubuntu:22.04|2.35|$DEB
+ubuntu:24.04|2.39|$DEB
+debian:11|2.31|$DEB
+debian:12|2.36|$DEB
+rockylinux:8|2.28|$RPM
+rockylinux:9|2.34|$RPM
+amazonlinux:2|2.26|$RPM
+amazonlinux:2023|2.34|$RPM
+fedora:latest|current|$RPM
+alpine:3.20|musl|true
+"
+
+echo "| runtime image | glibc | bare | with deps |" >> "$summary"
+echo "|---|---|---|---|" >> "$summary"
+
+run_smoke() { # $1=image $2=setup-cmd ("" for bare)
+  docker run --rm -v "$dir":/probe:ro "$1" sh -c \
+    "${2:+$2; }out=\$(/probe/joltc -e '(reduce + (range 10))' 2>&1); if [ \"\$out\" = 45 ]; then echo SMOKE-PASS; else echo \"SMOKE-FAIL: \$(echo \"\$out\" | head -1)\"; fi" \
+    2>&1 | grep '^SMOKE-' | tail -1
+}
+
+echo "$IMAGES" | while IFS='|' read -r img glibc inst; do
+  [ -n "$img" ] || continue
+  bare="$(run_smoke "$img" "" || echo "SMOKE-FAIL: docker run failed")"
+  if [ "$bare" = "SMOKE-PASS" ]; then
+    bcell="PASS"; dcell="-"
+  else
+    bcell="FAIL \`$(echo "$bare" | sed 's/^SMOKE-FAIL: //' | cut -c1-80 | sed 's/|/\\|/g')\`"
+    deps="$(run_smoke "$img" "$inst" || echo SMOKE-FAIL)"
+    case "$deps" in SMOKE-PASS) dcell="PASS";; *) dcell="FAIL";; esac
+  fi
+  echo "| $img | $glibc | $bcell | $dcell |" >> "$summary"
+done


### PR DESCRIPTION
Fixes #452.

The released Linux joltc demanded GLIBC 2.35 because it was built on the ubuntu-22.04 runner. Inspecting the v0.4.15 binary: every >=2.33 symbol it needs is a build-host artifact — the 2.34 libpthread/libdl-into-libc merge, the 2.33 stat family, math symbol version bumps (exp/log/pow@2.29, hypot@2.35) — not a real API requirement. The genuine floor is ~2.17.

Two parts:

- ci/glibc-floor.yml + scripts: a dispatchable probe that builds joltc inside ubuntu:20.04 (glibc 2.31), manylinux_2_28 (2.28), and manylinux2014 (2.17, plain + static-deps), then smokes each binary across 11 runtime images (Ubuntu 20.04-24.04, Debian 11/12, Rocky 8/9, Amazon Linux 2/2023, Fedora, Alpine-musl) bare and with deps, plus a self-contained app-build smoke. Findings: Chez 10.4.1 + joltc build fine even at 2.17; the plain 2.17 build links libncurses.so.5 (dead on modern distros); the static-deps variant (ncurses/tinfo/zlib static via de-symlinking, so Chez itself still builds normally) passes everything.
- release.yml: the Linux row now builds inside manylinux2014 with the static treatment via docker run (node-based actions can't run on a glibc-2.17 image, so the runner stays ubuntu-latest). Resulting binary: needs glibc >=2.17 + liblz4/libuuid, statically carries ncurses/tinfo/zlib — runs on any glibc distro since ~2014 (CentOS 7+, Ubuntu 14.04+, Debian 8+, Amazon Linux 2+).

Validated by four probe runs on this branch (last: all builds green, static binary green across the smoke matrix incl. the app-build smoke on ubuntu:20.04). A release dry-run (workflow_dispatch of release.yml on this branch — publish steps are tag-gated, so nothing uploads) is the remaining check before merge.