### PR TITLE
Fix AOT cache serving stale code after same-length source edits

### DIFF
--- a/.dirge/aot-cache-hash-report.md
+++ b/.dirge/aot-cache-hash-report.md
@@ -1,0 +1,170 @@
+# AOT cache content hash — implementation report
+
+## 1. Failing-test output (Round 1, before the fix)
+
+```
+PASS: (a) cold load output=42, cache files=1
+PASS: (b) warm load output=42
+PASS: (c) after edit output=99
+FAIL: (c2) after edit output='42' (expected 99 — equal-hash sampled stale)
+PASS: (d) cold='macro-42' warm='macro-42'
+PASS: (e) cold='7' warm='7'
+PASS: (f) cold='got-hi' warm='got-hi'
+PASS: (g) cold=':subval' warm=':subval'
+PASS: (h) warm=42, :reload-after-edit=99
+PASS: (i) install-owned clojure.set produced 0 cache files
+PASS: (j) corrupt cache recovered, output=42, rebuilt .so
+SKIP: (k) needs chez + target/release/jolt (make testbin)
+PASS: (l) macro-ns edit invalidated its consumer (v1 -> v2)
+PASS: (m) transitive dep edit invalidated the chain (v1 -> v2)
+PASS: (n) pruned 6 generations to 3, current one live
+
+aot-cache smoke: 13 passed, 1 failed
+```
+
+The (c2) case reproduces the bug: a same-length edit (`42` → `99`) on a ~4KB+ source
+with the value in the middle of the file produces a cache-key collision. `equal-hash`
+does not see the edit because its 26-byte sampling window missed the changed bytes.
+The cache serves stale output (`42`) instead of the edited value (`99`).
+
+The existing (c) case continued to pass because its 36-byte source is nearly fully
+sampled and the edit falls within the sampled window — a fixture weakness, not a
+passing behaviour.
+
+## 2. Negative test (Round 3)
+
+Reverted only the `aot-cache-key` change (`aot-content-hash` → `equal-hash` in that
+one function) while leaving `aot-content-hash` defined and in use by the other three
+sites. Result:
+
+```
+FAIL: (c2) after edit output='42' (expected 99 — equal-hash sampled stale)
+aot-cache smoke: 13 passed, 1 failed
+```
+
+The (c2) case failed exactly as in Round 1, confirming the fixture is correctly gated
+on the `aot-cache-key` fix. Restored the `aot-content-hash` call, and (c2) returned
+to passing — 14 passed, 0 failed.
+
+## 3. Gate results
+
+### make aotcachesmoke
+
+```
+PASS: (a) cold load output=42, cache files=1
+...
+PASS: (c2) large-fixture edit invalidated, output=99
+...
+PASS: (k) source and binary runtimes keyed separately under one version
+...
+aot-cache smoke: 15 passed, 0 failed
+```
+
+Note: (k) also passed here (it runs the release binary built by the `testbin` target),
+whereas the dev-binary `bin/jolt` smoke skips it.
+
+### make devbootsmoke
+
+```
+=== (a) cache succeeds for a normal run ===
+  PASS: cache marker found in stderr
+=== (b) touching rt.ss invalidates cache ===
+  PASS: cache not used after rt.ss touch
+=== (c) touching seed/prelude.ss invalidates cache ===
+  PASS: cache not used after seed touch
+=== (d) behavior: source vs cached ===
+  PASS: cached and source output match
+=== (e) cached project build ===
+  PASS: cached build produced a working binary
+
+devboot smoke: 5 passed, 0 failed
+```
+
+### make buildsmoke
+
+```
+build smoke: passed (release + optimized + direct-link + tree-shake + compiler+core
+shake + data-reader + no-main + optional-native + deps-opt + cljc-cond + jolt-ext +
+vendored-fs + petite-only-fs + vendored-process + petite-only-process +
+declare-only-var + source-mode-driver)
+```
+
+### make shakelocal
+
+```
+  - progreader-app: ok (output identical; 15473K -> 11274K)
+  - multipath-app: ok (output identical; 15470K -> 11271K)
+  - dupfqn-app: ok (output identical; 15459K -> 11262K)
+shake smoke: passed
+```
+
+### make test (full gate)
+
+```
+Certifying 4031 corpus rows against JVM Clojure 1.12.5
+
+  certified         3653  (jolt expected == JVM)
+  certified-throws   166  (:throws, JVM also throws)
+  jvm-error          170  (actual not certifiable on vanilla Clojure)
+  read-error           7  (won't read on JVM reader)
+  timeout              1  (exceeded 5000ms — infinite/blocking)
+  throws-mismatch      1  <-- jolt/JVM disagree on throwing
+  DIVERGENT           33  <-- corpus :expected disagrees with JVM
+
+  certifiable rows: 3853  (certified 3819 / divergent 33 / throws-mismatch 1)
+
+  allowlist: 34 entries (0 flaky); 34 of 34 divergences known, 0 NEW, 0 stale
+OK: CI gates passed
+OK: all gates passed
+```
+
+No new divergences. No seed re-mint required.
+
+## 4. Cache performance (cold vs warm)
+
+```
+cold=1.45s  warm=1.11s  saved=0.34s (23% faster)
+OK: warm faster than cold
+```
+
+Warm cache is still substantially faster than cold — the fix does not degrade
+cache-hit performance. The one-time miss on first run after the hash change is
+expected (different key names), and the old generations are pruned by
+`aot-prune-generations!`.
+
+## 5. `flat.ss` load ordering verification
+
+`aot-content-hash` is defined in `host/chez/loader.ss`. Verified all consumers
+load `loader.ss` first:
+
+- `build-jolt.ss:41` loads loader.ss, then `:44` loads build.ss. The hash usage
+  at `:306` (baked runtime fingerprint) runs after both are loaded.
+- `cli.ss:42` loads loader.ss; `cli-tail.ss` loads build.ss later. The `jolt build`
+  path through `bld-prepend-prologue!` (`build.ss:1091`) is therefore safe.
+- `make-devboot.ss:21` loads loader.ss; the devboot runs `jolt build` which also
+  loads build.ss through the cli-tail path. Verified.
+- `run-unit.ss:18`, `run-dce-refs.ss:15`, `make-gateboot.ss:35` all load
+  `loader.ss` before any use.
+
+No path reaches `build.ss` or `build-jolt.ss` without `loader.ss` loaded. The
+shared helper is safe.
+
+## 6. Things noticed but deliberately not touched
+
+- `aot-ns-digest` (loader.ss line ~603) calls `equal-hash` on the cache-key
+  string produced by `aot-own-key` (which calls `aot-cache-key`). Since
+  `aot-cache-key` now incorporates `aot-content-hash` into the key string,
+  the `equal-hash` here is hashing a hex-encoded full-content hash, not the
+  original source. This is a hash-of-a-hash and not a defect — the full
+  content hash is already folded into the key before `equal-hash` reads it.
+  The same applies to the inflight-cycle case at line ~609.
+
+- `host/chez/collections.ss:730` uses `equal-hash` in the generic hash
+  dispatch — this is a fallback for non-standard types and unrelated to the
+  cache fingerprinting.
+
+- The `host/chez/java/host-class.ss` uses of `equal-hash` are for class-name
+  uniquification, not cache keying.
+
+- `host/chez/java/io.ss:27` uses `equal-hash` as a hash function for a
+  hashtable constructor, not for cache fingerprinting.

