### PR TITLE
Drive the build gates through the prebuilt binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The gate runs about 2.7x faster.** `make -j8 ci` drops from 338s to 124s.
+  The build-driving gates (`buildsmoke`, `shakelocal`, `depssmoke`,
+  `staticnativesmoke`, `buildlibsmoke`) shelled out to source-mode `bin/jolt`,
+  where a `jolt build` costs ~12.5s against ~2.5s through a prebuilt binary, and
+  `buildsmoke` alone drives 26 of them. They now take `testbin` and default
+  `JOLT_BIN` to `target/release/jolt`, the way `smoke` and `cts` already did:
+  those five together go from 713s to 161s. `buildsmoke` keeps one explicit
+  `bin/jolt` build at the end so the source-mode driver stays gated, and
+  `JOLT_BIN=bin/jolt` puts any of them back in script mode. `testbin` itself is
+  now rebuilt only when something it bakes in is newer than the binary —
+  unconditional rebuilds were free under `make -j ci` but charged every
+  single-gate run 18s, enough to make `make buildlibsmoke` slower with the new
+  prerequisite than without it.
+
 ## [0.5.7] - 2026-07-27
 
 A `.jolt` source extension, `-e` and `:main-opts` fixes across the CLI entry

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,24 @@ unit:
 	@$(CHEZ) --script host/chez/run-unit.ss
 
 # Real-CLI smoke over bin/jolt.
-# smoke and cts spawn a jolt process per case; a prebuilt binary boots ~10x
-# faster than script mode (0.14s vs 1.5s), so both build one first (12s,
-# always rebuilt so it can't go stale against edited sources). JOLT_BIN=bin/jolt
-# forces script mode.
+# The CLI and build gates spawn a jolt process per case; a prebuilt binary boots
+# ~10x faster than script mode (0.14s vs 1.5s) and builds an app ~5x faster, so
+# they take this as a prerequisite. JOLT_BIN=bin/jolt forces script mode.
+#
+# Rebuilt only when something it bakes in is newer than the binary. It used to
+# rebuild unconditionally, which is free under `make -j ci` (one shared node in
+# the graph) but charged every single-gate run 18s — enough to make `make
+# buildlibsmoke` slower with the prerequisite than without it. The staleness
+# check covers the same inputs build-jolt.ss embeds: the runtime .ss files, the
+# install roots, and the launcher stub. JOLT_FORCE_TESTBIN=1 rebuilds anyway.
+TESTBIN_INPUTS := host/chez jolt-core stdlib vendor/fs/src vendor/process/src vendor/irregex
 testbin:
-	@$(CHEZ) --script host/chez/build-jolt.ss release target/release/jolt
+	@if [ -n "$${JOLT_FORCE_TESTBIN:-}" ] || [ ! -x target/release/jolt ] || \
+	   [ -n "$$(find $(TESTBIN_INPUTS) -type f -newer target/release/jolt -print -quit 2>/dev/null)" ]; then \
+	  $(CHEZ) --script host/chez/build-jolt.ss release target/release/jolt; \
+	else \
+	  echo "testbin: target/release/jolt up to date"; \
+	fi
 
 smoke: testbin
 	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/smoke.sh
@@ -56,18 +68,26 @@ smoke: testbin
 irvalidate:
 	@sh host/chez/ir-validate-smoke.sh
 
+# The build-driving gates take testbin for the same reason smoke and cts do,
+# only more so: a `jolt build` costs ~2.5s through the prebuilt binary and
+# ~12.5s through the source-mode driver, and buildsmoke alone drives 26 of them
+# (343s -> 78s measured). Under `make -j ci` the one testbin build is shared
+# with smoke/cts/aotcachesmoke. buildsmoke keeps an explicit bin/jolt build at
+# the end so the source-mode driver stays gated; JOLT_BIN=bin/jolt forces the
+# whole gate back to script mode.
+
 # `jolt build` produces a working standalone binary.
-buildsmoke:
-	@sh host/chez/build-smoke.sh
+buildsmoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/build-smoke.sh
 
 # `jolt build --library` produces a shared object callable from C/C++/Rust.
-buildlibsmoke:
-	@sh host/chez/build-lib-smoke.sh
+buildlibsmoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/build-lib-smoke.sh
 
 # `jolt build` cc-links a :jolt/native :static archive into the binary (the
 # default), and --dynamic keeps the runtime load-shared-object path.
-staticnativesmoke:
-	@sh host/chez/static-native-smoke.sh
+staticnativesmoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/static-native-smoke.sh
 
 # OPT-IN: jolt.mvn-http cert-verifying HTTPS fetch against Central + Clojars.
 # Not in `make test` — needs network + a working system OpenSSL.
