### PR TITLE
Don't fail resolution on a POM Grenadine can't model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Maven transitive deps come from the real effective POM.** jolt used to scrape
+  the `pom.xml` a jar happened to package under `META-INF/maven/`, so a jar that
+  ships without one — `metosin/malli` is one — contributed no transitive deps at
+  all, and a project had to list them by hand. jolt now embeds
+  [Grenadine](https://github.com/ingydotnet/grenadine) and builds the effective
+  POM from the repository: parent inheritance, properties, dependency
+  management, BOM imports, and `<exclusions>`, which the expander already
+  honored but never received. Resolving malli picks up its five deps and their
+  transitives instead of nothing. The cost is one small `.pom` fetch per
+  dependency, cached in the local repository beside the jar.
+
+  A POM jolt can't model no longer sinks the resolution: an unfetchable `.pom`
+  (a hand-installed jar, an offline machine) or a version left `${unresolved}`
+  because it comes from a profile now warns and falls back to whatever the jar
+  packages. Grenadine checks every declared dependency before jolt filters by
+  scope, so a test-scoped dependency jolt discards anyway was enough to abort.
+
 - **`-Spath` prints the classpath and runs nothing**, like the clj CLI. It can
   come on either side of the alias options — `jolt -A:test:dev -Spath` and
   `jolt -Spath -M:test` both print the source roots that run would use, and
@@ -62,6 +79,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-dispatches to (`run`, `build`, `repl`, `nrepl-server`, a task, `-e`,
   `-M`/`-X`/`-T`) resolves for itself — so each `-A` invocation walked the whole
   dependency tree twice and printed any resolution warning twice with it.
+
+### Changed
+
+- **A deps.edn `:mvn/local-repo` now outranks the `JOLT_LOCAL_REPO`
+  environment variable**, matching how tools.deps treats explicit configuration.
+  `GRENADINE_LOCAL_REPOSITORY` sits between them as the shared environment
+  default; `JOLT_LOCAL_REPO` still works.
 
 ## [0.5.14] - 2026-08-01
 

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -351,8 +351,10 @@
 
 (defn- raw-pom-deps-from
   "Transitive deps read from a pom.xml — as a deps map so the expansion walks
-  them like any other. This fallback is only for a local JAR whose Maven
-  coordinates are unknown; repository Maven deps use Grenadine effective POMs."
+  them like any other. Repository Maven deps use Grenadine effective POMs; this
+  reads whatever the jar itself packages, for a local jar whose Maven
+  coordinates are unknown and for a dep whose effective POM wouldn't build. It
+  skips a dependency it can't read a literal version for rather than failing."
   [pom]
   (do
     (when (file-exists? pom)
@@ -468,7 +470,16 @@
 (defn- effective-pom-deps
   "Build a Maven dependency map from Grenadine's effective POM model. Parent
   inheritance, properties, dependency management, BOM imports, and exclusions
-  have already been resolved by Grenadine."
+  have already been resolved by Grenadine.
+
+  nil when the effective POM can't be built — the .pom isn't in the repository
+  and can't be fetched (a hand-installed jar, or an offline machine), or the POM
+  names something Grenadine won't guess at, such as a version that stays
+  `${unresolved}` because it is set in a profile. Grenadine asserts every
+  declared coordinate before jolt filters by scope, so a test-scoped dependency
+  jolt drops anyway can be what makes a POM unmodellable. A nil sends the caller
+  to whatever pom.xml the jar itself carries; the alternative, failing the whole
+  resolution over a dependency that may not even be reachable, is worse."
   [lib coord]
   (memoized
    [:effective-pom lib (ext/dep-id lib coord)]
@@ -476,24 +487,31 @@
      (let [coords {:group (mvn-group lib)
                    :artifact (name lib)
                    :version (:mvn/version coord)}
-           effective (grenadine.pom/effective-pom coords pom-text)]
-       (into
-        {}
-        (keep
-         (fn [{:keys [group artifact version scope optional exclusions]}]
-           (when (and group artifact version
-                      (not (#{"test" "provided" "system"} scope))
-                      (not optional))
-             [(symbol group artifact)
-              (cond-> {:mvn/version version}
-                (seq exclusions)
-                (assoc :exclusions
-                       (set
-                        (map
-                         (fn [{:keys [group artifact]}]
-                           (symbol group artifact))
-                         exclusions))))])))
-        (:deps effective))))))
+           effective (try (grenadine.pom/effective-pom coords pom-text)
+                          (catch :default e
+                            (warn "no effective POM for " lib " "
+                                  (:mvn/version coord) ": " (ex-message e)
+                                  "\n  falling back to the pom.xml in its jar;"
+                                  " transitive deps may be incomplete")
+                            nil))]
+       (when effective
+         (into
+          {}
+          (keep
+           (fn [{:keys [group artifact version scope optional exclusions]}]
+             (when (and group artifact version
+                        (not (#{"test" "provided" "system"} scope))
+                        (not optional))
+               [(symbol group artifact)
+                (cond-> {:mvn/version version}
+                  (seq exclusions)
+                  (assoc :exclusions
+                         (set
+                          (map
+                           (fn [{:keys [group artifact]}]
+                             (symbol group artifact))
+                           exclusions))))])))
+          (:deps effective)))))))
 
 (defn- manifest-info
   "Manifest detection for a git/local directory root: its deps.edn, else a bare
@@ -537,8 +555,13 @@
           ;; a Maven dep with no jolt-loadable source contributes nothing and
           ;; its transitive deps are cljs/JVM tooling — don't walk them.
           (not (has-clj-source? root)) {:root nil :manifest :none}
+          ;; :pom is the fallback children-of reaches for when the effective POM
+          ;; can't be built — not every jar carries one, and the ones that do
+          ;; predate their own dependencyManagement, so it is second choice.
           :else {:root root :manifest :mvn
-                 :deps (effective-pom-deps lib coord)})))))
+                 :deps (effective-pom-deps lib coord)
+                 :pom (str root "/META-INF/maven/" (mvn-group lib) "/"
+                           (name lib) "/pom.xml")})))))
 
 (defn- git-info [lib coord]
   (memoized [:info lib (ext/dep-id lib coord)]

--- a/jolt-core/jolt/deps/ext.clj
+++ b/jolt-core/jolt/deps/ext.clj
@@ -14,11 +14,10 @@
   can register a fake type against the same expansion engine, exactly like
   tools.deps' faken extension.
 
-  Also carries a Maven version comparator (the ComparableVersion ordering
-  tools.deps gets from maven-resolver) so :mvn/version conflicts resolve
-  newest-wins without the JVM."
-  (:require [clojure.set :as set]
-            [clojure.string :as str]))
+  Maven version ordering — the ComparableVersion semantics tools.deps gets from
+  maven-resolver, so :mvn/version conflicts resolve newest-wins without the JVM
+  — lives in grenadine.version, which jolt.deps' :mvn method calls."
+  (:require [clojure.set :as set]))
 
 ;;;; Methods switching on coordinate type — lifted from
 ;;;; clojure.tools.deps.extensions (multimethod table read via `methods`
@@ -102,89 +101,3 @@
   (throw (ex-info (str "Unable to compare versions for " lib ": "
                        (pr-str coord-x) " and " (pr-str coord-y))
                   {:lib lib :coord-x coord-x :coord-y coord-y})))