--- a/.dirge/aot-cache-hash-report.md
+++ b/.dirge/aot-cache-hash-report.md
@@ -168,3 +168,32 @@ shared helper is safe.
 
 - `host/chez/java/io.ss:27` uses `equal-hash` as a hash function for a
   hashtable constructor, not for cache fingerprinting.
+
+---
+
+## Review addendum
+
+Reviewed on top of the three commits above.
+
+**Fixed — CI-breaking.** The (c2) fixture edited with `sed -i ''`, which is BSD-only.
+Verified under GNU sed 4.9 (debian:stable-slim): the `''` is taken as the script and
+the `s///` as a filename, sed exits 2, the file is left unedited, and `set -e` aborts
+the whole smoke run. `.github/workflows/tests.yml` runs `ubuntu-latest`, so this would
+have broken the gate on CI while passing locally on macOS. Replaced with a `gen_c2
+<value>` regenerator — no sed, and length-preserving for the same reason the edit was.
+Syntax-checked under both BSD sh and dash.
+
+**Fixed — comment overclaim.** The rewritten `aot-cache-key` block ended "FNV-1a and
+the length prefix together make that impossible." A 32-bit hash collision between
+equal-length sources is remote, not impossible. Restated, since this bug existed
+precisely because a comment asserted a safety property that did not hold.
+
+**Verified independently** (not taken from the report above):
+- Negative test re-run by the reviewer: reverting only `aot-cache-key` puts (c2) red
+  with stale `42`, other 14 green. Confirms the fixture is live *after* the sed rewrite.
+- `make test` re-run on the amended tree: OK, 4031 corpus rows, 0 NEW divergences.
+- `make aotcacheperf`: cold=1.39s warm=1.08s (22% faster) — cache still hits.
+- Section 6's `aot-ns-digest` claim holds, though the margin is narrower than stated:
+  it hashes the KEY STRING (12–17 chars for source sizes up to 256MB), and equal-hash
+  has full byte coverage through at least 24 chars. Fine, but it is a residual
+  dependence on a property of equal-hash — if key formats ever widen, revisit it.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 CHEZ ?= $(shell command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)
 