@@ -82,8 +102,8 @@ mvnhttp:
 # deps.edn alias + CLI semantics (tools.deps args-map keys, -X/-T/-Sdeps, the
 # user deps.edn chain, jar/git coordinates) through the real CLI, over local
 # fixture projects in test/chez/deps-alias/. Offline.
-depssmoke:
-	@sh host/chez/deps-alias-smoke.sh
+depssmoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/deps-alias-smoke.sh
 
 # Dependency-expansion unit tests: exclusions, version selection, orphan
 # cutting, and the Maven version comparator, driven through a fake coordinate
@@ -266,14 +286,14 @@ inline:
 # Tree-shake soundness: build example apps (incl. deps.edn git-lib apps) default vs
 # --tree-shake and require identical output. Slow (two builds per app); not in the
 # default gate. Skips without the examples repo / Chez kernel dev files.
-shakesmoke:
-	@sh host/chez/tree-shake-smoke.sh
+shakesmoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/tree-shake-smoke.sh
 
 # The no-git-dep tree-shake correctness fixtures only (ns-publics/defonce/
 # data-reader apps under test/chez) — build in seconds, no examples repo needed,
 # so they run in `make test`/ci. The git-dep apps stay in the manual shakesmoke.
-shakelocal:
-	@SHAKESMOKE_SCOPE=local sh host/chez/tree-shake-smoke.sh
+shakelocal: testbin
+	@SHAKESMOKE_SCOPE=local JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/tree-shake-smoke.sh
 
 # Runtime load-manifest drift guard: cli.ss (the live entry) and bootstrap.ss
 # (the seed rebuilder's reduced set) hand-mirror build.ss's bld-runtime-manifest;

--- a/host/chez/build-lib-smoke.sh
+++ b/host/chez/build-lib-smoke.sh
@@ -5,6 +5,14 @@
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
 
+# JOLT_BIN overrides the jolt under test. The gate targets point it at the
+# freshly built target/release/jolt: a `jolt build` costs ~2.5s through the
+# prebuilt binary and ~12.5s through the source-mode driver, and this gate
+# drives one. JOLT_BIN=bin/jolt forces script mode.
+jolt="${JOLT_BIN:-bin/jolt}"
+# Absolute form, for the cases that cd into a fixture directory first.
+case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
+
 # Preflight: same as build-smoke — a library build needs Chez's kernel dev files
 # (libkernel.a + scheme.h) and a C compiler. Skip cleanly where absent.
 csv="$JOLT_CHEZ_CSV"
@@ -33,7 +41,7 @@ case "$(uname -s)" in
 esac
 
 echo "build-lib smoke: compiling libadd.core -> $lib"
-build_out="$(JOLT_PWD="$app" bin/jolt build --library -m libadd.core -o "$lib" 2>&1)"
+build_out="$(JOLT_PWD="$app" "$jolt" build --library -m libadd.core -o "$lib" 2>&1)"
 if [ ! -f "$lib" ]; then
   # A shared object folds Chez's libkernel.a in, so that archive must be PIC. A
   # kernel built without -fPIC (the common default, incl. a stock source build)

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -5,6 +5,14 @@
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
 
+# JOLT_BIN overrides the jolt under test. The gate targets point it at the
+# freshly built target/release/jolt: a `jolt build` costs ~2.5s through the
+# prebuilt binary and ~12.5s through the source-mode driver, and this gate
+# drives 26 of them. JOLT_BIN=bin/jolt forces script mode.
+jolt="${JOLT_BIN:-bin/jolt}"
+# Absolute form, for the cases that cd into a fixture directory first.
+case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
+
 # Preflight: a standalone build needs Chez's kernel dev files (libkernel.a +
 # scheme.h) and a C compiler. A distro chezscheme package ships neither, so on
 # such hosts (CI included) skip — like `certify` skips without Clojure. Pin the
@@ -30,7 +38,7 @@ out="$(mktemp -d)/app-bin"
 trap 'rm -rf "$(dirname "$out")"' EXIT
 
 echo "build smoke: compiling app.core -> $out"
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out" >/dev/null 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out" >/dev/null 2>&1; then
   echo "  FAIL: jolt build exited non-zero"
   exit 1
 fi
@@ -70,7 +78,7 @@ fi
 # param seeded :double, so its * lowers to a flonum op. The same build with
 # JOLT_NO_WP_INFER=1 skips the fixpoint — the fl-op count must drop (area is the
 # delta). Same numeric result either way; this is the emit-level proof it ran.
