### PR TITLE
Document the variadic unchecked-* arity divergence

### DIFF
--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -119,6 +119,12 @@
    :jvm "throws (EOF while reading)"
    :jolt "nil"
    :note "Permissive."}
+  ;; unchecked-add/-subtract/-multiply accept any arity (the JVM's take exactly 2).
+  {:category :permissive
+   :behavior "(unchecked-add x) or (unchecked-add a b c), e.g. through apply"
+   :jvm "throws ArityException — these are arity-2 only"
+   :jolt "folds like +: no args => 0, one => the operand, N => a left fold"
+   :note "The overlay is variadic where the JVM's is fixed-arity. At arity 2 — every arity the JVM accepts — the wrapping result is identical, 64-bit edges included, so portable code is unaffected. Costs nothing on the hot path either: proven-long operands lower straight to jolt-uncadd2 (a left fold past 2 operands) and never reach the variadic overlay, which only serves value position."}
   ;; auto-gensym suffix differs by a trailing "__".
   {:category :reader-model
    :behavior "an auto-gensym x# expands to a symbol named"


### PR DESCRIPTION
Found while fixing the n-ary long arithmetic regression (#476), unrelated to it.

jolt's `unchecked-add`/`-subtract`/`-multiply` overlays fold over any arity
(`jolt-unchecked-add` is `[& xs]` with `fold-left`), while the JVM's take exactly
two and reject anything else. So `(apply unchecked-add [x])` returns `x` on jolt
and throws `ArityException` on Clojure.

Permissive rather than a bug, on both counts that matter:

- **Superset.** At arity 2 — every arity the JVM accepts — jolt matches the
  reference exactly, including the wrapping edges: `Long/MAX+1` -> `Long/MIN`,
  `Long/MIN-1` -> `Long/MAX`, `2^62*4` -> `0`, `Long/MAX*2` -> `-2`. No program
  Clojure accepts behaves differently.
- **No cost.** Proven-long operands lower to `(jolt-uncadd2 a b)` directly, and to
  a left fold past two operands. The variadic overlay is reachable only in value
  position (`apply`/`map`), which is off the arithmetic path by construction.

Goes in `:documented` (not `:entries`, which certify gates for staleness against
corpus rows) under the existing `:permissive` category. `make certify` still
reports 0 NEW, 0 stale.