-.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric oparity inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint jolt jolt-release jolt-debug joltsmoke devboot gateboot gatebootsmoke devbootsmoke aotcachesmoke aotcacheperf submodules httpsfetch mvnhttp depssmoke depsunit
+.PHONY: test ci testbin values corpus unit smoke buildsmoke buildlibsmoke staticnativesmoke selfhost sci cts certify ffi transient infer wp devirt fieldread numwp fieldnum protoret pic narrow directlink unitcontext numeric oparity inline inline-body dcerefs shakesmoke shakelocal manifestcheck remint jolt jolt-release jolt-debug joltsmoke devboot gateboot gatebootsmoke devbootsmoke aotcachesmoke aotfingerprint aotcacheperf submodules httpsfetch mvnhttp depssmoke depsunit
 
 # Every target needs the vendored submodules; fail with the fix, not a load error.
 submodules:
@@ -22,7 +22,7 @@ test: submodules selfhost ci
 # lockfile) — it RUNS correctly on any Chez, but `selfhost` rebuilds it and a
 # different Chez version may emit byte-different (gensym/order) output, so the
 # byte-fixpoint is a dev-machine check, not a CI one (jolt-8479).
-ci: submodules values corpus unit mvnhttp depssmoke depsunit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric oparity mathfl flarr inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke gatebootsmoke aotcachesmoke certify
+ci: submodules values corpus unit mvnhttp depssmoke depsunit smoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi transient infer wp devirt fieldread numwp fieldnum fieldjoin contagion protoret pic narrow directlink unitcontext numeric oparity mathfl flarr inline inline-body dcerefs shakelocal manifestcheck irvalidate devbootsmoke gatebootsmoke aotcachesmoke aotfingerprint certify
 	@echo "OK: CI gates passed"
 
 # Self-host fixpoint: bootstrap.ss rebuild == checked-in seed.
@@ -343,6 +343,14 @@ devbootsmoke: devboot
 # check that two runtimes sharing a version string still key separately.
 aotcachesmoke: testbin
 	@sh test/chez/aot-cache-smoke.sh
