### PR TITLE
Resolve a relative path against user.dir, not JOLT_PWD alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`.toAbsolutePath` was a no-op on a relative path in a built binary, so every
+  `fs/glob` under a relative root came back unusable.** A user-facing relative path
+  resolves against user.dir, which is `JOLT_PWD` → `PWD` → `"."` — the chain
+  `System/getProperty "user.dir"` answers with. `project-relative` implemented only
+  the first link, and `JOLT_PWD` is exported by `bin/jolt` but by nothing in a built
+  binary, which never cd's away and so needs none. There the path came back
+  unresolved, `jfile-abs` returned a relative string in defiance of its own
+  contract, and babashka.fs's `match` — which relativizes each result against
+  `(absolutize "")` whenever the glob root is relative — subtracted an absolute cwd
+  from a relative entry: `(fs/glob "examples" "**")` yielded
+  `../../../../examples/sample.clj`. Nothing threw; every subsequent open just
+  missed. `project-relative` and `jfile-abs` now share one `jolt-user-dir` helper,
+  so neither can implement half the chain again.
+
+  The dev launcher masked this end to end — it always exports `JOLT_PWD`, so no
+  `bin/jolt` run could reproduce it — and `test/chez/fs-test.clj` rooted every case
+  at an absolute temp dir, so the one gate that runs a built binary never exercised
+  a relative path. It now asserts that a relative path absolutizes under user.dir
+  and that `relativize` undoes `absolutize`, the round-trip `match` performs.
+
 - **A sub-process that could not be waited on hung the caller forever.** The reap
   loop retried on any `waitpid` failure, including `ECHILD` — the child already
   reaped by something else, which no number of retries changes. The loop holds the

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -120,15 +120,30 @@
          0)
         (else (system (string-append "chmod 755 '" path "'")))))))
 