-if ! JOLT_PWD="$app" JOLT_NO_WP_INFER=1 bin/jolt build -m app.core -o "$out.noop" >/dev/null 2>&1; then
+if ! JOLT_PWD="$app" JOLT_NO_WP_INFER=1 "$jolt" build -m app.core -o "$out.noop" >/dev/null 2>&1; then
   echo "  FAIL: JOLT_NO_WP_INFER build exited non-zero"; exit 1
 fi
 default_fl=$(grep -c '#3%fl' "$out.build/flat.ss" || true)
@@ -81,7 +89,7 @@ fi
 
 # --no-direct-link opts back out of the release default: the app->app call must
 # NOT lower to a jv$ binding (stays var-routed, dynamically linked).
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out.nodl" --no-direct-link >/dev/null 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out.nodl" --no-direct-link >/dev/null 2>&1; then
   echo "  FAIL: jolt build --no-direct-link exited non-zero"; exit 1
 fi
 if grep -q '(jv\$app.util\$shout' "$out.nodl.build/flat.ss"; then
@@ -103,7 +111,7 @@ echo "build smoke: portable-embed check"
 app_copy="$(mktemp -d)/app-copy"
 cp -R "$app" "$app_copy"
 pe_out="$(dirname "$out")/pe-bin"
-if ! JOLT_PWD="$app_copy" bin/jolt build -m app.core -o "$pe_out" >/dev/null 2>&1; then
+if ! JOLT_PWD="$app_copy" "$jolt" build -m app.core -o "$pe_out" >/dev/null 2>&1; then
   echo "  FAIL: portable-embed build exited non-zero"; exit 1
 fi
 rm -rf "$app_copy"
@@ -116,7 +124,7 @@ fi
 
 # Optimized mode (inference + flatten + scalar-replace) must produce the same
 # result — a sanity check that the passes don't miscompile this app.
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out" --opt >/dev/null 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out" --opt >/dev/null 2>&1; then
   echo "  FAIL: jolt build --opt exited non-zero"; exit 1
 fi
 got_opt="$(cd / && "$out" alpha bb ccc 2>&1)"
@@ -128,7 +136,7 @@ fi
 
 # Closed-world direct-linking (opt-in): same result, and the cross-namespace call
 # (app.core -> app.util/shout) must lower to a direct jv$ binding, not var-deref.
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out" --direct-link >/dev/null 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out" --direct-link >/dev/null 2>&1; then
   echo "  FAIL: jolt build --direct-link exited non-zero"; exit 1
 fi
 got_dl="$(cd / && "$out" alpha bb ccc 2>&1)"
@@ -160,7 +168,7 @@ done
 # the ArithmeticException fires, and -main prints THROW OK, not the folded 1.
 inline_throw_app="$root/test/chez/inline-throw-app"
 inline_throw_out="$(dirname "$out")/inline-throw-bin"
-if ! JOLT_PWD="$inline_throw_app" bin/jolt build -m app.core -o "$inline_throw_out" --opt --direct-link >/dev/null 2>&1; then
+if ! JOLT_PWD="$inline_throw_app" "$jolt" build -m app.core -o "$inline_throw_out" --opt --direct-link >/dev/null 2>&1; then
   echo "  FAIL: inline-throw --opt --direct-link build exited non-zero"; exit 1
 fi
 inline_throw_got="$(cd "$inline_throw_app" && "$inline_throw_out" 2>&1)"
@@ -173,7 +181,7 @@ fi
 # --opt build printed :b / :y instead of :a / :n.
 nil_fold_app="$root/test/chez/nil-fold-app"
 nil_fold_out="$(dirname "$out")/nil-fold-bin"
-if ! JOLT_PWD="$nil_fold_app" bin/jolt build -m app.core -o "$nil_fold_out" --opt >/dev/null 2>&1; then
+if ! JOLT_PWD="$nil_fold_app" "$jolt" build -m app.core -o "$nil_fold_out" --opt >/dev/null 2>&1; then
   echo "  FAIL: nil-fold --opt build exited non-zero"; exit 1
 fi
 nil_fold_got="$(cd "$nil_fold_app" && "$nil_fold_out" 2>&1)"
@@ -188,7 +196,7 @@ fi
 # raising, where Clojure raises IllegalArgumentException the second time.
 nil_devirt_app="$root/test/chez/nil-devirt-app"
 nil_devirt_out="$(dirname "$out")/nil-devirt-bin"
