### PR TITLE
jolt-flaget/flaset: fixnum-first index path

### DIFF
--- a/host/chez/java/natives-array.ss
+++ b/host/chez/java/natives-array.ss
@@ -174,12 +174,18 @@
 ;; unboxed read target for (aget ^doubles a i): direct flvector-ref on the backing,
 ;; skipping jolt-nth's case-lambda + jolt-array?/flvector? dispatch. Emitted only
 ;; when jolt.passes.numeric proved the array is a ^doubles/^floats (flvector) param.
-(define (jolt-flaget a i) (flvector-ref (jolt-array-vec a) (exact (na-idx i))))
+;; The index takes a fixnum?-first fast path: a proven-:long loop counter is always
+;; a fixnum, and the (exact (na-idx i)) coercion (two procedure calls) was the
+;; dominant per-access cost in the hot loop. Non-fixnum indices (flonum/bignum/
+;; ratio) keep the coercing path unchanged; out-of-range still raises via
+;; flvector-ref's range check (the array bounds contract).
+(define (jolt-flaget a i)
+  (flvector-ref (jolt-array-vec a) (if (fixnum? i) i (exact (na-idx i)))))
 ;; unboxed write target for (aset ^doubles a i v): direct flvector-set!, returning
-;; the stored flonum (JVM aset returns the val).
+;; the stored flonum (JVM aset returns the val). Same fixnum-first index path.
 (define (jolt-flaset a i v)
   (let ((fv (if (flonum? v) v (exact->inexact v))))
-    (flvector-set! (jolt-array-vec a) (exact (na-idx i)) fv) fv))
+    (flvector-set! (jolt-array-vec a) (if (fixnum? i) i (exact (na-idx i))) fv) fv))
 
 ;; --- array identity: type / class / instance? recognize arrays ---------------
 ;; (type arr) / (class arr) -> the JVM array class name; (class …) delegates to

--- a/host/chez/run-flarr.ss
+++ b/host/chez/run-flarr.ss
@@ -24,4 +24,28 @@
   (gate-check "(4) ^doubles LET-binding aget -> jolt-flaget" (gate-sub? e "jolt-flaget") #t))
 (let ((e (emit-num "(def _ (fn [m ^long i] (let [^doubles a (:pixels m)] (+ (aget a i) (aget a i)))))")))
   (gate-check "(5) arithmetic over ^doubles let read -> fl+" (gate-sub? e "fl+") #t))
+
+;; --- runtime value semantics of jolt-flaget/jolt-flaset ---------------------------
+;; Pin both index paths: the fixnum fast path (the hot case — loop counters are
+;; :long) and the coercing slow path (flonum index floors via na-idx). Guards the
+;; fast-path change against behavior drift: aset returns the stored value (JVM
+;; contract), an int value stores as its double, and an out-of-range or negative
+;; index raises (flvector-ref's range check = the array bounds contract).
+(define (ev s) (jolt-compile-eval s "user"))
+(gate-check "(6) aget fixnum index reads the stored double"
+            (ev "(let [^doubles a (double-array 3)] (aset a 1 7.25) (aget a 1))") 7.25)
+(gate-check "(6) aset returns the stored value"
+            (ev "(let [^doubles a (double-array 3)] (aset a 1 7.25))") 7.25)
+(gate-check "(6) aset of an int value stores its double"
+            (ev "(let [^doubles a (double-array 3)] (aset a 0 4) (aget a 0))") 4.0)
+(gate-check "(6) aget flonum index 1.0 floors to slot 1"
+            (ev "(let [^doubles a (double-array 3)] (aset a 1 7.25) (aget a 1.0))") 7.25)
+(gate-check "(6) aget flonum index 1.5 floors to slot 1"
+            (ev "(let [^doubles a (double-array 3)] (aset a 1 7.25) (aget a 1.5))") 7.25)
+(gate-check "(6) aget out-of-range fixnum index raises (catchable)"
+            (jolt-truthy? (ev "(try (let [^doubles a (double-array 3)] (aget a 5) false) (catch Throwable e true))")) #t)
+(gate-check "(6) aget negative index raises (catchable)"
+            (jolt-truthy? (ev "(try (let [^doubles a (double-array 3)] (aget a -1) false) (catch Throwable e true))")) #t)
+(gate-check "(6) aset out-of-range index raises (catchable)"
+            (jolt-truthy? (ev "(try (let [^doubles a (double-array 3)] (aset a 9 1.0) false) (catch Throwable e true))")) #t)
 (gate-summary "flarr")


### PR DESCRIPTION
arrays bench round 2 (after #454's counter typing): the dominant per-access cost in the unboxed aget/aset path was the (exact (na-idx i)) index coercion — two procedure calls on an index that is a proven-:long fixnum in every hot case. Take the fixnum directly; flonum/bignum indices keep the coercing path unchanged, and out-of-range still raises via flvector-ref's range check.

A/B/A vs main (isolated, 5 runs, A1≈A2 clean):

| bench | main | this | |
|---|---|---|---|
| arrays | 570.7 | 342.9 | 15.6x -> 9.3x JVM |
| mathfns / mandelbrot / fib / collections / binary-trees | | | flat |

run-flarr.ss grows runtime fixtures pinning both index paths (aset return value, int-value storage, flonum-index flooring, OOB/negative raises) — added before the change to pin current behavior, green on both sides. Full make test green; runtime-only change, no remint.

Remaining arrays gap is the O2 checked flvector-ref/record accessor + flonum boxing at the procedure boundary (my earlier ~180ms replica projection was measured at O3 — jolt binaries are O2, so the wrapper costs more there); emit-side inlining of proven aget sites is the queued next lever. Also noted while pinning behavior: OOB on primitive arrays raises a generic :object-classed error, not ArrayIndexOutOfBoundsException (jolt-po75).