### PR TITLE
Make -e work with -Sdeps, -A and -M, and order :extra-paths like clj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-e` composes with `-Sdeps`, `-A`, `-M`, and a project's `deps.edn`.** `-e` was
+  handled entirely in the launcher, before `jolt.main` was loaded, so it never
+  resolved a project and anything that re-dispatched into `jolt.main` first —
+  `jolt -Sdeps '{...}' -e EXPR`, `jolt -A:test -e EXPR` — died with `unknown
+  command or task: -e`. `jolt.main` now has its own `-e` arm that resolves the
+  project (paths, deps, native libraries) and then evaluates through the same
+  launcher primitive, so the two paths cannot drift. A bare `jolt -e EXPR` still
+  takes the launcher's fast path when the project directory has no `deps.edn`
+  (nothing to resolve, and it skips loading `jolt.main`); with a `deps.edn`
+  present it resolves the project, so `jolt -e "(require 'my.app)"` now works
+  from a project directory. The stdin forms (`-e -` and a bare `-`) follow the
+  same rule.
+- **`:main-opts` may be an `-e` expression.** `apply-main-opts` understood only
+  `["-m" NS]`, so a `deps.edn` alias or task declaring `:main-opts ["-e" "..."]`
+  failed with `unsupported :main-opts`.
+- **`-M` takes main options from the command line.** `jolt -M -e EXPR` and `jolt
+  -M -m NS` threw `alias(es) [] have no :main-opts`. The selected aliases'
+  `:main-opts` now precede the ones given on the command line, matching the clj
+  CLI, and when no alias declares any the command line supplies them on its own.
+  Only an empty command line with no `:main-opts` is still an error.
+
 ## [0.5.6] - 2026-07-27
 
 Fixes a 0.5.2 regression: long arithmetic with more than two operands did not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An alias's `:extra-paths` now precede the project's `:paths` on the source
+  roots.** jolt appended them instead, which is the opposite of the clj CLI:
+  `clojure -A:t -Spath` prints `test src`, jolt's `path` printed `src test`. The
+  order decides which copy of a namespace loads, since the loader takes the first
+  root that has it, so a `:extra-paths` directory that deliberately shadows one of
+  the project's own files was silently ignored. `:extra-paths` also precede an
+  alias's `:replace-paths`, and combine in alias-selection order, both matching
+  clj. Dependency roots still come last.
+
 ### Added
 
 - **`-e` composes with `-Sdeps`, `-A`, `-M`, and a project's `deps.edn`.** `-e` was

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ $ bin/jolt -e '(/ 1 2)'
 1/2
 ```
 
+When the current directory has a `deps.edn`, `-e` resolves it first, so the
+expression can require the project's own namespaces and its dependencies.
+`-Sdeps` and `-A` compose with it for a one-off evaluation, and `-M` takes the
+same main options on the command line when the selected aliases declare none:
+
+```bash
+bin/jolt -Sdeps '{:paths ["src" "test"]}' -e "(require 'my.app-test 'clojure.test)
+                                              (clojure.test/run-tests 'my.app-test)"
+bin/jolt -A:test -M -e "(println :hi)"
+```
+
 ## Diagnostics
 
 - **"Did you mean?"** — when a bare symbol doesn't resolve, the compile error lists

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -32,6 +32,11 @@
 (load "host/chez/host-contract.ss")
 (load "host/chez/seed/image.ss")
 (load "host/chez/compile-eval.ss")
+;; cli-core.ss is inlined into the emitted image below, but it also has to be
+;; loaded HERE: it defines jolt.host/run-expr-string, and jb-emit-cli-ns emits
+;; jolt.main in this process — an unresolved jolt.host var would emit as a class
+;; reference and the binary's -e arm would die with "Unknown class jolt.host".
+(load "host/chez/cli-core.ss")
 (load "host/chez/png.ss")
 (load "host/chez/loader.ss")
 (load "host/chez/java/ffi.ss")

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -2,7 +2,8 @@
 ;; (cli.ss under `chez --script`) and the standalone binary's launcher
 ;; (build-jolt.ss scheme-start). Both call jolt-cli-run so the -e handling,
 ;; end-of-options rule, and uncaught-throw reporting cannot drift apart — the