-if ! JOLT_PWD="$nil_devirt_app" bin/jolt build -m app.core -o "$nil_devirt_out" --opt --direct-link >/dev/null 2>&1; then
+if ! JOLT_PWD="$nil_devirt_app" "$jolt" build -m app.core -o "$nil_devirt_out" --opt --direct-link >/dev/null 2>&1; then
   echo "  FAIL: nil-devirt --opt --direct-link build exited non-zero"; exit 1
 fi
 nil_devirt_got="$(cd "$nil_devirt_app" && "$nil_devirt_out" 2>&1)"
@@ -204,7 +212,7 @@ fi
 # straight through to prove field reads still devirtualize.
 loop_shadow_app="$root/test/chez/loop-shadow-app"
 loop_shadow_out="$(dirname "$out")/loop-shadow-bin"
-if ! JOLT_PWD="$loop_shadow_app" bin/jolt build -m app.core -o "$loop_shadow_out" --opt >/dev/null 2>&1; then
+if ! JOLT_PWD="$loop_shadow_app" "$jolt" build -m app.core -o "$loop_shadow_out" --opt >/dev/null 2>&1; then
   echo "  FAIL: loop-shadow --opt build exited non-zero"; exit 1
 fi
 loop_shadow_got="$(cd "$loop_shadow_app" && "$loop_shadow_out" 2>&1)"
@@ -218,7 +226,7 @@ fi
 # printed 3.0. They must preserve the int.
 min_max_app="$root/test/chez/min-max-app"
 min_max_out="$(dirname "$out")/min-max-bin"
-if ! JOLT_PWD="$min_max_app" bin/jolt build -m app.core -o "$min_max_out" --opt >/dev/null 2>&1; then
+if ! JOLT_PWD="$min_max_app" "$jolt" build -m app.core -o "$min_max_out" --opt >/dev/null 2>&1; then
   echo "  FAIL: min-max --opt build exited non-zero"; exit 1
 fi
 min_max_got="$(cd "$min_max_app" && "$min_max_out" 2>&1)"
@@ -238,7 +246,7 @@ printf '{:paths ["src"]}\n' > "$nsp/deps.edn"
 printf '(ns nsp.lib)\n(defn thing [] 1)\n' > "$nsp/src/nsp/lib.clj"
 printf '(ns nsp.main (:require [nsp.lib :as l]))\n(defn -main [& _]\n  (println "ns:" (str *ns*))\n  (println "resolve:" (pr-str (resolve (quote l/thing))))\n  (println "ns-resolve:" (pr-str (ns-resolve (quote nsp.lib) (quote thing)))))\n' > "$nsp/src/nsp/main.clj"
 nspout="$(dirname "$out")/nsparity-bin"
-if ! JOLT_PWD="$nsp" bin/jolt build -m nsp.main -o "$nspout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$nsp" "$jolt" build -m nsp.main -o "$nspout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of the ns-parity app exited non-zero"; exit 1
 fi
 nsp_out="$(cd / && "$nspout" 2>&1)"
@@ -251,7 +259,7 @@ if ! printf '%s' "$nsp_out" | grep -q 'ns: user' \
 fi
 # Tree-shaking (opt-in): same result, and an unreachable def (the `twice` macro,
 # expanded at AOT and never called at runtime) is dropped.
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out" --tree-shake >/dev/null 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out" --tree-shake >/dev/null 2>&1; then
   echo "  FAIL: jolt build --tree-shake exited non-zero"; exit 1
 fi
 got_ts="$(cd / && "$out" alpha bb ccc 2>&1)"
@@ -279,7 +287,7 @@ fi
 # namespaces reachable only through the data-readers table.
 drapp="$root/test/chez/datareader-app"
 drout="$(dirname "$out")/dr-bin"
-if ! JOLT_PWD="$drapp" bin/jolt build -m drtest.main -o "$drout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$drapp" "$jolt" build -m drtest.main -o "$drout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of a data-reader app exited non-zero"; exit 1
 fi
 got_dr="$(cd / && "$drout" 2>&1)"
@@ -299,7 +307,7 @@ mkdir -p "$nomain/src"
 printf '{:paths ["src"]}\n' > "$nomain/deps.edn"
 printf '(ns script)\n(println "no-main script ran")\n' > "$nomain/src/script.clj"
 nmout="$(dirname "$out")/nomain-bin"
-if ! JOLT_PWD="$nomain" bin/jolt build -m script -o "$nmout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$nomain" "$jolt" build -m script -o "$nmout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of a no-main script exited non-zero"; exit 1
 fi
 got_nm="$(cd / && "$nmout" 2>&1)"; rc_nm=$?
