### PR TITLE
keys/vals: throw on an element that isn't an entry

### DIFF
--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -1173,11 +1173,28 @@
 ;; non-map still fails (its elements are not MapEntries).
 ;; Like RT.keys/vals, a non-map argument is any seq of map entries — (keys
 ;; (filter pred a-map)) walks the entries.
+;; An element the JVM could not cast to Map.Entry is a ClassCastException naming
+;; its class — never a nil, and never a stray index into whatever the element
+;; happened to be ((keys ["ab"]) must throw, not hand back the strings' first
+;; characters). A plain 2-element vector is accepted where the JVM casts: jolt
+;; reads a vector of pairs as a seq of entries, a documented superset.
+(define (entry-like? e)
+  (and (pvec? e) (= 2 (pvec-count e))))
+(define (entry-cast-error e)
+  (jolt-throw (jolt-host-throwable "java.lang.ClassCastException"
+                (string-append
+                  "class "
+                  (guard (x (#t "value"))
+                    (let ((c (jolt-class-name e)))
+                      (if (string? c) c (jolt-pr-str e))))
+                  " cannot be cast to class java.util.Map$Entry"))))
 (define (entry-seq-part m idx)
   (let loop ((s (jolt-seq m)) (acc '()))
     (if (jolt-nil? s)
         (list->cseq (reverse acc))
-        (loop (jolt-seq (seq-more s)) (cons (jolt-nth (seq-first s) idx jolt-nil) acc)))))
+        (let ((e (seq-first s)))
+          (unless (entry-like? e) (entry-cast-error e))
+          (loop (jolt-seq (seq-more s)) (cons (jolt-nth e idx jolt-nil) acc))))))
 (define (jolt-keys m)
   (cond ((jolt-nil? m) jolt-nil)
         ((pmap? m) (list->cseq (pmap-fold m (lambda (k v a) (cons k a)) '())))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1359,6 +1359,8 @@
   {:suite "maps / keys-vals-empty? as overlay fns" :label "keys sorted order" :expected "[1 2 3]" :actual "(vec (keys (sorted-map 2 :b 1 :a 3 :c)))" :portability :common}
   {:suite "maps / keys-vals-empty? as overlay fns" :label "vals sorted order" :expected "[:a :b :c]" :actual "(vec (vals (sorted-map 2 :b 1 :a 3 :c)))" :portability :common}
   {:suite "maps / keys-vals-empty? as overlay fns" :label "keys/vals zip" :expected "{:a 1, :b 2}" :actual "(zipmap (keys {:a 1 :b 2}) (vals {:a 1 :b 2}))" :portability :common}
+  {:suite "maps / keys-vals-empty? as overlay fns" :label "keys/vals walk a seq of map entries" :expected "[[:a :b] [1 2]]" :actual "[(vec (keys (filter (fn [e] true) {:a 1 :b 2}))) (vec (vals (filter (fn [e] true) {:a 1 :b 2})))]" :portability :common}
+  {:suite "maps / keys-vals-empty? as overlay fns" :label "a non-entry element is a ClassCastException" :expected "[:cce :cce :cce :cce]" :actual "[(try (vec (keys [\"ab\"])) (catch ClassCastException _ :cce)) (try (vec (vals [\"ab\"])) (catch ClassCastException _ :cce)) (try (vec (keys [1 2])) (catch ClassCastException _ :cce)) (try (vec (keys [[:a 1 2]])) (catch ClassCastException _ :cce))]" :portability :common}
   {:suite "maps / keys-vals-empty? as overlay fns" :label "empty? map" :expected "true" :actual "(empty? {})" :portability :common}
   {:suite "maps / keys-vals-empty? as overlay fns" :label "empty? vec" :expected "[true false]" :actual "[(empty? []) (empty? [1])]" :portability :common}
   {:suite "maps / keys-vals-empty? as overlay fns" :label "empty? list" :expected "[true false]" :actual "[(empty? ()) (empty? (list 1))]" :portability :common}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -176,6 +176,12 @@
    :jvm "throws ArityException — these are arity-2 only"
    :jolt "folds like +: no args => 0, one => the operand, N => a left fold"
    :note "The overlay is variadic where the JVM's is fixed-arity. At arity 2 — every arity the JVM accepts — the wrapping result is identical, 64-bit edges included, so portable code is unaffected. Costs nothing on the hot path either: proven-long operands lower straight to jolt-uncadd2 (a left fold past 2 operands) and never reach the variadic overlay, which only serves value position."}
+  ;; keys/vals accept a plain 2-element vector where the JVM casts to Map.Entry.
+  {:category :permissive
+   :behavior "(keys [[:a 1] [:b 2]]) — a vector of pairs rather than of map entries"
+   :jvm "throws ClassCastException — PersistentVector is not a java.util.Map$Entry"
+   :jolt "(:a :b)"
+   :note "jolt reads any 2-element vector as an entry, so a vector of pairs walks like a seq of map entries. Anything else — a string, a number, a longer vector — is the same ClassCastException the JVM throws, naming the same class; keys never returns a nil or an index into a non-entry."}
   ;; auto-gensym suffix differs by a trailing "__".
   {:category :reader-model
    :behavior "an auto-gensym x# expands to a symbol named"


### PR DESCRIPTION
`(keys ["ab" "cd"])` returned `(\a \c)` on jolt. `(keys [1 2])` returned `(nil nil)`. The JVM throws `ClassCastException` for both — `String`/`Long` cannot be cast to `java.util.Map$Entry`.

`entry-seq-part` walked the seq calling `jolt-nth` on each element, and `jolt-nth` indexes a string happily and returns nil for anything non-indexable. So a caller who passed the wrong shape got plausible-looking data instead of an error. The comment above the function already claimed a non-entry element fails; it just didn't.

Anything that isn't a 2-element vector now raises the JVM's ClassCastException naming the same class. A plain vector of pairs still walks as entries: that superset was already in the corpus as `permissive / keys on pair vector`, so it stays, and it's now written down in `known-divergences.edn` rather than only implied by a suite name. Maps, filtered map seqs, sorted maps and seqs-of-a-map are untouched.

Certify was already reporting this row as the one `throws-mismatch` before this change, and still is — the allowlist only covers `DIVERGENT` rows, so there is nothing to add there.

Found while checking that the cider-nrepl middleware loads for `examples/ring-app`, where a misused `(keys ...)` over a list of strings returned first characters instead of erroring.

Gate: `make test` green on this branch (corpus 4167/4186, 0 new divergences, certify 0 new / 0 stale). Bead jolt-1hi7.