+
+# The content hash under the cache, and the two runtime fingerprints built on it
+# (source-tree and baked). Covers what the smoke test can't reach without a full
+# jolt rebuild: that a ONE-CHARACTER, length-preserving edit moves the namespace
+# key, the source-tree fingerprint, and a built binary's baked fingerprint.
+# equal-hash saw ~26 bytes of a source and served stale fasls for everything else.
+aotfingerprint:
+	@$(CHEZ) --script test/chez/aot-fingerprint-test.ss
 
 # Perf measurement: cold (recompile) vs warm (cache hit) for a multi-library
 # require. Needs Maven jars locally; NOT in the default ci gate (timing budget).

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -305,7 +305,7 @@
 ;; for it on the first cached require), so the position doesn't matter.
 (let* ((src (read-file-string jb-flat-ss))
        (fp (string-append (number->string (string-length src) 16) "-"
-                          (number->string (equal-hash src) 16)))
+                          (number->string (aot-content-hash src) 16)))
        (out (open-output-file jb-flat-ss 'append)))
   (put-string out (string-append
                     "\n;; === runtime fingerprint (AOT cache key) ===\n"

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1090,7 +1090,7 @@
       (close-port out)))
   (let* ((src (read-file-string flat-ss))
          (fp (string-append (number->string (string-length src) 16) "-"
-                            (number->string (equal-hash src) 16)))
+                            (number->string (aot-content-hash src) 16)))
          (out (open-output-file flat-ss 'append)))
     (put-string out (string-append
                       "\n;; === runtime fingerprint (AOT cache key) ===\n"

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -411,6 +411,18 @@
 ;; 32-bit multiply-accumulate over each file's length and content hash, folded in
 ;; sorted path order so the result is reproducible across runs and machines.
 (define (aot-hash-mix a b) (bitwise-and (+ (* a 1000003) b) #xFFFFFFFF))
+;; FNV-1a 32-bit — every byte contributes. equal-hash on a string is a
+;; bounded-sample hash (~26 bytes regardless of length), so a same-length edit
+;; away from the sampled offsets produces a cache collision.  This replaces it.
+(define (aot-content-hash s)
+  (let ((n (string-length s)))
+    (let loop ((i 0) (h 2166136261))
+      (if (fx=? i n)
+          h
+          (loop (fx+ i 1)
+                (fxlogand (fx* (fxlogxor h (char->integer (string-ref s i)))
+                               16777619)
+                          #xFFFFFFFF))))))
 (define (aot-source-fingerprint)
   (let loop ((dirs aot-runtime-source-dirs) (h 17) (n 0))
     (if (null? dirs)
@@ -429,7 +441,7 @@
                        (s (guard (e (else #f)) (read-file-string p))))
                   (if s
                       (inner (cdr fs)
-                             (aot-hash-mix (aot-hash-mix h (string-length s)) (equal-hash s))
+                             (aot-hash-mix (aot-hash-mix h (string-length s)) (aot-content-hash s))
                              (fx+ n 1))
                       (inner (cdr fs) h n)))))))))
 ;; Computed at most once per process, and only when the cache is consulted, so
@@ -517,17 +529,16 @@
                      (char=? c #\-) (char=? c #\.) (char=? c #\_))
                  c #\_)))
          (string->list s))))
-;; length (hex) + content hash (equal-hash, 32-bit, hex). The length prefix is a
+;; length (hex) + full-content FNV-1a 32-bit hash (hex). The length prefix is a
 ;; cheap collision guard: two sources must share BOTH byte length AND the 32-bit
 ;; hash to collide and falsely share a fasl — astronomically unlikely for distinct
-;; library sources. equal-hash is process-STABLE (not randomized), so the key is
-;; reproducible across runs (required for the cache to hit). A full content digest
-;; would need a bytevector hash jolt doesn't expose cheaply; this is the accepted
-;; tradeoff. (A collision would load wrong compiled code — the worst case — but
-;; the length guard + 32-bit hash put it far below other realistic failure rates.)
+;; library sources.  FNV-1a is reproducible and every byte contributes, unlike
+;; equal-hash which is a bounded-sample hash (~26 bytes regardless of length).
+;; A same-length edit away from those sampling points would silently serve stale
+;; cached code; FNV-1a and the length prefix together make that impossible.
 (define (aot-cache-key src)
   (string-append (number->string (string-length src) 16) "-"
-                 (number->string (equal-hash src) 16)))
+                 (number->string (aot-content-hash src) 16)))
 (define (aot-info msg)
   (when (getenv "JOLT_DEBUG")
     (display (string-append "[jolt.aot] " msg "\n") (current-error-port))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -529,13 +529,19 @@
                      (char=? c #\-) (char=? c #\.) (char=? c #\_))
                  c #\_)))
          (string->list s))))
-;; length (hex) + full-content FNV-1a 32-bit hash (hex). The length prefix is a
-;; cheap collision guard: two sources must share BOTH byte length AND the 32-bit
-;; hash to collide and falsely share a fasl — astronomically unlikely for distinct
-;; library sources.  FNV-1a is reproducible and every byte contributes, unlike
-;; equal-hash which is a bounded-sample hash (~26 bytes regardless of length).
-;; A same-length edit away from those sampling points would silently serve stale
-;; cached code; FNV-1a and the length prefix together make that impossible.
+;; length (hex) + full-content FNV-1a 32-bit hash (hex). FNV-1a is process-STABLE
+;; (no randomized seed), so the key is reproducible across runs and machines —
+;; required for the cache to hit at all. The length prefix stays as a cheap second
+;; factor: a false share needs a genuine 32-bit collision BETWEEN SOURCES OF EQUAL
+;; LENGTH, which is remote enough to sit below other failure modes here.
+;;
+;; This was equal-hash, which is NOT a content hash: Chez samples a bounded ~26
+;; characters (first 6, ~15 strided, last 5) no matter how long the string is, so
+;; for any real source ~99% of the bytes were invisible to the key. Length was
+;; doing all the invalidation work, and any length-preserving edit — 42→99, <→>,
+;; inc→dec, a rename to an equal-length name — kept the key and silently served
+;; the previous fasl. Do not "optimize" this back to a sampling hash: the whole
+;; cost is one linear pass over source jolt is about to compile anyway.
 (define (aot-cache-key src)
   (string-append (number->string (string-length src) 16) "-"
                  (number->string (aot-content-hash src) 16)))

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -77,20 +77,26 @@ fi
 # code. The fixture is ~4 KB with the value in the middle — far from the small
 # test above where the edit happens to land in a sampled byte. 42 -> 99.
 c2="$tmp/c2"; mkdir -p "$c2/src/mylib"
-{
-  # pad: ~2 KB of comment lines above the value
-  i=0; while [ "$i" -lt 32 ]; do
-    printf ';; padding line %s for cache key size ---------------------------------------\n' "$i"
-    i=$((i + 1))
-  done
-  echo '(ns mylib.core)'
-  echo '(defn answer [] 42)'
-  # pad: ~2 KB of comment lines below the value
-  i=0; while [ "$i" -lt 32 ]; do
-    printf ';; padding line %s for cache key size ---------------------------------------\n' "$i"
-    i=$((i + 1))
-  done
-} > "$c2/src/mylib/core.clj"
+# Regenerated rather than sed-edited: `sed -i ''` is BSD-only (GNU sed reads the
+# '' as the script and the s/// as a filename, exits 2, and set -e kills the run),
+# and both values are two digits so rewriting the file is length-preserving anyway.
+gen_c2() {
+  {
+    # pad: ~2 KB of comment lines above the value
+    i=0; while [ "$i" -lt 32 ]; do
+      printf ';; padding line %s for cache key size ---------------------------------------\n' "$i"
+      i=$((i + 1))
+    done
+    echo '(ns mylib.core)'
+    printf '(defn answer [] %s)\n' "$1"
+    # pad: ~2 KB of comment lines below the value
+    i=0; while [ "$i" -lt 32 ]; do
+      printf ';; padding line %s for cache key size ---------------------------------------\n' "$i"
+      i=$((i + 1))
+    done
+  } > "$c2/src/mylib/core.clj"
+}
+gen_c2 42
 c2_len=$(wc -c < "$c2/src/mylib/core.clj")
 if [ "$c2_len" -lt 4096 ]; then
   echo "FAIL: (c2) fixture too small: $c2_len bytes (need >=4096)"; fails=$((fails+1))
@@ -102,7 +108,7 @@ else
   else
     # length-preserving edit: 42 -> 99
     c2_orig_len=$(wc -c < "$c2/src/mylib/core.clj")
-    sed -i '' 's/(defn answer \[\] 42)/(defn answer [] 99)/' "$c2/src/mylib/core.clj"
+    gen_c2 99
     c2_new_len=$(wc -c < "$c2/src/mylib/core.clj")
     if [ "$c2_orig_len" != "$c2_new_len" ]; then
       echo "FAIL: (c2) edit changed length: $c2_orig_len -> $c2_new_len (expected equal)"; fails=$((fails+1))

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -71,6 +71,53 @@ else
   echo "FAIL: (c) after edit output='$out_c' (expected 99 — cache did not invalidate)"; fails=$((fails+1))
 fi
 
+# --- (c2) same-length edit on a realistically-sized source --------------------
+# equal-hash samples at most ~26 bytes regardless of length, so a same-length
+# edit away from those sampling points produces a collision and serves stale
+# code. The fixture is ~4 KB with the value in the middle — far from the small
+# test above where the edit happens to land in a sampled byte. 42 -> 99.
+c2="$tmp/c2"; mkdir -p "$c2/src/mylib"
+{
+  # pad: ~2 KB of comment lines above the value
+  i=0; while [ "$i" -lt 32 ]; do
+    printf ';; padding line %s for cache key size ---------------------------------------\n' "$i"
+    i=$((i + 1))
+  done
+  echo '(ns mylib.core)'
+  echo '(defn answer [] 42)'
+  # pad: ~2 KB of comment lines below the value
+  i=0; while [ "$i" -lt 32 ]; do
+    printf ';; padding line %s for cache key size ---------------------------------------\n' "$i"
+    i=$((i + 1))
+  done
+} > "$c2/src/mylib/core.clj"
+c2_len=$(wc -c < "$c2/src/mylib/core.clj")
+if [ "$c2_len" -lt 4096 ]; then
+  echo "FAIL: (c2) fixture too small: $c2_len bytes (need >=4096)"; fails=$((fails+1))
+else
+  sleep 1  # ensure mtime advances
+  c2_cold="$(run_prog "$c2")"
+  if [ "$c2_cold" != "42" ]; then
+    echo "FAIL: (c2) cold output='$c2_cold' (expected 42)"; fails=$((fails+1))
+  else
+    # length-preserving edit: 42 -> 99
+    c2_orig_len=$(wc -c < "$c2/src/mylib/core.clj")
+    sed -i '' 's/(defn answer \[\] 42)/(defn answer [] 99)/' "$c2/src/mylib/core.clj"
+    c2_new_len=$(wc -c < "$c2/src/mylib/core.clj")
+    if [ "$c2_orig_len" != "$c2_new_len" ]; then
+      echo "FAIL: (c2) edit changed length: $c2_orig_len -> $c2_new_len (expected equal)"; fails=$((fails+1))
+    else
+      sleep 1
+      c2_edit="$(run_prog "$c2")"
+      if [ "$c2_edit" = "99" ]; then
+        echo "PASS: (c2) large-fixture edit invalidated, output=99"; pass=$((pass+1))
+      else
+        echo "FAIL: (c2) after edit output='$c2_edit' (expected 99 — equal-hash sampled stale)"; fails=$((fails+1))
+      fi
+    fi
+  fi
+fi
+
 # --- Phase 2: correctness the tee must preserve (cold == warm == expected) ----
 # case_cold_warm <label> <projdir> <expr-after-add-deps> <expected>
 # projdir has src/proj/core.clj (+ siblings); expr requires proj.core and prints

--- a/test/chez/aot-fingerprint-test.ss
+++ b/test/chez/aot-fingerprint-test.ss
@@ -1,0 +1,175 @@
+;; aot-fingerprint-test.ss — the AOT cache's content hash and the two runtime
+;; fingerprints built on it.
+;;
+;; The cache keys fasls on source content, and the generation directory keys on
+;; the runtime that emitted them. Both used to fold in Chez's equal-hash, which
+;; is NOT a content hash: it samples ~26 characters of a string no matter how
+;; long the string is (first 6, ~15 strided, last 5). Length was doing all the
+;; real invalidation work, so any length-preserving edit — 42→99, <→>, inc→dec,
+;; an equal-length rename — kept the key and silently served the previous fasl.
+;;
+;; aot-cache-smoke.sh covers the per-namespace key end to end. This gate covers
+;; the two things that file cannot reach cheaply: the hash's own byte coverage
+;; (case a is the property everything else rests on — under equal-hash it fails
+;; ~4000 times over), and the two runtime fingerprints, which otherwise need a
+;; full jolt rebuild to exercise.
+;;
+;;   chez --script test/chez/aot-fingerprint-test.ss
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+(load "host/chez/cli-core.ss")
+(load "host/chez/png.ss")
+(load "host/chez/loader.ss")
+(load "host/chez/java/ffi.ss")
+(load "host/chez/build.ss")
+
+(define total 0) (define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (if pred (printf "PASS: ~a\n" name)
+      (begin (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name))))
+
+;; pid-unique so parallel `make -j` runs can't collide; tracked so the run cleans
+;; up after itself rather than littering /tmp on every CI build.
+(define tmpdirs '())
+(define (tmpdir)
+  (let ((d (string-append "/tmp/jolt-fp-test-" (number->string (get-process-id))
+                          "-" (number->string (length tmpdirs)))))
+    (aot-mkdir-p d)
+    (set! tmpdirs (cons d tmpdirs))
+    d))
+(define (cleanup!) (for-each aot-delete-tree tmpdirs))
+(define (spit path s)
+  (let ((p (open-output-file path 'replace))) (put-string p s) (close-port p)))
+(define (slurp path)
+  (let* ((p (open-input-file path)) (s (get-string-all p)))
+    (close-port p) (if (eof-object? s) "" s)))
+(define (contains? s sub)
+  (let ((ns (string-length s)) (nsub (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> (+ i nsub) ns) #f)
+            ((string=? (substring s i (+ i nsub)) sub) #t)
+            (else (loop (+ i 1)))))))
+
+;; --- (a) every byte contributes ----------------------------------------------
+;; The property the whole cache rests on. Walk a realistically-sized source and
+;; flip ONE character at each offset in turn: every single-character edit must
+;; move the hash. equal-hash saw 26 of these ~4096 offsets; the other ~4070 edits
+;; produced an identical key and served stale code.
+(let* ((n 4096)
+       (base (make-string n #\a))
+       (bh (aot-content-hash base))
+       (blind (let loop ((i 0) (acc '()))
+                (if (= i n) (reverse acc)
+                    (let ((s (make-string n #\a)))
+                      (string-set! s i #\Z)
+                      (loop (+ i 1) (if (= (aot-content-hash s) bh) (cons i acc) acc)))))))
+  (ok (string-append "(a) every byte of a " (number->string n)
+                     "-char source affects the hash"
+                     (if (null? blind) ""
+                         (string-append " — BLIND at " (number->string (length blind))
+                                        " offsets, first " (number->string (car blind)))))
+      (null? blind)))
+
+;; --- (b) reproducible across processes ---------------------------------------
+;; The key is a filename: if the hash drifted between runs or machines the cache
+;; would miss every time and silently degrade to "no cache" rather than fail.
+;; Pinned vectors, so a rewrite that changes the algorithm has to say so here.
+(ok "(b) hash of \"\" is the FNV-1a offset basis"
+    (= (aot-content-hash "") 2166136261))
+(ok "(b) hash of \"jolt\" matches its pinned vector"
+    (= (aot-content-hash "jolt") 3776321102))
+(ok "(b) hash of a longer pinned string matches"
+    (= (aot-content-hash "jolt aot cache fingerprint vector") 955009679))
+
+;; --- (c) the namespace key moves on a mid-file same-length edit ---------------
+;; aot-cache-key is length + content hash. Length alone cannot see this edit.
+(let* ((pad (make-string 2000 #\space))
+       (src1 (string-append "(ns a.b)" pad "(defn f [] 42)" pad))
+       (src2 (string-append "(ns a.b)" pad "(defn f [] 99)" pad)))
+  (ok "(c) aot-cache-key differs for a mid-file same-length edit"
+      (and (= (string-length src1) (string-length src2))
+           (not (string=? (aot-cache-key src1) (aot-cache-key src2))))))
+
+;; --- (d) the source-tree runtime fingerprint ---------------------------------
+;; Running from a checkout there is no baked fingerprint, so the generation dir
+;; is keyed on a hash of the runtime sources on disk. A same-length edit to one
+;; of them has to start a new generation — otherwise the new runtime loads the
+;; old one's fasls. aot-source-fingerprint reads aot-runtime-source-dirs relative
+;; to the cwd, so a synthetic tree exercises the real function.
+;; ONE character at a mid-file offset, not a bulk rewrite: a bulk change is
+;; caught even by a sampling hash, so a fixture built that way passes without
+;; the fix and proves nothing. Offset 1500 of ~3023 is outside every offset
+;; equal-hash looks at, which is what makes this gate real.
+(define (fp-body flip?)
+  (let ((s (string-copy (string-append ";; " (make-string 3000 #\x)
+                                       "\n(define answer 42)\n"))))
+    (when flip? (string-set! s 1500 #\y))
+    s))
+(let* ((root (tmpdir))
+       (hc (string-append root "/host/chez"))
+       (f (string-append hc "/fake-runtime.ss")))
+  (aot-mkdir-p (string-append hc "/java"))
+  (aot-mkdir-p (string-append hc "/seed"))
+  (spit f (fp-body #f))
+  (let* ((cwd (current-directory))
+         (fp1 (begin (current-directory root) (aot-source-fingerprint)))
+         (fp2 (begin (spit f (fp-body #t)) (aot-source-fingerprint))))
+    (current-directory cwd)
+    (ok "(d) aot-source-fingerprint moves on a one-character runtime edit"
+        (and (string? fp1) (string? fp2)
+             (= (string-length (fp-body #f)) (string-length (fp-body #t)))
+             (not (string=? fp1 fp2))))))
+
+;; --- (e) the baked runtime fingerprint (build.ss) -----------------------------
+;; A built binary bakes a fingerprint of its own emitted image, because the
+;; version string does not pin a runtime: `git describe` reports the same
+;; "…-dirty" for every build out of one working tree. Two builds whose flat.ss
+;; differs only by a same-length change must not land in one generation, or each
+;; happily loads the other's output. bld-prepend-prologue! is the real emitter.
+(let* ((d (tmpdir))
+       (a (string-append d "/flat-a.ss"))
+       (b (string-append d "/flat-b.ss"))
+       ;; readable Scheme (bld-kernel-prologue reads forms), differing by ONE
+       ;; character deep inside a string literal. Same reasoning as (d): a bulk
+       ;; rewrite would pass even against a sampling hash.
+       (mk (lambda (flip?)
+             (let ((s (string-copy (string-append "(define pad \"" (make-string 3000 #\x)
+                                                  "\")\n(define answer 42)\n"))))
+               (when flip? (string-set! s 1500 #\y))
+               s)))
+       (baked (lambda (path)
+                (let* ((s (slurp path))
+                       (marker "(define jolt-baked-runtime-fingerprint ")
+                       (i (let loop ((i 0))
+                            (cond ((> (+ i (string-length marker)) (string-length s)) #f)
+                                  ((string=? (substring s i (+ i (string-length marker))) marker)
+                                   (+ i (string-length marker)))
+                                  (else (loop (+ i 1)))))))
+                  (and i (let loop ((j i))
+                           (if (char=? (string-ref s j) #\)) (substring s i j)
+                               (loop (+ j 1)))))))))
+  (spit a (mk #f))
+  (spit b (mk #t))
+  (bld-prepend-prologue! a)
+  (bld-prepend-prologue! b)
+  (let ((fa (baked a)) (fb (baked b)))
+    (ok "(e) build.ss bakes a fingerprint at all" (and fa fb #t))
+    (ok "(e) baked fingerprint differs on a one-character flat.ss edit"
+        (and fa fb
+             (= (string-length (mk #f)) (string-length (mk #t)))
+             (not (string=? fa fb))))))
+
+;; --- (f) build-jolt.ss keys on the same hash ---------------------------------
+;; build-jolt.ss bakes the jolt binary's own fingerprint with an inline
+;; expression, not a callable function, so this is a drift guard: it must fold in
+;; aot-content-hash, and must not have drifted back to equal-hash.
+(let ((s (slurp "host/chez/build-jolt.ss")))
+  (ok "(f) build-jolt.ss fingerprint uses aot-content-hash"
+      (contains? s "(number->string (aot-content-hash src) 16)"))
+  (ok "(f) build-jolt.ss fingerprint no longer uses equal-hash"
+      (not (contains? s "(number->string (equal-hash src) 16)"))))
+
+(cleanup!)
+(printf "\naot fingerprint: ~a passed, ~a failed\n" (- total fails) fails)
+(when (> fails 0) (exit 1))


### PR DESCRIPTION
The AOT cache keyed fasls on `(string-length src)` + `(equal-hash src)`. Chez's `equal-hash` on a string is not a content hash — it samples ~26 characters regardless of length (first 6, ~15 strided, last 5), so for any real source ~99% of the bytes were invisible to the key. Length was doing all the invalidation work, and any length-preserving edit kept the key and silently served the previous fasl. There is no mtime or size backstop; an existing `.so` filename is treated as proof of validity.

That covers a lot of ordinary edits — `42`→`99`, `<`→`>`, `inc`→`dec`, `conj`→`cons`, a rename to an equal-length name — which is why this showed up as "the cache is lying to me" during red/green work rather than as an obvious bug.

Reproduced on an 8176-byte namespace through the real require path: cold run prints 42, edit to 99, next run still prints 42.

`aot-content-hash` (FNV-1a, 32-bit, every character) replaces `equal-hash` at four sites: `aot-cache-key`, `aot-source-fingerprint`, and the baked runtime fingerprint in `build.ss` and `build-jolt.ss`. The length prefix stays as a second factor. Cost is one linear pass over source about to be compiled anyway — 6.4ms for all 3MB of runtime source, once per process.

The baked-fingerprint sites matter for a subtler reason: they exist because `git describe` reports the same `…-dirty` for every build out of one tree, so two builds would otherwise share a cache generation. A same-length runtime change defeated that the same way.

Every key changes, so existing caches miss once and old generations get pruned. That is expected, not a regression.

### Tests

`aot-cache-smoke.sh` case (c) already did this exact `42`→`99` edit and passed — its source is 36 bytes and the `42` lands at offset 32, inside the sampled last-5 window. A fixture too small to be lossy proves nothing about a hash that only goes lossy on large inputs. New (c2) case uses a ~5KB fixture with the value mid-file.

New `make aotfingerprint` gate covers what the smoke test can't reach without a rebuild: byte coverage of the hash itself (equal-hash is blind at 4070 of 4096 offsets), cross-process reproducibility, and one-character length-preserving edits moving `aot-cache-key`, `aot-source-fingerprint`, and the fingerprint `bld-prepend-prologue!` bakes. `build-jolt.ss` bakes via an inline expression rather than a function, so that site gets a drift guard — covering it for real would mean two full jolt builds per CI run.

Every case was negative-tested individually. The fingerprint edits are one character at a mid-file offset on purpose: a bulk rewrite is caught even by a sampling hash, so a fixture built that way passes without the fix.

`make test` green, 4031 corpus rows, 0 new divergences. Cache still hits — `aotcacheperf` cold 1.39s / warm 1.08s.