@@ -312,7 +320,7 @@ fi
 # succeeds and the binary runs when -main never calls it; calling it fails with
 # a catchable error, not a kernel abort.
 olout="$(dirname "$out")/optional-lib-bin"
-if ! JOLT_PWD="$root/test/chez/optional-lib-app" bin/jolt build -m app.optional-lib -o "$olout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$root/test/chez/optional-lib-app" "$jolt" build -m app.optional-lib -o "$olout" >/dev/null 2>&1; then
   echo "  FAIL: build with a missing optional native lib exited non-zero"; exit 1
 fi
 got_ol="$(cd / && "$olout" 2>&1)"
@@ -320,7 +328,7 @@ if [ "$got_ol" != "optional lib app ran successfully" ]; then
   echo "  FAIL: optional-lib binary — got \`$got_ol\`"; exit 1
 fi
 ocout="$(dirname "$out")/optional-call-bin"
-if ! JOLT_PWD="$root/test/chez/optional-lib-call-app" bin/jolt build -m app.optional-lib-call -o "$ocout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$root/test/chez/optional-lib-call-app" "$jolt" build -m app.optional-lib-call -o "$ocout" >/dev/null 2>&1; then
   echo "  FAIL: build of optional-lib-call app exited non-zero"; exit 1
 fi
 got_oc="$(cd / && "$ocout" 2>&1 | tail -1)"
@@ -335,7 +343,7 @@ mkdir -p "$optproj/src"
 printf '{:paths ["src"] :jolt/build {:opt true}}\n' > "$optproj/deps.edn"
 printf '(ns app)\n(defn -main [& _] (println "opt project ran"))\n' > "$optproj/src/app.clj"
 opout="$(dirname "$out")/optproj-bin"
-modeline="$(JOLT_PWD="$optproj" bin/jolt build -m app -o "$opout" 2>&1 | grep 'compiling app (')"
+modeline="$(JOLT_PWD="$optproj" "$jolt" build -m app -o "$opout" 2>&1 | grep 'compiling app (')"
 case "$modeline" in
   *"(optimized mode"*) : ;;
   *) echo "  FAIL: deps.edn :jolt/build {:opt true} did not select optimized mode — got \`$modeline\`"; exit 1 ;;
@@ -346,7 +354,7 @@ esac
 # emitted into the binary, or a call to it crashes on an unbound var.
 ccapp="$root/test/chez/cljc-cond-app"
 ccout="$(dirname "$out")/cljc-cond-bin"
-if ! JOLT_PWD="$ccapp" bin/jolt build -m cljccond.main -o "$ccout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$ccapp" "$jolt" build -m cljccond.main -o "$ccout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of a cljs-conditional app exited non-zero"; exit 1
 fi
 got_cc="$(cd / && "$ccout" 2>&1 | tail -1)"
@@ -359,7 +367,7 @@ fi
 # .clj. The fixture's .clj main requires a .jolt lib and uses a macro from it.
 jxapp="$root/test/chez/jolt-ext-app"
 jxout="$(dirname "$out")/jolt-ext-bin"
-if ! JOLT_PWD="$jxapp" bin/jolt build -m jxapp.main -o "$jxout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$jxapp" "$jolt" build -m jxapp.main -o "$jxout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of an app with a .jolt namespace exited non-zero"; exit 1
 fi
 got_jx="$(cd / && "$jxout" 2>&1 | tail -1)"
@@ -373,12 +381,12 @@ fi
 # runs the app from source and as a built binary and expects the same answer.
 umapp="$root/test/chez/unchecked-math-app"
 umwant="UNCHECKED-MATH -9223372036854775808 9223372036854775808 false"
-got_um_src="$(cd "$umapp" && JOLT_PWD="$umapp" "$root/bin/jolt" run -m umapp.main 2>&1 | tail -1)"
+got_um_src="$(cd "$umapp" && JOLT_PWD="$umapp" "$joltabs" run -m umapp.main 2>&1 | tail -1)"
 if [ "$got_um_src" != "$umwant" ]; then
   echo "  FAIL: top-level (set! *unchecked-math* …) from source — want \`$umwant\`, got \`$got_um_src\`"; exit 1
 fi
 umout="$(dirname "$out")/unchecked-math-bin"
-if ! JOLT_PWD="$umapp" bin/jolt build -m umapp.main -o "$umout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$umapp" "$jolt" build -m umapp.main -o "$umout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of an unchecked-math app exited non-zero"; exit 1
 fi
 got_um_bin="$(cd / && "$umout" 2>&1 | tail -1)"
