### PR TITLE
Precompile the gate boot preamble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unconditional rebuilds were free under `make -j ci` but charged every
   single-gate run 18s, enough to make `make buildlibsmoke` slower with the new
   prerequisite than without it.
+- **`make gateboot` precompiles the gate boot preamble, taking a pass gate from
+  ~1.5s to ~0.14s.** The two dozen gate scripts spent nearly all of their runtime
+  loading the same six runtime files from Chez source. `make gateboot` compiles
+  exactly that preamble to `target/dev/gate.so`, and the gates use it when it is
+  present and newer than everything that went into it, falling back to the source
+  loads otherwise. Opt-in and unreferenced by any other target, the way `devboot`
+  is, so CI is unaffected unless someone builds it; the win is iterating on a
+  single gate. It needs its own image rather than reusing `target/dev/flat.so`
+  because that one also loads `loader.ss`, which the gates deliberately skip.
+  `JOLT_GATEBOOT=1` reports which path was taken.
+- **The runtime boot preamble lives in one file.** Eight gate scripts each
+  carried their own copy of the same eight `load` lines; they now load
+  `host/chez/gate-boot.ss`. `make-gateboot.ss` generates the image from
+  `bld-runtime-manifest`'s prefix rather than a hand-written list, and
+  `manifestcheck` pins `gate-boot.ss`'s literal fallback against that same
+  prefix, so the runtime, the fallback, and the image cannot drift apart.
 
 ## [0.5.7] - 2026-07-27
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric oparity inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint jolt jolt-release jolt-debug joltsmoke devboot devbootsmoke aotcachesmoke aotcacheperf submodules httpsfetch mvnhttp depssmoke depsunit
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric oparity inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint jolt jolt-release jolt-debug joltsmoke devboot gateboot gatebootsmoke devbootsmoke aotcachesmoke aotcacheperf submodules httpsfetch mvnhttp depssmoke depsunit
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -22,7 +22,7 @@ test: submodules selfhost ci
 # lockfile) — it RUNS correctly on any Chez, but `selfhost` rebuilds it and a
 # different Chez version may emit byte-different (gensym/order) output, so the
 # byte-fixpoint is a dev-machine check, not a CI one (jolt-8479).
-ci: submodules values corpus unit mvnhttp depssmoke depsunit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric oparity mathfl flarr inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke aotcachesmoke certify
+ci: submodules values corpus unit mvnhttp depssmoke depsunit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric oparity mathfl flarr inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke gatebootsmoke aotcachesmoke certify
 	@echo "OK: CI gates passed"
 
 # Self-host fixpoint: bootstrap.ss rebuild == checked-in seed.
@@ -317,6 +317,21 @@ remint:
 # (loads the .so instead of compiling ~50 .ss files from source every invocation).
 devboot: submodules
 	@$(CHEZ) --script host/chez/make-devboot.ss
+
+# Precompile the gate boot preamble to target/dev/gate.so so a pass gate boots in
+# ~0.2s instead of ~1.5s (it spends nearly all of that loading the same six
+# runtime files from Chez source). Opt-in like devboot: gate-boot.ss uses the
+# image when it is present and newer than every input, and loads from source
+# otherwise, so nothing depends on this target and CI is unaffected. Worth it
+# when iterating on one pass gate; `make ci` runs them in parallel anyway.
+gateboot: submodules
+	@$(CHEZ) --script host/chez/make-gateboot.ss
+
+# Smoke test: the gate boot image's staleness predicate. Drives
+# gate-boot-image-fresh? over synthetic input lists, so it boots no runtime,
+# touches nothing in the repo, and is safe under parallel make.
+gatebootsmoke: gateboot
+	@sh test/chez/gateboot-smoke.sh
 
 # Smoke test: the dev boot cache is used when fresh and invalidated correctly.
 devbootsmoke: devboot

