### PR TITLE
Fill in the String surface, and two wrong answers on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.17] - 2026-08-01
+
+Gaps and wrong answers on the `java.lang.String` surface, found by probing it after
+`.toCharArray` turned out to be missing.
+
+### Added
+
+- **`.toCharArray`, `.strip` / `.stripLeading` / `.stripTrailing`,
+  `.compareToIgnoreCase`, `.contentEquals`, `.regionMatches` (both overloads), and
+  `String/join`.** `.toCharArray` answers a real `char[]` — the value `(char-array s)`
+  builds and `(String. ca)` reads back. The strip family is `Character.isWhitespace`,
+  where `.trim` cuts at `<= U+0020`, so strip removes the Unicode separators trim
+  leaves (U+3000) but not the non-breaking spaces Java deliberately excludes from
+  `isWhitespace` — the same predicate `clojure.string/trim` already used here, now
+  also covering U+001C..U+001F, which are whitespace to Java but carry no Unicode
+  White_Space property.
+
+### Fixed
+
+- **`.compareTo` answers an int.** It returned `-1.0` / `1.0` / `0.0`, so it read
+  correctly through `neg?` / `pos?` but printed as a double and was never `= -1`.
+
+- **`String/valueOf(char[])` is the characters.** It rendered the array itself, so
+  `(String/valueOf (char-array "hi"))` came back `"#object[[C]"` where
+  `(String. (char-array "hi"))` already gave `"hi"`.
+
 ## [0.5.16] - 2026-08-01
 
 Chez's clocks and collector counters are readable from Clojure now, as plain

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -464,7 +464,22 @@
     (if (jolt-nil? v) dflt v)))
 
 (register-class-statics! "String"
-  (list (cons "valueOf" (lambda (x . _) (if (jolt-nil? x) "null" (jolt-str-render-one x))))
+  ;; String.valueOf(char[]) is the chars as a string, not the array's own rendering —
+  ;; it answered "#object[[C]" where (String. ca) already gave "hi".
+  (list (cons "valueOf" (lambda (x . _)
+                          (cond ((jolt-nil? x) "null")
+                                ((and (jolt-array? x) (eq? (jolt-array-kind x) 'char))
+                                 (list->string (vector->list (jolt-array-vec x))))
+                                (else (jolt-str-render-one x)))))
+        ;; String.join(delim, elems) — elems as a collection or spread as varargs,
+        ;; the two shapes the JVM overloads on.
+        (cons "join" (lambda (delim . parts)
+                       (let ((items (if (and (fx=? (length parts) 1)
+                                             (not (string? (car parts))))
+                                        (seq->list (jolt-seq (car parts)))
+                                        parts)))
+                         (str-join-strs (map jolt-str-render-one items)
+                                        (jolt-str-render-one delim)))))
         ;; String.format(fmt, Object...) is called both ways in the wild: with the
         ;; args spread, and with a single Object[] holding them (which is what the
         ;; JVM's varargs actually compiles to, and what Selmer writes). Splat a lone

--- a/host/chez/java/natives-str.ss
+++ b/host/chez/java/natives-str.ss
@@ -46,10 +46,13 @@
 ;; Character.isWhitespace accepts, which reaches the Unicode space separators
 ;; (U+3000 and friends) but NOT the non-breaking ones. Keep them apart: str-trim
 ;; is String.trim, str-triml / str-trimr / str-trim* back clojure.string.
+;; U+001C..U+001F (the file/group/record/unit separators) are whitespace to Java but
+;; carry no Unicode White_Space property, so char-whitespace? alone misses them.
 (define (java-whitespace? c)
-  (and (char-whitespace? c)
-       (let ((cp (char->integer c)))
-         (not (or (fx=? cp #xA0) (fx=? cp #x2007) (fx=? cp #x202F))))))
+  (let ((cp (char->integer c)))
+    (cond ((or (fx=? cp #xA0) (fx=? cp #x2007) (fx=? cp #x202F)) #f)
+          ((and (fx>=? cp #x1C) (fx<=? cp #x1F)) #t)
+          (else (char-whitespace? c)))))
 
 (define (str-trim s)
   (let ((len (string-length s)))
@@ -72,6 +75,19 @@
           ((java-whitespace? (string-ref s j)) (loop (fx- j 1)))
           (else (substring s 0 (fx+ j 1))))))
 (define (str-trim* s) (str-trimr (str-triml s)))
+
+;; Java 11's strip family, over the same Character.isWhitespace as clojure.string's
+;; trim. String.trim cuts at <= U+0020 — its notion of "space" predates Unicode —
+;; where strip also removes the Unicode separators trim leaves behind.
+(define (str-strip s left? right?)
+  (let ((len (string-length s)))
+    (let scan-l ((i 0))
+      (cond ((fx=? i len) "")
+            ((and left? (java-whitespace? (string-ref s i))) (scan-l (fx+ i 1)))
+            (else (let scan-r ((j (fx- len 1)))
+                    (if (and right? (fx>? j i) (java-whitespace? (string-ref s j)))
+                        (scan-r (fx- j 1))
+                        (substring s i (fx+ j 1)))))))))
 
 ;; --- substring search: first index of `needle` in `s` at/after `from`, or -1 --
 (define (char-by-char-match? s si needle nlen)
@@ -278,8 +294,39 @@
     ((string=? method "replace") (str-replace-literal s (str-needle (arg 0)) (str-needle (arg 1))))
     ((string=? method "equalsIgnoreCase")
      (string=? (ascii-string-down s) (ascii-string-down (arg 0))))
+    ;; compareTo answers an INT on the JVM, not a double — it fed straight into
+    ;; (neg? …) fine but printed as -1.0, and (= -1 (.compareTo …)) was false.
     ((string=? method "compareTo")
-     (let ((o (arg 0))) (cond ((string<? s o) -1.0) ((string>? s o) 1.0) (else 0.0))))
+     (let ((o (jolt-need-str (arg 0)))) (cond ((string<? s o) -1) ((string>? s o) 1) (else 0))))
+    ((string=? method "compareToIgnoreCase")
+     (let ((a (string-downcase s)) (b (string-downcase (jolt-need-str (arg 0)))))
+       (cond ((string<? a b) -1) ((string>? a b) 1) (else 0))))
+    ;; CharSequence content equality — the same characters, whatever the receiver's
+    ;; concrete type (a StringBuilder compares equal to the String it holds).
+    ((string=? method "contentEquals")
+     (string=? s (jolt-str-render-one (arg 0))))
+    ;; (.regionMatches s toffset other ooffset len), plus the leading-boolean
+    ;; ignore-case overload the JVM also has.
+    ((string=? method "regionMatches")
+     (let* ((ic? (and (boolean? (arg 0)) (arg 0)))
+            (base (if (boolean? (arg 0)) 1 0))
+            (toff (jolt->idx (arg base)))
+            (other (jolt-need-str (arg (fx+ base 1))))
+            (ooff (jolt->idx (arg (fx+ base 2))))
+            (len (jolt->idx (arg (fx+ base 3)))))
+       (and (fx>=? toff 0) (fx>=? ooff 0)
+            (fx<=? (fx+ toff len) (string-length s))
+            (fx<=? (fx+ ooff len) (string-length other))
+            (let ((a (substring s toff (fx+ toff len)))
+                  (b (substring other ooff (fx+ ooff len))))
+              (if ic? (string-ci=? a b) (string=? a b))))))
+    ;; char[] of the string's characters — a real 'char array, the same value
+    ;; (char-array s) builds and (String. ca) reads back.
+    ((string=? method "toCharArray") (na-char-array s))
+    ;; Java 11 strip family. Unicode-aware whitespace, where trim cuts at <= U+0020.
+    ((string=? method "strip") (str-strip s #t #t))
+    ((string=? method "stripLeading") (str-strip s #t #f))
+    ((string=? method "stripTrailing") (str-strip s #f #t))
     ((string=? method "getBytes")
      ;; (.getBytes s) / (.getBytes s charset) -> a jolt byte-array (seqable /
      ;; countable / alength-able, like (byte-array …)); the JVM returns byte[].

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -499,6 +499,36 @@
   {:suite "str" :expr "(.replaceAll \"a_b_c\" \"_\" \"-\")" :expected "\"a-b-c\""}
   {:suite "str" :expr "(.replaceFirst \"a_b_c\" \"_\" \"-\")" :expected "\"a-b_c\""}
   {:suite "str" :expr "(vec (.split \"a,b,c\" \",\"))" :expected "[\"a\" \"b\" \"c\"]"}
+  ;; .toCharArray -> a real char[], the value (char-array s) builds and (String. ca) reads back
+  {:suite "str" :expr "(vec (.toCharArray \"ab\"))" :expected "[\\a \\b]"}
+  {:suite "str" :expr "(String. (.toCharArray \"hello\"))" :expected "\"hello\""}
+  {:suite "str" :expr "(alength (.toCharArray \"abc\"))" :expected "3"}
+  ;; compareTo answers an INT; it used to answer -1.0/1.0/0.0, so it read fine
+  ;; through (neg? …) but printed as a double and never = -1.
+  {:suite "str" :expr "(.compareTo \"a\" \"b\")" :expected "-1"}
+  {:suite "str" :expr "(= -1 (.compareTo \"a\" \"b\"))" :expected "true"}
+  {:suite "str" :expr "(.compareToIgnoreCase \"ABC\" \"abc\")" :expected "0"}
+  {:suite "str" :expr "(.contentEquals \"ab\" (StringBuilder. \"ab\"))" :expected "true"}
+  {:suite "str" :expr "[(.regionMatches \"abcd\" 1 \"bc\" 0 2) (.regionMatches \"abcd\" 1 \"xy\" 0 2)]" :expected "[true false]"}
+  ;; the leading-boolean ignore-case overload, and an out-of-range region (false, not a throw)
+  {:suite "str" :expr "[(.regionMatches \"abcd\" true 1 \"BC\" 0 2) (.regionMatches \"abcd\" false 1 \"BC\" 0 2)]" :expected "[true false]"}
+  {:suite "str" :expr "(.regionMatches \"ab\" 1 \"bc\" 0 5)" :expected "false"}
+  ;; strip is Character.isWhitespace where trim cuts at <= U+0020: the ideographic
+  ;; space goes, the NON-BREAKING space stays (Java excludes it from isWhitespace).
+  {:suite "str" :expr "[(.strip \"  a  \") (.stripLeading \"  a  \") (.stripTrailing \"  a  \")]" :expected "[\"a\" \"a  \" \"  a\"]"}
+  ;; by length, so the row carries no invisible characters: strip takes the
+  ;; ideographic spaces off (1 char left) where trim keeps them (3), and NEITHER
+  ;; touches the non-breaking space (3), which Java excludes from isWhitespace.
+  {:suite "str" :expr "[(count (.strip \"\\u3000a\\u3000\")) (count (.trim \"\\u3000a\\u3000\"))]" :expected "[1 3]"}
+  {:suite "str" :expr "(count (.strip \"\\u00a0a\\u00a0\"))" :expected "3"}
+  ;; U+001C..U+001F are whitespace to Java but carry no Unicode White_Space property
+  {:suite "str" :expr "(.strip \"\\u001ca\\u001c\")" :expected "\"a\""}
+  ;; String/valueOf(char[]) is the chars, not the array's own #object[[C] rendering
+  {:suite "str" :expr "(String/valueOf (char-array \"hi\"))" :expected "\"hi\""}
+  {:suite "str" :expr "[(String/valueOf 42) (String/valueOf nil)]" :expected "[\"42\" \"null\"]"}
+  ;; String/join over a collection and spread as varargs, the JVM's two overloads
+  {:suite "str" :expr "(String/join \",\" [\"a\" \"b\" \"c\"])" :expected "\"a,b,c\""}
+  {:suite "str" :expr "[(String/join \"-\" \"a\" \"b\") (String/join \",\" [])]" :expected "[\"a-b\" \"\"]"}
   ;; .split's limit, on both String and Pattern: >0 caps the parts and leaves the
   ;; last one unsplit, 0 (and the 1-arg form) drops trailing empties, <0 keeps them.
   ;; The limit used to be discarded, so splitting a key from a value that may itself


### PR DESCRIPTION
`(.toCharArray "ab")` was missing. Rather than add the one method, I probed the rest
of the `java.lang.String` surface — which turned up two methods returning *wrong
answers*, not just gaps.

## Wrong answers

**`.compareTo` returned a double.** `(.compareTo "a" "b")` was `-1.0`. It read
correctly through `neg?` / `pos?`, which is why nothing caught it, but it printed as
a double and `(= -1 (.compareTo "a" "b"))` was false.

**`String/valueOf(char[])` rendered the array.** `(String/valueOf (char-array "hi"))`
came back `"#object[[C]"`, where `(String. (char-array "hi"))` already gave `"hi"`.

## Added

`.toCharArray` (a real `char[]` — the value `(char-array s)` builds and
`(String. ca)` reads back), `.strip` / `.stripLeading` / `.stripTrailing`,
`.compareToIgnoreCase`, `.contentEquals`, `.regionMatches` (both the plain and the
leading-boolean ignore-case overload), and `String/join` over a collection or spread
as varargs.

The strip family is `Character.isWhitespace`, where `.trim` cuts at `<= U+0020` — so
strip removes the Unicode separators trim leaves behind, but **not** the non-breaking
spaces, which Java deliberately excludes from `isWhitespace`:

| input | `.strip` | `.trim` |
| --- | --- | --- |
| `U+3000 a U+3000` (ideographic space) | `"a"` | unchanged |
| `U+00A0 a U+00A0` (no-break space) | unchanged | unchanged |
| `U+001C a U+001C` (file separator) | `"a"` | unchanged |

U+001C..U+001F are whitespace to Java but carry no Unicode White_Space property, so
`char-whitespace?` alone missed them. That predicate already existed in
`natives-str.ss` backing `clojure.string/trim`, so strip shares it rather than
growing a second one, and the missing range is fixed there once.

## Not added

`.lines`, `.chars` and `.indent` return `Stream` / `IntStream` on the JVM, and jolt
has no stream model. Inventing a seq-returning shape for them would be a jolt-only
semantic, so they stay unimplemented rather than subtly wrong.

## Tests

19 new rows in `test/chez/unit.edn`. The whitespace rows assert on `count` rather
than on the string, so the file carries no invisible characters. `make ci` green.