@@ -391,7 +399,7 @@ fi
 # conditionals (directory?/cwd/which). Guards the vendored-namespace baking.
 fsapp="$root/test/chez/fs-app"
 fsout="$(dirname "$out")/fs-app-bin"
-if ! JOLT_PWD="$fsapp" bin/jolt build -m fsapp.main -o "$fsout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$fsapp" "$jolt" build -m fsapp.main -o "$fsout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of a jolt.fs / babashka.fs app exited non-zero"; exit 1
 fi
 got_fs="$(cd / && "$fsout" 2>&1 | tail -1)"
@@ -404,7 +412,7 @@ fi
 # under jolt.fs) must resolve as compiled foreign-procedures — an eval'd form
 # would silently return #f under the interpreter and the output would change.
 fsshake="$(dirname "$out")/fs-app-shake-bin"
-if ! JOLT_PWD="$fsapp" bin/jolt build -m fsapp.main -o "$fsshake" --tree-shake >/dev/null 2>&1; then
+if ! JOLT_PWD="$fsapp" "$jolt" build -m fsapp.main -o "$fsshake" --tree-shake >/dev/null 2>&1; then
   echo "  FAIL: jolt build --tree-shake of the jolt.fs app exited non-zero"; exit 1
 fi
 if grep -q 'scheme.boot' "$fsshake.build/compile.ss" 2>/dev/null; then
@@ -419,7 +427,7 @@ fi
 # be able to spawn a real sub-process. Guards the vendored-namespace baking.
 procapp="$root/test/chez/process-app"
 procout="$(dirname "$out")/process-app-bin"
-if ! JOLT_PWD="$procapp" bin/jolt build -m procapp.main -o "$procout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$procapp" "$jolt" build -m procapp.main -o "$procout" >/dev/null 2>&1; then
   echo "  FAIL: jolt build of a jolt.process / babashka.process app exited non-zero"; exit 1
 fi
 got_proc="$(cd / && "$procout" 2>&1 | tail -1)"
@@ -432,7 +440,7 @@ fi
 # jolt.process) must resolve as compiled foreign-procedures — an eval'd form would
 # silently return #f under the interpreter and the exit codes would be lost.
 procshake="$(dirname "$out")/process-app-shake-bin"
-if ! JOLT_PWD="$procapp" bin/jolt build -m procapp.main -o "$procshake" --tree-shake >/dev/null 2>&1; then
+if ! JOLT_PWD="$procapp" "$jolt" build -m procapp.main -o "$procshake" --tree-shake >/dev/null 2>&1; then
   echo "  FAIL: jolt build --tree-shake of the jolt.process app exited non-zero"; exit 1
 fi
 if grep -q 'scheme.boot' "$procshake.build/compile.ss" 2>/dev/null; then
@@ -463,7 +471,7 @@ cat > "$decl_app/src/da/core.clj" <<'DECL_EOF'
   (println "interned:" (contains? (ns-interns 'da.core) 'only-declared)))
 DECL_EOF
 decl_out="$(dirname "$out")/decl-bin"
-if ! JOLT_PWD="$decl_app" bin/jolt build -m da.core -o "$decl_out" >/dev/null 2>&1; then
+if ! JOLT_PWD="$decl_app" "$jolt" build -m da.core -o "$decl_out" >/dev/null 2>&1; then
   echo "  FAIL: declaration-only-var app build exited non-zero"; exit 1
 fi
 got_decl="$(cd / && "$decl_out" 2>&1)"
@@ -473,4 +481,21 @@ if ! printf '%s' "$got_decl" | grep -q '^declared: true$' || ! printf '%s' "$got
   echo "--- got ----"; echo "$got_decl"; exit 1
 fi
 
-echo "build smoke: passed (release + optimized + direct-link + tree-shake + compiler+core shake + data-reader + no-main + optional-native + deps-opt + cljc-cond + jolt-ext + vendored-fs + petite-only-fs + vendored-process + petite-only-process + declare-only-var)"
+# Everything above builds through $jolt, which the make target points at the
+# prebuilt binary. Build one app through the source-mode driver too, so the
+# bin/jolt path a developer actually runs stays gated here and not only as a
+# side effect of devbootsmoke's cached-project-build case. Redundant when $jolt
+# already is bin/jolt, so skip it then.
+if [ "$jolt" != "bin/jolt" ]; then
+  echo "build smoke: source-mode driver check"
+  srcout="$(dirname "$out")/srcmode-bin"
+  if ! JOLT_PWD="$root/test/chez/jolt-ext-app" bin/jolt build -m jxapp.main -o "$srcout" >/dev/null 2>&1; then
+    echo "  FAIL: source-mode (bin/jolt) build exited non-zero"; exit 1
+  fi
+  got_src="$(cd / && "$srcout" 2>&1 | tail -1)"
+  if [ "$got_src" != "JOLT-EXT BUILT! (:x :x)" ]; then
+    echo "  FAIL: source-mode build output — want 'JOLT-EXT BUILT! (:x :x)', got \`$got_src\`"; exit 1
+  fi
+fi
+
+echo "build smoke: passed (release + optimized + direct-link + tree-shake + compiler+core shake + data-reader + no-main + optional-native + deps-opt + cljc-cond + jolt-ext + vendored-fs + petite-only-fs + vendored-process + petite-only-process + declare-only-var + source-mode-driver)"

