### PR TITLE
deps: never trust an unfinished git checkout in the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An interrupted git fetch no longer poisons the dependency cache.**
+  `ensure-git` created the cache directory with `mkdir -p` and then cloned into
+  it, so the directory existed before the clone had produced anything. Interrupt
+  the fetch (a `^C` while `jolt serve` resolves deps is enough, since the
+  `SIGINT` reaches the child `git`) and the empty directory stayed behind: `git`
+  cleans up a clone directory only when it created that directory itself. Every
+  later run found the path and took it for a finished checkout, so the dependency
+  contributed no source root and the run failed far from the cause, with `Could
+  not locate ring_chez/adapter.jolt (or .clj/.cljc) on the source roots` for a
+  dep deps.edn plainly declared. Deleting the directory by hand was the only way
+  out. A fetch now clones, checks out, and updates submodules in a staging
+  directory beside its destination, and moves it into place only once all three
+  succeed, so the cache holds nothing but finished checkouts and a failure at any
+  step removes the staging directory instead of leaving a trap. Completeness is
+  recorded by a `.jolt-git-ok` marker, with `.git` accepted for a checkout an
+  earlier jolt cloned in place, so an already-poisoned cache also heals itself on
+  the next run.
+
 ## [0.5.8] - 2026-07-27
 
 The AOT cache no longer serves stale code after a length-preserving source edit,

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -9,7 +9,9 @@
 # / :main-opts — plus multi-alias combination rules, alias visibility in `path`,
 # -A composing with -M, an undeclared alias failing, the java.time library
 # autoload from the source roots, and the tools.deps CLI surface: -X/-T exec,
-# -Sdeps, the user deps.edn chain, :local/root jars, and :git/tag + short sha.
+# -Sdeps, the user deps.edn chain, :local/root jars, :git/tag + short sha, and
+# git cache integrity (an interrupted or failed fetch is never trusted as a
+# cached checkout).
 #
 # The expansion engine itself (exclusions, version selection, orphan cutting) is
 # unit-tested in test/deps_expand_test.clj — see `make depsunit`.
@@ -249,6 +251,35 @@ case "$out" in
   *"does not match tag"*) check "short sha not matching the tag errors" ok ok ;;
   *) check "short sha not matching the tag errors" "sha/tag mismatch error" "$(printf '%s' "$out" | head -1)" ;;
 esac
+
+# git cache integrity: only a finished checkout counts as cached. An interrupted
+# fetch used to leave the pre-created sha directory behind empty, and every later
+# run took it for a valid checkout — the dep contributed no source root and the
+# failure surfaced as a "Could not locate" on one of its namespaces.
+sha="$(git -C "$tmp/gitrepo" rev-parse HEAD)"
+san="$(printf '%s' "file://$tmp/gitrepo" | sed 's/[^A-Za-z0-9.-]/_/g')"
+cat > "$tmp/gitproj/deps.edn" <<EOF
+{:paths ["src"]
+ :deps {local/gitdep {:git/url "file://$tmp/gitrepo" :git/sha "$sha"}}}
+EOF
+mkdir -p "$tmp/gitlibs3/$san/$sha"
+check "an empty cached checkout is re-fetched" "git dep: tagged" \
+      "$(JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 JOLT_GITLIBS="$tmp/gitlibs3" "$JOLT" run -m gapp 2>&1 | tail -1)"
+# and the re-fetch is durable: the second run reuses it without cloning again
+out="$(JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 JOLT_DEBUG=1 JOLT_GITLIBS="$tmp/gitlibs3" "$JOLT" run -m gapp 2>&1)"
+case "$out" in
+  *fetching*) check "a complete checkout is reused" "no re-fetch" "$(printf '%s' "$out" | grep fetching)" ;;
+  *) check "a complete checkout is reused" ok ok ;;
+esac
+
+# a failed fetch leaves nothing the next run would trust
+cat > "$tmp/gitproj/deps.edn" <<EOF
+{:paths ["src"]
+ :deps {local/gitdep {:git/url "file://$tmp/not-a-repo" :git/sha "$sha"}}}
+EOF
+JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 JOLT_GITLIBS="$tmp/gitlibs4" "$JOLT" run -m gapp >/dev/null 2>&1
+check "a failed fetch caches no checkout" "" \
+      "$(find "$tmp/gitlibs4" -mindepth 2 -maxdepth 2 2>/dev/null)"
 
 echo "deps-alias smoke: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -134,26 +134,62 @@
                   (when (and tag (not sha)) " (a :git/tag alone doesn't pin a commit)") ".")
              {:coord coord :spec spec}))))
 
