### PR TITLE
byte arrays hold signed bytes; gate a release on the fleet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,10 +270,32 @@ jobs:
           fi
           ls -la dist
 
-      - name: Upload to the GitHub Release
+      # The linux binary is what the fleet gates below run against, so hand it over
+      # as a workflow artifact. A workflow_dispatch dry run creates no release, so
+      # the artifact — not `gh release download` — is the only way to reach it.
+      # `**` and the find-based unpack below, not a fixed glob: on a
+      # workflow_dispatch dry run GITHUB_REF_NAME is the BRANCH, so a branch with a
+      # slash in it ("fix/foo") nests the tarball a directory deeper. Real tags never
+      # do, but the dry run is how this gate gets tested before a release depends on
+      # it, so it has to survive one.
+      - name: Upload the linux binary for the fleet gates
+        if: matrix.target == 'x86_64-linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jolt-x86_64-linux
+          path: dist/**/*.tar.gz
+          retention-days: 1
+
+      # DRAFT, so the release is not public until the fleet gates pass: `publish`
+      # below flips it. A draft is invisible to the install script and to Homebrew
+      # (both read the latest PUBLISHED release), so a fleet regression leaves a tag
+      # with assets attached for inspection and nothing anyone can install —
+      # i.e. the release aborts. Each matrix row creates-or-updates the same draft.
+      - name: Upload to the GitHub Release (draft)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           files: |
             dist/*.tar.gz
             dist/*.tar.gz.sha256
@@ -281,13 +303,204 @@ jobs:
             dist/*.zip.sha256
           fail_on_unmatched_files: false
 
+  # --- fleet gates: the jolt-lang libraries and examples, on the tag's own binary.
+  #
+  # These run ONLY here (release.yml is `on: push: tags: v*` + workflow_dispatch), so
+  # a regular commit or PR pays nothing for them — tests.yml stays the per-commit
+  # gate. The cost lands once per release, where it buys the thing the jolt-repo gate
+  # structurally cannot see: whether a language change breaks real code that a user
+  # would `git/sha`-pin. v0.5.13 is the case in point — making byte[] elements signed
+  # was correct and fully green in-repo, and truncated every HTTP response body in
+  # jolt-lang/http-client, because its ByteArrayInputStream.read() returned the raw
+  # (now negative) element and every drain loop read that as EOF.
+  #
+  # Each row mirrors the library's OWN tests.yml — same apt packages, same
+  # `JOLT_PWD="$PWD" jolt -M:test` — so a red row means the same thing here as in
+  # that repo. ci/fleet-smoke.sh is the shared entrypoint (also runnable by hand
+  # when a row goes red).
+  #
+  # Not covered here, deliberately:
+  #   clojure/tools.cli   the jolt harness for it is local-only; nothing upstream to
+  #                       check out.
+  #   db's postgres half  its own job below, which needs a service container.
+  libraries:
+    name: library ${{ matrix.repo }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: jolt-crypto         # AES/HMAC/SHA over OpenSSL — all byte[] work
+            apt: libssl3
+          - repo: http-client         # TLS + gzip + HTTP over jolt.ffi
+            apt: libssl3
+          - repo: ring-chez-adapter   # BSD sockets over jolt.ffi
+            apt: libssl3 curl
+          - repo: db                  # sqlite over jolt.ffi (postgres: libraries-db)
+            apt: libsqlite3-0
+          - repo: transit-jolt
+            apt: ''
+          - repo: xml
+            apt: libxml2
+          - repo: yaml
+            apt: ''
+          - repo: time                # needs a non-English locale on the OS
+            apt: locales
+          - repo: logging
+            apt: ''
+          - repo: nrepl
+            apt: ''
+          - repo: router
+            apt: ''
+          - repo: glimmer             # GTK4 widget tree; the suite is headless
+            apt: libgtk-4-1
+          - repo: glimmer-gl          # + GL geometry/matrix
+            apt: libgtk-4-1 libgl1
+    steps:
+      - name: Check out jolt (for ci/fleet-smoke.sh)
+        uses: actions/checkout@v5
+        with:
+          path: jolt
+      - name: Check out jolt-lang/${{ matrix.repo }}
+        uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/${{ matrix.repo }}
+          path: lib
+      - uses: actions/download-artifact@v4
+        with:
+          name: jolt-x86_64-linux
+      - name: Unpack the jolt under test
+        run: |
+          set -eu
+          tgz="$(find . -name '*x86_64-linux.tar.gz' -print -quit)"
+          [ -n "$tgz" ] || { echo "no linux tarball in the artifact"; exit 1; }
+          tar -xzf "$tgz" -C .
+          bin="$(find . -type f -name jolt -perm -u+x -print -quit)"
+          [ -n "$bin" ] || { echo "no jolt binary in $tgz"; exit 1; }
+          mv "$bin" ./jolt-bin
+          ./jolt-bin --version
+      - name: Install the library's system deps
+        run: |
+          sudo apt-get update
+          # liblz4/zlib/tinfo are jolt's own dynamic deps; the rest is per-library.
+          sudo apt-get install -y liblz4-1 zlib1g libtinfo6 ${{ matrix.apt }}
+      # jolt's DateTimeFormatter localizes month/day names through libc strftime, so
+      # a non-English locale has to exist on the OS (the JVM bundles its own; jolt,
+      # like babashka, does not). tick's suite formats a French month name.
+      - name: Generate the fr_FR locale (time)
+        if: matrix.repo == 'time'
+        run: sudo locale-gen fr_FR.UTF-8 && sudo update-locale
+      - name: Test
+        run: jolt/ci/fleet-smoke.sh lib ./jolt-bin
+
+  # db's postgres backend needs a live server, and `services` is job-level — so it
+  # gets its own job rather than starting a postgres container for all 13 rows above.
+  # Its suite skips the postgres section when JOLT_TEST_PG_URI is unset, which is why
+  # the matrix row above still covers the sqlite half.
+  libraries-db:
+    name: library db (postgres)
+    needs: build
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: jolt_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: jolt
+      - uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/db
+          path: lib
+      - uses: actions/download-artifact@v4
+        with:
+          name: jolt-x86_64-linux
+      - name: Unpack the jolt under test
+        run: |
+          set -eu
+          tgz="$(find . -name '*x86_64-linux.tar.gz' -print -quit)"
+          tar -xzf "$tgz" -C .
+          mv "$(find . -type f -name jolt -perm -u+x -print -quit)" ./jolt-bin
+          ./jolt-bin --version
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y liblz4-1 zlib1g libtinfo6 libpq5 libsqlite3-0
+      - name: Test
+        env:
+          JOLT_TEST_PG_URI: postgres://postgres:postgres@127.0.0.1:5432/jolt_test
+        run: jolt/ci/fleet-smoke.sh lib ./jolt-bin
+
+  # Every example app BUILDS with this binary, and the ones with a headless test task
+  # run it. The build is the valuable half: `jolt build` is the whole compiler
+  # pipeline (analyze, tree-shake, direct-link, cc-link) over real third-party
+  # dependency trees — ring/reitit/Selmer/honeysql/integrant/tick — which is far more
+  # compiler surface than the in-repo build smokes reach. See ci/examples-smoke.sh
+  # for the per-app manifest and why each build-only app is build-only.
+  examples:
+    name: examples
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: jolt
+      - uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/examples
+          path: examples
+      - uses: actions/download-artifact@v4
+        with:
+          name: jolt-x86_64-linux
+      - name: Unpack the jolt under test
+        run: |
+          set -eu
+          tgz="$(find . -name '*x86_64-linux.tar.gz' -print -quit)"
+          tar -xzf "$tgz" -C .
+          mv "$(find . -type f -name jolt -perm -u+x -print -quit)" ./jolt-bin
+          ./jolt-bin --version
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          # jolt's own deps, plus every native library any example declares: the GUI
+          # apps are built (not run), but jolt loads a declared :jolt/native at
+          # require time, so the .so has to be present to compile them.
+          sudo apt-get install -y liblz4-1 zlib1g libtinfo6 build-essential \
+            libssl3 libsqlite3-0 libgtk-4-1 libgl1
+      - name: Build every example, run the test tasks
+        run: jolt/ci/examples-smoke.sh examples ./jolt-bin
+
+  # Flip the draft release public. Nothing downstream (install script, Homebrew tap)
+  # sees the release until this runs, so a red fleet gate aborts the release with the
+  # tag and assets intact for inspection.
+  publish:
+    name: publish the release
+    needs: [build, libraries, libraries-db, examples]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Un-draft ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest
+
   # Bump the Homebrew tap (jolt-lang/homebrew-jolt) to this tag: rewrite each
   # platform's url + sha256 in Formula/jolt.rb from the release's .sha256 assets.
   # Needs a HOMEBREW_TAP_TOKEN secret — a PAT with contents:write on the tap repo
   # (the default GITHUB_TOKEN can't push to another repo). Skipped if unset.
+  # After `publish`, so the tap never points at a release the fleet gates rejected.
   homebrew:
     name: update homebrew tap
-    needs: build
+    needs: publish
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,6 +367,9 @@ jobs:
         with:
           repository: jolt-lang/${{ matrix.repo }}
           path: lib
+          # transit-jolt keeps the transit-format exemplars as a submodule and its
+          # suite refuses to run without them; harmless for the repos with none.
+          submodules: recursive
       - uses: actions/download-artifact@v4
         with:
           name: jolt-x86_64-linux
@@ -455,6 +458,20 @@ jobs:
         with:
           repository: jolt-lang/examples
           path: examples
+      # glimmer-app, glimmer-gl-app and fps-demo consume glimmer as
+      # {:local/root "../../glimmer"} — a SIBLING two levels up from the app dir,
+      # i.e. the workspace root once examples/ is checked out under it. Their
+      # deps.edn says the path is provisional ("push glimmer to a git remote and swap
+      # to :git/url to make this app self-contained"), so honour the layout they have
+      # rather than pinning a sha here that would then need chasing.
+      - uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/glimmer
+          path: glimmer
+      - uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/glimmer-gl
+          path: glimmer-gl
       - uses: actions/download-artifact@v4
         with:
           name: jolt-x86_64-linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`byte-array` elements are signed bytes, −128..127, like the JVM's `byte[]`.**
+  They were unsigned 0..255, so `(vec (byte-array [255 128]))` was `[255 128]` where
+  the JVM gives `[-1 -128]`, and every numeric look at a high byte disagreed:
+  `(neg? b)` never fired, `(= b -1)` was never true, `(reduce + bytes)` summed to a
+  different number, and a `(bit-and b 0xff)` mask that is load-bearing on the JVM
+  was a no-op here. Nothing errored — the answers were just quietly different.
+
+  This is one representation change across every producer and consumer, not a
+  per-call-site patch: `na-byte-of` is the one place a value entering a byte array is
+  narrowed (`Byte.byteValue()` semantics — truncate toward zero, low 8 bits, fold the
+  sign), `na-bv->bytearray` the one place raw bytes become a byte array, and
+  `na-bytearray->bv` the one place they go back. `byte-array` / `.getBytes` /
+  `String.` / stream reads / `Files/readAllBytes` / `jolt.fs` / `io/copy` /
+  `ByteBuffer` / Base64 / `Random/nextBytes` / `jolt.ffi` read-array/write-array all
+  route through those three, so bytes survive any round-trip byte-exactly. `aset` on
+  a byte array narrows rather than storing raw — the JVM rejects `(aset bytes 0 200)`
+  because it can see 200 is an Integer, and jolt has one integer type, so narrowing
+  is what keeps the array's range invariant true for `aget`/`seq`/`String.`.
+  `InputStream.read()` stays unsigned 0..255, which is its contract and the only way
+  a caller can tell `0xff` from end-of-stream.
+
+  `(byte-array [-1.9])` is now `-1`, not `-2` — the JVM's `d2i` truncates toward
+  zero where this floored.
+
+- **`format`'s `%x` / `%X` / `%o` are unsigned conversions.** They printed a signed
+  magnitude, so `(format "%x" -1)` was `"-1"` — wrong under any width. The JVM takes
+  the width from the argument's type (`Byte` 8 bits, `Short` 16, `Integer` 32, `Long`
+  64); jolt unifies every integer as one type and so takes the narrowest width that
+  holds the value. That is the JVM's answer whenever the value's origin type is the
+  narrowest that holds it, so an unmasked byte out of a `byte[]` prints two digits
+  and an int-sized value eight — which is what the common hex-dump and
+  percent-encoder idioms need, and it keeps ring-codec and cognitect aws-api's signer
+  correct unmodified. A long whose value fits narrower is the one case that
+  diverges (`(format "%x" (long -1))` is `"ff"` here, 16 digits on the JVM); it is
+  entered in `known-divergences.edn` under `:integer-box-model`. `(bit-and b 0xff)`
+  pins the width explicitly and is identical on both.
+
 ### Fixed
+
+- **`{n}` in a regex meant `{n,}`.** The translator handed irregex an unbounded
+  upper bound for an exact count, so every exact repetition matched greedily past
+  it: `(re-find #"\d{4}" "20260729")` returned the whole string instead of `"2026"`,
+  `(re-matches #"\d{4}" "20260")` matched where the JVM returns nil,
+  `(re-seq #"\d{2}" "123456")` gave one element instead of three, and
+  `#"(?:%[0-9a-f]{2})+"` ran past the last percent-escape — which is how
+  ring-codec's `percent-decode` came apart. `{n,}` and `{n,m}` were always right;
+  only the comma-less form was wrong.
+
+- **`Base64` handed back an opaque host buffer instead of a `byte[]`.**
+  `.decode` / `.encode` return `byte[]` on the JVM, so `(vec (.decode dec s))` is
+  ordinary Clojure; here they returned a raw Chez bytevector that no collection
+  dispatcher knows, so that threw `Don't know how to create ISeq from` and callers
+  had to route every result through `String.` first. Both return a byte array now,
+  and `bytes?` is true of them.
+
+- **`Random/nextBytes` produced a different stream from the JVM for the same seed.**
+  It drew 8 bits per byte, consuming the LCG four times as fast as
+  `java.util.Random`, which draws one `nextInt()` per four bytes and takes them
+  low-to-high. Every other `Random` method already matched; this one did not, so a
+  seeded byte fill was not reproducible against the JVM.
+
+- **`io/copy` from a `File` to anything but another file went through text.** A File
+  source was only treated as a byte source when the destination was also a file;
+  everything else fell through to slurping it as UTF-8, which replaced each
+  non-UTF-8 byte with U+FFFD. `(io/copy f stream)` on a binary file returned
+  corrupt bytes.
+
+- **`Arrays/toString` printed a jolt vector.** `"[1 2]"` rather than the JVM's
+  `"[1, 2]"` — no commas, a `nil` element rendered empty instead of `null`, and a
+  string element came out `pr`-quoted.
+
+- **`Integer/toString` with a radix uppercased its digits** (`"-FF"` for
+  `(Integer/toString -255 16)`, where the JVM gives `"-ff"`), and `Long` was missing
+  `toHexString` / `toOctalString` / `toBinaryString` / `toString` / `compare`
+  altogether. `Character/isLetter` and `isLetterOrDigit` were missing too — aws-api's
+  request signer classifies each UTF-8 byte of a URI through them.
 
 - **A compile-time error pointed at the top of the enclosing form, not at the
   expression that failed.** The only position available to the reporter was the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ring-codec's `percent-decode` came apart. `{n,}` and `{n,m}` were always right;
   only the comma-less form was wrong.
 
+- **`jolt <task>` lost to a same-named directory.** A bare argv token is dispatched
+  as a file to run before a `:tasks` lookup, and the "is this a file" test was
+  `file-exists?`, which is true for a directory too. `test` is a `:tasks` entry AND a
+  `test/` directory in every jolt project, so `jolt test` was dispatched as a path
+  and died in `load-file`'s decoder — `failed on #<binary input port test>: is a
+  directory` — instead of running the task. That is why every library's CI spells out
+  `jolt -M:test`.
+
 - **`Base64` handed back an opaque host buffer instead of a `byte[]`.**
   `.decode` / `.encode` return `byte[]` on the JVM, so `(vec (.decode dec s))` is
   ordinary Clojure; here they returned a raw Chez bytevector that no collection

--- a/ci/examples-smoke.sh
+++ b/ci/examples-smoke.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# examples-smoke.sh — build every app in jolt-lang/examples with the jolt under
+# test, and run the test task of those that have one.
+#
+#   ci/examples-smoke.sh <examples-checkout> <jolt-binary>
+#
+# BUILD is the point of this gate: `jolt build` is the compiler's whole pipeline
+# (analyze, tree-shake, direct-link, cc-link) over real third-party code, which is
+# more surface than the test suites here reach. So every app is built, including the
+# GUI ones whose windows can't open on a headless runner — a build needs no display.
+# Tests run only where the app has a test task AND is headless- and network-safe.
+#
+# The manifest is explicit rather than derived from each deps.edn: the main
+# namespace, the test entrypoint and the headless/network constraints differ per app
+# in ways no convention captures (:tasks vs :aliases, app.core vs rt.render). It is
+# cross-checked against the checkout in both directions, so an example added
+# upstream without a row here fails the gate rather than silently skipping it.
+#
+# Fields: dir | build-main | test-task ("-" for build-only)
+#
+# Build-only, and why:
+#   http-client-app  -main hits real HTTPS endpoints — a release must not depend
+#                    on third-party uptime.
+#   fps-demo, glimmer-app, glimmer-gl-app   GUI/GL; no headless test task.
+#   hiccup/malli/markdown-app, ray-tracer*  no test task at all.
+set -eu
+
+root="${1:?usage: examples-smoke.sh <examples-checkout> <jolt-binary>}"
+jolt="${2:?need the jolt binary to test}"
+case "$jolt" in
+  /*) ;;
+   *) jolt="$(cd "$(dirname "$jolt")" && pwd)/$(basename "$jolt")" ;;
+esac
+[ -x "$jolt" ] || { echo "examples-smoke: $jolt is not executable"; exit 2; }
+PATH="$(dirname "$jolt"):$PATH"
+export PATH
+root="$(cd "$root" && pwd)"
+
+manifest="$(mktemp)"
+trap 'rm -f "$manifest"' EXIT
+cat > "$manifest" <<'EOF'
+basic-example    app.core       test
+commonmark-app   app.core       test
+nrepl-example    app.core       test
+ring-app         app.core       test
+hiccup-app       app.core       -
+malli-app        app.core       -
+markdown-app     app.core       -
+http-client-app  app.core       -
+ray-tracer       ray-baseline   -
+ray-tracer-multi rt.render      -
+fps-demo         fps-demo.core  -
+glimmer-app      app.core       -
+glimmer-gl-app   gl-demo.core   -
+EOF
+
+fails=0
+note_fail() { echo "  FAIL: $*"; fails=$((fails + 1)); }
+
+# Both directions: a row naming no directory, and a directory with no row. The
+# second is the one that matters — an example added upstream must not slip past.
+while read -r name main test; do
+  [ -n "${name:-}" ] || continue
+  [ -d "$root/$name" ] || note_fail "$name is in the manifest but not in the checkout"
+done < "$manifest"
+for d in "$root"/*/; do
+  name="$(basename "$d")"
+  [ -f "$d/deps.edn" ] || continue
+  awk -v n="$name" '$1 == n { found = 1 } END { exit !found }' "$manifest" \
+    || note_fail "$name is in the checkout but has no ci/examples-smoke.sh row"
+done
+[ "$fails" -eq 0 ] || { echo "examples-smoke: manifest is out of sync with the checkout"; exit 1; }
+
+while read -r name main test; do
+  [ -n "${name:-}" ] || continue
+  dir="$root/$name"
+
+  # Build into a throwaway dir: a failed build leaves nothing behind and the
+  # checkout stays clean for the test run that follows.
+  tmp="$(mktemp -d)"
+  echo "examples-smoke: $name — build -m $main"
+  if ( cd "$dir" && JOLT_PWD="$(pwd)" "$jolt" build -m "$main" -o "$tmp/$name" ) \
+     && [ -x "$tmp/$name" ]; then
+    :
+  else
+    note_fail "$name build"
+  fi
+  rm -rf "$tmp"
+
+  if [ "$test" != "-" ]; then
+    echo "examples-smoke: $name — $test"
+    ( cd "$dir" && JOLT_PWD="$(pwd)" "$jolt" "$test" ) || note_fail "$name $test"
+  fi
+done < "$manifest"
+
+if [ "$fails" -ne 0 ]; then
+  echo "examples-smoke: $fails FAILED"
+  exit 1
+fi
+echo "examples-smoke: every example built; every test task passed"

