### PR TITLE
Normalize register-num-arm! op names to their var names

### DIFF
--- a/host/chez/java/bigdec.ss
+++ b/host/chez/java/bigdec.ss
@@ -352,11 +352,11 @@
     (lambda (prev)
       (lambda (a b)
         (if (or (jbigdec? a) (jbigdec? b)) (handler a b) (prev a b))))))
-(jbd-num-arm 'add (lambda (a b) (jbd-binop + jbd2+ a b)))
-(jbd-num-arm 'sub (lambda (a b) (jbd-binop - jbd2- a b)))
-(jbd-num-arm 'mul (lambda (a b) (jbd-binop * jbd2* a b)))
-(jbd-num-arm 'div (lambda (a b) (jbd-binop / jbd2-div a b)))
-(register-num-arm! 'cmp
+(jbd-num-arm 'add-slow (lambda (a b) (jbd-binop + jbd2+ a b)))
+(jbd-num-arm 'sub-slow (lambda (a b) (jbd-binop - jbd2- a b)))
+(jbd-num-arm 'mul-slow (lambda (a b) (jbd-binop * jbd2* a b)))
+(jbd-num-arm 'div-slow (lambda (a b) (jbd-binop / jbd2-div a b)))
+(register-num-arm! 'num-cmp-slow
   (lambda (prev)
     (lambda (a b)
       (if (and (or (jbigdec? a) (jbigdec? b)) (jbd-numberish? a) (jbd-numberish? b))
@@ -365,15 +365,15 @@
 ;; quot/rem/mod: a double operand demotes to the double path; exact operands use
 ;; the integer-division bigdec ops (mod = rem, floor-adjusted to the divisor's sign).
 (define (jbd->num x) (if (jbigdec? x) (jbigdec->flonum x) x))
-(jbd-num-arm 'quot
+(jbd-num-arm 'quot-slow
   (lambda (a b) (if (or (flonum? a) (flonum? b))
                     (jolt-quot (jbd->num a) (jbd->num b))
                     (jbd-int-quot (jbd-coerce a) (jbd-coerce b)))))
-(jbd-num-arm 'rem
+(jbd-num-arm 'rem-slow
   (lambda (a b) (if (or (flonum? a) (flonum? b))
                     (jolt-rem (jbd->num a) (jbd->num b))
                     (jbd-int-rem (jbd-coerce a) (jbd-coerce b)))))
-(jbd-num-arm 'mod
+(jbd-num-arm 'mod-slow
   (lambda (a b)
     (if (or (flonum? a) (flonum? b))
         (jolt-mod (jbd->num a) (jbd->num b))

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -313,30 +313,41 @@
 ;; contract, the shim hands over (lambda (prev) handler) and never touches a
 ;; core var directly. Same convention as register-eq-arm!/register-compare-arm!.
 ;; `handler` must decline operands it can't handle by calling prev.
+;;
+;; OP NAMING RULE: an op is the runtime var it extends with the `jolt-` prefix
+;; stripped, no abbreviating and no dropping the `-slow` suffix — 'add-slow is
+;; jolt-add-slow, 'num-cmp-slow is jolt-num-cmp-slow. Nothing here has to be
+;; memorized: read off the var name. Registrations are top level, so a name that
+;; doesn't follow the rule hits the else below when the shim loads, not later.
+;; The vars live in three files; the comments mark where each group is defined.
 (define (register-num-arm! op extend)
   (case op
-    ((add)      (set! jolt-add-slow  (extend jolt-add-slow)))
-    ((sub)      (set! jolt-sub-slow  (extend jolt-sub-slow)))
-    ((mul)      (set! jolt-mul-slow  (extend jolt-mul-slow)))
-    ((div)      (set! jolt-div-slow  (extend jolt-div-slow)))
-    ((quot)     (set! jolt-quot-slow (extend jolt-quot-slow)))
-    ((rem)      (set! jolt-rem-slow  (extend jolt-rem-slow)))
-    ((mod)      (set! jolt-mod-slow  (extend jolt-mod-slow)))
-    ((cmp)      (set! jolt-num-cmp-slow (extend jolt-num-cmp-slow)))
-    ((num-slow?) (set! jolt-num-slow? (extend jolt-num-slow?)))
-    ((inc)      (set! jolt-inc  (extend jolt-inc)))
-    ((dec)      (set! jolt-dec  (extend jolt-dec)))
-    ((zero?)    (set! jolt-zero? (extend jolt-zero?)))
-    ((pos?)     (set! jolt-pos? (extend jolt-pos?)))
-    ((neg?)     (set! jolt-neg? (extend jolt-neg?)))
+    ;; seq.ss (this file)
+    ((add-slow)      (set! jolt-add-slow      (extend jolt-add-slow)))
+    ((sub-slow)      (set! jolt-sub-slow      (extend jolt-sub-slow)))
+    ((mul-slow)      (set! jolt-mul-slow      (extend jolt-mul-slow)))
+    ((div-slow)      (set! jolt-div-slow      (extend jolt-div-slow)))
+    ((quot-slow)     (set! jolt-quot-slow     (extend jolt-quot-slow)))
+    ((rem-slow)      (set! jolt-rem-slow      (extend jolt-rem-slow)))
+    ((mod-slow)      (set! jolt-mod-slow      (extend jolt-mod-slow)))
+    ((num-cmp-slow)  (set! jolt-num-cmp-slow  (extend jolt-num-cmp-slow)))
+    ((num-slow?)     (set! jolt-num-slow?     (extend jolt-num-slow?)))
+    ((zero?)         (set! jolt-zero?         (extend jolt-zero?)))
+    ((pos?)          (set! jolt-pos?          (extend jolt-pos?)))
+    ((neg?)          (set! jolt-neg?          (extend jolt-neg?)))
+    ;; rt.ss
+    ((inc)           (set! jolt-inc           (extend jolt-inc)))
+    ((dec)           (set! jolt-dec           (extend jolt-dec)))
     ;; predicates.ss
-    ((number?)  (set! jolt-number? (extend jolt-number?)))
-    ((decimal?) (set! jolt-decimal? (extend jolt-decimal?)))
+    ((number?)       (set! jolt-number?       (extend jolt-number?)))
+    ((decimal?)      (set! jolt-decimal?      (extend jolt-decimal?)))
     ((num-equiv-slow) (set! jolt-num-equiv-slow (extend jolt-num-equiv-slow)))
     ;; converters.ss
-    ((double-slow) (set! jolt-double-slow (extend jolt-double-slow)))
+    ((double-slow)   (set! jolt-double-slow   (extend jolt-double-slow)))
     ((cast-truncate-slow) (set! jolt-cast-truncate-slow (extend jolt-cast-truncate-slow)))
-    (else (error 'register-num-arm! "unknown numeric extension point" op))))
+    (else (error 'register-num-arm!
+                 "unknown numeric extension point (an op is its jolt- var minus the prefix)"
+                 op))))
 (define (jolt-num-check1 x)   ; (+ x)/(* x) return x but still type-check it
   (if (or (number? x) (jolt-num-slow? x)) x (jolt-num-cast-throw x)))
 (define (jolt-add . xs)


### PR DESCRIPTION
Follow-up to #488, which had already merged by the time this came up.

The op vocabulary `register-num-arm!` introduced was inconsistent about the `-slow` suffix. `add`, `sub`, `mul`, `div`, `quot`, `rem` and `mod` dropped it, while `num-equiv-slow`, `double-slow` and `cast-truncate-slow` kept it, and `cmp` was an abbreviation of `num-cmp-slow`. Nineteen names that don't map mechanically onto the vars they set is the setup where a typo is plausible, so an op is now exactly the runtime var it extends with the `jolt-` prefix stripped. There is nothing left to memorize, and the rule is written down at the hook.

The safety story that makes this low-stakes is worth stating: every registration is a top-level form in the shim, so a name that doesn't follow the rule hits the `else` when the shim loads rather than silently failing to install an arm. I checked that directly, and `(register-num-arm! 'add ...)` now raises "unknown numeric extension point" instead of being accepted.

Two smaller things in the same diff. The case branches are grouped by the file that defines each var, which corrects the old grouping's implication that `inc` and `dec` live in seq.ss when they are rt.ss:79-80. And the `else` message now says what the naming rule is, so the error is self-explanatory.

**Verification**

Full `make ci` passes. Corpus reports 0 NEW divergences with 173 throws verified, cts matches baseline, SCI is 211/218, manifestcheck passes. `make remint` converges in one pass with no seed diff, as expected for a host-only change. I also re-ran the same 60 bigdec, seqable, bit-op and `==` cases I used to check #488 against main, and the output is byte-identical before and after the rename.