-;; A user-facing relative path resolves against JOLT_PWD — the user's cwd before
+;; user.dir — the project dir every user-facing relative path resolves against.
+;; JOLT_PWD carries it when the launcher moved away from it (bin/jolt exports the
+;; user's cwd before cd'ing to the repo root); a built binary never moves, so its
+;; own cwd is the project dir and PWD names it. This is the same chain
+;; System/getProperty "user.dir" answers with — kept in one place so a caller
+;; cannot implement half of it.
+(define (jolt-user-dir)
+  (let ((jp (getenv "JOLT_PWD")))
+    (if (and jp (> (string-length jp) 0))
+        jp
+        (let ((wd (getenv "PWD")))
+          (if (and wd (> (string-length wd) 0)) wd ".")))))
+
+;; A user-facing relative path resolves against user.dir — the user's cwd before
 ;; the launcher cd'd to the jolt repo root — matching the JVM, where io/file is
 ;; cwd-relative. (io/resource builds jfiles from the source roots directly, so it
 ;; isn't routed through here.)
 (define (project-relative p)
   (if (or (= (string-length p) 0) (char=? (string-ref p 0) #\/))
       p
-      (let ((pwd (getenv "JOLT_PWD")))
-        (if (and pwd (> (string-length pwd) 0)) (string-append pwd "/" p) p))))
+      (let ((base (jolt-user-dir)))
+        ;; "." adds nothing the OS won't do itself when it resolves a relative
+        ;; path — leave it alone rather than prefixing "./".
+        (if (string=? base ".") p (string-append base "/" p)))))
 
 ;; (io/file path) / (io/file parent child) — join children with "/". The File
 ;; keeps the path AS GIVEN (like the JVM: new File("rel").getPath() is "rel");
@@ -154,13 +169,13 @@
          (sort string<? (directory-list p)))))
 (define (jolt-dir? path) (if (file-directory? (project-relative (file-path-of path))) #t #f))
 
-;; absolute path string: a relative path resolves against JOLT_PWD (user.dir) —
-;; the same base every filesystem touch uses (project-relative). Resolving
-;; against (current-directory) here instead reported paths under the jolt repo
-;; root the launcher cd'd into, diverging from the JVM where io/file and
-;; getAbsolutePath are user.dir-relative.
+;; absolute path string: a relative path resolves against user.dir — the same
+;; base every filesystem touch uses (project-relative). Resolving against
+;; (current-directory) here instead reported paths under the jolt repo root the
+;; launcher cd'd into, diverging from the JVM where io/file and getAbsolutePath
+;; are user.dir-relative.
 (define (jfile-abs p)
-  (cond ((= (string-length p) 0) (or (getenv "JOLT_PWD") (getenv "PWD") "."))
+  (cond ((= (string-length p) 0) (jolt-user-dir))
         ((char=? (string-ref p 0) #\/) p)
         (else (project-relative p))))
 

--- a/test/chez/fs-test.clj
+++ b/test/chez/fs-test.clj
@@ -88,6 +88,21 @@
 (check "which nonsense" (fs/which "no-such-binary-xyz") nil)
 (check "cwd is dir" (fs/directory? (fs/cwd)) true)
 
+;; user.dir-relative resolution (string algebra only — touches no disk).
+;; Regression: project-relative consulted only JOLT_PWD. bin/jolt always exports
+;; it, but a built binary never does, so there absolutize was a no-op on a
+;; relative path and every fs/glob under a relative root came back relativized
+;; against the wrong base ("../../../../<root>/x"), breaking directory walks.
+;; Every case above roots at an absolute temp dir, which is why none caught it.
+(def user-dir (System/getProperty "user.dir"))
+(check "absolutize rel is absolute" (fs/absolute? (fs/absolutize "a/b.txt")) true)
+(check "absolutize rel roots at user.dir"
+       (str (fs/absolutize "a/b.txt")) (str user-dir "/a/b.txt"))
+(check "absolutize empty is user.dir" (str (fs/absolutize "")) (str user-dir))
+;; the round-trip babashka.fs/match runs on every relative-rooted glob
+(check "relativize undoes absolutize"
+       (str (fs/relativize (fs/absolutize "") (fs/absolutize "a/b.txt"))) "a/b.txt")
+
 ;; deletion
 (check "delete-if-exists" (fs/delete-if-exists (fs/path root "d3" "empty.txt")) true)
 (check "delete-if-exists neg" (fs/delete-if-exists (fs/path root "d3" "empty.txt")) false)


### PR DESCRIPTION
Fixes #504.

A user-facing relative path resolves against user.dir — the chain
`JOLT_PWD` → `PWD` → `"."` that `System/getProperty "user.dir"` answers with
(`host-static-methods.ss:585`). `project-relative` implemented only its first
link. `bin/jolt` exports `JOLT_PWD` before it `cd`s to the repo root, so in dev
the missing links never show; a built binary never `cd`s anywhere and so exports
nothing, and there the path came back unresolved. `jfile-abs` — whose sibling
arm already spelled the full chain — then returned a relative string from a
function whose contract is to return an absolute one.

`fs/glob` is what trips over it. babashka.fs's `match` walks from an absolutized
root and, when the given root is relative, relativizes each result against
`(absolutize "")`. The first absolutize is the no-op and the second is not, so it
subtracts an absolute cwd from a relative entry — one `..` per cwd component.
Nothing throws; the paths just stop naming files.

## Approach

The two halves of one concept had drifted, so rather than add the fallback in a
second place this routes `project-relative` and `jfile-abs` through a single
`jolt-user-dir` helper that spells the chain once. Neither can implement half of
it again.

Two judgement calls worth surfacing for review:

- **`"."` is left alone rather than prefixed.** When neither variable is set
  there is no better name for the cwd than the one the OS will use anyway, and
  prefixing `./` would churn every path string for no gain.
- **The third copy of the chain, `host-static-methods.ss`'s `user.dir` arm, is
  untouched.** It is the correct one, and it loads at `rt.ss:859` against
  `io.ss`'s `872` — sharing the helper there would mean a forward reference
  across load units. Happy to do it as a follow-up if you would rather the
  helper move somewhere earlier.

## Tests

`fs-test.clj` gains the case that would have caught this: a relative path
absolutizes under user.dir, and `relativize` undoes `absolutize` — the exact
round-trip `match` performs. Every existing case there roots at an absolute temp
dir, which is why `make smoke` never exercised it despite being the one gate that
runs a built binary (`JOLT_BIN=target/release/jolt`).

The new cases fail on an unpatched release binary with precisely the reported
symptom:

```
FAIL: absolutize rel is absolute: want true got false
FAIL: absolutize rel roots at user.dir: want "/…/jolt/a/b.txt" got "a/b.txt"
FAIL: relativize undoes absolutize: want "a/b.txt" got "../../../../a/b.txt"
```

and pass with the fix under the dev launcher, under a built binary with
`JOLT_PWD` unset, and with `JOLT_PWD` pointed at a directory other than the cwd
(precedence preserved).

## Verification

- `make smoke` — 99/99, including `FS-TEST OK` on `target/release/jolt`
- `make shakelocal` — pass
- The downstream project that surfaced this (a tree-sitter binding whose CLI
  enumerates sources via `fs/glob`) goes from four failing suites to green
  against a patched binary with its `JOLT_PWD` workaround removed.

One thing I could not certify: `make -j8 ci` exits 2 here, but it does so on
clean `main` as well. `buildsmoke` fails serially on unpatched upstream on this
machine, and `staticnativesmoke` is flaky — over 4 runs each way, clean `main`
passed 1/4 and this branch 2/4, both failing with empty binary output rather than
wrong output. That reads as environmental (macOS, unsigned binaries) rather than
related to this change, but you will have a better idea than I do whether those
two are green in your CI.