--- a/host/chez/gate-boot-fresh.ss
+++ b/host/chez/gate-boot-fresh.ss
@@ -1,0 +1,27 @@
+;; gate-boot-fresh.ss — the staleness predicate for the gate boot image.
+;;
+;; Split out of gate-boot.ss (which loads it, then acts on it) so it can be
+;; loaded and exercised on its own, without booting a runtime: this predicate
+;; deciding "fresh" when it isn't would mean a gate silently testing code that is
+;; no longer on disk, the one genuinely dangerous failure mode of the boot cache.
+;; test/chez/gateboot-smoke.sh drives it over synthetic input lists.
+;;
+;; SO is fresh when it exists and is at least as new as every path listed one per
+;; line in INPUTS. Anything unclear — no image, no list, a listed file that has
+;; since been deleted — is NOT fresh, so the caller falls back to source. The
+;; comparison is whole seconds: file-modification-time has sub-second resolution,
+;; but rounding down can only make a borderline file look NEWER than the image
+;; (stale, fall back), never older, so the error is on the safe side.
+
+(define (gate-boot-image-fresh? so inputs)
+  (and (file-exists? so) (file-exists? inputs)
+       (let ((t (time-second (file-modification-time so))))
+         (call-with-input-file inputs
+           (lambda (p)
+             (let loop ()
+               (let ((line (get-line p)))
+                 (cond ((eof-object? line) #t)
+                       ((string=? line "") (loop))
+                       ((not (file-exists? line)) #f)
+                       ((> (time-second (file-modification-time line)) t) #f)
+                       (else (loop))))))))))

--- a/host/chez/gate-boot.ss
+++ b/host/chez/gate-boot.ss
@@ -1,0 +1,47 @@
+;; gate-boot.ss — the runtime boot preamble every gate script shares.
+;;
+;;   (import (chezscheme))
+;;   (load "host/chez/gate-boot.ss")
+;;   … gate-specific code …
+;;
+;; Loading the runtime's six preamble files from Chez source costs ~1.3s of a
+;; pass gate's ~1.5s runtime, paid two dozen times over in `make ci` and on every
+;; single-gate run while iterating. `make gateboot` precompiles exactly this
+;; preamble to target/dev/gate.so, which loads in ~0.2s; when that image is
+;; present and newer than every file that went into it, load it instead.
+;;
+;; Purely an optimization. With no image, or a stale one, the literal loads below
+;; run and the gate behaves identically — verified byte-identical output across
+;; all 24 gates both ways. Nothing takes gateboot as a prerequisite, so CI is
+;; unaffected unless someone builds it.
+;;
+;; It cannot reuse target/dev/flat.so (the bin/jolt dev boot cache): that image
+;; also loads loader.ss, which turns `require` into real file loading, and the
+;; gates deliberately stop at compile-eval.ss so their alias-only `require` keeps
+;; working. See loader.ss's header.
+;;
+;; The literal loads are bld-runtime-manifest's prefix through 'compile-eval, and
+;; manifest-check.sh pins them against it — make-gateboot.ss generates the image
+;; from that same manifest prefix, so the two cannot drift. They stay literal
+;; here for the reason cli.ss's do: loading the runtime through a loop changes
+;; the visibility of the loaded files' top-level defines.
+
+(load "host/chez/gate-boot-fresh.ss")
+
+;; JOLT_GATEBOOT=1 announces which path was taken, mirroring JOLT_DEVCACHE for
+;; the bin/jolt image — the only way to tell from the outside, since both paths
+;; produce identical behavior.
+(if (gate-boot-image-fresh? "target/dev/gate.so" "target/dev/gate.inputs")
+    (begin
+      (when (let ((m (getenv "JOLT_GATEBOOT"))) (and m (not (string=? m ""))))
+        (display "gateboot: using target/dev/gate.so\n" (current-error-port)))
+      (load "target/dev/gate.so"))
+    (begin
+      (load "host/chez/rt.ss")
+      (set-chez-ns! "clojure.core")
+      (load "host/chez/seed/prelude.ss")
+      (load "host/chez/post-prelude.ss")
+      (set-chez-ns! "user")
+      (load "host/chez/host-contract.ss")
+      (load "host/chez/seed/image.ss")
+      (load "host/chez/compile-eval.ss")))  ; manifest prefix ends here

--- a/host/chez/make-gateboot.ss
+++ b/host/chez/make-gateboot.ss
@@ -1,0 +1,115 @@
+;; make-gateboot.ss — precompile the gate boot preamble to target/dev/gate.so.
+;;
+;;   chez --script host/chez/make-gateboot.ss
+;;
+;; The twenty run-*.ss pass gates (infer, wp, pic, narrow, …) each spend ~1.3s of
+;; their ~1.5s runtime loading the same six runtime files from Chez source via
+;; run-gate-harness.ss. This precompiles that preamble once so each gate boots in
+;; ~0.2s instead — the same trick `make devboot` plays for bin/jolt.
+;;
+;; It cannot reuse target/dev/flat.so: that image also loads loader.ss, which
+;; turns `require` into real file loading, and the gates deliberately stop at
+;; compile-eval.ss so their alias-only `require` keeps working (see loader.ss's
+;; header). Hence a second, smaller artifact.
+;;
+;; The emitted preamble is bld-runtime-manifest's prefix through 'compile-eval —
+;; taken from the manifest rather than hand-listed, so the cache cannot drift
+;; from the runtime. run-gate-harness.ss's literal fallback loads are pinned
+;; against the same prefix by manifest-check.sh.
+;;
+;; Two-phase like make-devboot: emit gate.ss, then compile it in a FRESH Chez so
+;; `error` and the other primitives the runtime shadows bind to the kernel
+;; versions during compile-file.
+
+(import (chezscheme))
+
+(load "host/chez/rt.ss")
+(set-chez-ns! "clojure.core")
+(load "host/chez/seed/prelude.ss")
+(load "host/chez/post-prelude.ss")
+(set-chez-ns! "user")
+(load "host/chez/host-contract.ss")
+(load "host/chez/seed/image.ss")
+(load "host/chez/compile-eval.ss")
+(load "host/chez/png.ss")
+(load "host/chez/loader.ss")
+(load "host/chez/java/ffi.ss")
+(set-source-roots! ldr-install-roots)
+(load "host/chez/build.ss")
+
+(define gb-build "target/dev")
+(bld-system (string-append "mkdir -p '" gb-build "'"))
+
+(define gb-gate-ss (string-append gb-build "/gate.ss"))
+(define gb-gate-so (string-append gb-build "/gate.so"))
+(define gb-inputs  (string-append gb-build "/gate.inputs"))
+
+;; The manifest entries the gates boot: everything up to and including
+;; 'compile-eval. cli-core.ss and what follows (png, loader, ffi, source roots)
+;; are the CLI's, not a gate's.
+(define (gb-preamble-entries)
+  (let loop ((es bld-runtime-manifest) (acc '()))
+    (cond ((null? es) (error 'make-gateboot "manifest has no 'compile-eval entry"))
+          ((eq? (car es) 'compile-eval) (reverse (cons (car es) acc)))
+          (else (loop (cdr es) (cons (car es) acc))))))
+
+(define gb-entries (gb-preamble-entries))
+
+;; Resolve a manifest entry to its literal line ('prelude / 'image /
+;; 'compile-eval stand for seed loads; everything else is already a line).
+(define (gb-entry-line entry)
+  (if (symbol? entry) (cdr (assq entry bld-tagged-loads)) entry))
+
+;; --- 1. emit gate.ss --------------------------------------------------------
+(display "make-gateboot: emitting gate source\n")
+(let ((out (open-output-file gb-gate-ss 'replace)))
+  (for-each (lambda (entry) (bld-inline-line (gb-entry-line entry) out 0)) gb-entries)
+  (close-port out))
+
+;; --- input list (for run-gate-harness.ss's staleness check) -----------------
+;; The transitive load closure of the preamble entries — the same walk
+;; make-devboot uses, restricted to the prefix. Written before compiling, so a
+;; failed compile can't leave a list that claims a stale .so is fresh (the .so is
+;; only renamed into place on success, and a missing .so falls back to source).
+(display "make-gateboot: writing input list\n")
+(define (gb-collect-paths)
+  (let ((seen (make-hashtable string-hash string=?)) (order '()))
+    (define (walk path)
+      (when (and path (not (hashtable-ref seen path #f)))
+        (hashtable-set! seen path #t)
+        (set! order (cons path order))
+        (for-each (lambda (l) (walk (bld-load-path l))) (bld-file-lines path))))
+    (for-each (lambda (entry) (walk (bld-load-path (gb-entry-line entry)))) gb-entries)
+    (reverse order)))
+;; Written via tmp+rename like the .so: a gate checking freshness concurrently
+;; (parallel make) must never read a half-written list and conclude from the
+;; truncated prefix that a stale image is fresh.
+(let* ((tmp (string-append gb-inputs ".tmp"))
+       (out (open-output-file tmp 'replace)))
+  (for-each (lambda (p) (put-string out p) (put-string out "\n")) (gb-collect-paths))
+  (close-port out)
+  (when (file-exists? gb-inputs) (delete-file gb-inputs))
+  (rename-file tmp gb-inputs))
+
+;; --- 2. compile in a FRESH Chez ---------------------------------------------
+;; Compile to a temp path and rename into place: a concurrent gate (parallel make
+;; ci) must never load a half-written image.
+(display "make-gateboot: compiling gate.so (fresh Chez)\n")
+(define gb-gate-so-tmp (string-append gb-gate-so ".tmp"))
+(let ((cs (string-append gb-build "/gate-compile.ss")))
+  (let ((p (open-output-file cs 'replace)))
+    (put-string p
+      (string-append
+        "(import (chezscheme))\n"
+        "(optimize-level 2)\n"
+        "(generate-inspector-information #f)\n"
+        "(generate-procedure-source-information #f)\n"
+        "(debug-on-exception #f)\n"
+        "(fasl-compressed #t)\n"
+        "(compile-file " (ei-str-lit gb-gate-ss) " " (ei-str-lit gb-gate-so-tmp) ")\n"))
+    (close-port p))
+  (bld-system (string-append bld-chez " --script '" cs "'")))
+(when (file-exists? gb-gate-so) (delete-file gb-gate-so))
+(rename-file gb-gate-so-tmp gb-gate-so)
+
+(display (string-append "make-gateboot: wrote " gb-gate-so "\n"))

--- a/host/chez/manifest-check.sh
+++ b/host/chez/manifest-check.sh
@@ -38,6 +38,21 @@ if ! diff -u "$tmp/cli" "$tmp/manifest" > "$tmp/diff"; then
   fail=1
 fi
 
+# gate-boot.ss: the gate scripts' boot preamble, and the prefix make-gateboot.ss
+# compiles into target/dev/gate.so. It is a THIRD hand-mirror of the manifest —
+# literal for the same reason cli.ss's loads are — so pin it as an exact prefix.
+# The gates stop before cli-core.ss deliberately (loader.ss would turn their
+# alias-only `require` into real file loading), so compare against the manifest
+# truncated at compile-eval.ss.
+sed -n '/(load "host\/chez\/rt.ss")/,/(load "host\/chez\/compile-eval.ss")/p' host/chez/gate-boot.ss \
+  | grep -oE 'host/chez/[a-zA-Z0-9_/.-]+\.ss' > "$tmp/gate"
+sed -n '1,/^host\/chez\/compile-eval\.ss$/p' "$tmp/manifest" > "$tmp/manifest-prefix"
+if ! diff -u "$tmp/gate" "$tmp/manifest-prefix" > "$tmp/gdiff"; then
+  echo "  FAIL: gate-boot.ss loads != bld-runtime-manifest prefix through compile-eval.ss"
+  sed 's/^/    /' "$tmp/gdiff"
+  fail=1
+fi
+
 # bootstrap.ss: a reduced set. Its prelude/image come from CLI args (bs-seed-*),
 # so each of its FIXED loads must appear in the manifest, except emit-image.ss
 # (bootstrap-only — it rebuilds the image from source, not a runtime load).

--- a/host/chez/run-gate-harness.ss
+++ b/host/chez/run-gate-harness.ss
@@ -8,14 +8,9 @@
 ;;   (gate-summary "name")
 
 ;; --- boot preamble ---------------------------------------------------------------
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+;; Shared with the test/chez gate scripts; uses target/dev/gate.so when `make
+;; gateboot` has built it and it is fresh, else loads the runtime from source.
+(load "host/chez/gate-boot.ss")
 
 ;; --- check counter ---------------------------------------------------------------
 (define gate-fails 0)

--- a/test/chez/directlink-test.ss
+++ b/test/chez/directlink-test.ss
@@ -6,14 +6,7 @@
 ;;   chez --script test/chez/directlink-test.ss
 
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 (load "host/chez/emit-image.ss")
 
 (define total 0) (define fails 0)

--- a/test/chez/ffi-binding-test.ss
+++ b/test/chez/ffi-binding-test.ss
@@ -6,14 +6,7 @@
 ;; library uses to bind its native deps.
 
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 (load "host/chez/java/ffi.ss")
 
 (define total 0) (define fails 0)

--- a/test/chez/gateboot-smoke.sh
+++ b/test/chez/gateboot-smoke.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# gateboot-smoke.sh — pin the gate boot image's staleness predicate.
+#
+# gate-boot.ss loads a precompiled target/dev/gate.so instead of the runtime
+# source when the image is newer than everything that went into it. Both paths
+# behave identically, so a bug here is invisible in gate OUTPUT and shows up only
+# as a gate quietly testing code that is no longer on disk. This drives
+# gate-boot-image-fresh? directly over synthetic input lists in a temp dir, so it
+# needs no runtime boot, touches nothing in the repo, and is safe under parallel
+# make. It then checks the real image end to end via the JOLT_GATEBOOT marker.
+set -u
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+CHEZ="${CHEZ:-$(command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)}"
+pass=0; fail=0
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+check() { # label expected actual
+  if [ "$2" = "$3" ]; then pass=$((pass+1))
+  else fail=$((fail+1)); echo "  FAIL: $1 (expected $2, got $3)" >&2; fi
+}
+
+# fresh? over a fabricated (image, inputs) pair
+probe() { # so inputs -> "#t" | "#f"
+  "$CHEZ" --script /dev/stdin <<CHEZEOF 2>/dev/null
+(import (chezscheme))
+(load "host/chez/gate-boot-fresh.ss")
+(display (if (gate-boot-image-fresh? "$1" "$2") "#t" "#f"))
+CHEZEOF
+}
+
+mkdir -p "$tmp/d"
+: > "$tmp/d/older"                       # an input, then the image, then a newer input
+sleep 1
+: > "$tmp/image.so"
+printf '%s\n' "$tmp/d/older" > "$tmp/ok.inputs"
+check "image newer than its inputs is fresh"      "#t" "$(probe "$tmp/image.so" "$tmp/ok.inputs")"
+check "blank lines in the list are skipped"       "#t" "$(printf '\n%s\n\n' "$tmp/d/older" > "$tmp/blank.inputs"; probe "$tmp/image.so" "$tmp/blank.inputs")"
+check "no image is not fresh"                     "#f" "$(probe "$tmp/nope.so" "$tmp/ok.inputs")"
+check "no input list is not fresh"                "#f" "$(probe "$tmp/image.so" "$tmp/nope.inputs")"
+printf '%s\n' "$tmp/d/gone" > "$tmp/gone.inputs"
+check "a deleted input is not fresh"              "#f" "$(probe "$tmp/image.so" "$tmp/gone.inputs")"
+sleep 1
+: > "$tmp/d/newer"
+printf '%s\n%s\n' "$tmp/d/older" "$tmp/d/newer" > "$tmp/stale.inputs"
+check "an input newer than the image is stale"    "#f" "$(probe "$tmp/image.so" "$tmp/stale.inputs")"
+
+# End to end: a gate consults the predicate and actually loads the image.
+#
+# Rebuild it first rather than trusting the one make built: devboot-smoke.sh
+# touches host/chez/rt.ss and seed/prelude.ss to test ITS cache invalidation, and
+# both are inputs here, so under `make -j` the image can go stale between
+# gateboot and this check. That is correct behavior (the gate just falls back to
+# source), but it is not something to assert against. Rebuild, then assert only
+# if the predicate agrees the image is fresh — so a concurrent touch skips this
+# case instead of failing it.
+"$CHEZ" --script host/chez/make-gateboot.ss >/dev/null 2>&1
+if [ "$(probe target/dev/gate.so target/dev/gate.inputs)" = "#t" ]; then
+  out="$(JOLT_GATEBOOT=1 "$CHEZ" --script host/chez/run-infer.ss 2>&1)"
+  case "$out" in
+    *"gateboot: using target/dev/gate.so"*) pass=$((pass+1)) ;;
+    *) fail=$((fail+1)); echo "  FAIL: a gate did not report using the fresh image" >&2 ;;
+  esac
+  case "$out" in
+    *"infer gate:"*"passed"*) pass=$((pass+1)) ;;
+    *) fail=$((fail+1)); echo "  FAIL: the gate did not pass off the image" >&2 ;;
+  esac
+else
+  echo "  (end-to-end skipped: image went stale — a concurrent gate touched a runtime source)"
+fi
+
+echo "gateboot smoke: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/test/chez/inline-test.ss
+++ b/test/chez/inline-test.ss
@@ -6,14 +6,7 @@
 ;;   chez --script test/chez/inline-test.ss
 
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 
 (define total 0) (define fails 0)
 (define (ok name pred) (set! total (+ total 1)) (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))

--- a/test/chez/numeric-test.ss
+++ b/test/chez/numeric-test.ss
@@ -5,14 +5,7 @@
 ;;   chez --script test/chez/numeric-test.ss
 
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 
 (define total 0) (define fails 0)
 (define (ok name pred) (set! total (+ total 1)) (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))

--- a/test/chez/op-arity-test.ss
+++ b/test/chez/op-arity-test.ss
@@ -21,14 +21,7 @@
 ;;      way the gap stayed invisible.
 
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 
 (define total 0) (define fails 0)
 (define (ok name pred) (set! total (+ total 1)) (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))

--- a/test/chez/transient-test.ss
+++ b/test/chez/transient-test.ss
@@ -6,14 +6,7 @@
 ;; gate out).
 
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 
 (define total 0) (define fails 0)
 (define (ok name pred) (set! total (+ total 1)) (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))

--- a/test/chez/unit-context-test.ss
+++ b/test/chez/unit-context-test.ss
@@ -10,14 +10,7 @@
 ;;
 ;;   chez --script test/chez/unit-context-test.ss
 (import (chezscheme))
-(load "host/chez/rt.ss")
-(set-chez-ns! "clojure.core")
-(load "host/chez/seed/prelude.ss")
-(load "host/chez/post-prelude.ss")
-(set-chez-ns! "user")
-(load "host/chez/host-contract.ss")
-(load "host/chez/seed/image.ss")
-(load "host/chez/compile-eval.ss")
+(load "host/chez/gate-boot.ss")
 (load "host/chez/emit-image.ss")
 
 (define total 0) (define fails 0)


### PR DESCRIPTION
Follow-up to #482, now merged. That one went after the five gates that dominate wall time; this is the other thing the measurements turned up.

A pass gate takes about 1.5s, and about 1.3s of that is loading the same six runtime files from Chez source. Eight gate scripts each carried their own copy of those eight `load` lines. This extracts the preamble into `host/chez/gate-boot.ss` and adds `make gateboot`, which compiles exactly it to `target/dev/gate.so`. A gate loads that image when it is present and newer than everything that went into it, and loads from source otherwise.

Over the 27 gates that share the preamble: 38s against 72s. A single gate goes from 1.5s to 0.14s.

The image is opt-in and no target depends on it, the same arrangement `devboot` has with `bin/jolt`, so CI is unaffected unless someone builds it. The win is iterating on one gate; `make ci` runs them in parallel anyway, where 34s of aggregate boot is close to free. It needs its own artifact rather than reusing `target/dev/flat.so` because that image also loads `loader.ss`, which turns `require` into real file loading, and the gates stop at `compile-eval.ss` so their alias-only `require` keeps working.

## The failure mode this has to avoid

Both paths behave identically, which is the point and also the hazard: a bug in the staleness check is invisible in gate output and shows up only as a gate quietly passing against code that is no longer on disk. Three things guard it.

`make-gateboot.ss` generates the image from `bld-runtime-manifest`'s prefix through `'compile-eval` rather than a hand-written list, and `manifestcheck` now pins `gate-boot.ss`'s literal fallback against that same prefix. So the runtime, the fallback and the image cannot drift apart. Net, this replaces eight hand-mirrors of the preamble with one that is gated. I confirmed the new check fires by deleting a load from `gate-boot.ss`.

The staleness predicate lives in its own file, `gate-boot-fresh.ss`, so `test/chez/gateboot-smoke.sh` can drive it over synthetic input lists without booting a runtime or touching anything in the repo, which also keeps it safe to run under parallel make. It covers image-newer, image-missing, list-missing, a deleted input, a newer input, and blank lines. That is in `ci`.

`gate.inputs` is written tmp+rename like the `.so`, so a gate checking freshness during a concurrent rebuild cannot read a truncated list and conclude from the prefix that a stale image is fresh.

`JOLT_GATEBOOT=1` reports which path was taken, mirroring `JOLT_DEVCACHE`.

The smoke's end-to-end case rebuilds the image itself and asserts only when the predicate agrees it is fresh. `devboot-smoke.sh` touches `host/chez/rt.ss` and `seed/prelude.ss` to test its own cache invalidation, and both are inputs here, so under `make -j` the image can legitimately go stale mid-run; the gate then falls back to source, which is correct and not something to assert against. CI caught that on the first push.

## Not converted

`values-test.ss` loads `rt.ss` alone rather than the full six, so it keeps its own preamble. `bench-chez.ss` keeps its own deliberately: the image is compiled at optimize-level 2 and a source load is not, so pointing a benchmark at it would move its baseline. `regex-compare.ss` is a utility, not a gate.

## Testing

Ran every converted gate with the image present and absent and diffed the output: byte-identical across all of them. `manifestcheck` passes, and fails as intended when the fallback drifts. Both branches of the staleness check verified by putting an input's mtime in the future. Full `make -j8` gate on top of #482, cold with no prebuilt binary and no image: 128s, green.

`sci` is excluded from the parallel runs; it fails in my checkout at 209 against a 211 floor from vendored submodule drift, unrelated to this change.