--- a/host/chez/static-native-smoke.sh
+++ b/host/chez/static-native-smoke.sh
@@ -6,6 +6,14 @@
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
 
+# JOLT_BIN overrides the jolt under test. The gate targets point it at the
+# freshly built target/release/jolt: a `jolt build` costs ~2.5s through the
+# prebuilt binary and ~12.5s through the source-mode driver, and this gate
+# drives two of them. JOLT_BIN=bin/jolt forces script mode.
+jolt="${JOLT_BIN:-bin/jolt}"
+# Absolute form, for the cases that cd into a fixture directory first.
+case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
+
 # Preflight: needs cc (to build the test libs AND to cc-link the app) + Chez's
 # kernel dev files, same as build-smoke. Skip otherwise (CI on a distro package).
 csv="$JOLT_CHEZ_CSV"
@@ -61,7 +69,7 @@ cat > "$app/deps.edn" <<EOF
  :jolt/native [{:name "greet" :static {:archive "$work/libgreet.a"}}]}
 EOF
 echo "static-native smoke: building (default: static link)"
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out" >"$work/build.log" 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out" >"$work/build.log" 2>&1; then
   echo "  FAIL: jolt build (static) exited non-zero"; cat "$work/build.log"; exit 1
 fi
 [ -x "$out" ] || { echo "  FAIL: no executable produced"; exit 1; }
@@ -92,7 +100,7 @@ cat > "$app/deps.edn" <<EOF
                 $plat ["$work/libgreet.$soext"]}]}
 EOF
 echo "static-native smoke: building (--dynamic: runtime load)"
-if ! JOLT_PWD="$app" bin/jolt build -m app.core -o "$out" --dynamic >"$work/build.log" 2>&1; then
+if ! JOLT_PWD="$app" "$jolt" build -m app.core -o "$out" --dynamic >"$work/build.log" 2>&1; then
   echo "  FAIL: jolt build --dynamic exited non-zero"; cat "$work/build.log"; exit 1
 fi
 # --dynamic loads the shared object at runtime.

--- a/host/chez/tree-shake-smoke.sh
+++ b/host/chez/tree-shake-smoke.sh
@@ -9,6 +9,14 @@
 # default gate — run with `make shakesmoke`.
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
+
+# JOLT_BIN overrides the jolt under test. The gate targets point it at the
+# freshly built target/release/jolt: a `jolt build` costs ~2.5s through the
+# prebuilt binary and ~12.5s through the source-mode driver, and this gate
+# drives two per app. JOLT_BIN=bin/jolt forces script mode.
+jolt="${JOLT_BIN:-bin/jolt}"
+# Absolute form, for the cases that cd into a fixture directory first.
+case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
 # SHAKESMOKE_SCOPE=local runs ONLY the no-git-dep correctness fixtures under
 # test/chez (ns-publics/defonce/data-reader apps) — these build in seconds and
 # don't need the examples repo, so they're wired into `make shakelocal` / ci. The