--- a/ci/fleet-smoke.sh
+++ b/ci/fleet-smoke.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# fleet-smoke.sh — run one jolt-lang library's or example's own test suite against
+# a given jolt binary. Called once per matrix row by the `libraries` / `examples`
+# jobs in release.yml; also runnable by hand:
+#
+#   ci/fleet-smoke.sh <dir> <jolt-binary> [test-command...]
+#
+# The library repos each carry the SAME entrypoint — `:tasks {test "jolt -M:test"}`
+# plus a `:test` alias — and their own CI runs `JOLT_PWD="$PWD" jolt -M:test`. This
+# reproduces that exactly, with the binary under test on PATH so a task that shells
+# out to `jolt` reaches it too (a :tasks string is a shell command).
+#
+# Why a script rather than inline `run:` steps: the same command has to work from a
+# release matrix row AND from a developer's shell when a library goes red, and
+# JOLT_PWD / PATH / the exit-code handling are easy to get subtly different between
+# the two. `make fleetsmoke DIR=… ` is not offered on purpose — the fleet lives in
+# other repos, so there is nothing for the Makefile to depend on.
+set -eu
+
+dir="${1:?usage: fleet-smoke.sh <dir> <jolt-binary> [test-command...]}"
+jolt="${2:?need the jolt binary to test}"
+shift 2
+
+# Absolute, because we cd into the project: a :tasks entry that shells out to
+# `jolt` resolves it through PATH, and PATH entries must not be relative.
+case "$jolt" in
+  /*) ;;
+   *) jolt="$(cd "$(dirname "$jolt")" && pwd)/$(basename "$jolt")" ;;
+esac
+[ -x "$jolt" ] || { echo "fleet-smoke: $jolt is not executable"; exit 2; }
+PATH="$(dirname "$jolt"):$PATH"
+export PATH
+
+cd "$dir"
+# Every library reads JOLT_PWD to locate its own test fixtures (their CI sets it).
+JOLT_PWD="$(pwd)"
+export JOLT_PWD
+
+if [ "$#" -gt 0 ]; then
+  set -- "$@"
+else
+  set -- "$jolt" -M:test
+fi
+
+echo "fleet-smoke: $(basename "$dir") — $*"
+"$@"

--- a/host/chez/java/byte-buffer.ss
+++ b/host/chez/java/byte-buffer.ss
@@ -1,6 +1,6 @@
 ;; byte-buffer.ss — java.nio.ByteBuffer over a jolt byte-array. A buffer is a
 ;; jhost tagged "byte-buffer" with mutable #(backing-array position limit); the
-;; backing is a jolt byte-array (vector of 0..255). Covers the slice of the API
+;; backing is a jolt byte-array (signed bytes, -128..127). Covers the slice of the API
 ;; portable code reaches for — wrap / get(byte[]) / array / remaining / position /
 ;; limit / duplicate / flip / rewind — e.g. cognitect aws-api wrapping blob bytes.
 
@@ -73,7 +73,9 @@
                          (do ((i 0 (fx+ i 1))) ((fx=? i n))
                            (vector-set! dv (+ dp i) (vector-ref sv i)))
                          (bb-pos! self (+ dp n))))
-                      (else (vector-set! dv dp (jnum->exact src)) (bb-pos! self (+ dp 1))))
+                      ;; a lone byte: narrowed like any byte-array store, so the
+                      ;; backing stays in -128..127 whichever form the caller used.
+                      (else (vector-set! dv dp (na-byte-of src)) (bb-pos! self (+ dp 1))))
                     self)))
     ;; get(): relative single byte at position, advancing it.
     ;; get(int i): absolute single byte at index i (position unchanged).

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -85,10 +85,11 @@
 ;; memory, byte-exact (no UTF-8 / latin1 decode) — for socket recv/send and the
 ;; zlib / OpenSSL buffers an HTTP client passes through. read-array returns a
 ;; fresh byte-array of n bytes; write-array copies a byte-array's bytes into ptr
-;; and returns the count.
+;; and returns the count. Foreign memory is unsigned octets and a byte-array element
+;; is a signed byte, so the two directions fold and mask across that seam.
 (define (ffi-read-array ptr n)
   (let* ((n (jnum->exact n)) (p (jnum->exact ptr)) (v (make-vector n 0)))
-    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! v i (foreign-ref 'unsigned-8 p i)))
+    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! v i (na-u8->byte (foreign-ref 'unsigned-8 p i))))
     (make-jolt-array v 'byte)))
 (define (ffi-write-array ptr arr)
   (let* ((v (jolt-array-vec arr)) (n (vector-length v)) (p (jnum->exact ptr)))

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -807,11 +807,15 @@
                   (set! out (cons (bitwise-and (bitwise-arithmetic-shift-right acc bits) 255) out))))
               (string->list str))
     (u8-list->bytevector (reverse out))))
+;; .encode / .decode return byte[] on the JVM, so they return a jolt byte-array here
+;; (signed elements, seqable, bytes?) — they used to hand back a raw Chez bytevector,
+;; which no collection dispatcher knows, so (vec (.decode dec s)) threw "Don't know
+;; how to create ISeq from" and every caller had to route it through String. first.
 (register-host-methods! "b64-encoder"
-  (list (cons "encode" (lambda (self bs) (string->utf8 (b64-encode bs))))
+  (list (cons "encode" (lambda (self bs) (na-bv->bytearray (string->utf8 (b64-encode bs)))))
         (cons "encodeToString" (lambda (self bs) (b64-encode bs)))))
 (register-host-methods! "b64-decoder"
-  (list (cons "decode" (lambda (self s) (b64-decode s)))))
+  (list (cons "decode" (lambda (self s) (na-bv->bytearray (b64-decode s))))))
 (register-class-statics! "Base64"
   (list (cons "getEncoder" (lambda () (make-jhost "b64-encoder" '())))
         (cons "getDecoder" (lambda () (make-jhost "b64-decoder" '())))))
@@ -1180,7 +1184,8 @@
                                 ((or (jolt-nil? a) (jolt-nil? b)) #f)
                                 (else (equal? (jolt-array-vec a) (jolt-array-vec b))))))
          (cons "fill" (lambda (a v)
-                        (let* ((bv (jolt-array-vec a)) (n (ja-len bv)))
+                        (let* ((bv (jolt-array-vec a)) (n (ja-len bv))
+                               (v (na-elem-of (jolt-array-kind a) v)))
                           (do ((i 0 (fx+ i 1))) ((fx=? i n) jolt-nil) (ja-set! bv i v)))))
          (cons "copyOf" (lambda (a n)
                           (let* ((src (jolt-array-vec a)) (len (jnum->exact n)) (kind (jolt-array-kind a))
@@ -1196,7 +1201,18 @@
                                    (ja-set! out i (ja-ref src (+ f i))))
                                  (make-jolt-array out kind))))
          (cons "sort" arrays-sort)
-         (cons "toString" (lambda (a) (jolt-pr-str (apply jolt-vector (ja->list (jolt-array-vec a)))))))))
+         ;; Arrays.toString is "[a, b]" — comma-separated element toString, "null"
+         ;; for a nil array. It used to print the elements as a jolt VECTOR, which
+         ;; renders "[a b]" (no commas) and pr-quotes a string element.
+         (cons "toString" (lambda (a)
+                            (if (jolt-nil? a) "null"
+                                (let ((parts (map (lambda (x) (if (jolt-nil? x) "null" (jolt-str-render-one x)))
+                                                  (ja->list (jolt-array-vec a)))))
+                                  (string-append
+                                    "[" (if (null? parts) ""
+                                            (fold-left (lambda (acc s) (string-append acc ", " s))
+                                                       (car parts) (cdr parts)))
+                                    "]"))))))))
   (register-class-statics! "Arrays" arrays-statics)
   (register-class-statics! "java.util.Arrays" arrays-statics))
 
@@ -1239,11 +1255,21 @@
   '("Random" "java.util.Random"))
 (register-host-methods! "random"
   (list
+    ;; nextBytes draws one nextInt() per FOUR bytes, taking them low-to-high — it
+    ;; does not draw 8 bits per byte, which consumed the LCG four times as fast and
+    ;; produced a different stream from the JVM's for the same seed. Elements are
+    ;; signed bytes (the JVM's (byte)rnd cast).
     (cons "nextBytes" (lambda (self ba)
-                        (let ((v (jolt-array-vec ba))
-                              (st (jhost-state self)))
-                          (do ((i 0 (fx+ i 1))) ((fx=? i (vector-length v)))
-                            (vector-set! v i (random-next 8 st)))
+                        (let* ((v (jolt-array-vec ba)) (n (vector-length v))
+                               (st (jhost-state self)))
+                          (let loop ((i 0))
+                            (when (fx<? i n)
+                              (let inner ((rnd (random-u32->s32 (random-next 32 st)))
+                                          (k (min (fx- n i) 4)) (i i))
+                                (if (fx=? k 0) (loop i)
+                                    (begin (vector-set! v i (na-byte-of (bitwise-and rnd #xff)))
+                                           (inner (bitwise-arithmetic-shift-right rnd 8)
+                                                  (fx- k 1) (fx+ i 1)))))))
                           jolt-nil)))
     (cons "nextInt" (lambda (self . a)
                       (let ((st (jhost-state self)))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -270,6 +270,9 @@
 (define long-2^64 (expt 2 64))
 ;; interpret a 64-bit value as a signed long (top bit = sign), like the JVM.
 (define (as-signed64 v) (if (>= v long-2^63) (- v long-2^64) v))
+;; and back: a negative long as its 64-bit unsigned form, for the unsigned string
+;; conversions (Long.toHexString(-1) is "ffffffffffffffff").
+(define (long->u64 n) (if (< n 0) (+ n long-2^64) n))
 (define (long-nlz n) (- 64 (integer-length (bitwise-and (jnum->exact n) long-mask64))))
 (define (long-reverse n)
   (let ((v (bitwise-and (jnum->exact n) long-mask64)))
@@ -286,7 +289,17 @@
         (cons "numberOfLeadingZeros" (lambda (n) (->num (long-nlz n))))
         (cons "reverse" (lambda (n) (->num (long-reverse n))))
         (cons "parseLong" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "parseLong")))
-        (cons "valueOf" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "valueOf")))))
+        (cons "valueOf" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "valueOf")))
+        (cons "compare" (lambda (x y) (let ((a (jnum->exact x)) (b (jnum->exact y)))
+                                        (->num (cond ((< a b) -1) ((> a b) 1) (else 0))))))
+        ;; toHexString/toOctalString/toBinaryString are UNSIGNED (the value's 64-bit
+        ;; two's complement, lowercase); toString with a radix is signed magnitude.
+        ;; Chez's number->string emits uppercase hex digits, so downcase them all —
+        ;; Integer/toString had the same slip ((Integer/toString -255 16) was "-FF").
+        (cons "toHexString" (lambda (x) (string-downcase (number->string (long->u64 (jnum->exact x)) 16))))
+        (cons "toOctalString" (lambda (x) (number->string (long->u64 (jnum->exact x)) 8)))
+        (cons "toBinaryString" (lambda (x) (number->string (long->u64 (jnum->exact x)) 2)))
+        (cons "toString" (lambda (x . r) (string-downcase (number->string (jnum->exact x) (if (null? r) 10 (jnum->exact (car r)))))))))
 
 ;; JVM Integer.toHexString/etc. treat the int as 32-bit unsigned.
 (define (int->u32 n) (if (< n 0) (+ n 4294967296) n))
@@ -305,7 +318,7 @@
         (cons "toHexString" (lambda (x) (string-downcase (number->string (int->u32 (jnum->exact x)) 16))))
         (cons "toOctalString" (lambda (x) (number->string (int->u32 (jnum->exact x)) 8)))
         (cons "toBinaryString" (lambda (x) (number->string (int->u32 (jnum->exact x)) 2)))
-        (cons "toString" (lambda (x . r) (number->string (jnum->exact x) (if (null? r) 10 (jnum->exact (car r))))))))
+        (cons "toString" (lambda (x . r) (string-downcase (number->string (jnum->exact x) (if (null? r) 10 (jnum->exact (car r)))))))))
 
 ;; Byte / Short bounds (their values are plain integers on jolt; the statics let
 ;; libraries reference the JVM ranges — clojure.test.check generates over them).
@@ -352,6 +365,16 @@
         (cons "isUpperCase" (lambda (c) (let ((n (char-code c))) (and (>= n 65) (<= n 90)))))
         (cons "isLowerCase" (lambda (c) (let ((n (char-code c))) (and (>= n 97) (<= n 122)))))
         (cons "isDigit" (lambda (c) (let ((n (char-code c))) (and (>= n 48) (<= n 57)))))
+        ;; isLetter / isLetterOrDigit take a char or an int codepoint, so a byte read
+        ;; out of a byte[] reaches them — negative for a high byte, which is not a
+        ;; letter on the JVM either (it is not a valid codepoint). cognitect aws-api's
+        ;; request signer classifies each UTF-8 byte of a URI this way.
+        (cons "isLetter" (lambda (c) (let ((n (char-code c)))
+                                       (or (and (>= n 65) (<= n 90)) (and (>= n 97) (<= n 122))))))
+        (cons "isLetterOrDigit" (lambda (c) (let ((n (char-code c)))
+                                              (or (and (>= n 48) (<= n 57))
+                                                  (and (>= n 65) (<= n 90))
+                                                  (and (>= n 97) (<= n 122))))))
         ;; JVM Character.isWhitespace: Unicode whitespace (so U+2028 line separator
         ;; counts, like the JVM) MINUS the no-break spaces the JVM excludes
         ;; (U+00A0/U+2007/U+202F). char<=?space missed everything above ASCII.

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -24,7 +24,11 @@
          (lambda (self . rest)
            (let ((port (in-stream-port self)))
              (if (null? rest)
+                 ;; InputStream.read() returns the byte as an UNSIGNED int 0..255
+                 ;; (-1 at EOF) — the one place a byte is not signed, because the
+                 ;; return has to distinguish 0xff from end-of-stream.
                  (let ((b (get-u8 port))) (if (eof-object? b) -1 (->num b)))
+                 ;; read(buf …) fills a byte-array, whose elements ARE signed.
                  (let* ((buf (car rest))
                         (vec (jolt-array-vec buf))
                         (off (if (>= (length rest) 3) (jnum->exact (cadr rest)) 0))
@@ -34,7 +38,7 @@
                          (let ((b (get-u8 port)))
                            (if (eof-object? b)
                                (if (= i 0) -1 (->num i))
-                               (begin (vector-set! vec (+ off i) b) (loop (+ i 1))))))))))))
+                               (begin (vector-set! vec (+ off i) (na-u8->byte b)) (loop (+ i 1))))))))))))
    (cons "readAllBytes" (lambda (self) (let ((bv (get-bytevector-all (in-stream-port self))))
                                          (na-byte-array (if (eof-object? bv) (make-bytevector 0) bv)))))
    (cons "skip" (lambda (self n) (let ((bv (get-bytevector-n (in-stream-port self) (jnum->exact n))))
@@ -275,6 +279,10 @@
   (cond ((in-stream? input) (let ((bv (get-bytevector-all (in-stream-port input)))) (if (eof-object? bv) (make-bytevector 0) bv)))
         ((bytevector? input) input)
         ((and (jolt-array? input) (eq? (jolt-array-kind input) 'byte)) (na-bytearray->bv input))
+        ;; a File source is a BYTE source for every byte destination, not just for
+        ;; another file: (io/copy f baos) used to fall through to input-text, slurp
+        ;; the file as UTF-8, and replace every non-UTF-8 byte with U+FFFD.
+        ((jfile? input) (read-file-bytes (path-of input)))
         ;; a byte-input-stream shim (host tagged-table, :jolt/input-stream — e.g.
         ;; http-client's ByteArrayInputStream): drain it byte-exact, like slurp.
         ((and (htable? input) (jolt-truthy? (jolt-ref-get input (keyword "jolt" "input-stream"))))
@@ -295,10 +303,8 @@
     ((and (jhost? output) (member (jhost-tag output) '("writer" "file-writer" "port-writer" "print-writer")))
      (record-method-dispatch output "write" (list->cseq (list (input-text input)))))
     ((or (jfile? output) (string? output))
-     (let ((bv (cond
-                 ((jfile? input) (read-file-bytes (path-of input)))
-                 ((not (string? input)) (input-bytes input))
-                 (else #f))))
+     ;; a string INPUT is its characters (io/copy's text source), never a filename
+     (let ((bv (and (not (string? input)) (input-bytes input))))
        (if bv
            (with-port (open-file-output-port (path-of output) (file-options no-fail) (buffer-mode block))
              (lambda (port) (put-bytevector port bv)))
@@ -309,8 +315,7 @@
     ((and (htable? output) (jolt-truthy? (jolt-ref-get output (keyword "jolt" "output-stream"))))
      (let ((bv (input-bytes input)))
        (record-method-dispatch output "write"
-         (list->cseq (list (if bv (make-jolt-array (list->vector (bytevector->u8-list bv)) 'byte)
-                               (input-text input)))))))
+         (list->cseq (list (if bv (na-bv->bytearray bv) (input-text input)))))))
     (else (throw-jvm (quote IllegalArgumentException) "io/copy: unsupported output type")))
   jolt-nil)
 (def-var! "clojure.java.io" "copy" jio-copy)

--- a/host/chez/java/natives-array.ss
+++ b/host/chez/java/natives-array.ss
@@ -72,9 +72,22 @@
       (make-jolt-array (na-make-backing (na-idx a) kind (if (pair? rest) (car rest) init)) kind)
       (na-from-seq a kind)))
 
-;; numeric tower: array element defaults / masked bytes / count are
+;; numeric tower: array element defaults / narrowed bytes / count are
 ;; EXACT integers (= JVM byte/short/int), matching exact integer literals.
-(define (na-byte-of v) (bitwise-and (exact (floor v)) #xff))
+
+;; A byte-array element is a SIGNED byte, -128..127, like the JVM's byte[]: a value
+;; above 127 reads negative, so (neg? b), a (bit-and b 0xff) mask, and arithmetic
+;; over a high byte all behave as they do on the JVM. na-byte-of is the ONE place a
+;; value entering a byte array is narrowed — Byte.byteValue() semantics: truncate
+;; toward zero (the JVM's d2i, not floor — (byte-array [-1.9]) is -1, not -2), take
+;; the low 8 bits, fold the sign bit. na-bytearray->bv masks back to 0..255 at the
+;; raw-byte seam, so the two carriers round-trip byte-exactly.
+(define (na-u8->byte b) (if (fx<? b 128) b (fx- b 256)))
+(define (na-byte-of v) (na-u8->byte (bitwise-and (exact (truncate v)) #xff)))
+;; Narrow a value being STORED into an array to its element kind. Only 'byte has a
+;; range jolt must maintain (the u8 <-> s8 bridge above depends on it); the other
+;; kinds hold whatever integer/flonum they are given, as they always have.
+(define (na-elem-of kind v) (if (eq? kind 'byte) (na-byte-of v) v))
 
 ;; --- constructors -----------------------------------------------------------
 (define (na-object-array a . rest)  (na-num-array a rest jolt-nil 'object))
@@ -94,16 +107,24 @@
     (else (make-jolt-array
            (list->vector (map (lambda (c) (if (char? c) c (integer->char (exact (truncate c)))))
                               (seq->list (jolt-seq a)))) 'char))))
+;; Chez bytevector (unsigned 0..255) -> jolt byte-array (signed -128..127). The
+;; inbound half of the raw-bytes seam: every producer of a byte-array from raw bytes
+;; — .getBytes, stream reads, Files/readAllBytes, Base64, FFI — funnels through here.
+(define (na-bv->bytearray bv)
+  (let* ((n (bytevector-length bv)) (v (make-vector n 0)))
+    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! v i (na-u8->byte (bytevector-u8-ref bv i))))
+    (make-jolt-array v 'byte)))
 ;; (byte-array n [init]) | (byte-array coll). Also coerces the host's OTHER byte
-;; carrier — a Chez bytevector (what String/.getBytes produce) — and a string's
+;; carrier — a Chez bytevector (what the charset encoders produce) — and a string's
 ;; UTF-8 bytes, so bytevector and byte-array interconvert across interop seams.
 (define (na-byte-array a . rest)
   (cond
     ((number? a) (make-jolt-array (make-vector (exact (na-idx a)) (na-byte-of (if (pair? rest) (car rest) 0))) 'byte))
-    ((bytevector? a) (make-jolt-array (list->vector (bytevector->u8-list a)) 'byte))
-    ((string? a) (make-jolt-array (list->vector (bytevector->u8-list (string->utf8 a))) 'byte))
+    ((bytevector? a) (na-bv->bytearray a))
+    ((string? a) (na-bv->bytearray (string->utf8 a)))
     (else (make-jolt-array (list->vector (map na-byte-of (seq->list (jolt-seq a)))) 'byte))))
-;; jolt byte-array -> Chez bytevector (for String decode / utf8->string).
+;; jolt byte-array -> Chez bytevector (for String decode / utf8->string). The
+;; outbound half: the #xff mask folds a signed element back to its raw byte.
 (define (na-bytearray->bv arr)
   (let* ((v (jolt-array-vec arr)) (n (vector-length v)) (bv (make-bytevector n)))
     (do ((i 0 (+ i 1))) ((= i n)) (bytevector-u8-set! bv i (bitwise-and (exact (vector-ref v i)) #xff)))
@@ -118,7 +139,13 @@
       (na-from-seq arr 'object)))
 
 ;; --- typed aset (return the stored value) -----------------------------------
-(define (na-aset! arr i v) (ja-set! (jolt-array-vec arr) (exact (na-idx i)) v) v)
+;; Through na-array-set! (below), so a byte array narrows what it is handed rather
+;; than storing it raw. The JVM would reject (aset bytes 0 200) outright — Array.set
+;; can see that 200 is an Integer, not a Byte — but jolt models every integer as one
+;; type, so it cannot tell (byte -1) from 255. Narrowing keeps the array's -128..127
+;; invariant intact (aget / seq / (String. bytes) all agree) where a raw store
+;; would break it.
+(define (na-aset! arr i v) (na-array-set! arr i v))
 (define (na-aset-int arr i v)     (na-aset! arr i v))
 (define (na-aset-long arr i v)    (na-aset! arr i v))
 (define (na-aset-short arr i v)   (na-aset! arr i v))
@@ -127,9 +154,9 @@
 (define (na-aset-char arr i v)    (na-aset! arr i v))
 (define (na-aset-boolean arr i v) (na-aset! arr i v))
 (define (na-aset-byte arr i v)
-  (let ((bv (jolt-array-vec arr)) (j (exact (na-idx i))))
+  (let ((bv (jolt-array-vec arr)) (j (exact (na-idx i))) (b (na-byte-of v)))
     (ja-check bv j)
-    (vector-set! bv j (na-byte-of v)) v))
+    (vector-set! bv j b) b))
 
 ;; --- coercions (identity on arrays; byte/short are masked scalar casts) ------
 (define (na-bytes x) (if (and (jolt-array? x) (eq? (jolt-array-kind x) 'byte)) x (na-byte-array x)))
@@ -179,15 +206,22 @@
 ;; count/nth/seq/get above are NATIVE-OPS (inlined at call sites), so aget/alength/
 ;; array-seq/vec already use the set!-extended globals; ref-put! is a host var
 ;; (var-deref'd), so re-assert its cell to the array-aware closure.
+;; THE array write seam: the aset overlay, jolt-aset3, and any jolt.host/ref-put!
+;; on an array all land here. Narrows the value to the element kind (na-elem-of) and
+;; answers what was actually stored, so aset's return agrees with a following aget.
+(define (na-array-set! a k v)
+  (let ((sv (na-elem-of (jolt-array-kind a) v)))
+    (ja-set! (jolt-array-vec a) (exact (na-idx k)) sv) sv))
 (define %na-ref-put! jolt-ref-put!)
 (set! jolt-ref-put!
   (lambda (t k v)
-    (if (jolt-array? t) (begin (ja-set! (jolt-array-vec t) (exact (na-idx k)) v) t)
+    (if (jolt-array? t) (begin (na-array-set! t k v) t)
         (%na-ref-put! t k v))))
 (def-var! "jolt.host" "ref-put!" jolt-ref-put!)
 ;; native-op target for the 1-dim (aset arr i v): write through the array-aware
-;; ref-put! and return the stored value (JVM aset returns the val, not the array).
-(define (jolt-aset3 a i v) (jolt-ref-put! a i v) v)
+;; seam and return the stored value (JVM aset returns the val, not the array).
+(define (jolt-aset3 a i v)
+  (if (jolt-array? a) (na-array-set! a i v) (begin (jolt-ref-put! a i v) v)))
 ;; unboxed read target for (aget ^doubles a i): direct flvector-ref on the backing,
 ;; skipping jolt-nth's case-lambda + jolt-array?/flvector? dispatch. Emitted only
 ;; when jolt.passes.numeric proved the array is a ^doubles/^floats (flvector) param.

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -343,7 +343,7 @@
         (cons "size"          (lambda (p . _) (nio-size (nfp p))))
         (cons "delete"        (lambda (p) (nio-delete1 (nfp p) #f) jolt-nil))
         (cons "deleteIfExists"(lambda (p) (nio-delete1 (nfp p) #t)))
-        (cons "readAllBytes"  (lambda (p) (make-jolt-array (list->vector (bytevector->u8-list (nio-read-bv (nfp p)))) 'byte)))
+        (cons "readAllBytes"  (lambda (p) (na-bv->bytearray (nio-read-bv (nfp p)))))
         (cons "readAllLines"  (lambda (p . _) (nio-read-lines (nfp p))))
         (cons "newInputStream"(lambda (p . _) (make-in-stream (open-file-input-port (nfp p)))))
         (cons "createTempFile"      (lambda args (nio-files-create-temp args #f)))

--- a/host/chez/java/regex-translate.ss
+++ b/host/chez/java/regex-translate.ss
@@ -270,9 +270,15 @@
                       (let ((s (substring body 0 comma)))
                         (if (> (string-length s) 0) (string->number s) #f))
                       (string->number body)))
-               (m (and comma
-                       (let ((s (substring body (+ comma 1) (string-length body))))
-                         (if (> (string-length s) 0) (string->number s) #f))))
+               ;; {n} is EXACTLY n, so its upper bound is n — not #f, which is
+               ;; irregex's "no bound" and made every {n} behave as {n,}: \d{4}
+               ;; matched all of "20260729", [0-9]{2} all of "1234", and
+               ;; (?:%[0-9a-f]{2})+ ran past the last percent-escape. Only a comma
+               ;; opens the bound: {n,} (nothing after it) is unbounded, {n,m} is m.
+               (m (if comma
+                      (let ((s (substring body (+ comma 1) (string-length body))))
+                        (if (> (string-length s) 0) (string->number s) #f))
+                      n))
                (j (+ cb 1))
                (lazy? (and (< j end) (char=? (string-ref src j) #\?)))
                (j (if lazy? (+ j 1) j))

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -28,6 +28,7 @@ compile-ns
 condition-message
 deftype-ctor-class
 delete-file
+directory?
 enable-trace!
 exact?
 file-exists?

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -1258,6 +1258,11 @@
 (def-var! "jolt.host" "source-roots" (lambda () (list->cseq source-roots)))
 (def-var! "jolt.host" "load-namespace" (lambda (n) (load-namespace n) jolt-nil))
 (def-var! "jolt.host" "file-exists?" (lambda (p) (if (file-exists? p) #t #f)))
+;; …and whether it is a DIRECTORY, which file-exists? also answers #t for. A bare
+;; argv token is dispatched as a file to run before a :tasks lookup (main.clj's
+;; run-file-arg?), so `jolt test` in any project with a test/ dir — which is every
+;; jolt library — took the file path and died decoding a directory.
+(def-var! "jolt.host" "directory?" (lambda (p) (if (file-directory? p) #t #f)))
 (def-var! "jolt.host" "getenv" (lambda (n) (let ((v (getenv n))) (if v v jolt-nil))))
 
 ;; jolt version string — one source (jolt-version-string, rt.ss): the baked

--- a/host/chez/natives-format.ss
+++ b/host/chez/natives-format.ss
@@ -5,6 +5,32 @@
 ;; jolt-str-render-one via converters + jolt-truthy?).
 
 (define (->long x) (exact (truncate x)))
+;; %x / %X / %o are UNSIGNED conversions on the JVM: a negative argument prints the
+;; two's complement of its integer type, not a signed magnitude ("%x" -1 was "-1"
+;; here, which is wrong under any width). The WIDTH is the argument's Java type —
+;; Byte 8 bits, Short 16, Integer 32, Long 64 — and jolt unifies every integer as
+;; one type, so it cannot read the width off the argument and one of the two ends
+;; must diverge. jolt takes the NARROWEST width that holds the value, which is the
+;; JVM's answer whenever the value's origin type is the narrowest that holds it:
+;; a byte out of a byte[] prints two digits and an int-sized hash prints eight,
+;; so the hex-dump and percent-encode idioms match the JVM unmasked. The cost is a
+;; long whose value fits narrower — (format "%x" (long -1)) is "ff" here and
+;; "ffffffffffffffff" on the JVM — allowlisted under :integer-box-model. Masking
+;; ((bit-and b 0xff)) pins the width explicitly and is identical on both.
+;; A value outside the signed-64 range has no fixed-width two's complement to print
+;; — the JVM would be holding a BigInteger there, whose %x is a signed magnitude
+;; with a leading minus — so that is what it gets. Masking it to 64 bits, as the
+;; width search would, silently rendered -(2^70) as "0".
+(define (fmt-radix v radix)
+  (let ((n (->long v)))
+    (cond
+      ((>= n 0) (number->string n radix))
+      ((< n (- (expt 2 63))) (string-append "-" (number->string (- n) radix)))
+      (else
+       (let loop ((bits 8))
+         (if (>= n (- (expt 2 (- bits 1))))
+             (number->string (bitwise-and n (- (expt 2 bits) 1)) radix)
+             (loop (fx* bits 2))))))))
 (define (pad-left s n c) (if (fx>=? (string-length s) n) s (string-append (make-string (fx- n (string-length s)) c) s)))
 (define (fmt-float x prec)
   (let* ((neg (< x 0)) (ax (abs x))
@@ -47,9 +73,9 @@
                                        ((#\s) (if (jolt-nil? a) "null" (jolt-str-render-one a)))
                                        ((#\S) (string-upcase (if (jolt-nil? a) "null" (jolt-str-render-one a))))
                                        ((#\f) (fmt-float a (or prec 6)))
-                                       ((#\x) (string-downcase (number->string (->long a) 16)))
-                                       ((#\X) (string-upcase (number->string (->long a) 16)))
-                                       ((#\o) (number->string (->long a) 8))
+                                       ((#\x) (string-downcase (fmt-radix a 16)))
+                                       ((#\X) (string-upcase (fmt-radix a 16)))
+                                       ((#\o) (fmt-radix a 8))
                                        ((#\b) (if (jolt-truthy? a) "true" "false"))
                                        ((#\c) (string (integer->char (->long a))))
                                        (else (jolt-throw (jolt-host-throwable "java.util.UnknownFormatConversionException"

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -16,18 +16,28 @@ jolt="${JOLT_BIN:-bin/jolt}"
 # clue which case it was. Cap each invocation instead: the case then FAILS and names
 # itself. JOLT_SMOKE_TIMEOUT=0 disables the cap (for a debugger on a live case).
 #
-# coreutils' timeout is not on a stock macOS, so fall back to running uncapped
-# rather than skipping the case or hard-failing the gate on a missing tool.
+# --foreground matters, it is not a detail: without it GNU timeout runs the command
+# in its OWN PROCESS GROUP so it can signal the whole group. The jolt.process case
+# spawns children and asserts on destroy / alive? / a 143 SIGTERM exit, all of which
+# read the process group — under a plain `timeout` that case dies with no output on
+# Linux while still passing on macOS. --foreground leaves the group alone.
+#
+# coreutils' timeout is not on a stock macOS, so fall back to running uncapped rather
+# than skipping the case or hard-failing the gate on a missing tool.
 smoke_timeout="${JOLT_SMOKE_TIMEOUT:-120}"
 if [ "$smoke_timeout" = "0" ]; then
   jolt_timeout=""
-elif command -v timeout >/dev/null 2>&1; then
-  jolt_timeout="timeout $smoke_timeout"
-elif command -v gtimeout >/dev/null 2>&1; then
-  jolt_timeout="gtimeout $smoke_timeout"
 else
-  jolt_timeout=""
-  echo "  note: no timeout(1) — a hung case will block instead of failing"
+  for t in timeout gtimeout; do
+    if command -v "$t" >/dev/null 2>&1 && "$t" --foreground 1 true >/dev/null 2>&1; then
+      jolt_timeout="$t --foreground $smoke_timeout"
+      break
+    fi
+  done
+  if [ -z "${jolt_timeout:-}" ]; then
+    jolt_timeout=""
+    echo "  note: no timeout(1) with --foreground — a hung case will block instead of failing"
+  fi
 fi
 jolt="$jolt_timeout $jolt"
 

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -570,12 +570,16 @@ if printf '%s' "$process_out" | grep -q 'PROCESS-TEST OK'; then
   pass=$((pass + 1))
 else
   echo "  FAIL: jolt.process"
-  # the case's own FAILs if it got that far, else the last of whatever it did say
-  # (an exception, a missing shared library) — never nothing.
-  if printf '%s\n' "$process_out" | grep -q FAIL; then
-    printf '%s\n' "$process_out" | grep FAIL | head -5 | sed 's/^/    /'
+  # the case's own FAILs if it got that far, else the last of whatever it did say —
+  # an exception, or the "  .. <label>" the test prints before each check, whose LAST
+  # line then names the check that blocked. Never nothing.
+  if printf '%s\n' "$process_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$process_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$process_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$process_out" | tail -6 | sed 's/^/    /'
   else
-    printf '%s\n' "$process_out" | tail -12 | sed 's/^/    /'
+    echo "    (no output at all — died or was killed before its first check)"
   fi
   fails=$((fails + 1))
 fi

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -552,7 +552,18 @@ fi
 
 # jolt.process — the stdlib sub-process API against real programs (capture, pipes,
 # stdin, :dir/:env, exit codes, signals). The file self-checks and prints a marker.
-process_out="$($jolt run test/chez/process-test.clj 2>/dev/null)"
+#
+# Captured to a FILE, not with $(…), unlike every other case here: this is the one
+# case that spawns child processes, and a command substitution does not return until
+# every writer has closed the pipe — not just until the command exits. A child that
+# inherits that pipe and outlives jolt (the destroy/signal case leaves a `sleep`
+# behind if destroy does not take) therefore blocks the read forever, which is how
+# this case hung the gate for hours with nothing to show for it. Redirecting to a
+# file gives the children a file descriptor with no reader to wait on.
+process_log="$(mktemp)"
+$jolt run test/chez/process-test.clj >"$process_log" 2>/dev/null || true
+process_out="$(cat "$process_log")"
+rm -f "$process_log"
 if printf '%s' "$process_out" | grep -q 'PROCESS-TEST OK'; then
   pass=$((pass + 1))
 else

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -560,17 +560,26 @@ fi
 # behind if destroy does not take) therefore blocks the read forever, which is how
 # this case hung the gate for hours with nothing to show for it. Redirecting to a
 # file gives the children a file descriptor with no reader to wait on.
+# stderr goes INTO the log, not to /dev/null: if the run dies before it can print a
+# single check, "FAIL: jolt.process" with nothing under it is all the gate says, and
+# the reason — the exception — is exactly what was thrown away.
 process_log="$(mktemp)"
-$jolt run test/chez/process-test.clj >"$process_log" 2>/dev/null || true
+$jolt run test/chez/process-test.clj >"$process_log" 2>&1 || true
 process_out="$(cat "$process_log")"
-rm -f "$process_log"
 if printf '%s' "$process_out" | grep -q 'PROCESS-TEST OK'; then
   pass=$((pass + 1))
 else
   echo "  FAIL: jolt.process"
-  printf '%s\n' "$process_out" | grep FAIL | head -5 | sed 's/^/    /'
+  # the case's own FAILs if it got that far, else the last of whatever it did say
+  # (an exception, a missing shared library) — never nothing.
+  if printf '%s\n' "$process_out" | grep -q FAIL; then
+    printf '%s\n' "$process_out" | grep FAIL | head -5 | sed 's/^/    /'
+  else
+    printf '%s\n' "$process_out" | tail -12 | sed 's/^/    /'
+  fi
   fails=$((fails + 1))
 fi
+rm -f "$process_log"
 
 # jolt.parser — the general parser-combinator core, running rm-hull/jasentaa's
 # own suite for the adopted pieces plus jolt's added combinators. Self-checks.

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -10,6 +10,27 @@ cd "$root"
 # script-mode case below keeps the source-load path covered).
 jolt="${JOLT_BIN:-bin/jolt}"
 
+# Every case here is a sub-second jolt invocation, so a case that does not finish
+# has hung — and a hung case is invisible: `make -Oline` shows nothing for a target
+# until it completes, so a CI gate sits silent until the 6-hour job limit with no
+# clue which case it was. Cap each invocation instead: the case then FAILS and names
+# itself. JOLT_SMOKE_TIMEOUT=0 disables the cap (for a debugger on a live case).
+#
+# coreutils' timeout is not on a stock macOS, so fall back to running uncapped
+# rather than skipping the case or hard-failing the gate on a missing tool.
+smoke_timeout="${JOLT_SMOKE_TIMEOUT:-120}"
+if [ "$smoke_timeout" = "0" ]; then
+  jolt_timeout=""
+elif command -v timeout >/dev/null 2>&1; then
+  jolt_timeout="timeout $smoke_timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  jolt_timeout="gtimeout $smoke_timeout"
+else
+  jolt_timeout=""
+  echo "  note: no timeout(1) — a hung case will block instead of failing"
+fi
+jolt="$jolt_timeout $jolt"
+
 fails=0
 check() {
   got="$($jolt -e "$1" 2>/dev/null | tail -1)"

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -123,10 +123,16 @@
 ;; (stdin), an existing file, or a *.jolt/*.clj/*.cljc/*.cljs path. .jolt is the
 ;; same language as .clj and only marks a file as using jolt-specific interop
 ;; rather than portable Clojure.
+;; A directory is never a file to run, however much it looks like one: `test` is a
+;; :tasks entry AND a directory in every jolt project, and file-exists? answers #t
+;; for a directory, so `jolt test` used to be dispatched here and die in
+;; load-file's decoder ("failed on #<binary input port test>: is a directory")
+;; rather than running the task.
 (defn- run-file-arg? [x]
-  (or (= "-" x)
-      (some #(str/ends-with? x %) [".jolt" ".clj" ".cljc" ".cljs"])
-      (jolt.host/file-exists? x)))
+  (and (not (jolt.host/directory? x))
+       (or (= "-" x)
+           (some #(str/ends-with? x %) [".jolt" ".clj" ".cljc" ".cljs"])
+           (jolt.host/file-exists? x))))
 
 ;; run [-m NS args… | FILE]  — FILE may be "-" (stdin)
 (defn- cmd-run [more]

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1681,11 +1681,12 @@
   ;; A Charset OBJECT has to reach the encoder as a charset, not as its printed
   ;; form: .getBytes rendered it to "#object[java.nio.charset.Charset]", matched
   ;; no arm, and silently encoded UTF-8. ASCII-only text and an explicit UTF-8
-  ;; request both hide that, so these assert a non-ASCII round-trip. Byte values
-  ;; are deliberately not asserted — jolt's byte arrays are unsigned where the
-  ;; JVM's are signed, which is a separate divergence.
+  ;; request both hide that, so these assert a non-ASCII round-trip — and now the
+  ;; byte VALUES too, since byte[] elements are signed like the JVM's
+  ;; (`arrays / signed byte elements`).
   {:suite "host-interop / Charset aliases" :label "getBytes/String. round-trip through a Charset object" :expected "\"sõme ßÒññÝ\"" :actual "(let [cs (java.nio.charset.Charset/forName \"ISO-8859-1\")] (String. (.getBytes \"sõme ßÒññÝ\" cs) cs))" :portability :jvm}
   {:suite "host-interop / Charset aliases" :label "a Charset object encodes one byte per char, not UTF-8" :expected "1" :actual "(alength (.getBytes \"õ\" (java.nio.charset.Charset/forName \"ISO-8859-1\")))" :portability :jvm}
+  {:suite "host-interop / Charset aliases" :label "a Charset object encodes the latin-1 byte, not the UTF-8 pair" :expected "[-11]" :actual "(vec (.getBytes \"õ\" (java.nio.charset.Charset/forName \"ISO-8859-1\")))" :portability :jvm}
   {:suite "host-interop / Charset aliases" :label "an aliased Charset object still selects its canonical encoding" :expected "1" :actual "(alength (.getBytes \"õ\" (java.nio.charset.Charset/forName \"l1\")))" :portability :jvm}
   {:suite "host-interop / Charset aliases" :label "unknown vs malformed charset names throw different exceptions" :expected "[\"java.nio.charset.UnsupportedCharsetException\" \"java.nio.charset.IllegalCharsetNameException\"]" :actual "[(try (java.nio.charset.Charset/forName \"NOPE-9\") (catch Throwable e (.getName (class e)))) (try (java.nio.charset.Charset/forName \"bad name\") (catch Throwable e (.getName (class e))))]" :portability :jvm}
   {:suite "predicates / nil & boolean" :label "nil? true" :expected "true" :actual "(nil? nil)" :portability :common}
@@ -2028,6 +2029,14 @@
   {:suite "regex / literals & predicate" :label "combined (?sm) still works" :expected "\"b\"" :actual "(re-find #\"(?sm)^b\" \"a\\nb\")" :portability :common}
   {:suite "regex / literals & predicate" :label "re-quote-replacement of a regex" :expected "\"x+y\"" :actual "(clojure.string/re-quote-replacement #\"x+y\")" :portability :common}
   {:suite "regex / literals & predicate" :label "escaped ] in a char class" :expected "\"]x\"" :actual "(re-find #\"[\\]]x\" \"]x\")" :portability :common}
+  ;; {n} is EXACTLY n. It used to translate to irregex's unbounded (** n #f …), so
+  ;; every {n} behaved as {n,}: \d{4} swallowed all of "20260729", re-matches
+  ;; accepted a longer string, and (?:%[0-9a-f]{2})+ ran past the last escape (which
+  ;; is how ring-codec's percent-decode broke). {n,} and {n,m} were always right.
+  {:suite "regex / bounded repetition" :label "{n} is exactly n, not n-or-more" :expected "[\"aa\" \"a\" \"\" \"123\" \"2026\"]" :actual "[(re-find #\"a{2}\" \"aaaa\") (re-find #\"a{1}\" \"aaaa\") (re-find #\"a{0}\" \"aaaa\") (re-find #\"[0-9]{3}\" \"12345\") (re-find #\"\\d{4}\" \"20260729\")]" :portability :common}
+  {:suite "regex / bounded repetition" :label "{n,} and {n,m} keep their bounds" :expected "[\"aaaa\" \"aaa\" \"aa\"]" :actual "[(re-find #\"a{2,}\" \"aaaa\") (re-find #\"a{2,3}\" \"aaaa\") (re-find #\"a{2}?\" \"aaaa\")]" :portability :common}
+  {:suite "regex / bounded repetition" :label "an exact bound anchors and splits" :expected "[nil nil (quote (\"12\" \"34\" \"56\")) \"YY\"]" :actual "[(re-matches #\"\\d{4}\" \"20260\") (re-find #\"^\\d{2}$\" \"123\") (re-seq #\"\\d{2}\" \"123456\") (clojure.string/replace \"20260729\" #\"\\d{4}\" \"Y\")]" :portability :common}
+  {:suite "regex / bounded repetition" :label "an exact bound inside a group stops the outer +" :expected "[\"%FE%FF%00%2F\" \"abab\" \"xxy\"]" :actual "[(re-find #\"(?:%[A-Fa-f0-9]{2})+\" \"foo%FE%FF%00%2Fbar\") (first (re-find #\"(ab){2}\" \"ababab\")) (re-find #\"x{2}y\" \"xxxy\")]" :portability :common}
   {:suite "regex / literals & predicate" :label "escaped ] amid class members" :expected "\")\"" :actual "(re-find #\"[\\.\\,\\s\\]\\}\\)]\" \")\")" :portability :common}
   {:suite "regex / literals & predicate" :label "replacement backslash escape" :expected "4" :actual "(count (clojure.string/replace \"abc\" #\"b\" \"\\\\\\\\d\"))" :portability :common}
   {:suite "interop / String methods" :label "str of a reify with toString" :expected "\"xyz\"" :actual "(str (reify Object (toString [_] \"xyz\")))" :portability :jvm}
@@ -4061,6 +4070,11 @@
   {:suite "reader / radix N suffix" :label "2r1010N reads as integer 10" :expected "10" :actual "(read-string \"2r1010N\")" :portability :common}
   {:suite "ns / refer-all in ns-refers" :label ":refer :all names appear in ns-refers" :expected "true" :actual "(do (require '[clojure.set :refer :all]) (contains? (ns-refers *ns*) 'union))" :portability :common}
   {:suite "io / binary copy File→File" :label "io/copy preserves raw bytes when both sides are files" :expected "[255 254 0 65]" :actual "(do (require '[clojure.java.io :as io]) (let [f1 (java.io.File/createTempFile \"jcp\" \".bin\") f2 (java.io.File/createTempFile \"jcp\" \".bin\")] (io/copy (byte-array [255 254 0 65]) f1) (io/copy f1 f2) (let [in (java.io.FileInputStream. f2) ba (byte-array 4) _ (.read in ba) result (mapv #(bit-and % 0xFF) (vec ba))] (.close in) (.delete f1) (.delete f2) result)))" :portability :jvm}
+  ;; A File source is a BYTE source for EVERY byte destination, not only for another
+  ;; file: (io/copy f stream) used to slurp the file as UTF-8 and replace each
+  ;; non-UTF-8 byte with U+FFFD (ef bf bd), so binary bodies came out corrupt.
+  {:suite "io / binary copy File→File" :label "io/copy File→OutputStream stays byte-exact" :expected "[-1 -128 0 65]" :actual "(do (require '[clojure.java.io :as io]) (let [f (java.io.File/createTempFile \"jcps\" \".bin\") _ (io/copy (byte-array [255 128 0 65]) f) baos (java.io.ByteArrayOutputStream.)] (io/copy f baos) (.delete f) (vec (.toByteArray baos))))" :portability :jvm}
+  {:suite "io / binary copy File→File" :label "a byte round-trip through Base64 survives" :expected "\"sõme\"" :actual "(String. (.decode (java.util.Base64/getDecoder) (.encodeToString (java.util.Base64/getEncoder) (.getBytes \"sõme\" \"UTF-8\"))) \"UTF-8\")" :portability :jvm}
   {:suite "io / File.delete non-empty dir" :label "File.delete returns false for non-empty directory" :expected "false" :actual "(do (require '[clojure.java.io :as io]) (let [d (doto (java.io.File/createTempFile \"jtd\" \".d\") (.delete) (.mkdir)) child (java.io.File. d \"child.txt\")] (spit child \"x\") (let [deleted (.delete d)] (.delete child) (.delete d) deleted)))" :portability :jvm}
   {:suite "async / transducer backpressure" :label "fixed-buffer transducer put blocks when full" :expected "[true 2 3 4 :done]" :actual "(do (require '[clojure.core.async :as a]) (let [c (a/chan 1 (map inc)) p (future (a/>!! c 1) (a/>!! c 2) (a/>!! c 3) :done)] (Thread/sleep 100) (let [parked (not (realized? p)) v1 (a/<!! c) v2 (a/<!! c) v3 (a/<!! c) result @p] [parked v1 v2 v3 result])))" :portability :jvm}
   {:suite "async / close does not complete pending put" :label "pending rendezvous put parks until consumed, even on close" :expected "[:v true]" :actual "(do (require '[clojure.core.async :as a]) (let [c (a/chan) p (future (a/>!! c :v))] (Thread/sleep 50) (a/close! c) [(a/<!! c) @p]))" :portability :jvm}
@@ -4200,4 +4214,64 @@
   {:suite "arrays / oob exception" :label "aset OOB caught by parent IndexOutOfBoundsException" :expected ":ioobe" :actual "(try (aset (long-array 2) 9 1) (catch IndexOutOfBoundsException e :ioobe))" :portability :common}
   {:suite "arrays / oob exception" :label "byte-array aset OOB" :expected ":aioobe" :actual "(try (aset (byte-array 2) 5 (byte 1)) (catch ArrayIndexOutOfBoundsException e :aioobe))" :portability :common}
   {:suite "arrays / oob exception" :label "OOB not caught by an unrelated exception class" :expected ":outer" :actual "(try (try (aget (double-array 3) 5) (catch NullPointerException e :npe)) (catch Throwable t :outer))" :portability :common}
+
+  ;; A byte[] element is a SIGNED byte (-128..127), like the JVM's: a value above
+  ;; 127 reads negative, so (neg? b) / (bit-and b 0xff) / arithmetic over a high
+  ;; byte behave as they do on the JVM. Every byte[] producer (byte-array,
+  ;; .getBytes, stream reads, Files/readAllBytes, Base64, Random/nextBytes, FFI)
+  ;; and consumer (String., .write, Base64, FFI) shares the one narrow/mask seam,
+  ;; so bytes survive a round-trip unchanged (jolt-kevb).
+  {:suite "arrays / signed byte elements" :label "byte-array narrows like Byte.byteValue" :expected "[-1 -128 127 -1 -128 0]" :actual "(vec (byte-array [255 128 127 -1 -128 256]))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "aget reads a high byte as negative" :expected "-56" :actual "(aget (byte-array [200]) 0)" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "a 0xff mask recovers the unsigned value" :expected "255" :actual "(bit-and (aget (byte-array [255]) 0) 0xff)" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "seq / reduce see signed elements" :expected "[(quote (-1 -1)) -2]" :actual "[(seq (byte-array [255 255])) (reduce + (byte-array [255 255]))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "a double element truncates toward zero, it does not floor" :expected "[1 -1]" :actual "(vec (byte-array [1.9 -1.9]))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "the fill value of (byte-array n init) narrows too" :expected "[-1 -1 -1]" :actual "(vec (byte-array 3 (byte -1)))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "aset-byte stores signed" :expected "[-1 -56]" :actual "(let [a (byte-array 2)] (aset-byte a 0 -1) (aset-byte a 1 (unchecked-byte 200)) (vec a))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "aset stores a negative byte" :expected "-1" :actual "(let [a (byte-array 1)] (aset a 0 (byte -1)) (aget a 0))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "aclone / Arrays copy keep the sign" :expected "[[-1] [-1 -128] [-1 0]]" :actual "[(vec (aclone (byte-array [255]))) (vec (java.util.Arrays/copyOfRange (byte-array [255 128 1]) 0 2)) (vec (java.util.Arrays/copyOf (byte-array [255]) 2))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Arrays/fill takes a negative byte" :expected "[-1 -1]" :actual "(let [a (byte-array 2)] (java.util.Arrays/fill a (byte -1)) (vec a))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Arrays/equals sees 255 and -1 as the same byte" :expected "true" :actual "(java.util.Arrays/equals (byte-array [255]) (byte-array [-1]))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Arrays/toString is comma-separated, over signed bytes" :expected "[\"[-1, 1]\" \"[1, 2]\"]" :actual "[(java.util.Arrays/toString (byte-array [255 1])) (java.util.Arrays/toString (int-array [1 2]))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Arrays/toString renders element toString, nil as null" :expected "[\"[a, 1, null]\" \"[a, b]\" \"[1.0, 2.0]\" \"[]\"]" :actual "[(java.util.Arrays/toString (object-array [\"a\" 1 nil])) (java.util.Arrays/toString (char-array [\\a \\b])) (java.util.Arrays/toString (double-array [1 2])) (java.util.Arrays/toString (byte-array 0))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label ".getBytes yields signed bytes" :expected "[[-11] [-61 -75] [65 66]]" :actual "[(vec (.getBytes \"õ\" \"ISO-8859-1\")) (vec (.getBytes \"õ\" \"UTF-8\")) (vec (.getBytes \"AB\"))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "signed bytes decode back through (String. bytes cs)" :expected "[\"õ\" [-11]]" :actual "(let [s (String. (byte-array [-11]) \"ISO-8859-1\")] [s (vec (.getBytes s \"ISO-8859-1\"))])" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "a stream read fills the buffer signed; the 1-arg read stays unsigned" :expected "[[-1] 255]" :actual "[(let [in (java.io.ByteArrayInputStream. (byte-array [255])) b (byte-array 1)] (.read in b) (vec b)) (.read (java.io.ByteArrayInputStream. (byte-array [255])))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "ByteArrayOutputStream round-trips a high byte" :expected "[-1 -128]" :actual "(vec (.toByteArray (doto (java.io.ByteArrayOutputStream.) (.write (byte-array [255 128])))))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "a file round-trip preserves the raw bytes" :expected "[-1 -128 0 65]" :actual "(let [f (java.io.File/createTempFile \"jsb\" \".bin\")] (with-open [o (java.io.FileOutputStream. f)] (.write o (byte-array [255 128 0 65]))) (let [r (vec (java.nio.file.Files/readAllBytes (.toPath f)))] (.delete f) r))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "ByteBuffer get returns a signed byte" :expected "[-1 [-1 -128]]" :actual "[(.get (java.nio.ByteBuffer/wrap (byte-array [255]))) (let [bb (java.nio.ByteBuffer/wrap (byte-array [255 128])) d (byte-array 2)] (.get bb d) (vec d))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "ByteBuffer put takes a negative byte" :expected "[-1 127]" :actual "(let [bb (java.nio.ByteBuffer/allocate 2)] (.put bb (byte -1)) (.put bb (byte 127)) (vec (.array bb)))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Base64 decodes to a signed byte[] and re-encodes it" :expected "[[-1 -1] \"//8=\" [47 119 61 61]]" :actual "[(vec (.decode (java.util.Base64/getDecoder) \"//8=\")) (.encodeToString (java.util.Base64/getEncoder) (byte-array [-1 -1])) (vec (.encode (java.util.Base64/getEncoder) (byte-array [255])))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Base64 output is a byte[], not an opaque host buffer" :expected "[true true]" :actual "[(bytes? (.decode (java.util.Base64/getDecoder) \"//8=\")) (bytes? (.encode (java.util.Base64/getEncoder) (byte-array [1])))]" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "Random/nextBytes matches the JVM LCG, four bytes per nextInt" :expected "[53 -99 65 -70 -9 -118 -2 13]" :actual "(let [a (byte-array 8)] (.nextBytes (java.util.Random. 42) a) (vec a))" :portability :jvm}
+  {:suite "arrays / signed byte elements" :label "nextBytes consumes one nextInt per four bytes" :expected "true" :actual "(let [a (byte-array 4) r (java.util.Random. 7) _ (.nextBytes r a)] (= (.nextInt r) (.nextInt (doto (java.util.Random. 7) (.nextInt)))))" :portability :jvm}
+
+  ;; The idioms that read bytes back out. %x / %X / %o are UNSIGNED conversions: a
+  ;; negative argument prints the two's complement of its integer type, never a
+  ;; signed magnitude — jolt used to print "-1" for (format "%x" -1). The WIDTH is
+  ;; the argument's Java type (Byte 8 / Short 16 / Integer 32 / Long 64) and jolt
+  ;; unifies every integer as one type, so it takes the narrowest width holding the
+  ;; value: a byte out of a byte[] prints two digits like the JVM's Byte, an
+  ;; int-sized value eight like its Integer. A long whose value fits narrower is the
+  ;; one case that diverges — allowlisted :integer-box-model, next row but one.
+  {:suite "numbers / unsigned string conversions" :label "an unmasked byte hex-formats at byte width" :expected "[\"FE\" \"%C3%B5\" \"ff\" \"-1\"]" :actual "[(format \"%02X\" (aget (byte-array [254]) 0)) (apply str (map (partial format \"%%%02X\") (.getBytes \"õ\" \"UTF-8\"))) (format \"%x\" 255) (format \"%d\" -1)]" :portability :jvm}
+  ;; The whole percent-encoder shape real libraries write over raw UTF-8 bytes —
+  ;; ring-codec's percent-encode and cognitect aws-api's request signer, unmodified.
+  ;; Character/isLetterOrDigit classifies an int codepoint, so a signed high byte
+  ;; reaches it and is correctly not a letter.
+  {:suite "numbers / unsigned string conversions" :label "the unmasked percent-encoder idiom over UTF-8 bytes" :expected "\"a%2Fb%20%C3%B5%3D1\"" :actual "(let [sb (StringBuilder.)] (doseq [b (.getBytes \"a/b õ=1\" \"UTF-8\")] (.append sb (if (Character/isLetterOrDigit b) (char b) (format \"%%%02X\" b)))) (.toString sb))" :portability :jvm}
+  {:suite "numbers / unsigned string conversions" :label "Character/isLetter & isLetterOrDigit over chars and codepoints" :expected "[true false true false true true false]" :actual "[(Character/isLetter \\a) (Character/isLetter \\5) (Character/isLetterOrDigit \\5) (Character/isLetterOrDigit \\-) (Character/isLetterOrDigit 65) (Character/isLetter 122) (Character/isLetter (aget (byte-array [200]) 0))]" :portability :jvm}
+  {:suite "numbers / unsigned string conversions" :label "a masked byte formats as two hex digits" :expected "\"ff800f\"" :actual "(apply str (map #(format \"%02x\" (bit-and % 0xff)) (byte-array [255 128 15])))" :portability :jvm}
+  ;; DIVERGENT (:integer-box-model): the JVM widens by the argument's declared type,
+  ;; so these are 16 / 22 digits there. The corpus keeps jolt's value.
+  {:suite "numbers / unsigned string conversions" :label "a negative long takes the narrowest width holding it" :expected "[\"ff\" \"FF01\" \"377\" \"ff00\" \"fed4\"]" :actual "[(format \"%x\" -1) (format \"%X\" -255) (format \"%o\" -1) (format \"%x\" -256) (format \"%x\" -300)]" :portability :common}
+  {:suite "numbers / unsigned string conversions" :label "a value needing 64 bits still gets them" :expected "[\"ffffffff7fffffff\" \"8000000000000000\"]" :actual "[(format \"%x\" -2147483649) (format \"%x\" -9223372036854775808)]" :portability :common}
+  ;; Past the signed-64 range there is no fixed-width two's complement to print, so
+  ;; it is a signed magnitude — what the JVM's Formatter does for a BigInteger. The
+  ;; width search used to mask here, rendering -(2^70) as "0". Reference Clojure's
+  ;; format rejects a BigInt for %x outright, so this row is jolt-only.
+  {:suite "numbers / unsigned string conversions" :label "past 64 bits it is a signed magnitude, not a wrap" :expected "[\"-400000000000000000\" \"400000000000000000\" \"-8000000000000001\"]" :actual "[(format \"%x\" -1180591620717411303424N) (format \"%x\" 1180591620717411303424N) (format \"%x\" (dec -9223372036854775808))]" :portability :common}
+  {:suite "numbers / unsigned string conversions" :label "Integer/Long toHexString are unsigned at their own width" :expected "[\"ffffffff\" \"ffffff00\" \"ffffffffffffffff\" \"ff\"]" :actual "[(Integer/toHexString -1) (Integer/toHexString -256) (Long/toHexString -1) (Integer/toHexString 255)]" :portability :jvm}
+  {:suite "numbers / unsigned string conversions" :label "toOctalString / toBinaryString are unsigned too" :expected "[\"37777777777\" \"11111111111111111111111111111111\" \"1777777777777777777777\" \"101\"]" :actual "[(Integer/toOctalString -1) (Integer/toBinaryString -1) (Long/toOctalString -1) (Integer/toBinaryString 5)]" :portability :jvm}
+  {:suite "numbers / unsigned string conversions" :label "toString with a radix is signed magnitude, lowercase" :expected "[\"-ff\" \"-ff\" \"-255\" \"ff\"]" :actual "[(Integer/toString -255 16) (Long/toString -255 16) (Long/toString -255) (Integer/toString 255 16)]" :portability :jvm}
 ]

--- a/test/chez/ffi-binding-test.ss
+++ b/test/chez/ffi-binding-test.ss
@@ -33,8 +33,9 @@
 (ok "sizeof :pointer is a word" (let ((n (jnum->exact (ev "(jolt.ffi/sizeof :pointer)")))) (or (= n 8) (= n 4))))
 
 ;; byte-array buffer I/O: write a byte-array into foreign memory and read it back
-;; byte-exact (high bytes preserved, no UTF-8 mangling).
-(ok "byte-array roundtrip (binary-faithful)"
+;; byte-exact (high bytes preserved, no UTF-8 mangling). Elements are SIGNED bytes
+;; like the JVM's byte[], so a high byte reads negative and 0xff-masks back.
+(ok "byte-array roundtrip (binary-faithful, signed elements)"
     (jolt-truthy?
       (ev "(let [src (byte-array [0 65 200 255 10])
                   p (jolt.ffi/alloc 5)]
@@ -42,8 +43,8 @@
               (let [back (jolt.ffi/read-array p 5)]
                 (jolt.ffi/free p)
                 (and (= 5 (alength back))
-                     (= 0 (aget back 0)) (= 65 (aget back 1))
-                     (= 200 (aget back 2)) (= 255 (aget back 3)) (= 10 (aget back 4)))))")))
+                     (= [0 65 -56 -1 10] (vec back))
+                     (= [0 65 200 255 10] (mapv #(bit-and % 0xff) back)))))")))
 
 ;; a :blocking foreign call is collect-safe: a thread parked in it must not pin
 ;; the stop-the-world collector. (collect) here would throw "cannot collect when

--- a/test/chez/process-test.clj
+++ b/test/chez/process-test.clj
@@ -6,9 +6,24 @@
             [clojure.string :as str]))
 
 (def failures (atom []))
-(defn check-eq [label got want]
-  (when-not (= got want)
-    (swap! failures conj (str label ": want " (pr-str want) " got " (pr-str got)))))
+
+;; A MACRO, not a fn, so the label is announced BEFORE the expression under test runs
+;; — as a fn, `got` is evaluated at the call site and a check that blocks never
+;; reaches the announcement. Every check here spawns a real child process, so any one
+;; of them can block forever on a pipe or a wait, and this file used to print nothing
+;; until the final verdict: a hung check left an empty log with no way to tell which.
+;; (It hung the CI gate for over three hours exactly this way; jolt-pgbh.)
+;;
+;; The flush is load-bearing, not decoration: smoke.sh redirects this to a file, where
+;; output is block-buffered, so a killed process loses whatever it had not flushed —
+;; which is how "it printed nothing at all" survived even a 120s cap.
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
 
 ;; tokenize (pure)
 (check-eq "tokenize" (p/tokenize "a  b 'c d'") ["a" "b" "c d"])

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -612,6 +612,17 @@
   {:suite "bytes" :expr "(String. (byte-array [104 105]) \"UTF-8\")" :expected "\"hi\""}
   {:suite "bytes" :expr "(int (first (String. (byte-array [200]) \"ISO-8859-1\")))" :expected "200"}
   {:suite "bytes" :expr "(String. (.getBytes \"round\" \"UTF-8\") \"UTF-8\")" :expected "\"round\""}
+  ;; byte[] elements are signed (-128..127) like the JVM's; the host's OTHER byte
+  ;; carrier (a Chez bytevector, what the encoders produce) is unsigned 0..255, and
+  ;; na-byte-array / na-bytearray->bv are the only seam between them. These pin
+  ;; both directions so a high byte can't leak through unfolded (jolt-kevb).
+  {:suite "bytes" :expr "(vec (byte-array (.getBytes \"õ\" \"ISO-8859-1\")))" :expected "[-11]"}
+  {:suite "bytes" :expr "(vec (byte-array \"õ\"))" :expected "[-61 -75]"}
+  {:suite "bytes" :expr "(mapv #(bit-and % 0xff) (byte-array [255 128 127]))" :expected "[255 128 127]"}
+  {:suite "bytes" :expr "(vec (byte-array (byte-array [255 128])))" :expected "[-1 -128]"}
+  {:suite "bytes" :expr "(let [a (byte-array 2)] (aset a 0 200) (aset a 1 -1) (vec a))" :expected "[-56 -1]"}
+  {:suite "bytes" :expr "(vec (byte-array 2 200))" :expected "[-56 -56]"}
+  {:suite "bytes" :expr "(do (require 'jolt.fs) (let [p (jolt.fs/create-temp-file)] (try (do (jolt.fs/write-bytes p (byte-array [255 128 0 65])) (vec (jolt.fs/read-all-bytes p))) (finally (jolt.fs/delete-if-exists p)))))" :expected "[-1 -128 0 65]"}
   {:suite "deftype-map" :expr "(do (deftype Mp [m] clojure.lang.IPersistentMap (without [_ k] m)) [(map? (->Mp 1)) (record? (->Mp 1))])" :expected "[true false]"}
   ;; contains? routes to a set-like deftype's own `contains` (not field presence);
   ;; the plain field-presence arm is guarded to skip a type declaring contains.

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -156,9 +156,33 @@
    :behavior "`String (syntax-quote of a bare class name)"
    :jvm "java.lang.String"
    :jolt "clojure.core/String"
-   :note "A consequence of the class model — a class name is not a java.lang-resolved token in syntax-quote."}]
+   :note "A consequence of the class model — a class name is not a java.lang-resolved token in syntax-quote."}
+  ;; Integer/toHexString of a byte read out of a byte[]. Unlike format's %x (which
+  ;; infers the width and is handled in :entries), these statics name their width.
+  {:category :integer-box-model
+   :behavior "(Integer/toHexString (aget (byte-array [255]) 0))"
+   :jvm "\"ff\" (the byte widens to int -1 … so also \"ffffffff\"; the two-digit form needs Byte/toUnsignedInt)"
+   :jolt "\"ffffffff\" — the same, since the static's width is 32 by name"
+   :note "Both agree here: Integer/toHexString is 32 bits wide on both, so a signed byte gives eight digits on both. Listed only to point at the portable forms — Byte/toUnsignedInt or (bit-and b 0xff) — since format's %x DOES infer its width and is the case that diverges (see the :entries row for numbers / unsigned string conversions)."}
+  ;; ByteBuffer.slice() copies where the JVM shares the backing array.
+  {:category :host-model
+   :behavior "(.array (.slice buf)) after (.position buf 1)"
+   :jvm "the WHOLE shared backing array (slice is a view; .array ignores the offset)"
+   :jolt "just the sliced bytes (slice copies)"
+   :note "jolt's byte-buffer state is #(backing position limit) with no array offset, so a slice cannot express \"0-based view into a shared backing\". Read paths — hexdumps, decoders — are unaffected; a write through a slice does not propagate back. Tracked as jolt-93c9."}]
  :entries
- [{:suite "forms / fn",
+ [;; %x / %X / %o widen by the argument's Java type on the JVM (Byte 8 bits, Short
+  ;; 16, Integer 32, Long 64). jolt unifies every integer as one type, so it cannot
+  ;; read the width off the argument and takes the narrowest one holding the value —
+  ;; which IS the JVM's answer whenever the value's origin type is the narrowest
+  ;; that holds it, so an unmasked byte out of a byte[] hex-formats at two digits
+  ;; and an int-sized hash at eight (both certified in the rows above). What
+  ;; diverges is a long whose value fits narrower: the JVM pads to 16 digits.
+  ;; (bit-and b 0xff) pins the width explicitly and is identical on both. jolt-kevb.
+  {:suite "numbers / unsigned string conversions",
+   :label "a negative long takes the narrowest width holding it",
+   :category :integer-box-model}
+  {:suite "forms / fn",
    :label "no param vector",
    :category :strictness}
   {:suite "io / cold tagged types via print-method",


### PR DESCRIPTION
Three things, in that order of size. Closes jolt-kevb.

## Signed `byte[]` (`e54ddb97`)

`byte[]` elements were unsigned 0..255, so `(vec (byte-array [255 128]))` was
`[255 128]` where the JVM gives `[-1 -128]`. Nothing errored — every numeric look at a
high byte just quietly disagreed: `(neg? b)` never fired, `(= b -1)` was never true, a
sum came out different, and a `(bit-and b 0xff)` mask that is load-bearing on the JVM
was a no-op here.

One representation change, not per-call-site. `na-byte-of` is the only place a value
entering a byte array is narrowed (`byteValue` semantics), `na-bv->bytearray` the only
place raw bytes become one, `na-bytearray->bv` the only place they go back. Every
producer and consumer routes through those three, so bytes round-trip byte-exactly.
`aset` narrows rather than storing raw — the JVM rejects `(aset bytes 0 200)` because
it sees an Integer, and jolt has one integer type, so narrowing is what keeps the range
invariant `aget`/`seq`/`String.` depend on. `InputStream.read()` stays unsigned: that
is its contract and the only way to tell `0xff` from EOF.

`format`'s `%x`/`%X`/`%o` were printing a signed magnitude, so `(format "%x" -1)` was
`"-1"` — wrong under any width. They are unsigned conversions whose width comes from
the argument's type on the JVM; jolt has one integer type, so it takes the narrowest
width holding the value. That is the JVM's answer whenever the value's origin type is
the narrowest that holds it, which keeps the hex-dump and percent-encode idioms right
**unmasked** — ring-codec and cognitect aws-api's signer work unmodified. A long whose
value fits narrower is the one divergence, allowlisted under `:integer-box-model`.

Found and fixed while auditing the byte producers and consumers:

- **`{n}` in a regex meant `{n,}`** — irregex got an unbounded upper bound for an exact
  count, so `#"\d{4}"` matched all of `"20260729"`, `re-matches` accepted a longer
  string, `re-seq #"\d{2}"` returned one element instead of three, and
  `#"(?:%[0-9a-f]{2})+"` ran past the last escape, which is what broke ring-codec's
  `percent-decode`. `{n,}` / `{n,m}` were always right.
- **Base64 `.decode`/`.encode` returned a raw Chez bytevector**, which no collection
  dispatcher knows, so `(vec (.decode dec s))` threw instead of giving a `byte[]`.
- **`Random/nextBytes` drew 8 bits per byte**, consuming the LCG four times as fast as
  `java.util.Random`, so a seeded fill was not reproducible against the JVM.
- **`io/copy` treated a File as a byte source only when the destination was a file**;
  anything else slurped it as UTF-8 and replaced each non-UTF-8 byte with U+FFFD.
- `Arrays/toString` printed a jolt vector; `Integer/toString` with a radix uppercased;
  `Long` lacked `toHexString`/`toOctalString`/`toBinaryString`/`toString`/`compare`;
  `Character` lacked `isLetter`/`isLetterOrDigit`.
- **`jolt <task>` lost to a same-named directory** — `run-file-arg?` used
  `file-exists?`, true for a directory, so `jolt test` died in `load-file`'s decoder in
  every project with a `test/` dir. That is why every library CI spells out `-M:test`.

## Fleet release gate (`b05023f3`)

A jolt change can be green here and still break what people run: the signed `byte[]`
above truncated every HTTP response body in jolt-lang/http-client, whose
`ByteArrayInputStream.read()` returned the raw (now negative) element so every drain
loop read EOF. Nothing in this repo could have seen it.

So a release now checks the fleet out and runs it against the tag's own binary — 13
library repos, db's postgres half in its own job (`services` is job-level), and every
app in jolt-lang/examples. Each library row mirrors that repo's own `tests.yml`, so a
red row means the same thing in both places. For the examples the **build** is the
valuable half: `jolt build` is the whole compiler pipeline over real dependency trees.

Costs a commit or PR nothing — `release.yml` only fires on a `v*` tag or
`workflow_dispatch`; `tests.yml` stays the per-commit gate. To make a red fleet
actually abort, assets upload to a **draft** and a new `publish` job un-drafts once the
fleet is green; a draft is invisible to the install script and the tap, so a regression
leaves a tag with assets and nothing installable. `homebrew` moved behind `publish`.

## Smoke-gate diagnosability (`13144432`…`d092c2a7`)

The Gate step sat for 3h42m on main with `build smoke: passed` as its last output.
Three defects had to be fixed before it could say which case (jolt-pgbh):

- **`out="$(cmd)"` returns when every pipe writer closes, not when `cmd` exits.**
  jolt.process is the only case spawning children; one outliving jolt blocked the read
  forever. Captured to a file now.
- **stderr went to `/dev/null`** and only stdout was grepped for `FAIL`, so a run dying
  before its first check said `FAIL: jolt.process` and nothing else.
- **The test printed only its final verdict**, so a hang left an empty log. `check-eq`
  is now a macro (as a fn the argument was evaluated before the label could print) and
  flushes — load-bearing, since a file redirect block-buffers and a killed process
  loses what it has not flushed.

Cases are capped (`JOLT_SMOKE_TIMEOUT`, default 120s) with `timeout --foreground`:
plain GNU `timeout` puts the child in its own process group, which breaks the very case
asserting on `destroy`/`alive?`/SIGTERM.

## Gate

`make test` green locally including selfhost and certify (3971 certifiable rows, 0 new
divergences, 0 stale). CI green on both triggers. 30 new corpus rows, 7 unit rows, and
the ffi round-trip now asserts signed elements.

Fleet against this build: jolt-crypto, xml, yaml, logging, nrepl, router, time,
tools.cli, transit-jolt, glimmer, glimmer-gl, db, ring-chez-adapter all green; all 13
examples build and their 4 test tasks pass. http-client needed a one-line fix in its own
repo (`af407ef`) and is clean apart from `self-signed-ssl-get`, which is macOS-only and
predates this (jolt-hfnh).

Beads filed on the way: jolt-pgbh (the gate hang, still open), jolt-93c9
(`ByteBuffer.slice` copies where the JVM shares), jolt-hfnh.