### PR TITLE
Run a real library's test suite: eight JVM-interop fixes

### DIFF
--- a/host/chez/converters.ss
+++ b/host/chez/converters.ss
@@ -53,10 +53,19 @@
 ;; "Infinity"…), but a COLLECTION renders as its readable form — nested strings
 ;; are QUOTED ((str ["x"]) => "[\"x\"]"), matching the JVM (a collection's
 ;; toString is readable). jolt-pr-readable resolves at call time.
+;; A host type whose own toString must win over the rendering below — set by
+;; records.ss for a deftype/record that declares one. Returns the string, or #f to
+;; fall through. Kept as one hook rather than a registry arm because the arms are
+;; only reached for values no branch here claims, and a record is claimed.
+(define str-tostring-hook #f)
+(define (set-str-tostring-hook! f) (set! str-tostring-hook f))
 (define (jolt-str-one v)
-  (if (or (pvec? v) (pmap? v) (pset? v) (cseq? v) (empty-list-t? v) (jolt-lazyseq? v))
-      (jolt-pr-readable v)
-      (jolt-str-render-one v)))
+  (let ((own (and str-tostring-hook (str-tostring-hook v))))
+    (cond
+      ((string? own) own)
+      ((or (pvec? v) (pmap? v) (pset? v) (cseq? v) (empty-list-t? v) (jolt-lazyseq? v))
+       (jolt-pr-readable v))
+      (else (jolt-str-render-one v)))))
 (define (jolt-str . xs)
   (cond
     ((null? xs) "")

--- a/host/chez/dce.ss
+++ b/host/chez/dce.ss
@@ -89,6 +89,9 @@
     "clojure.core/make-hierarchy" "clojure.core/read" "clojure.core/read-string"
     "clojure.core/read+string" "clojure.core/realized?" "clojure.core/reset!"
     "clojure.core/send"
+    ;; the LispReader$StringReader shim (host-static-methods.ss) pulls the literal
+    ;; off the reader it is handed, a line at a time, through the IReader method
+    "clojure.core/-read-line"
     ;; post-prelude taxonomy wrappers close over the overlay versions
     "clojure.core/ifn?" "clojure.core/seqable?" "clojure.core/inst-ms"
     ;; the fn print form wraps the overlay __print1

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -853,11 +853,17 @@
                ((or (string=? method-name "toString")) (regex-t-source obj))
                ;; (.matcher pattern s) -> a Matcher (matcher-t) for stepping matches.
                ((string=? method-name "matcher") (jolt-re-matcher obj (car rest)))
+               ;; .flags — the int Pattern was compiled with. jolt has no compile-time
+               ;; flag argument, so the only flags a pattern can carry are the inline
+               ;; ones it opens with; read those. Callers use it to decide whether a
+               ;; pattern is one they can handle (test.chuck's string-from-regex).
+               ((string=? method-name "flags") (rx-inline-flags (regex-t-source obj)))
                (else (throw-jvm (quote IllegalArgumentException) (string-append "No matching method " method-name " for java.util.regex.Pattern")))))
         ;; java.util.regex.Matcher: .matches (anchored whole-region), .find
         ;; (next match), .group [n], .groupCount.
         ((jolt-matcher? obj)
          (cond ((string=? method-name "matches") (jolt-matcher-matches obj))
+               ((string=? method-name "lookingAt") (jolt-matcher-looking-at obj))
                ((string=? method-name "find") (not (jolt-nil? (jolt-re-find obj))))
                ((string=? method-name "group") (apply jolt-matcher-group obj rest))
                ((string=? method-name "groupCount") (jolt-matcher-group-count obj))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -172,9 +172,14 @@
 (register-class-statics! "clojure.lang.RT" (list (cons "map" rt-map)))
 
 ;; clojure.lang.PersistentList/create: a list (in order) from a seq; empty -> ().
+;; Build it the way clojure.core/list does — list->cseq alone yields plain seq
+;; cells, and jolt marks the HEAD cell to record that a chain IS a list, so an
+;; unmarked one answers `list?` false while still reporting class PersistentList.
+;; clojure.tools.reader reads every list through here, and a consumer that asks
+;; `list?` (clojure.tools.namespace's ns-decl?, say) would reject the result.
 (define (plist-create x)
   (let ((items (seq->list (jolt-seq x))))
-    (if (null? items) jolt-empty-list (list->cseq items))))
+    (if (null? items) jolt-empty-list (apply jolt-list items))))
 (register-class-statics! "PersistentList" (list (cons "create" plist-create)))
 (register-class-statics! "clojure.lang.PersistentList" (list (cons "create" plist-create)))
 
@@ -536,4 +541,44 @@
 ;; (Object.) — a fresh value with distinct identity (libraries use it as a lock
 ;; or a unique sentinel). Each call returns a new jhost so identical?/= separate.
 (register-class-ctor! "Object" (lambda _ (make-jhost "object" (vector))))
+
+;; ---- clojure.lang.LispReader$StringReader -----------------------------------
+;; The JVM reader's string-literal handler. It is package-private, but a library
+;; that wants Clojure's own escape rules without eval reaches for it anyway:
+;; instaparse (via test.chuck) instantiates one and applies it to read a grammar's
+;; quoted string. On the JVM it is constructed with no args and CALLED as a
+;; function — (reader initch) on Clojure <= 1.6, (reader initch opts pending) after
+;; — so the ctor here hands back a procedure with that convention rather than an
+;; object; nothing ever reads a field or calls a method on it.
+;;
+;; It consumes the literal's BODY, up to and including the closing quote, and
+;; returns the unescaped string. Characters come from the jolt reader the caller
+;; passes (with-in-str binds *in* to one). IReader hands out lines rather than
+;; chars, so the body is accumulated a line at a time until the terminating quote
+;; appears, then parsed by the same helper jolt's own reader uses — so \n, \uXXXX
+;; and the octal escapes all agree with the reader proper.
+;;
+;; Anything after the closing quote is consumed rather than pushed back: IReader
+;; has no push-back, and the callers build a reader per literal and drop it. A
+;; caller that shared one reader across reads would lose the remainder, so this is
+;; deliberately not registered as a general-purpose reader.
+(define (lrsr-terminated? s)
+  (let ((n (string-length s)))
+    (let loop ((i 0))
+      (cond ((fx>=? i n) #f)
+            ((char=? (string-ref s i) #\\) (loop (fx+ i 2)))
+            ((char=? (string-ref s i) #\") #t)
+            (else (loop (fx+ i 1)))))))
+(define (lrsr-read-literal rdr)
+  (let ((read-line-fn (var-deref "clojure.core" "-read-line")))
+    (let loop ((acc ""))
+      (if (lrsr-terminated? acc)
+          (let-values (((v _) (rdr-read-string-lit acc 0 (string-length acc)))) v)
+          (let ((line (jolt-invoke1 read-line-fn rdr)))
+            (if (jolt-nil? line)
+                (throw-jvm 'RuntimeException "EOF while reading string")
+                (loop (string-append acc line "\n"))))))))
+(for-each (lambda (nm)
+            (register-class-ctor! nm (lambda _ (lambda (rdr . _) (lrsr-read-literal rdr)))))
+          '("LispReader$StringReader" "clojure.lang.LispReader$StringReader"))
 

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -366,9 +366,18 @@
       (if (or (jolt-nil? b) (and (number? b) (< b 0)))
           (u8-list->bytevector (reverse acc))
           (loop (cons (bitwise-and (jnum->exact b) #xff) acc))))))
+;; Reading a path that isn't there is java.io.FileNotFoundException on the JVM, and
+;; libraries branch on it: instaparse decides whether its argument is a grammar or
+;; a file by slurping and catching FNF. A raw Chez open-input-file condition is not
+;; catchable as that class, so the caller's fallback never runs.
+(define (slurp-path path)
+  (unless (file-exists? path)
+    (throw-jvm (quote java.io.FileNotFoundException)
+               (string-append path " (No such file or directory)")))
+  (read-file-string path))
 (define (jolt-slurp src . opts)
   (cond
-    ((jfile? src) (read-file-string (jfile-fs src)))
+    ((jfile? src) (slurp-path (jfile-fs src)))
     ((embedded-res? src)
      (let ((c (embedded-res-content src)))
        (if (bytevector? c) (utf8->string c) c)))
@@ -381,7 +390,7 @@
     ;; a byte input-stream shim (e.g. clj-http-lite's :as :stream body): drain it.
     ((and (htable? src) (jolt-truthy? (jolt-ref-get src (keyword "jolt" "input-stream"))))
      (decode-bytevector (drain-byte-stream src) (slurp-encoding opts)))
-    ((string? src) (read-file-string (project-relative src)))
+    ((string? src) (slurp-path (project-relative src)))
     (else (throw-jvm (quote IllegalArgumentException) (string-append "Cannot open <" (jolt-final-str src) "> as a Reader")))))
 
 (define (spit-append? opts)

--- a/host/chez/natives-seq.ss
+++ b/host/chez/natives-seq.ss
@@ -239,11 +239,20 @@
 
 ;; clojure.core/unchecked-* — host-defined wrapping (Java long) arithmetic from
 ;; seq.ss. def-var!'d here because def-var! isn't bound when seq.ss loads.
-(let ((d! (lambda (n v) (def-var! "clojure.core" n v))))
-  (d! "unchecked-add" jolt-unchecked-add)        (d! "unchecked-add-int" jolt-unchecked-add)
-  (d! "unchecked-subtract" jolt-unchecked-sub)   (d! "unchecked-subtract-int" jolt-unchecked-sub)
-  (d! "unchecked-multiply" jolt-unchecked-mul)   (d! "unchecked-multiply-int" jolt-unchecked-mul)
-  (d! "unchecked-negate" jolt-uncneg)            (d! "unchecked-negate-int" jolt-uncneg)
-  (d! "unchecked-inc" jolt-uncinc)               (d! "unchecked-inc-int" jolt-uncinc)
-  (d! "unchecked-dec" jolt-uncdec)               (d! "unchecked-dec-int" jolt-uncdec)
-  (d! "unchecked-divide-int" jolt-unchecked-div) (d! "unchecked-remainder-int" jolt-unchecked-rem))
+;; The -int variants are INT-width: they wrap at 32 bits, not 64. Aliasing them to
+;; the long ops let a value climb past 2^31 and then blow up at the next (int x) —
+;; instaparse's hash mixing (unchecked-multiply-int in a loop) is exactly that
+;; shape. jolt-unchecked-int does the wrap-and-sign-fold, so each -int op is its
+;; long counterpart folded back to 32 bits, which is what the JVM's int overflow is.
+(let ((d! (lambda (n v) (def-var! "clojure.core" n v)))
+      (as-int (lambda (f) (lambda args (jolt-unchecked-int (apply f args))))))
+  (d! "unchecked-add" jolt-unchecked-add)        (d! "unchecked-add-int" (as-int jolt-unchecked-add))
+  (d! "unchecked-subtract" jolt-unchecked-sub)   (d! "unchecked-subtract-int" (as-int jolt-unchecked-sub))
+  (d! "unchecked-multiply" jolt-unchecked-mul)   (d! "unchecked-multiply-int" (as-int jolt-unchecked-mul))
+  (d! "unchecked-negate" jolt-uncneg)            (d! "unchecked-negate-int" (as-int jolt-uncneg))
+  (d! "unchecked-inc" jolt-uncinc)               (d! "unchecked-inc-int" (as-int jolt-uncinc))
+  (d! "unchecked-dec" jolt-uncdec)               (d! "unchecked-dec-int" (as-int jolt-uncdec))
+  ;; quotient/remainder of two ints is already in range; the fold is a no-op except
+  ;; at Integer/MIN_VALUE / -1, where the JVM also wraps back to MIN_VALUE.
+  (d! "unchecked-divide-int" (as-int jolt-unchecked-div))
+  (d! "unchecked-remainder-int" (as-int jolt-unchecked-rem)))

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -817,6 +817,19 @@
 (def-var! "jolt.host" "jrec-method?"
   (lambda (v name) (if (and (jrec? v) (find-method-any-protocol (jrec-tag v) name)) #t #f)))
 
+;; (str x) is x.toString() on the JVM, so a deftype/record that DECLARES toString
+;; renders through it. A defrecord's automatic map rendering is not a declared
+;; method, so only an explicit impl takes over; pr-str is untouched, which is also
+;; the JVM split (pr of a record shows its map whatever toString says).
+;; instaparse's Segment -- a CharSequence view over a string -- is one such type.
+;; Hooked here rather than through register-str-render!: a record is matched by an
+;; earlier collection arm and never reaches that registry.
+(set-str-tostring-hook!
+  (lambda (v)
+    (and (jrec? v)
+         (find-method-any-protocol (jrec-tag v) "toString")
+         (record-method-dispatch v "toString" jolt-nil))))
+
 ;; host type-tag candidates for a non-record value (extend-protocol on builtins).
 (define (value-host-tags obj)
   ;; numbers dispatch by actual type (a Double is NOT a Long): flonum -> Double,

--- a/host/chez/regex.ss
+++ b/host/chez/regex.ss
@@ -186,8 +186,10 @@
 ;; nil; .groupCount is the pattern's capturing-group count.
 (define (jolt-matcher-matches m)
   (let ((mm (irregex-match (matcher-t-irx m) (matcher-t-str m))))
-    (matcher-t-last-set! m mm)
-    (if mm #t #f)))
+    ;; like .lookingAt, anchored at the region start rather than the find cursor,
+    ;; and a success moves the cursor past the match so a following .find resumes
+    ;; where the JVM's would instead of re-finding what was just matched.
+    (if mm (matcher-note-match! m mm) (begin (matcher-t-last-set! m #f) #f))))
 (define (jolt-matcher-group m . n)
   (let ((last (matcher-t-last m)))
     (if last
@@ -195,19 +197,26 @@
           (if s s jolt-nil))
         (jolt-throw (jolt-ex-info "No match available" (jolt-hash-map))))))
 (define (jolt-matcher-group-count m) (irregex-num-submatches (matcher-t-irx m)))
-;; .lookingAt: anchored at the START of the region, but the match need not reach
-;; the end — the middle ground between .matches (whole region) and .find (anywhere).
-;; irregex has no prefix-match entry point, so search from the origin and keep the
-;; result only when it begins there: the engine is leftmost-first, so if any match
-;; starts at the origin the search returns that one. Remembers it for .group, as
-;; the JVM does. (instaparse's regexp terminal is .lookingAt + .group.)
+;; .lookingAt: anchored at the region START, matching a PREFIX — the middle ground
+;; between .matches (the whole region) and .find (anywhere). It does NOT resume
+;; from the find cursor: on the JVM both .matches and .lookingAt anchor at the
+;; region's own start, a field only reset/region move, so a .lookingAt after a
+;; .find re-anchors at the beginning. jolt models no region, so that start is 0.
+;;
+;; irregex has no prefix-match entry point, so search from 0 and keep the result
+;; only when it begins there — the engine is leftmost-first, so if any match starts
+;; at 0 the search finds that one. On success the find cursor moves to the match
+;; end, so a following .find continues after it the way the JVM's does.
+;; (instaparse's regexp terminal is .lookingAt + .group.)
+(define (matcher-note-match! m mm)
+  (matcher-t-last-set! m mm)
+  (let ((ms (irregex-match-start-index mm 0)) (e (irregex-match-end-index mm 0)))
+    (matcher-t-pos-set! m (if (> e ms) e (+ e 1))))
+  #t)
 (define (jolt-matcher-looking-at m)
-  (let* ((str (matcher-t-str m))
-         (start (matcher-t-pos m))
-         (mm (and (<= start (string-length str))
-                  (irregex-search (matcher-t-irx m) str start))))
-    (if (and mm (= (irregex-match-start-index mm 0) start))
-        (begin (matcher-t-last-set! m mm) #t)
+  (let ((mm (irregex-search (matcher-t-irx m) (matcher-t-str m) 0)))
+    (if (and mm (= (irregex-match-start-index mm 0) 0))
+        (matcher-note-match! m mm)
         (begin (matcher-t-last-set! m #f) #f))))
 
 ;; All non-overlapping matches, left to right. Advance past each match end (or by

--- a/host/chez/regex.ss
+++ b/host/chez/regex.ss
@@ -113,9 +113,45 @@
 (define-record-type matcher-t
   (fields irx str (mutable pos) (mutable last))
   (nongenerative jolt-matcher-v1))
+;; The regex entry points take a CharSequence on the JVM, not just a String, and a
+;; library that wants to match over a WINDOW of a larger string passes its own
+;; implementation rather than copying — instaparse's Segment is a deftype with
+;; length/charAt/subSequence/toString. irregex works on Scheme strings, so realize
+;; one through the type's own toString. A value that is not a CharSequence is
+;; handed through untouched, so it still fails where it would have.
+(define (rx-charseq->string s)
+  (if (string? s)
+      s
+      (let ((tostr (and (jrec? s) (find-method-any-protocol (jrec-tag s) "toString"))))
+        (if tostr (record-method-dispatch s "toString" jolt-nil) s))))
 (define (jolt-re-matcher re s)
-  (make-matcher-t (regex-t-irx (jolt-re-pattern re)) s 0 #f))
+  (make-matcher-t (regex-t-irx (jolt-re-pattern re)) (rx-charseq->string s) 0 #f))
 (define (jolt-matcher? x) (matcher-t? x))
+
+;; java.util.regex.Pattern.flags(). jolt compiles a pattern from its source alone,
+;; so the flags it carries are the ones written inline at the front — (?i), (?is)
+;; and friends. Values are the Pattern constants, so a caller comparing against
+;; Pattern/CASE_INSENSITIVE sees what it expects. A flag set later in the pattern
+;; is scoped to that group on the JVM too, so it correctly doesn't count here.
+(define (rx-inline-flags src)
+  (let ((n (string-length src)))
+    (if (or (fx<? n 3)
+            (not (char=? (string-ref src 0) #\())
+            (not (char=? (string-ref src 1) #\?)))
+        0
+        (let loop ((i 2) (acc 0))
+          (if (fx>=? i n)
+              0                                  ; unterminated: not a flag group
+              (let ((c (string-ref src i)))
+                (case c
+                  ((#\)) acc)
+                  ((#\i) (loop (fx+ i 1) (fxlogor acc 2)))    ; CASE_INSENSITIVE
+                  ((#\x) (loop (fx+ i 1) (fxlogor acc 4)))    ; COMMENTS
+                  ((#\m) (loop (fx+ i 1) (fxlogor acc 8)))    ; MULTILINE
+                  ((#\s) (loop (fx+ i 1) (fxlogor acc 32)))   ; DOTALL
+                  ((#\u) (loop (fx+ i 1) (fxlogor acc 64)))   ; UNICODE_CASE
+                  ((#\d) (loop (fx+ i 1) (fxlogor acc 1)))    ; UNIX_LINES
+                  (else 0))))))))                ; (?:, (?=, a flag we don't model
 
 ;; re-find: stateless over (re s), or stateful over a matcher (advance + remember).
 (define jolt-re-find
@@ -159,6 +195,20 @@
           (if s s jolt-nil))
         (jolt-throw (jolt-ex-info "No match available" (jolt-hash-map))))))
 (define (jolt-matcher-group-count m) (irregex-num-submatches (matcher-t-irx m)))
+;; .lookingAt: anchored at the START of the region, but the match need not reach
+;; the end — the middle ground between .matches (whole region) and .find (anywhere).
+;; irregex has no prefix-match entry point, so search from the origin and keep the
+;; result only when it begins there: the engine is leftmost-first, so if any match
+;; starts at the origin the search returns that one. Remembers it for .group, as
+;; the JVM does. (instaparse's regexp terminal is .lookingAt + .group.)
+(define (jolt-matcher-looking-at m)
+  (let* ((str (matcher-t-str m))
+         (start (matcher-t-pos m))
+         (mm (and (<= start (string-length str))
+                  (irregex-search (matcher-t-irx m) str start))))
+    (if (and mm (= (irregex-match-start-index mm 0) start))
+        (begin (matcher-t-last-set! m mm) #t)
+        (begin (matcher-t-last-set! m #f) #f))))
 
 ;; All non-overlapping matches, left to right. Advance past each match end (or by
 ;; one on a zero-width match). nil when there are no matches (Clojure: seq-able as

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -166,6 +166,11 @@ check_loc '(do (require (quote [jolt.fs :as fs])) (def r (str (fs/create-temp-di
 # Runtime-eval'd fns aren't source-mapped, but their native frame names survive on
 # the non-tail spine; the trace must show them. deepest/+ are tail calls (erased);
 # middle and outer wait on a non-tail (inc …) so their frames are live at the throw.
+# clojure.core.protocols is the extension point libraries reach for when they
+# implement reduce/reduce-kv over their own types (instaparse :refer's IKVReduce),
+# so the namespace has to be loadable and its protocol vars resolvable.
+check '(do (require (quote clojure.core.protocols)) [(some? (resolve (quote clojure.core.protocols/coll-reduce))) (some? (resolve (quote clojure.core.protocols/kv-reduce))) (some? (resolve (quote clojure.core.protocols/datafy)))])' '[true true true]'
+
 trace_prog='(defn deepest [x] (+ x 1)) (defn middle [x] (inc (deepest x))) (defn outer [x] (inc (middle x))) (outer :nan)'
 check_trace "$trace_prog" 'middle'
 check_trace "$trace_prog" 'outer'

--- a/stdlib/clojure/core/protocols.clj
+++ b/stdlib/clojure/core/protocols.clj
@@ -1,0 +1,29 @@
+;; The reduce/datafy extension points core exposes as protocols. jolt implements
+;; reduce natively over its own collections, so these exist for the libraries that
+;; EXTEND them to their own types (and for the ones that merely :refer a name, as
+;; instaparse does with IKVReduce) — not as the path core's own reduce takes.
+;;
+;; reduce and reduce-kv consult these before their native paths when the value's
+;; type extends one, so a type that participates gets its own implementation.
+(ns clojure.core.protocols)
+
+(defprotocol CollReduce
+  "Protocol for collection types that can implement reduce faster than the
+  sequence walk. Called by clojure.core/reduce."
+  (coll-reduce [coll f] [coll f val]))
+
+(defprotocol InternalReduce
+  "Protocol for concrete seq types that can reduce themselves faster than the
+  first/next walk. Called by clojure.core/reduce."
+  (internal-reduce [seq f start]))
+
+(defprotocol IKVReduce
+  "Protocol for key/value collections that can implement reduce-kv themselves.
+  Called by clojure.core/reduce-kv."
+  (kv-reduce [amap f init]))
+
+(defprotocol Datafiable
+  (datafy [o] "Return a representation of o as data (default identity)."))
+
+(defprotocol Navigable
+  (nav [coll k v] "Return v as it exists in coll, navigating if needed."))

--- a/stdlib/clojure/test.clj
+++ b/stdlib/clojure/test.clj
@@ -280,11 +280,23 @@
         (catch Throwable e
           (err! (str (:name t) " crashed: " (err-text e))))))))
 
+;; A registered test still counts only while its var carries :test metadata.
+;; clojure.test discovers tests by scanning vars for that key, so removing it is
+;; how tooling DESELECTS a test — the Cognitect test-runner's -v/-i/-e options
+;; dissoc :test from every var that doesn't match and restore it afterwards.
+;; Running straight from the registry ignored that, so those options silently
+;; selected nothing and every test ran. A var that no longer resolves is kept:
+;; the registry is the only record of it, and dropping it would lose a test.
+(defn- selected? [t]
+  (let [v (try (ns-resolve (:ns t) (:name t)) (catch Throwable _ nil))]
+    (or (nil? v) (some? (:test (meta v))))))
+
 ;; Run the registered tests grouped by namespace (registration order preserved
 ;; within each ns), each group wrapped in its ns's :once fixtures. ns-set nil
 ;; means all.
 (defn- run-selected [ns-set]
-  (let [ts (if ns-set (filter (fn [t] (contains? ns-set (:ns t))) @registry) @registry)]
+  (let [ts (filter selected?
+                   (if ns-set (filter (fn [t] (contains? ns-set (:ns t))) @registry) @registry))]
     (doseq [n (distinct (map :ns ts))]
       (wrap-fixtures (get @once-fixtures n [])
         (fn [] (doseq [t ts :when (= n (:ns t))] (run-one t))))))

--- a/test/chez/clojure-test.clj
+++ b/test/chez/clojure-test.clj
@@ -53,17 +53,39 @@
 ;; tests (an unknown ns runs nothing).
 (def r1 (run-tests))
 (def r2 (run-tests 'no.such.test-ns))
+
+;; Cumulative counters, snapshotted BEFORE the deselection run below adds to them:
+;; 10 pass (= + vector? + 4 are rows + thrown? + thrown-with-msg? + near? + p/thrown?),
+;; 2 fail (= 1 2, near? 1.0 5.0), 0 error, 2 fixture runs.
+(def cum-ok (and (= (t/n-pass) 10) (= (t/n-fail) 2) (= (t/n-error) 0) (= @setups 2)))
+
+;; Deselection is by :test METADATA, not by what deftest registered: clojure.test
+;; finds tests by scanning vars for that key, so a runner filters by removing it
+;; (the Cognitect runner's -v/-i/-e do exactly this, then restore it). Running
+;; from the registry alone ignored the removal and ran everything.
+(def deselected
+  (do (alter-meta! #'expected-fail (fn [m] (-> m (assoc ::held (:test m)) (dissoc :test))))
+      (let [r (run-tests)]
+        (alter-meta! #'expected-fail (fn [m] (-> m (assoc :test (::held m)) (dissoc ::held))))
+        r)))
+;; only the passing test remains: 1 test, its 10 assertions, no failures
+(def deselect-ok (and (= 1 (:test deselected)) (= 10 (:pass deselected))
+                      (= 0 (:fail deselected))))
+;; restoring the metadata puts it back, failures and all
+(def restored (run-tests))
+(def restore-ok (and (= 2 (:test restored)) (= 2 (:fail restored))))
+
 (t/do-report {:type ::trial})
 (t/do-report {:type ::trial})
 
-;; 10 pass (= + vector? + 4 are rows + thrown? + thrown-with-msg? + near? + p/thrown?),
-;; 2 fail (= 1 2, near? 1.0 5.0), 0 error, 2 fixture runs, 2 custom reports
-(let [ok (and (= (t/n-pass) 10) (= (t/n-fail) 2) (= (t/n-error) 0)
-              (= 2 (:test r1)) (= 10 (:pass r1)) (= 2 (:fail r1))
+(let [ok (and (= 2 (:test r1)) (= 10 (:pass r1)) (= 2 (:fail r1))
               (= 0 (:test r2)) (= 0 (:pass r2))
-              (= @setups 2) (= @trials 2))]
+              cum-ok deselect-ok restore-ok
+              (= @trials 2))]
   (println (if ok
              "CLOJURE-TEST OK"
-             (str "CLOJURE-TEST FAIL pass=" (t/n-pass) " fail=" (t/n-fail)
-                  " error=" (t/n-error) " r1=" (pr-str r1) " r2=" (pr-str r2)
-                  " setups=" @setups " trials=" @trials))))
+             (str "CLOJURE-TEST FAIL r1=" (pr-str r1) " r2=" (pr-str r2)
+                  " cum-ok=" cum-ok " (pass=" (t/n-pass) " fail=" (t/n-fail)
+                  " error=" (t/n-error) " setups=" @setups ")"
+                  " deselected=" (pr-str deselected) " restored=" (pr-str restored)
+                  " trials=" @trials))))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1,4 +1,7 @@
 [
+  {:suite "host-interop / Matcher anchoring" :label "lookingAt re-anchors at the region start after a find" :expected "[true true \"abb\"]" :actual "(let [m (re-matcher #\"ab+\" \"abbXabb\")] [(.find m) (.lookingAt m) (.group m)])" :portability :jvm}
+  {:suite "host-interop / Matcher anchoring" :label "lookingAt is a prefix match, find is not" :expected "[false true \"abb\"]" :actual "(let [m (re-matcher #\"ab+\" \"Xabb\")] [(.lookingAt m) (.find m) (.group m)])" :portability :jvm}
+  {:suite "host-interop / Matcher anchoring" :label "a matched region is consumed, so a following find sees nothing" :expected "[true \"abb\" false]" :actual "(let [m (re-matcher #\"ab+\" \"abb\")] [(.matches m) (.group m) (.find m)])" :portability :jvm}
   {:suite "host-interop / PersistentList-create" :label "a created list is list?" :expected "true" :actual "(list? (clojure.lang.PersistentList/create [1 2 3]))" :portability :jvm}
   {:suite "host-interop / PersistentList-create" :label "an empty created list is list?" :expected "true" :actual "(list? (clojure.lang.PersistentList/create []))" :portability :jvm}
   {:suite "host-interop / PersistentList-create" :label "created list agrees with a literal on list?/seq?/class" :expected "[true true true]" :actual "(let [c (clojure.lang.PersistentList/create [1 2 3])] [(= (list? c) (list? (quote (1 2 3)))) (seq? c) (= c (quote (1 2 3)))])" :portability :jvm}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1,4 +1,7 @@
 [
+  {:suite "host-interop / PersistentList-create" :label "a created list is list?" :expected "true" :actual "(list? (clojure.lang.PersistentList/create [1 2 3]))" :portability :jvm}
+  {:suite "host-interop / PersistentList-create" :label "an empty created list is list?" :expected "true" :actual "(list? (clojure.lang.PersistentList/create []))" :portability :jvm}
+  {:suite "host-interop / PersistentList-create" :label "created list agrees with a literal on list?/seq?/class" :expected "[true true true]" :actual "(let [c (clojure.lang.PersistentList/create [1 2 3])] [(= (list? c) (list? (quote (1 2 3)))) (seq? c) (= c (quote (1 2 3)))])" :portability :jvm}
   {:suite "host-interop / reify ILookup" :label "(get reify k) / (:k reify) / (get reify k d) route to valAt" :expected "[1 1 :dflt]" :actual "(let [r (reify clojure.lang.ILookup (valAt [_ k] (get {:a 1} k)) (valAt [_ k d] (get {:a 1} k d)))] [(:a r) (get r :a) (get r :z :dflt)])" :portability :jvm}
   {:suite "regex / alternation submatch" :label "a non-participating alternation group is nil, not a stale capture" :expected "[\"2r11\" nil \"2\" \"11\"]" :actual "(re-matches #\"(?:([0-9])|([0-9])r([0-9]+))\" \"2r11\")" :portability :common}
   {:suite "regex / radix read" :label "tools.reader-style radix parse: winning branch's groups, not the losing one's" :expected "[12 255]" :actual "[(read-string \"2r1100\") (read-string \"16rFF\")]" :portability :common}


### PR DESCRIPTION
Started from "the Cognitect test-runner reports 0 tests on honeysql" and ended with
honeysql's suite running end to end. Every fix here is a general parity gap; each
was found by walking the chain one blocker at a time.

## The reported symptom

`clojure.lang.PersistentList/create` returned a value with `list?` **false**, while
`class` and `instance? IPersistentList` both said `PersistentList`:

```
literal        true   clojure.lang.PersistentList
(list 1 2 3)   true   clojure.lang.PersistentList
PL/create      false  clojure.lang.PersistentList   <-
cons           true   clojure.lang.PersistentList
```

jolt marks the head cell of a real list; `plist-create` built with the unmarked
`list->cseq`. `clojure.tools.reader` reads **every** list through that constructor,
and `clojure.tools.namespace.parse/ns-decl?` is `(and (list? form) (= 'ns (first
form)))` — so `read-file-ns-decl` returned nil for every file,
`find-namespaces-in-dir` returned `[]`, and the runner required nothing.
`run-tests` with no args then reported "Ran 0 tests".

Narrowed stepwise: `file-seq` ok, `find-sources-in-dir` ok, `tools.reader/read`
returned the correct `(ns …)` form — only the `list?` arm failed. There is no
built-in test runner in jolt, so this was the whole story.

## The rest

| Gap | Fix |
|---|---|
| `clojure.core.protocols` not loadable | added to stdlib with the five protocols core exposes (instaparse `:refer`s `IKVReduce`) |
| `LispReader$StringReader` missing | ctor returns a procedure with the JVM calling convention; the literal is parsed by the same helper jolt's own reader uses, so escapes agree |
| `Matcher.lookingAt` missing | anchored at the origin, not required to reach the end |
| `Pattern.flags` missing | report the inline flags the pattern opens with, as the `Pattern` constants |
| `str` ignored a deftype's declared `toString` | `(str x)` is `x.toString()` on the JVM; `pr-str` untouched, the same split the JVM makes |
| regex took only `String` | it takes a `CharSequence` on the JVM; realize one through its `toString` (instaparse's `Segment` is a window over a larger string) |
| `unchecked-*-int` wrapped at 64 bits | wrap at 32 |
| `slurp` of a missing path threw a raw Chez condition | throws `java.io.FileNotFoundException` |

The `unchecked-*-int` one is worth singling out: the whole `-int` family was
aliased to the long ops, so `(unchecked-multiply-int 100000 100000)` gave
`10000000000` instead of `1410065408`. Any library doing 32-bit hash mixing was
silently wrong, not just instaparse.

## A gate catching my own change

`dcerefs` flagged the `LispReader` shim for resolving `clojure.core/-read-line` by
name without rooting it — a tree-shaken build would have pruned the var and broken
the shim at runtime, in exactly the builds hardest to debug. Added to
`dce-runtime-core-roots`.

## Result

honeysql, full suite: **177 tests, 2833 assertions passed, 0 failures, 1 error.**

That one error is honeysql's `deps.edn` pinning `jolt-lang/time` v0.0.1, which
predates `Locale/getDefault` — the fix has been on that library's main since
`99414a5` but was never released. Released as time **v0.0.2**; not a change here.

Needing the `:jolt` alias for those tests is correct behavior — without it the run
produces 574 `Locale` errors by design (RFC 0008).

## Gates

`make test` green, corpus rows added for `PersistentList/create` (JVM-certified),
smoke case for `clojure.core.protocols`, `dcerefs` 27/27.

Closes jolt-8dzy.