### PR TITLE
Seed the PRNG per process and per thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rand`, `rand-int`, `Math/random` and `random-uuid` now differ between
+  processes and between threads.** Chez starts its PRNG from a fixed seed and
+  keeps the state per thread, so every jolt process replayed one identical
+  stream and every forked thread restarted it from the top. Two unrelated
+  processes agreed on every "random" value, and eight threads in one process
+  drew eight identical UUIDs. Clojure runs these off a process-global
+  `java.util.Random` seeded from the clock; jolt now seeds lazily on first draw
+  per thread, from the clock mixed with pid, thread id and a counter.
+
+- **`(java.util.Random.)` with no seed never worked.** It seeded from
+  `(truncate (current-time))`, and `current-time` answers a time object rather
+  than a number, so the no-arg constructor always threw. Seeded instances were
+  unaffected and still reproduce the JVM's exact LCG stream.
+
 ## [0.5.17] - 2026-08-01
 
 Gaps and wrong answers on the `java.lang.String` surface, found by probing it after

--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -531,7 +531,7 @@
 ;; LOCK ORDER: channel mu → fmu → wmu. Never hold two channel mutexes at once.
 (define (jolt-async-do-alts ports priority?)
   (let* ((n (pvec-count ports))
-         (start (if (jolt-truthy? priority?) 0 (random n)))
+         (start (if (jolt-truthy? priority?) 0 (jolt-random n)))
          (idx-of (lambda (k) (let ((m (fx+ start k))) (if (fx<? m n) m (fx- m n))))))
     ;; FAST PASS: one non-blocking attempt per op, no handler. Consumption here IS
     ;; the alts result, so consuming directly is correct on this pass only.

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1537,7 +1537,12 @@
   (lambda (nm)
     (register-class-ctor! nm
       (lambda args
-        (let ((given (if (pair? args) (car args) (exact (truncate (current-time))))))
+        ;; No-seed (Random.) used (truncate (current-time)) — current-time returns a
+        ;; time OBJECT, not a number, so truncate threw and the no-arg ctor never
+        ;; worked at all. The JVM seeds this instance from nanoTime mixed with a
+        ;; uniquifier; jolt-random is already seeded per process and per thread, so
+        ;; drawing the 48-bit seed from it gives distinct instances the same way.
+        (let ((given (if (pair? args) (car args) (jolt-random 281474976710656))))
           (make-jhost "random" (vector (random-init-seed given)))))))
   '("Random" "java.util.Random"))
 (register-host-methods! "random"

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -83,7 +83,7 @@
         (cons "max" (lambda (a b) (if (> a b) a b))) (cons "min" (lambda (a b) (if (< a b) a b)))
         (cons "signum" (lambda (x) (cond ((< x 0) -1.0) ((> x 0) 1.0) (else 0.0))))
         (cons "PI" (->dbl (* 4 (atan 1)))) (cons "E" (->dbl (exp 1)))
-        (cons "random" (lambda args (random 1.0))))))
+        (cons "random" (lambda args (jolt-random 1.0))))))
 
 ;; Thread: real OS threads back futures/promises.
 ;;  - sleep parks the calling thread for `ms` ms (a worker sleeping doesn't block

--- a/host/chez/natives-coll.ss
+++ b/host/chez/natives-coll.ss
@@ -18,7 +18,7 @@
 ;; rand: a flonum in [0, n) (n defaults to 1.0) — jolt is all-flonum, so the
 ;; result is a double like every other number.
 (define (jolt-rand . n)
-  (let ((r (random 1.0)))
+  (let ((r (jolt-random 1.0)))
     (if (null? n) r (* r (exact->inexact (car n))))))
 
 (def-var! "clojure.core" "hash-map" jolt-hash-map-fn)

--- a/host/chez/natives-misc.ss
+++ b/host/chez/natives-misc.ss
@@ -11,7 +11,7 @@
 (define (jolt-uuid-pred? x) (juuid? x))
 
 (define hexd "0123456789abcdef")
-(define (rand-hex) (string-ref hexd (random 16)))
+(define (rand-hex) (string-ref hexd (jolt-random 16)))
 ;; v4: 8-4-4-4-12, version nibble (index 14) = 4, variant nibble (index 19) in 8-b.
 (define (random-uuid-str)
   (let ((cs (make-string 36)))
@@ -21,7 +21,7 @@
             (string-set! cs i
               (cond ((or (fx=? i 8) (fx=? i 13) (fx=? i 18) (fx=? i 23)) #\-)
                     ((fx=? i 14) #\4)
-                    ((fx=? i 19) (string-ref "89ab" (random 4)))
+                    ((fx=? i 19) (string-ref "89ab" (jolt-random 4)))
                     (else (rand-hex))))
             (loop (fx+ i 1)))))))
 (define (jolt-random-uuid) (make-juuid (random-uuid-str)))

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -816,6 +816,46 @@
 ;; jolt-pr-str/jolt-str-join) + seq.ss (jolt-invoke).
 (load "host/chez/printing.ss")
 
+;; --- randomness -------------------------------------------------------------
+;; Chez's PRNG starts every thread from the SAME fixed seed, and the state is
+;; per-thread rather than shared. Both halves of that diverge from Clojure, where
+;; rand/rand-int/Math.random run off one process-global java.util.Random seeded
+;; from the clock:
+;;
+;;   - across processes, every jolt run replayed one identical stream, so two
+;;     unrelated processes agreed on every "random" value — including every
+;;     random-uuid, so a fleet minted colliding UUIDs;
+;;   - across threads, each forked thread restarted that same stream from the
+;;     top, so N request threads drew N identical values in ONE process.
+;;
+;; Seeding lazily on first use covers both: a thread that never draws pays
+;; nothing, and one that does is seeded before its first value. Seed from the
+;; clock (as the JVM does) mixed with pid and thread id so two threads starting
+;; inside the same nanosecond still diverge, and a counter so that even a
+;; coarse clock cannot hand out one seed twice.
+(define random-seeded? (make-thread-parameter #f))
+(define random-seed-counter 0)
+(define random-seed-mutex (make-mutex))
+
+(define (seed-random!)
+  (let* ((t (current-time 'time-utc))
+         (n (with-mutex random-seed-mutex
+              (set! random-seed-counter (+ random-seed-counter 1))
+              random-seed-counter))
+         (mix (bitwise-xor (time-nanosecond t)
+                           (* 1000000007 (time-second t))
+                           (* 2654435761 (get-process-id))
+                           (* 40503 (get-thread-id))
+                           (* 2246822519 n))))
+    ;; random-seed's domain is 1 .. 2^32-1
+    (random-seed (+ 1 (modulo mix 4294967294)))
+    (random-seeded? #t)))
+
+;; Every jolt-level draw goes through this, never `random` directly.
+(define (jolt-random n)
+  (unless (random-seeded?) (seed-random!))
+  (random n))
+
 ;; collection constructors + rand: bind the public
 ;; clojure.core names hash-map/hash-set/array-map/set/rand to the existing
 ;; pmap/pset ctors. After collections.ss (the ctors) + seq.ss (seq->list).

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -9,6 +9,11 @@ cd "$root"
 # built target/release/jolt — 10x faster boot than script mode; the explicit
 # script-mode case below keeps the source-load path covered).
 jolt="${JOLT_BIN:-bin/jolt}"
+# The same default, kept unwrapped: the cases that need an ABSOLUTE path to the
+# binary (they cd elsewhere first) resolved $JOLT_BIN directly, so running this
+# script without JOLT_BIN set built "<repo>/" — a directory — and failed three
+# cases that the make gate never saw, because the gate always sets JOLT_BIN.
+jolt_bin="${JOLT_BIN:-bin/jolt}"
 
 # Every case here is a sub-second jolt invocation, so a case that does not finish
 # has hung — and a hung case is invisible: `make -Oline` shows nothing for a target
@@ -49,6 +54,21 @@ check() {
   else
     echo "  FAIL: $1"
     echo "    want \`$2\` got \`$got\`"
+    fails=$((fails + 1))
+  fi
+}
+# Two separate jolt processes must not produce the same random draw. Chez seeds
+# its PRNG identically at every process start, so anything built on `random` —
+# rand, rand-int, Math/random, random-uuid — replayed one fixed stream: every
+# process agreed on "random" and every UUID a fleet minted collided.
+check_varies() {
+  a="$($jolt -e "$1" 2>/dev/null | tail -1)"
+  b="$($jolt -e "$1" 2>/dev/null | tail -1)"
+  if [ "$a" != "$b" ] && [ -n "$a" ]; then
+    pass=$((pass + 1))
+  else
+    echo "  FAIL (varies): $1"
+    echo "    two processes both produced \`$a\`"
     fails=$((fails + 1))
   fi
 }
@@ -871,7 +891,7 @@ bare="$(mktemp -d)"
 mkdir -p "$bare/app/src/app"
 printf '{:paths ["src"]}\n' > "$bare/app/deps.edn"
 printf '(ns app.core)\n(defn -main [& _] (println "bare:" (+ 40 2)))\n' > "$bare/app/src/app/core.clj"
-abs_jolt="$(cd "$(dirname "$JOLT_BIN")" && pwd)/$(basename "$JOLT_BIN")"
+abs_jolt="$(cd "$(dirname "$jolt_bin")" && pwd)/$(basename "$jolt_bin")"
 if ( cd "$bare/app" && "$abs_jolt" build -m app.core -o app >/dev/null 2>&1 )    && [ "$("$bare/app/app" 2>/dev/null | tail -1)" = "bare: 42" ]; then
   pass=$((pass + 1))
 else
@@ -890,7 +910,7 @@ stale="$(mktemp -d)"
 mkdir -p "$stale/proj/src/sp"
 printf '{:paths ["src"] :aliases {:run {:main-opts ["-m" "sp.core"]}}}\n' > "$stale/proj/deps.edn"
 printf '(ns sp.core)\n(defn -main [& _] (println "cwd-wins:" (System/getProperty "user.dir")))\n' > "$stale/proj/src/sp/core.clj"
-abs_jolt2="$(cd "$(dirname "$JOLT_BIN")" && pwd)/$(basename "$JOLT_BIN")"
+abs_jolt2="$(cd "$(dirname "$jolt_bin")" && pwd)/$(basename "$jolt_bin")"
 stale_out="$( cd "$stale/proj" && PWD=/definitely/not/here "$abs_jolt2" -M:run 2>&1 )"
 if printf '%s' "$stale_out" | grep -q "cwd-wins:.*/proj"; then
   pass=$((pass + 1))
@@ -910,6 +930,28 @@ else
   fails=$((fails + 1))
 fi
 rm -rf "$stale"
+
+# --- randomness is per-process and per-thread -------------------------------
+# Clojure on the JVM seeds Math/random from the clock, so every process draws a
+# different stream. jolt must match: a fixed seed makes rand-int, random-uuid
+# and Math/random agree across unrelated processes.
+check_varies '(rand-int 1000000000)'
+check_varies '(rand)'
+check_varies '(Math/random)'
+check_varies '(str (random-uuid))'
+check_varies '(str (java.util.UUID/randomUUID))'
+# Chez keeps the PRNG state per thread, and a forked thread started from the same
+# default seed — so two threads in ONE process drew identical "random" values.
+check '(let [t (atom nil) th (Thread. (fn [] (reset! t (rand-int 1000000000))))] (.start th) (.join th) (= @t (rand-int 1000000000)))' 'false'
+check '(let [n 8 out (atom []) ths (doall (map (fn [_] (Thread. (fn [] (swap! out conj (str (random-uuid)))))) (range n)))] (doseq [t ths] (.start t)) (doseq [t ths] (.join t)) (count (distinct @out)))' '8'
+# (java.util.Random.) with no seed fed a time OBJECT to truncate and always threw.
+check '(int? (.nextInt (java.util.Random.) 1000))' 'true'
+check_varies '(.nextInt (java.util.Random.) 1000000000)'
+# An explicit seed must still reproduce the JVM's exact LCG stream (values taken
+# from a real JVM, not derived from jolt's own implementation).
+check '(let [r (java.util.Random. 42)] [(.nextInt r 100) (.nextInt r 100) (.nextInt r 100)])' '[30 63 48]'
+check '(let [r (java.util.Random. 42)] [(.nextInt r 64) (.nextInt r 64)])' '[46 3]'
+check '(.nextLong (java.util.Random. 12345))' '6674089274190705457'
 
 echo "cli smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
`rand`, `rand-int`, `Math/random` and `random-uuid` produced the same values in
every jolt process, and the same values again in every forked thread.

```
$ jolt -e '(prn (rand-int 1000000) (str (random-uuid)))'
499807 "706b05c0-5e6f-4e19-8ab0-1120e443d96e"
$ jolt -e '(prn (rand-int 1000000) (str (random-uuid)))'
499807 "706b05c0-5e6f-4e19-8ab0-1120e443d96e"
```

Chez seeds its PRNG from a fixed default and keeps the state per thread rather
than sharing one. Clojure runs these off a process-global `java.util.Random`
seeded from the clock, so this is a semantic divergence, and the UUID case makes
it a correctness bug: a fleet mints colliding ids, and eight threads in one
process drew eight identical UUIDs.

Seeding is now lazy on the first draw in each thread, from the clock mixed with
pid, thread id and a counter — a thread that never draws pays nothing, and two
threads starting inside the same nanosecond still diverge. Every jolt-level draw
goes through `jolt-random`; nothing calls Chez's `random` directly any more.

Separately, `(java.util.Random.)` with no seed always threw: it seeded from
`(truncate (current-time))` and `current-time` answers a time object, not a
number. It now draws its 48-bit seed from `jolt-random`. Seeded instances are
untouched — the new smoke cases pin `(java.util.Random. 42)` and `nextLong`
against values taken from a real JVM rather than from jolt's own output.

Also fixes three pre-existing smoke cases that resolved `$JOLT_BIN` directly
instead of the script's default, so `sh host/chez/smoke.sh` without `JOLT_BIN`
built `"<repo>/"` and failed on a directory. The gate always sets `JOLT_BIN`,
which is why it stayed invisible.

## Testing

`make ci` green (40 gates). CLI smoke goes 104 → 116 cases, covering
cross-process variation for each entry point, thread-level variation, the
no-arg ctor, and the seeded-LCG vectors.