-;; binary once carried a stale copy of the -e arm.
+;; binary once carried a stale copy of the -e arm. jolt.main's own (project-aware)
+;; -e arm calls back into jolt-run-expr-string here for the same reason.
 
 ;; Flush stdout/stderr on EVERY exit path. Buffered stdout is otherwise lost
 ;; when the process ends while helper threads are winding down (the throwing
@@ -165,6 +166,27 @@
         (when (and print? (not (string=? s "")))
           (display s) (newline))))))
 
+;; Expose the evaluator (and the stdin reader it pairs with) to Clojure. jolt.main's
+;; -e arm — the project-aware path, reached from -Sdeps/-A/-M, an alias's
+;; :main-opts ["-e" …], or a project dir that has a deps.edn — evaluates through
+;; this same primitive, so the launcher's -e and jolt.main's -e cannot drift the
+;; way the binary's forked copy of the -e arm once did.
+(def-var! "jolt.host" "run-expr-string"
+  (lambda (expr app-args print?)
+    (jolt-run-expr-string expr (seq->list app-args) (jolt-truthy? print?))
+    jolt-nil))
+(def-var! "jolt.host" "read-all-stdin" (lambda () (jolt-read-all-stdin)))
+
+;; Does the project dir have a deps.edn? The launcher's -e / - arms below skip
+;; jolt.main entirely — no deps chain, no project source roots, no natives — which
+;; is only equivalent to the real thing when there is no project to resolve. With a
+;; deps.edn present the argv falls through to jolt.main instead, so `jolt -e
+;; "(require 'my.app)"` sees the project's paths and deps like every other command.
+(define (jolt-project-deps-edn?)
+  (let* ((pwd (getenv "JOLT_PWD"))
+         (dir (if (and pwd (string? pwd) (not (string=? pwd ""))) pwd ".")))
+    (file-exists? (string-append dir "/deps.edn"))))
+
 (define (jolt-cli-run cli-args prepare-build!)
   (guard (v (#t (jolt-report-uncaught v)))
     (jolt-cli-dispatch cli-args prepare-build!)
@@ -179,13 +201,16 @@
       ;; EXPR are *command-line-args* (nil when empty),
       ;; with the first standalone "--" consumed as POSIX end-of-options. `-e -`
       ;; reads the expression from stdin.
+      ;; Taken only when there is no project deps.edn to resolve — otherwise
+      ;; jolt.main's -e arm handles it, resolving the project first.
       ((and (pair? cli-args) (string=? (car cli-args) "-e")
-            (pair? (cdr cli-args)))
+            (pair? (cdr cli-args)) (not (jolt-project-deps-edn?)))
        (let ((expr (if (string=? (cadr cli-args) "-") (jolt-read-all-stdin) (cadr cli-args))))
          (jolt-run-expr-string expr (drop-end-of-options (cddr cli-args)) #t)))
       ;; `-` [args…] — read a PROGRAM from stdin and run it as a script (the final
       ;; value is not echoed, like `clojure -M -`); args after it are the argv.
-      ((and (pair? cli-args) (string=? (car cli-args) "-"))
+      ((and (pair? cli-args) (string=? (car cli-args) "-")
+            (not (jolt-project-deps-edn?)))
        (jolt-run-expr-string (jolt-read-all-stdin) (drop-end-of-options (cdr cli-args)) #f))
       ;; otherwise dispatch the argv through jolt.main/-main
       (else

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -120,6 +120,30 @@ check "-Sdeps adds a dep" "libc C" \
 check "-Sdeps adds an alias" "libc C" \
       "$(run -Sdeps '{:aliases {:inj {:extra-deps {local/libc {:local/root "../libc"}}}}}' -A:inj run -m appc)"
 
+# -e in a project resolves deps.edn first, so the expression can require the
+# project's namespaces and its deps — and it composes with -Sdeps/-A/-M, which
+# used to fail with "unknown command or task: -e".
+check "-e sees the project's namespaces" "main1" "$(run -e "(require 'appmain) (appmain/-main)")"
+check "-Sdeps + -e" "libc C" \
+      "$(run -Sdeps '{:deps {local/libc {:local/root "../libc"}}}' -e "(require 'appc) (appc/-main)")"
+check "-A + -e" "devmain" "$(run -A:dev2 -e "(require 'devmain) (devmain/-main)")"
+check "bare -M -e uses the command line as main-opts" "main1" \
+      "$(run -M -e "(require 'appmain) (appmain/-main)")"
+check "bare -M -m uses the command line as main-opts" "main1" "$(run -M -m appmain)"
+check ":main-opts may be an -e expression" "main1" "$(run -M:e1)"
+check "-M:alias main-opts precede the command line" "main1" "$(run -M:m1 -m appmain2)"
+check "-e passes the rest as *command-line-args*" '(a b)' \
+      "$(run -e '(println *command-line-args*)' a b)"
+check "-e - reads the expression from stdin" "main1" \
+      "$(printf "(require 'appmain) (appmain/-main)" | JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" -e - 2>&1 | tail -1)"
+check "- runs a stdin program against the project" "main1" \
+      "$(printf "(require 'appmain) (appmain/-main)" | JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" - 2>&1 | tail -1)"
+out="$(runfull -M)"
+case "$out" in
+  *"have no :main-opts"*) check "bare -M with nothing to run errors" ok ok ;;
+  *) check "bare -M with nothing to run errors" "no-main-opts error" "$(printf '%s' "$out" | head -1)" ;;
+esac
+
 # -X: :exec-fn / :exec-args from the alias, k v overrides, a trailing map, an
 # explicit ns/fn argument, and :ns-aliases qualification
 check "-X runs :exec-fn with :exec-args" 'exec: {:greeting "hi"}' "$(run -X:xbuild)"

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -88,6 +88,23 @@ out="$(run -A:dev:dev2 path)"
 n="$(printf '%s' "$out" | tr ':' '\n' | grep -c "^$APP/dev$")"
 check "multi-alias extra-paths distinct" "1" "$n"
 
+# Path order matches `clojure -Spath`: the aliases' :extra-paths (in selection
+# order), then the project's :paths — or an alias's :replace-paths, which
+# :extra-paths still precedes — then the dep roots. own_paths keeps only the
+# project's own directories; a :local/root dep root is under "$APP/../".
+own_paths() { run "$@" path | tr ':' '\n' | grep -E "^$APP/[a-z0-9]+\$" | tr '\n' ' ' | sed 's/ $//'; }
+check "extra-paths precede the project paths" "$APP/dev $APP/extra $APP/src" \
+      "$(own_paths -A:dev2)"
+check "extra-paths follow alias selection order" "$APP/shadow $APP/dev $APP/src" \
+      "$(own_paths -A:shadow:dev)"
+check "extra-paths precede replace-paths" "$APP/shadow $APP/dev" \
+      "$(own_paths -A:rp:shadow)"
+
+# and the order is load-bearing: shadow/appmain.clj and src/appmain.clj both
+# define `appmain`, and the loader takes the first root that has it.
+check "no alias => the project's own copy loads" "main1" "$(run run -m appmain)"
+check ":extra-paths shadow the project's paths" "shadowed" "$(run -A:shadow run -m appmain)"
+
 # :main-opts last-wins across aliases
 check "multi-alias main-opts last-wins" "main2" "$(run -M:m1:m2)"
 

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -94,6 +94,7 @@ map-entry
 park-until-interrupt
 protocol-methods
 rational-type?
+read-all-stdin
 record-ctor-key
 record-shapes
 record-type?
@@ -104,6 +105,7 @@ register-source!
 resolvable-names
 resolve-class-hint
 resolve-global
+run-expr-string
 run-interruptible
 run-main-pump
 set-field!

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -806,8 +806,12 @@
   (legacy :deps) replaces the project deps map, :extra-deps merges into it,
   :override-deps / :default-deps adjust coordinates at every node of the walk;
   :replace-paths (legacy :paths) replaces the project paths, :extra-paths
-  appends; :main-opts is last-wins across the selected aliases. Custom Maven
-  repositories come from the merged :mvn/repos."
+  precede them; :main-opts is last-wins across the selected aliases. Custom
+  Maven repositories come from the merged :mvn/repos.
+
+  :roots is ordered like the clj CLI's classpath — the aliases' :extra-paths,
+  then the project's :paths, then the dependency roots — and the loader takes
+  the first root that has a namespace, so the order decides which copy wins."
   ([project-dir] (resolve-project project-dir []))
   ([project-dir alias-kws] (resolve-project project-dir alias-kws nil))
   ([project-dir alias-kws extra-edn] (resolve-project project-dir alias-kws extra-edn nil))
@@ -826,12 +830,19 @@
                (throw (ex-info (str "Specified aliases are undeclared: " (vec missing))
                                {:aliases (vec missing)}))))
          main-opts (:main-opts argmap)
+         ;; Path order matches the clj CLI: the selected aliases' :extra-paths
+         ;; come FIRST (in alias-selection order), then the project's :paths —
+         ;; or an alias's :replace-paths, which :extra-paths still precedes.
+         ;; `clojure -A:t -Spath` prints `test src`, not `src test`, and the
+         ;; order is load-bearing: the loader takes the first root that has the
+         ;; namespace, so a -A:dev extra path shadows the project's own copy
+         ;; rather than being shadowed by it.
          ;; tool mode (-T): the project's own paths and deps are replaced —
          ;; the tool's alias supplies its own (clj CLI tool-basis defaults
          ;; :replace-paths ["."] :replace-deps {}).
-         project-paths (concat (or (:replace-paths argmap) (:paths argmap)
-                                   (if tool? ["."] (or (:paths edn) ["src"])))
-                               (:extra-paths argmap))
+         project-paths (concat (:extra-paths argmap)
+                               (or (:replace-paths argmap) (:paths argmap)
+                                   (if tool? ["."] (or (:paths edn) ["src"]))))
          project-roots (map #(abspath project-dir %) project-paths)
          all-deps (merge (or (:replace-deps argmap) (:deps argmap)
                              (if tool? {} (:deps edn)))

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -88,14 +88,28 @@
       (apply (deref mainv) app-args)
       (throw (ex-info (str "namespace " ns-name " has no -main") {:ns ns-name})))))
 
-;; main-opts is a vector like ["-m" "app.core"] (optionally trailing args). Apply
-;; it with the user-supplied extra args appended.
+;; Evaluate a string of forms through the launcher's evaluator (cli-core.ss), the
+;; same primitive a bare `jolt -e` runs — so the fast path and the project-aware
+;; path share their read/compile/eval loop, their require auto-quoting, and their
+;; final-value printing. EXPR of "-" reads the expression from stdin. Assumes the
+;; project has already been resolved by the caller.
+(defn- eval-expr-string [expr app-args print?]
+  (when (nil? expr)
+    (throw (ex-info "-e needs an expression (or - to read it from stdin)" {})))
+  (jolt.host/run-expr-string (if (= "-" expr) (jolt.host/read-all-stdin) expr)
+                             (vec (drop-end-of-options app-args))
+                             print?))
+
+;; main-opts is a vector like ["-m" "app.core"] or ["-e" "(prn :hi)"] (optionally
+;; with trailing args). The user-supplied extra args are appended, so an alias's
+;; :main-opts and the command line combine exactly like the clj CLI, which
+;; prepends the alias's :main-opts to the argv.
 (defn- apply-main-opts [main-opts extra-args]
-  (cond
-    (and (seq main-opts) (= "-m" (first main-opts)))
-    (run-ns (second main-opts) (concat (drop 2 main-opts) extra-args))
-    :else
-    (throw (ex-info (str "unsupported :main-opts " (pr-str main-opts)) {}))))
+  (let [opts (concat main-opts extra-args)]
+    (cond
+      (= "-m" (first opts)) (run-ns (second opts) (drop 2 opts))
+      (= "-e" (first opts)) (eval-expr-string (second opts) (drop 2 opts) true)
+      :else (throw (ex-info (str "unsupported :main-opts " (pr-str (vec opts))) {})))))
 
 (defn- parse-aliases [s]            ; "-M:a:b" / ":a:b" -> [:a :b]
   (let [s (if (str/starts-with? s "-") (subs s 2) s)]
@@ -122,13 +136,16 @@
                               (load-file (file-arg (first more))) nil)
     :else (throw (ex-info "run needs -m NS or a FILE" {}))))
 
-;; -M:alias…  — resolve with the aliases (plus any bound by a leading -A),
-;; run their :main-opts
+;; -M[:alias…] [main-opts…] — resolve with the aliases (plus any bound by a
+;; leading -A), then run their :main-opts followed by the command-line ones. With
+;; no :main-opts anywhere in the selected aliases the command line supplies them
+;; on its own, so a bare `jolt -M -e EXPR` (or `-M -m NS`) works like clj — only
+;; an empty command line with no :main-opts is an error.
 (defn- cmd-M [arg more]
   (let [aliases (parse-aliases arg)
         {:keys [main-opts] :as resolved} (resolve-current aliases)]
     (apply-project! resolved)
-    (if main-opts
+    (if (or (seq main-opts) (seq more))
       (apply-main-opts main-opts more)
       (throw (ex-info (str "alias(es) " (pr-str aliases) " have no :main-opts") {})))))
 
@@ -484,14 +501,20 @@
   (println "  -e - [args]            evaluate an EXPR read from stdin")
   (println "  - [args]               run a program read from stdin (as a script)")
   (println "  -m NS [args]           shorthand for run -m")
-  (println "  -M:alias [args]        run the alias's :main-opts")
+  (println "  -M[:alias] [main-opts] run the alias's :main-opts, then the ones given")
+  (println "                         here (-m NS [args] or -e EXPR [args]); with no")
+  (println "                         :main-opts the command line supplies them")
   (println "  -A:alias [args]        add the alias's paths/deps, run the rest")
   (println "  -X:alias [ns/fn] [k v …]  invoke :exec-fn (or ns/fn) with :exec-args")
   (println "  -T:alias [ns/fn] [k v …]  like -X, with the project paths/deps replaced")
   (println "  -Sdeps '<edn>' …       merge an extra deps.edn map, run the rest")
   (println)
   (println "The first standalone -- ends option parsing; everything after it is")
-  (println "passed to the program as *command-line-args*."))
+  (println "passed to the program as *command-line-args*.")
+  (println)
+  (println "-e and - resolve deps.edn when the project has one, so the expression")
+  (println "can require the project's namespaces and its dependencies. Combine them")
+  (println "with -Sdeps/-A to add paths or deps for a one-off evaluation."))
 
 (defn -main [& args]
   (let [[cmd & more] args]
@@ -511,6 +534,18 @@
         (when (nil? edn-str) (throw (ex-info "-Sdeps needs an edn map argument" {})))
         (binding [*cli-extra-edn* (clojure.core/read-string edn-str)]
           (apply -main rest-args)))
+      ;; -e EXPR [args] / - [args] — evaluate with the project resolved. The
+      ;; launcher (cli-core.ss) short-circuits these when the project dir has no
+      ;; deps.edn (nothing to resolve, and it skips loading jolt.main); a project,
+      ;; or a leading -Sdeps/-A, lands here instead so the expression sees the
+      ;; project's paths, deps, and native libs. Both paths evaluate through the
+      ;; same jolt.host/run-expr-string.
+      (= cmd "-e")
+      (do (apply-project! (resolve-current))
+          (eval-expr-string (first more) (rest more) true))
+      (= cmd "-")
+      (do (apply-project! (resolve-current))
+          (eval-expr-string "-" more false))
       (str/starts-with? cmd "-M")        (cmd-M cmd more)
       (str/starts-with? cmd "-A")        (cmd-A cmd more)
       (str/starts-with? cmd "-X")        (cmd-X cmd more)

--- a/test/chez/deps-alias/app/deps.edn
+++ b/test/chez/deps-alias/app/deps.edn
@@ -11,6 +11,8 @@
   :rp     {:replace-paths ["dev"]}
   :m1     {:main-opts ["-m" "appmain"]}
   :m2     {:main-opts ["-m" "appmain2"]}
+  ;; :main-opts may be an -e expression, not just -m
+  :e1     {:main-opts ["-e" "(require 'appmain) (appmain/-main)"]}
   :time   {:extra-deps {local/timefix {:local/root "../timefix"}}}
   ;; a dep directory with NO deps.edn defaults to its src path
   :noedn  {:extra-deps {local/libnoedn {:local/root "../libnoedn"}}}

--- a/test/chez/deps-alias/app/deps.edn
+++ b/test/chez/deps-alias/app/deps.edn
@@ -5,6 +5,8 @@
            :extra-deps {local/libc {:local/root "../libc"}}}
   :dev2   {:extra-paths ["dev" "extra"]}
   :vb     {:override-deps {local/liba {:local/root "../libb"}}}
+  ;; shadow/appmain.clj also defines `appmain`; :extra-paths order decides which wins
+  :shadow {:extra-paths ["shadow"]}
   :defd   {:default-deps {local/libc {:local/root "../libc"}}
            :extra-deps {local/libc nil}}
   :bare   {:replace-deps {local/libc {:local/root "../libc"}}}

--- a/test/chez/deps-alias/app/shadow/appmain.clj
+++ b/test/chez/deps-alias/app/shadow/appmain.clj
@@ -1,0 +1,5 @@
+;; Shadows src/appmain.clj. The :shadow alias puts this directory on the roots
+;; as an :extra-path, which the clj CLI orders BEFORE the project's :paths — so
+;; requiring appmain must load this copy, not src/appmain.clj.
+(ns appmain)
+(defn -main [& args] (println "shadowed"))


### PR DESCRIPTION
Fixes #470.

`-e` was handled entirely in the Scheme launcher, before `jolt.main` is loaded, so it only worked when it was the very first argv token. Anything that re-dispatches through `jolt.main` first, like `-Sdeps` or `-A`, reached the unknown-command fallthrough and failed with "unknown command or task: -e". The same launcher-only handling meant `-e` never resolved a project at all, so requiring the project's own namespaces failed even without `-Sdeps`.

`jolt.main` now has its own `-e` arm that resolves the project and then evaluates through the launcher's `jolt-run-expr-string`, newly exposed as `jolt.host/run-expr-string`. Sharing the primitive keeps the read/compile/eval loop, the require auto-quoting, and the final-value printing identical on both paths, which is the same reason the two entry points already share `jolt-cli-run`. A bare `jolt -e` still takes the launcher fast path when the project directory has no `deps.edn`, since there is nothing to resolve and it saves loading `jolt.main`; with a `deps.edn` present it falls through. The stdin forms, `-e -` and a bare `-`, follow the same rule.

`apply-main-opts` understood only `["-m" NS]`, so an alias or task declaring `:main-opts ["-e" "..."]` failed with "unsupported :main-opts". It now takes `-e` as well, and concatenates the alias's `:main-opts` with the ones given on the command line the way the clj CLI prepends them. That also makes a bare `jolt -M -e EXPR` work: when no selected alias declares `:main-opts` the command line supplies them on its own, and only an empty command line with no `:main-opts` is still an error.

`build-jolt.ss` has to load `cli-core.ss` into the build process too. It emits `jolt.main` at build time, and without the load the new `jolt.host` var was unresolved at emit time, so the binary's `-e` arm died with "Unknown class jolt.host". Source mode passed and the binary did not, which is why the gates run against both.

The second commit is a follow-up on a divergence found while checking `-Sdeps` against the real thing. jolt appended an alias's `:extra-paths` to the project's `:paths`, the opposite of the clj CLI: `clojure -A:t -Spath` prints `test src` where jolt's `path` printed `src test`. The loader takes the first root that has a namespace, so under the old order the project's own `src` always won and an `:extra-paths` directory meant to shadow one of its files was silently ignored. The full order is now the aliases' `:extra-paths` in selection order, then the project's `:paths` or an alias's `:replace-paths`, then the dependency roots, which matches `clojure -Spath` on every case in the fixture. This is a behavior change for any project that has a namespace in both an extra path and `src`.

Worth noting for anyone reading the issue: `-Sdeps '{:extra-paths ["test"]}'` from the report is a no-op in JVM clj as well, verified against Clojure CLI 1.12.3.1577. `:extra-paths` is only read from a combined alias argmap in tools.deps, and `-Sdeps` is treated as the last deps.edn file. The working forms are `-Sdeps '{:paths ["src" "test"]}'` or an alias selected with `-A`.

## Testing

deps-alias smoke goes from 29 to 47 cases, covering `-e` with `-Sdeps`/`-A`/`-M`, `:main-opts ["-e" ...]`, both stdin forms, and the path ordering including a `shadow/appmain.clj` fixture that must win over `src/appmain.clj` under `-A:shadow`. It passes in source mode and against `target/release/jolt`, as does the 80-case cli smoke. `depsunit`, `devbootsmoke`, `aotcachesmoke`, `buildsmoke` and `manifestcheck` all pass.

`smoke` in source mode reports 5 failures (trace source-map cases and one standalone build case). Those are pre-existing; I confirmed they reproduce identically at `main` by stashing and rebuilding.