### PR TITLE
perf: concat a seq of colls with one cell per element (seqs 558ms -> 382ms)

### DIFF
--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -951,14 +951,33 @@
             (else (concat2 (jolt-seq (car colls)) (lambda () (apply jolt-concat (cdr colls))))))))))
 
 ;; Lazily concatenate a (possibly infinite) SEQ of colls — what (apply concat ss)
-;; means, but without realizing ss. Pulls one coll at a time, concatenating it with
-;; a lazy tail, so mapcat / (apply concat …) over an infinite source stays lazy.
+;; means, but without realizing ss. Pulls one coll at a time, so mapcat /
+;; (apply concat …) over an infinite source stays lazy.
+;;
+;; Emits ONE cseq cell per ELEMENT and nothing per collection boundary. Routing
+;; through jolt-concat instead — (jolt-concat inner (make-lazy-seq …)) — cost a
+;; lazyseq node + closure for the tail, a second node + closure inside
+;; jolt-concat (plus its variadic rest-args list), and a third through
+;; `apply jolt-concat` when forced: ~3 nodes and ~5 closures per inner
+;; collection, which dominates when the inner colls are small (mapcat over
+;; 2-element lists is the common shape).
+;;
+;; An empty inner coll is skipped without emitting a cell, and the outer seq is
+;; advanced only at a boundary — so f runs once per inner collection, lazily,
+;; exactly as before.
 (define (lazy-concat-seq ss)
-  (let ((s (jolt-seq ss)))
+  (let outer ((s (jolt-seq ss)))
     (if (jolt-nil? s)
         jolt-empty-list
-        (jolt-concat (seq-first s)
-                     (jolt-make-lazy-seq (lambda () (lazy-concat-seq (seq-more s))))))))
+        (let inner ((cur (jolt-seq (seq-first s))))
+          (if (jolt-nil? cur)
+              (outer (jolt-seq (seq-more s)))          ; empty inner: skip, no cell
+              (cseq-lazy (seq-first cur)
+                         (lambda ()
+                           (let ((nx (jolt-seq (seq-more cur))))
+                             (if (jolt-nil? nx)
+                                 (outer (jolt-seq (seq-more s)))   ; boundary
+                                 (inner nx))))))))))
 
 ;; (apply f a b ... coll): spread the trailing seqable into the call. concat is
 ;; special-cased: it produces a LAZY result, so spreading an infinite tail through


### PR DESCRIPTION
Follow-up to #463. With `iterate` fixed, `mapcat` became the largest remaining piece of `seqs`: 302ms for 800k elements where `into []` over a chunked source is 60ms.

**Cause.** `lazy-concat-seq` — which both `mapcat` and `(apply concat ss)` route through — built every inner collection via `jolt-concat`:

- a lazyseq node + closure for the lazy tail,
- a second node + closure inside `jolt-concat` (plus its variadic rest-args list),
- a third through `apply jolt-concat` when forced.

That is roughly three lazy nodes and five closures to yield a two-element inner list — and two-element inner lists are the common `mapcat` shape. The per-boundary cost swamped the per-element work.

**Fix.** Walk the inner seqs directly, emitting one `cseq` cell per *element* and nothing at a collection boundary. An empty inner coll is skipped without emitting a cell, and the outer seq advances only at a boundary.

**Semantics verified, not assumed.** Values, empty inner collections, and laziness over an infinite source all check out, and the realization counts are identical to the previous build — `f` called 0 times at construction and 32 after `first` (the 32 is `map`'s chunking over `range`, unchanged). Both before and after, jolt is *lazier* than the JVM here, which reports 32 at construction; that pre-existing difference comes from mapcat's outer deferral and is untouched.

**Measured** (A/B/A, `--direct-link --opt`, `COMPILER_FILES=host/chez/seq.ss`): seqs **557.6 / 381.9 / 564.0 ms** — 31% faster on top of #463. transducers 229.7/232.8/232.6, collections 22.0/22.9/22.1, binary-trees 276.5/277.1/277.1 — flat. Component level: `mapcat` 302ms -> 122ms, `(apply concat (map f …))` 356ms -> 116ms, the `expand` phase 396ms -> 230ms.

Taken with #463, `seqs` goes 913ms -> ~404ms against the JVM's 147ms — from ~6.2x to ~2.7x. Runtime-only change, no re-mint. Full `make test` green: selfhost fixpoint holds, corpus 0 NEW divergences, certify 34/34 known / 0 new / 0 stale.