+(defn- checkout-complete?
+  "Does `dir` hold a finished checkout? jolt publishes a checkout by moving a
+  fully populated staging dir into place and marks it with `.jolt-git-ok`, so
+  anything jolt wrote there is complete. A checkout an older jolt cloned in
+  place carries no marker, and its `.git` stands in — which still rejects the
+  empty directory an interrupted in-place clone left behind. That leftover is
+  why this check exists: git only cleans up a clone directory it created itself,
+  the in-place clone pre-created it with mkdir -p, and a plain existence test
+  then read the empty remains as a valid checkout. The dep resolved to nothing
+  on every later run, and the failure surfaced much later as `Could not locate`
+  on one of its namespaces."
+  [dir]
+  (or (file-exists? (str dir "/.jolt-git-ok"))
+      (file-exists? (str dir "/.git"))))
+
+(defn- fetch-git!
+  "Clone url@sha under `repo-dir` and return the checkout dir. The work happens
+  in a staging dir beside it (same filesystem, so publishing is a rename) and
+  any failure removes it: the cache only ever holds finished checkouts. The
+  staging name carries a nonce so two jolt processes fetching the same dep at
+  once don't clone over each other."
+  [url sha repo-dir]
+  (let [dir (str repo-dir "/" sha)
+        stage (str repo-dir "/.part-" sha "-" (System/currentTimeMillis) "-" (rand-int 100000))
+        scrub #(sh (str "rm -rf " (pr-str stage)))
+        fail (fn [msg data] (scrub) (throw (ex-info msg (merge {:url url :sha sha} data))))]
+    (info "fetching " url " @ " (subs sha 0 (min 12 (count sha))))
+    (sh (str "mkdir -p " (pr-str repo-dir)))
+    (when-not (zero? (sh (str "git clone --quiet " (pr-str url) " " (pr-str stage))))
+      (fail (str "git clone failed: " url) nil))
+    (when-not (zero? (sh (str "git -C " (pr-str stage) " checkout --quiet " (pr-str sha))))
+      (fail (str "git checkout failed: " sha " in " url) nil))
+    ;; submodules are pinned in the checkout; pull them if the dep uses any.
+    (when-not (zero? (sh (str "git -C " (pr-str stage) " submodule update --init --recursive --quiet")))
+      (fail (str "git submodule update failed for " url) nil))
+    (sh (str "touch " (pr-str (str stage "/.jolt-git-ok"))))
+    (if (checkout-complete? dir)
+      (do (scrub) dir)                    ; another process published it first
+      (do
+        ;; clears the incomplete remains of an interrupted in-place clone
+        (sh (str "rm -rf " (pr-str dir)))
+        (when-not (zero? (sh (str "mv " (pr-str stage) " " (pr-str dir))))
+          (fail (str "git checkout could not be moved into the cache: " dir) {:dir dir}))
+        dir))))
+
 (defn- ensure-git
-  "Return a checkout dir for url@sha: an existing tools.gitlibs checkout for
-  `lib` when present, else clone into jolt's cache (once)."
+  "Return a checkout dir for url@sha: jolt's cached checkout when complete, else
+  an existing tools.gitlibs checkout for `lib`, else a fresh clone into jolt's
+  cache."
   [lib url sha]
-  (let [dir (str (gitlibs-dir) "/" (sanitize url) "/" sha)]
-    (if-let [shared (and (not (file-exists? dir)) (gitlibs-shared-checkout lib sha))]
-      shared
-      (if (file-exists? dir)
-        dir
-        (do
-          (info "fetching " url " @ " (subs sha 0 (min 12 (count sha))))
-          (sh (str "mkdir -p " (pr-str dir)))
-          (when-not (zero? (sh (str "git clone --quiet " (pr-str url) " " (pr-str dir))))
-            (throw (ex-info (str "git clone failed: " url) {:url url})))
-          (when-not (zero? (sh (str "git -C " (pr-str dir) " checkout --quiet " (pr-str sha))))
-            (throw (ex-info (str "git checkout failed: " sha " in " url) {:url url :sha sha})))
-          ;; submodules are pinned in the checkout; pull them if the dep uses any.
-          (when-not (zero? (sh (str "git -C " (pr-str dir) " submodule update --init --recursive --quiet")))
-            (throw (ex-info (str "git submodule update failed for " url) {:url url})))
-          dir)))))
+  (let [repo-dir (str (gitlibs-dir) "/" (sanitize url))
+        dir (str repo-dir "/" sha)]
+    (if (checkout-complete? dir)
+      dir
+      (or (gitlibs-shared-checkout lib sha)
+          (fetch-git! url sha repo-dir)))))
 
 ;; --- maven cache ------------------------------------------------------------
 ;; jolt has no JVM, but a Clojure library's Maven JAR carries its .clj/.cljc/.cljs


### PR DESCRIPTION
`ensure-git` created the cache directory with `mkdir -p` and then cloned into it, so the directory existed before the clone had produced anything. Interrupting a fetch left it behind empty, because git cleans up a clone directory only when it created that directory itself. Every later run found the path, took it for a finished checkout, and resolved the dependency to no source root at all, so the run failed far from the cause:

```
$ PORT=8080 jolt serve
^CUnhandled exception: git clone failed: https://github.com/jolt-lang/ring-chez-adapter

$ PORT=8080 jolt serve
Unhandled exception: Could not locate ring_chez/adapter.jolt (or .clj/.cljc) on the source roots
  at ./src/app/core.clj:1:1
```

The dep was plainly declared in deps.edn, the cache directory for its sha was right there, and the only way out was deleting that directory by hand. A `^C` while a project resolves its deps is enough to get into this state, since the SIGINT reaches the child git.

A fetch now clones, checks out, and updates submodules in a staging directory beside its destination and moves it into place only once all three succeed. The move is a rename within the same directory, so the cache holds nothing but finished checkouts, and a failure at any step removes the staging directory rather than leaving a trap. The staging name carries a nonce so two processes fetching the same dep don't clone over each other. Completeness is recorded by a `.jolt-git-ok` marker, with `.git` accepted for a checkout an earlier jolt cloned in place, so an already-poisoned cache heals itself on the next run instead of needing the manual delete.

## Testing

Three checks added to the deps smoke gate, offline over the fixture repo it already builds: an empty cached checkout is re-fetched, a complete one is still reused without cloning again, and a failed fetch caches nothing. `make depssmoke` passes 50/50 and `make depsunit` 31/31. Reverting only the deps.clj change fails two of the three, so they are not vacuous.