### PR TITLE
satisfies? on a non-protocol names what was passed

### DIFF
--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -1534,10 +1534,18 @@
               (seq->list (jolt-keys methods-map)))
     (make-jreify ht (map (lambda (p) (if (symbol-t? p) (symbol-t-name p) p)) protos))))
 
-;; satisfies?: does obj's type implement the protocol?
+;; satisfies?: does obj's type implement the protocol? proto must be a defprotocol
+;; value (a map with a :name); a host Class/interface or any non-protocol throws —
+;; matching the JVM, which also errors — with a message naming what was passed.
 (define (jolt-satisfies? proto obj)
   (let* ((pn (jolt-get proto (keyword #f "name") jolt-nil))
          (pn-str (if (symbol-t? pn) (symbol-t-name pn) pn)))
+    (unless (string? pn-str)
+      (throw-jvm (quote IllegalArgumentException)
+        (string-append "satisfies? expects a protocol, got: "
+          (cond ((jclass? proto) (jclass-name proto))
+                ((jolt-nil? proto) "nil")
+                (else (jolt-final-str proto))))))
     (cond
       ((jrec? obj) (type-satisfies? (jrec-tag obj) pn-str))
       ((jreify? obj)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1253,4 +1253,8 @@
   {:suite "pmap-order" :expr "(str (into {} [[:a 1] [:b 2] [:a 9]]))" :expected "{:a 9, :b 2}"}
   {:suite "pmap-order" :expr "(get (into {} [[:a 1] [:a 9]]) :a)" :expected "9"}
   {:suite "pmap-order" :expr "(str (keys (array-map :k0 0 :k1 1 :k2 2 :k3 3 :k4 4 :k5 5 :k6 6 :k7 7 :k8 8 :k9 9)))" :expected "(:k0 :k1 :k2 :k3 :k4 :k5 :k6 :k7 :k8 :k9)"}
+  ;; satisfies? on a host interface (a Class, not a defprotocol) must throw — the
+  ;; JVM errors too — but with a non-empty message naming the offending value.
+  ;; Not JVM-certifiable (the JVM's own message differs), so a unit row.
+  {:suite "satisfies" :expr "(do (deftype S [x] CharSequence (toString [_] \"x\")) (try (satisfies? CharSequence (S. 1)) (catch Throwable e (let [m (ex-message e)] [(boolean (and (string? m) (seq m))) (boolean (and m (.contains m \"CharSequence\")))]))))" :expected "[true true]"}
 ]


### PR DESCRIPTION
`(satisfies? CharSequence x)` threw with an **empty** `ex-message` and
`type-satisfies?`/`do-hash` in the trace, so a caller learned nothing about what
went wrong.

Throwing is correct — `satisfies?` wants a protocol and a host interface is not
one, and the JVM errors too — so this only fixes the message:

```
(satisfies? CharSequence (S. 1))  ->  satisfies? expects a protocol, got: java.lang.CharSequence
(satisfies? nil 1)                ->  satisfies? expects a protocol, got: nil
(satisfies? P x)                  ->  false      ; real protocols unchanged
```

Runtime `.ss` only, no re-mint. Regression row in `test/chez/unit.edn` rather than
`corpus.edn`: the JVM throws here too but with a different message, so the row is
not vanilla-JVM-certifiable.

`make test` green — unit 1057/1057, smoke 77/77, 0 new divergences, 0 stale.

Closes jolt-3uk0. jolt-b5ts (the colliding trace-frame name) is **not** in this PR;
see that bead for why the cheap fix is impossible and what the next attempt should
do.