@@ -39,9 +47,9 @@ run_case() {
   app="$examples/$1"; ns="$2"; args="$3"
   [ -d "$app" ] || { echo "  - $1: skipped (not present)"; return; }
   b0="$tmp/$1-plain"; b1="$tmp/$1-shake"
-  if ! JOLT_PWD="$app" bin/jolt build -m "$ns" -o "$b0" >/dev/null 2>&1; then
+  if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b0" >/dev/null 2>&1; then
     echo "  - $1: FAIL (default build)"; fail=1; return; fi
-  if ! JOLT_PWD="$app" bin/jolt build -m "$ns" -o "$b1" --tree-shake >/dev/null 2>&1; then
+  if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b1" --tree-shake >/dev/null 2>&1; then
     echo "  - $1: FAIL (--tree-shake build)"; fail=1; return; fi
   o0="$(cd "$app" && "$b0" $args 2>&1)"
   o1="$(cd "$app" && "$b1" $args 2>&1)"
@@ -64,9 +72,9 @@ run_local_case() {
   [ -d "$app" ] || { echo "  - $1: skipped (not present)"; return; }
   b0="$tmp/$1-plain"; b1="$tmp/$1-shake"
   bdir="$tmp/$1-shake.build"
-  if ! JOLT_PWD="$app" bin/jolt build -m "$ns" -o "$b0" >/dev/null 2>&1; then
+  if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b0" >/dev/null 2>&1; then
     echo "  - $1: FAIL (default build)"; fail=1; return; fi
-  if ! JOLT_PWD="$app" bin/jolt build -m "$ns" -o "$b1" --tree-shake 2>"$tmp/$1-shake-err"; then
+  if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b1" --tree-shake 2>"$tmp/$1-shake-err"; then
     echo "  - $1: FAIL (--tree-shake build)"
     cat "$tmp/$1-shake-err" | head -5
     fail=1; return; fi


### PR DESCRIPTION
`make -j8` over the whole gate goes from 338s to 124s on this machine, about 2.7x.

## What was slow

I timed every target in `make ci` individually. Five of them accounted for 73% of a serial run, and all five for the same reason: they shell out to `bin/jolt` in source mode. A `jolt build` costs about 12.5s that way and about 2.5s through `target/release/jolt`, and `buildsmoke` alone drives 26 builds. `smoke` and `cts` already took `testbin` and defaulted `JOLT_BIN` to the prebuilt binary; the build-oriented gates never got the same treatment.

Measured with a warm `testbin`:

| gate | before | after |
|---|---|---|
| `buildsmoke` | 343.6s | 92.1s |
| `shakelocal` | 204.4s | 42.0s |
| `depssmoke` | 120.7s | 7.7s |
| `staticnativesmoke` | 29.9s | 6.6s |
| `buildlibsmoke` | 14.9s | 12.6s |
| total | 713.5s | 161.0s |

This matters more than the totals suggest because CI runs `make -j$(nproc)`, where wall time is bounded below by the longest single gate. `buildsmoke` at 5.7 min was the critical path; at 1.5 min it no longer is.

`JOLT_BIN=bin/jolt` puts any of them back in script mode.

## Coverage

Switching means `buildsmoke` stops exercising the source-mode build driver, which is what a developer actually runs. `devbootsmoke` case (e) already builds a project through the devcache launcher and runs the result, so it was not going to be uncovered, but relying on that alone felt thin for a gate whose whole subject is `jolt build`. So `buildsmoke` keeps one explicit `bin/jolt` build at the end over the small `jolt-ext-app` fixture, mirroring how `smoke.sh` keeps a script-mode case. It costs 12.5s and is skipped when `JOLT_BIN` already is `bin/jolt`.

## testbin

Adding the prerequisite exposed a second problem. `testbin` rebuilt unconditionally, which is free under `make -j ci` where it is one shared node in the graph, but it charged every single-gate run 18s. That was enough to make `make buildlibsmoke` slower with the new prerequisite than without it, 14.9s before against 30s after. It now rebuilds only when a file under `host/chez`, `jolt-core`, `stdlib` or the vendored source roots is newer than the binary, which is the same set `build-jolt.ss` bakes in. `JOLT_FORCE_TESTBIN=1` rebuilds anyway. This also speeds up single runs of `smoke`, `cts` and `aotcachesmoke`, which were already paying it.

## Testing

Ran the full gate in parallel before and after, cold with no prebuilt binary, everything passing both times: 338s to 124s. Also ran each of the five individually and confirmed the assertion counts are unchanged (`deps-alias smoke: 47 passed`, `cli smoke: 87 passed`, `cts: 5717 pass`, `build smoke: passed`, `shake smoke: passed`).

`sci` is excluded from those runs. It fails in my checkout at 209 against a 211 floor from vendored submodule drift, unrelated to this change and unaffected by it.

## Left on the table

Twenty pass gates (`infer`, `wp`, `pic`, `narrow`, and so on) take about 1.5s each, essentially all of it `run-gate-harness.ss` loading the runtime from source. That is 30s aggregate and near zero under `-j`, but it makes iterating on a single pass gate sluggish. A precompiled preamble would take each to about 0.2s. It needs its own artifact rather than reusing `target/dev/flat.so`, because the gates deliberately stop at `compile-eval.ss` and do not load `loader.ss`. Not done here.