-
-;;;; Maven version ordering (org.apache.maven.artifact.versioning
-;;;; ComparableVersion semantics: dot/dash tokenization, digit<->letter
-;;;; transitions split, numeric items compare numerically, known qualifiers
-;;;; order below release, null-padding).
-
-(def ^:private qualifier-order
-  ;; ComparableVersion QUALIFIERS: alpha < beta < milestone < rc < snapshot
-  ;; < '' (release) < sp; an unlisted qualifier sorts after sp, lexically.
-  {"alpha" 0 "beta" 1 "milestone" 2 "rc" 3 "cr" 3 "snapshot" 4
-   "" 5 "final" 5 "ga" 5 "release" 5 "sp" 6})
-
-(defn- expand-alias
-  ;; a/b/m followed by a digit are shorthand qualifiers (1.0a1 = 1.0-alpha-1)
-  [s]
-  (case s "a" "alpha" "b" "beta" "m" "milestone" s))
-
-(defn- tokenize-version
-  "Split a version string into items: longs for numeric runs, lowercase strings
-  for qualifier runs. Dots, dashes, and digit<->letter transitions separate."
-  [s]
-  (let [s (str/lower-case s)
-        n (count s)
-        release-item? (fn [it] (or (and (number? it) (zero? it))
-                                   (contains? #{"" "final" "ga" "release"} it)))
-        trim-trailing (fn [items]
-                        ;; ComparableVersion normalization: trailing zeros and
-                        ;; release-equivalent qualifiers drop, so 1.0 = 1.0.0 =
-                        ;; 1.0-ga = 1.0.0-release.
-                        (loop [v items]
-                          (if (and (seq v) (release-item? (peek v)))
-                            (recur (pop v))
-                            v)))]
-    (loop [i 0 start 0 items [] prev nil]
-      (if (>= i n)
-        (let [items (if (> i start) (conj items (subs s start i)) items)]
-          (trim-trailing
-            (mapv (fn [it]
-                    (if (re-matches #"[0-9]+" it)
-                      (parse-long it)
-                      (expand-alias it)))
-                  items)))
-        (let [c (get s i)
-              kind (cond (Character/isDigit c) :digit
-                         (or (= c \.) (= c \-)) :sep
-                         :else :letter)]
-          (cond
-            (= kind :sep)
-            (recur (inc i) (inc i)
-                   (if (> i start) (conj items (subs s start i)) items)
-                   nil)
-            (and prev (not= kind prev))
-            (recur (inc i) i (conj items (subs s start i)) kind)
-            :else
-            (recur (inc i) start items kind)))))))
-
-(defn- item-compare
-  [a b]
-  (cond
-    (and (nil? a) (nil? b)) 0
-    ;; null padding: a number pads as 0; a qualifier compares against release
-    (nil? a) (- (item-compare b nil))
-    (nil? b) (if (number? a)
-               (if (zero? a) 0 1)
-               (compare (get qualifier-order a 7) (get qualifier-order "" 5)))
-    (and (number? a) (number? b)) (compare a b)
-    ;; a number is newer than any qualifier (1.0.1 > 1.0-rc)
-    (number? a) 1
-    (number? b) -1
-    :else (let [qa (get qualifier-order a) qb (get qualifier-order b)]
-            (cond
-              (and qa qb) (compare qa qb)
-              qa (compare qa 7)
-              qb (compare 7 qb)
-              :else (compare a b)))))
-
-(defn compare-mvn-versions
-  "Compare two Maven version strings by ComparableVersion ordering."
-  [x y]
-  (let [xs (tokenize-version x) ys (tokenize-version y)
-        n (max (count xs) (count ys))]
-    (loop [i 0]
-      (if (>= i n)
-        0
-        (let [c (item-compare (get xs i) (get ys i))]
-          (if (zero? c) (recur (inc i)) c))))))

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -6,6 +6,7 @@
 
 (ns deps-expand-test
   (:require [clojure.string :as str]
+            [grenadine.version :as version]
             [jolt.deps :as deps]
             [jolt.deps.ext :as ext]))
 
@@ -19,7 +20,7 @@
 
 (defmethod ext/compare-versions [:fkn :fkn]
   [_lib coord-x coord-y]
-  (ext/compare-mvn-versions (:fkn/version coord-x) (:fkn/version coord-y)))
+  (version/compare-versions (:fkn/version coord-x) (:fkn/version coord-y)))
 
 (defmethod ext/coord-deps :fkn
   [lib coord]
@@ -186,8 +187,12 @@
 
 ;;;; Maven version comparator ordering
 
-(defn- lt [a b] (is= (str a " < " b) true (neg? (ext/compare-mvn-versions a b))))
-(defn- veq [a b] (is= (str a " = " b) 0 (ext/compare-mvn-versions a b)))
+(defn- cmp
+  "Through the :mvn method, so this pins the comparator the resolver really uses."
+  [a b]
+  (ext/compare-versions 'a/b {:mvn/version a} {:mvn/version b}))
+(defn- lt [a b] (is= (str a " < " b) true (neg? (cmp a b))))
+(defn- veq [a b] (is= (str a " = " b) 0 (cmp a b)))
 
 (lt "1.2.3" "1.2.10")
 (lt "1.9.0" "1.10.0")
@@ -203,6 +208,8 @@
 (veq "1.0" "1.0-final")
 (veq "1.0-ga" "1.0.0-release")
 (lt "1.0a1" "1.0")
+;; a dash opens a sub-list, which sorts under an integer in the same position
+(lt "1.0-1" "1.0.1")
 
 (println (str "deps-expand: " (- @checks @failures) "/" @checks " passed"))
 (when (pos? @failures)

--- a/test/grenadine_test.clj
+++ b/test/grenadine_test.clj
@@ -77,4 +77,58 @@
          (ex-info "Jolt did not use Grenadine's effective POM or prune Clojure"
                   {:raw raw :filtered filtered}))))))
 
+;;;; A POM Grenadine cannot model degrades to the jar's own pom.xml rather than
+;;;; failing the whole resolution.
+
+(defn- deps-of
+  "effective-pom-deps for a lib whose POM text comes from `poms-by-coords`."
+  [poms-by-coords lib]
+  (with-redefs-fn
+    {(var jolt.deps/pom-text)
+     (fn [{:keys [group artifact version]}]
+       (or (get poms-by-coords [group artifact version])
+           (throw (ex-info (str "POM not found: " group "/" artifact " " version)
+                           {:type :jolt.deps/pom-not-found}))))}
+    (fn [] (@#'deps/effective-pom-deps lib {:mvn/version "1"}))))
+
+;; A jar sitting in the local repository without its .pom beside it — installed
+;; by hand, or fetched before the machine went offline. Its transitive deps are
+;; unknown, not a reason to abandon the resolution.
+(when-not (nil? (deps-of {} 'demo/unfetchable))
+  (throw (ex-info "an unfetchable POM should degrade to nil, not deps" {})))
+
+;; An unresolved ${property} anywhere in the POM — commonly a version defined
+;; only in a <profile>, and just as commonly on a test-scoped dependency jolt
+;; drops anyway. Grenadine asserts every declared coordinate before jolt gets to
+;; filter by scope, so the whole POM degrades.
+(when-not (nil? (deps-of
+                 {["demo" "unresolved" "1"]
+                  "<project>
+                     <modelVersion>4.0.0</modelVersion>
+                     <groupId>demo</groupId>
+                     <artifactId>unresolved</artifactId><version>1</version>
+                     <dependencies>
+                       <dependency>
+                         <groupId>junit</groupId><artifactId>junit</artifactId>
+                         <version>${junit.version}</version><scope>test</scope>
+                       </dependency>
+                     </dependencies>
+                   </project>"}
+                 'demo/unresolved))
+  (throw (ex-info "an unresolvable ${property} should degrade to nil, not deps" {})))
+
+;; ...and a degraded lib still reports whatever pom.xml its jar carries.
+(let [pom (str (System/getProperty "java.io.tmpdir") "/jolt-grenadine-fallback.xml")]
+  (spit pom "<project><dependencies>
+               <dependency>
+                 <groupId>demo</groupId><artifactId>packaged</artifactId>
+                 <version>3</version>
+               </dependency>
+             </dependencies></project>")
+  (let [children (@#'deps/children-of
+                  {:root "." :manifest :mvn :deps nil :pom pom})]
+    (when-not (= [['demo/packaged {:mvn/version "3"}]] (vec children))
+      (throw (ex-info "a degraded Maven dep should fall back to its jar's pom.xml"
+                      {:children children})))))
+
 (println "grenadine gate: passed")


### PR DESCRIPTION
Follow-up to #509.

Two POM shapes that resolved fine before now abort the whole resolution, both
verified against a planted local repo:

- a jar in the local repository with no `.pom` beside it — hand-installed, or
  fetched before the machine went offline — throws `:jolt.deps/pom-not-found`
- a version left `${unresolved}` because it's defined in a profile throws
  `:grenadine.pom/unresolved-coordinate`, and since Grenadine checks every
  declared dependency before jolt filters by scope, a *test*-scoped dep jolt
  discards anyway is enough to do it

Both now warn and fall back to whatever `pom.xml` the jar packages, which is
where transitive deps came from before #509. The happy path is untouched:
malli still resolves its five deps and their transitives.

Also drops jolt's own Maven comparator — dead since the `:mvn` method started
calling `grenadine.version` — and points its ordering tests at the one that
actually ships. They disagreed on `1.0-1` vs `1.0.1`, where the dead one
returned "equal"; a dash opens a sub-list, which sorts under an integer in the
same position, so Grenadine is right.

`make test` green (MAKE_EXIT=0); deps-expand 32/32.