### PR TITLE
Make random-uuid unpredictable, and implement SecureRandom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `java.util.Random` seeded from the clock; jolt now seeds lazily on first draw
   per thread, from the clock mixed with pid, thread id and a counter.
 
+- **`random-uuid` and `UUID/randomUUID` now draw from the OS CSPRNG.** They were
+  built out of `random`, which is seeded from the clock — unique per process
+  after the fix above, but still guessable by anyone who knows roughly when the
+  process started. Clojure backs `random-uuid` with `SecureRandom` because v4
+  UUIDs get used as session ids, CSRF nonces and reset tokens, where guessable
+  means forgeable. Bytes now come from `/dev/urandom`, or `BCryptGenRandom` /
+  `RtlGenRandom` on Windows. If a host offers no entropy source at all the
+  fallback says so on stderr rather than degrading quietly.
+
+### Added
+
+- **`java.security.SecureRandom`**, implemented natively over the same OS
+  entropy: `nextBytes`, `nextInt` (both arities), `nextLong`, `nextDouble`,
+  `nextFloat`, `nextBoolean`, `generateSeed`, `setSeed`, and the `getInstance` /
+  `getInstanceStrong` statics. `nextInt(bound)` rejection samples rather than
+  taking a bare modulo, which would bias toward the low residues. It no longer
+  auto-loads `jolt-crypto`: it is a JDK class on the JVM, and reaching for one
+  should not make a program declare a dependency.
+
+### Fixed
+
 - **`(java.util.Random.)` with no seed never worked.** It seeded from
   `(truncate (current-time))`, and `current-time` answers a time object rather
   than a number, so the no-arg constructor always threw. Seeded instances were

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1598,6 +1598,70 @@
                           (/ (random-next 24 st) (exact->inexact (expt 2 24))))))
     (cons "nextBoolean" (lambda (self) (fx=? 1 (random-next 1 (jhost-state self)))))))
 
+;; --- java.security.SecureRandom ----------------------------------------------
+;; Every draw comes straight from the OS CSPRNG (jolt-random-bytes), so there is
+;; no seed and no internal state to carry: unlike java.util.Random above, two
+;; instances are not distinguishable and none of this is reproducible. That is
+;; the contract — SecureRandom promises unpredictability, and the JVM explicitly
+;; does not promise a repeatable stream for a given seed.
+(define (sr-uint n)
+  (let ((bv (jolt-random-bytes n)))
+    (let loop ((i 0) (acc 0))
+      (if (fx=? i n) acc (loop (fx+ i 1) (+ (* acc 256) (bytevector-u8-ref bv i)))))))
+
+(define (sr-next-int-bound bound)
+  (if (<= bound 0)
+      (throw-jvm (quote IllegalArgumentException) "bound must be positive")
+      ;; Rejection sampling, not a bare modulo: taking (mod u bound) over a range
+      ;; that is not a multiple of bound makes the low residues more likely, which
+      ;; is a real bias in something callers reach for to pick tokens and salts.
+      (let loop ()
+        (let* ((u (bitwise-and (sr-uint 4) #x7fffffff))
+               (r (modulo u bound)))
+          (if (<= (- u r) (- 2147483648 bound)) (->num r) (loop))))))
+
+(for-each
+  (lambda (nm)
+    (register-class-ctor! nm
+      ;; (SecureRandom. seed) is accepted and the seed ignored: the JVM's seeded
+      ;; ctor SUPPLEMENTS entropy rather than replacing it, so ignoring it cannot
+      ;; make the output weaker than the caller asked for.
+      (lambda args (make-jhost "securerandom" #f)))
+    (register-class-statics! nm
+      (list (cons "getInstance" (lambda args (make-jhost "securerandom" #f)))
+            (cons "getInstanceStrong" (lambda args (make-jhost "securerandom" #f))))))
+  '("SecureRandom" "java.security.SecureRandom"))
+
+(register-host-methods! "securerandom"
+  (list
+    (cons "nextBytes" (lambda (self ba)
+                        (let* ((v (jolt-array-vec ba))
+                               (n (vector-length v))
+                               (bv (jolt-random-bytes n)))
+                          (let loop ((i 0))
+                            (when (fx<? i n)
+                              (vector-set! v i (na-byte-of (bytevector-u8-ref bv i)))
+                              (loop (fx+ i 1))))
+                          jolt-nil)))
+    (cons "nextInt" (lambda (self . a)
+                      (if (pair? a)
+                          (sr-next-int-bound (exact (truncate (car a))))
+                          (->num (random-u32->s32 (sr-uint 4))))))
+    (cons "nextLong" (lambda (self)
+                       (let ((u (sr-uint 8)))
+                         (->num (if (>= u #x8000000000000000) (- u #x10000000000000000) u)))))
+    (cons "nextDouble" (lambda (self)
+                         (* (bitwise-and (sr-uint 7) (- (expt 2 53) 1)) (/ 1.0 (expt 2 53)))))
+    (cons "nextFloat" (lambda (self)
+                        (/ (bitwise-and (sr-uint 3) (- (expt 2 24) 1))
+                           (exact->inexact (expt 2 24)))))
+    (cons "nextBoolean" (lambda (self) (fx=? 1 (bitwise-and (sr-uint 1) 1))))
+    (cons "generateSeed" (lambda (self n)
+                           (na-bv->bytearray (jolt-random-bytes (exact (truncate n))))))
+    ;; setSeed supplements on the JVM and never replaces; with an OS source there
+    ;; is nothing to supplement, so it is a no-op rather than a weakening.
+    (cons "setSeed" (lambda (self . _) jolt-nil))))
+
 ;; --- java.util.Optional -----------------------------------------------------
 ;; Returned by getters across java.time / java.net.http (e.g. HttpRequest.timeout,
 ;; HttpClient.connectTimeout). Value-equal so (= (Optional/of x) (Optional/of x)).

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -246,8 +246,10 @@
 (define lib-class-providers
   (list
    (vector "jolt.crypto" "io.github.jolt-lang/jolt-crypto"
+           ;; SecureRandom is NOT here: the runtime implements it natively over the
+           ;; OS CSPRNG, so it needs no dependency — it is a JDK class on the JVM
+           ;; and reaching for one should not make a program declare a library.
            '("MessageDigest" "java.security.MessageDigest"
-             "SecureRandom" "java.security.SecureRandom"
              "Mac" "javax.crypto.Mac"
              "Cipher" "javax.crypto.Cipher"
              "SecretKeySpec" "javax.crypto.spec.SecretKeySpec"

--- a/host/chez/natives-misc.ss
+++ b/host/chez/natives-misc.ss
@@ -11,18 +11,32 @@
 (define (jolt-uuid-pred? x) (juuid? x))
 
 (define hexd "0123456789abcdef")
-(define (rand-hex) (string-ref hexd (jolt-random 16)))
-;; v4: 8-4-4-4-12, version nibble (index 14) = 4, variant nibble (index 19) in 8-b.
+;; Position of hex digit j within the 8-4-4-4-12 layout: one extra character for
+;; each hyphen already passed (they sit after hex digits 8, 12, 16 and 20).
+(define (uuid-hex-pos j)
+  (fx+ j
+       (if (fx>=? j 8) 1 0) (if (fx>=? j 12) 1 0)
+       (if (fx>=? j 16) 1 0) (if (fx>=? j 20) 1 0)))
+;; v4 from 16 bytes of OS entropy (jolt-random-bytes), NOT from the seeded PRNG:
+;; v4 UUIDs get used as session ids and reset tokens, where a guessable value is a
+;; forgeable one. RFC 4122 then overwrites 6 of the 128 bits — version 4 in the
+;; high nibble of byte 6, variant 10 in the top two bits of byte 8 — leaving 122
+;; random bits.
 (define (random-uuid-str)
-  (let ((cs (make-string 36)))
+  (let ((b (jolt-random-bytes 16))
+        (cs (make-string 36)))
+    (bytevector-u8-set! b 6 (fxior (fxand (bytevector-u8-ref b 6) #x0f) #x40))
+    (bytevector-u8-set! b 8 (fxior (fxand (bytevector-u8-ref b 8) #x3f) #x80))
+    (string-set! cs 8 #\-) (string-set! cs 13 #\-)
+    (string-set! cs 18 #\-) (string-set! cs 23 #\-)
     (let loop ((i 0))
-      (if (fx=? i 36) cs
-          (begin
-            (string-set! cs i
-              (cond ((or (fx=? i 8) (fx=? i 13) (fx=? i 18) (fx=? i 23)) #\-)
-                    ((fx=? i 14) #\4)
-                    ((fx=? i 19) (string-ref "89ab" (jolt-random 4)))
-                    (else (rand-hex))))
+      (if (fx=? i 16)
+          cs
+          (let ((v (bytevector-u8-ref b i)))
+            (string-set! cs (uuid-hex-pos (fx* i 2))
+                         (string-ref hexd (fxarithmetic-shift-right v 4)))
+            (string-set! cs (uuid-hex-pos (fx+ (fx* i 2) 1))
+                         (string-ref hexd (fxand v 15)))
             (loop (fx+ i 1)))))))
 (define (jolt-random-uuid) (make-juuid (random-uuid-str)))
 

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -856,6 +856,84 @@
   (unless (random-seeded?) (seed-random!))
   (random n))
 
+;; --- OS entropy ---------------------------------------------------------------
+;; jolt-random is seeded from the clock, which makes it unique per process but
+;; still guessable: an observer who knows roughly when a process started can
+;; narrow the seed to a small range and enumerate it. Clojure backs random-uuid
+;; with SecureRandom because callers do use v4 UUIDs as session ids, CSRF nonces
+;; and password-reset links, where guessable means forgeable. The bytes behind a
+;; UUID therefore come from the OS, not from any seeded PRNG.
+;;
+;; Resolved lazily on first use and cached, never at load time: in a built binary
+;; top-level forms run during heap build, so a port opened there would be baked
+;; into the image and be a stale descriptor — shared by every process started
+;; from it — by the time anything drew from it.
+(define entropy-source 'unset)      ; 'unset | #f | input port (posix) | procedure (windows)
+
+(define (entropy-open-urandom)
+  (guard (e (#t #f))
+    (and (file-exists? "/dev/urandom")
+         (open-file-input-port "/dev/urandom" (file-options) (buffer-mode none)))))
+
+;; Windows has no /dev/urandom. BCryptGenRandom with a null algorithm handle and
+;; BCRYPT_USE_SYSTEM_PREFERRED_RNG (2) is the documented system CSPRNG;
+;; RtlGenRandom — exported from advapi32 only under its ordinal alias
+;; SystemFunction036 — covers anything without bcrypt. eval rather than a
+;; compiled foreign-procedure for the same reason jolt-foreign-proc-safe uses it
+;; there: on Windows a foreign reference inside a fasl is a load-time relocation
+;; that aborts the boot outright if the symbol is missing, before any guard runs.
+(define (entropy-open-windows)
+  (guard (e (#t #f))
+    (or (and (guard (e2 (#t #f)) (load-shared-object "bcrypt.dll") #t)
+             (foreign-entry? "BCryptGenRandom")
+             (let ((f (eval '(foreign-procedure "BCryptGenRandom"
+                                                (void* u8* unsigned-32 unsigned-32) int))))
+               (lambda (bv n) (fx=? 0 (f 0 bv n 2)))))
+        (and (guard (e2 (#t #f)) (load-shared-object "advapi32.dll") #t)
+             (foreign-entry? "SystemFunction036")
+             (let ((f (eval '(foreign-procedure "SystemFunction036" (u8* unsigned-32) boolean))))
+               (lambda (bv n) (f bv n)))))))
+
+(define (jolt-entropy-source)
+  (when (eq? entropy-source 'unset)
+    (set! entropy-source
+          (if (memq (machine-type) '(a6nt ta6nt i3nt ti3nt))
+              (entropy-open-windows)
+              (entropy-open-urandom))))
+  entropy-source)
+
+(define entropy-warned? #f)
+(define (entropy-warn-once!)
+  (unless entropy-warned?
+    (set! entropy-warned? #t)
+    ;; Loud, once: silently degrading a CSPRNG to a clock-seeded PRNG is how
+    ;; guessable session ids ship. Uniqueness still holds; unpredictability does not.
+    (display "jolt: no OS entropy source available -- random-uuid is falling back to the seeded PRNG\n"
+             (console-error-port))))
+
+;; `n` bytes from the OS CSPRNG. Falls back to the seeded PRNG only if the host
+;; offers no entropy source at all, which on every platform jolt ships is never.
+(define (jolt-random-bytes n)
+  (let ((bv (make-bytevector n 0))
+        (src (jolt-entropy-source)))
+    (cond
+      ((and (port? src)
+            (guard (e (#t #f))
+              ;; short reads are legal on a character device — loop to n
+              (let loop ((got 0))
+                (or (fx>=? got n)
+                    (let ((k (get-bytevector-n! src bv got (fx- n got))))
+                      (and (fixnum? k) (fx>? k 0) (loop (fx+ got k))))))))
+       bv)
+      ((and (procedure? src) (guard (e (#t #f)) (src bv n))) bv)
+      (else
+       (entropy-warn-once!)
+       (let loop ((i 0))
+         (if (fx=? i n)
+             bv
+             (begin (bytevector-u8-set! bv i (jolt-random 256))
+                    (loop (fx+ i 1)))))))))
+
 ;; collection constructors + rand: bind the public
 ;; clojure.core names hash-map/hash-set/array-map/set/rand to the existing
 ;; pmap/pset ctors. After collections.ss (the ctors) + seq.ss (seq->list).

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -952,6 +952,11 @@ check_varies '(.nextInt (java.util.Random.) 1000000000)'
 check '(let [r (java.util.Random. 42)] [(.nextInt r 100) (.nextInt r 100) (.nextInt r 100)])' '[30 63 48]'
 check '(let [r (java.util.Random. 42)] [(.nextInt r 64) (.nextInt r 64)])' '[46 3]'
 check '(.nextLong (java.util.Random. 12345))' '6674089274190705457'
+# random-uuid draws from the OS CSPRNG, not the seeded PRNG. The fallback is
+# deliberately loud, so its absence is the assertion that entropy was reached —
+# a silent degradation here ships guessable session ids.
+check_no '(dotimes [_ 100] (random-uuid))' 'no OS entropy'
+check '(let [u (str (random-uuid))] [(count u) (nth u 14) (contains? #{\8 \9 \a \b} (nth u 19))])' '[36 \4 true]'
 
 echo "cli smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1,4 +1,22 @@
 [
+  {:suite "securerandom" :expr "(let [r (java.security.SecureRandom.)] (int? (.nextInt r)))" :expected "true"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (every? (fn [x] (and (>= x 0) (< x 10))) (repeatedly 500 (fn [] (.nextInt r 10)))))" :expected "true"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.) b (byte-array 16)] (.nextBytes r b) [(alength b) (> (count (distinct (seq b))) 4)])" :expected "[16 true]"}
+  {:suite "securerandom" :expr "(alength (.generateSeed (SecureRandom.) 32))" :expected "32"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (every? (fn [x] (and (>= x 0.0) (< x 1.0))) (repeatedly 200 (fn [] (.nextDouble r)))))" :expected "true"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (= #{true false} (set (repeatedly 200 (fn [] (.nextBoolean r))))))" :expected "true"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (= 200 (count (distinct (repeatedly 200 (fn [] (.nextLong r)))))))" :expected "true"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (= 200 (count (distinct (repeatedly 200 (fn [] (.nextInt r)))))))" :expected "true"}
+  {:suite "securerandom" :expr "(int? (.nextInt (SecureRandom/getInstance \"SHA1PRNG\") 100))" :expected "true"}
+  {:suite "securerandom" :expr "(int? (.nextInt (SecureRandom/getInstanceStrong) 100))" :expected "true"}
+  {:suite "securerandom" :expr "(try (.nextInt (SecureRandom.) 0) :no-throw (catch IllegalArgumentException e :threw))" :expected ":threw"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (.setSeed r 42) (int? (.nextInt r 100)))" :expected "true"}
+  {:suite "securerandom" :expr "(let [r (SecureRandom.)] (every? (fn [x] (and (>= x 0.0) (< x 1.0))) (repeatedly 100 (fn [] (.nextFloat r)))))" :expected "true"}
+  {:suite "uuid" :expr "(let [u (str (random-uuid))] [(count u) (nth u 14) (contains? #{\\8 \\9 \\a \\b} (nth u 19))])" :expected "[36 \\4 true]"}
+  {:suite "uuid" :expr "(count (distinct (repeatedly 2000 #(str (random-uuid)))))" :expected "2000"}
+  {:suite "uuid" :expr "(every? (fn [_] (re-matches #\"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\" (str (random-uuid)))) (range 200))" :expected "true"}
+  {:suite "uuid" :expr "(let [us (repeatedly 400 #(str (random-uuid)))] (every? #(> (count (distinct (map (fn [u] (nth u %)) us))) 8) [0 1 2 7 9 35]))" :expected "true"}
+  {:suite "uuid" :expr "(= (str (random-uuid)) (str (random-uuid)))" :expected "false"}
   {:suite "special-form precedence" :expr "(do (ns sftest (:refer-clojure :exclude [def])) (defmacro def [n v] :shadowed) (clojure.core/defn ff [] 99) (ff))" :expected "99"}
   {:suite "special-form precedence" :expr "(do (set! (. clojure.lang.RT checkSpecAsserts) true) clojure.lang.RT/checkSpecAsserts)" :expected "true"}
   {:suite "atomwatch" :expr "(let [a (atom 0) seen (atom 0)] (add-watch a :k (fn [k r o n] (reset! seen 1))) (reset! a 5) @seen)" :expected "1"}


### PR DESCRIPTION
Stacked on #517 — review that first; this PR targets its branch.

#517 made `random-uuid` unique per process. It is still *guessable*: the bytes
come from a PRNG seeded off the clock, so an observer who knows roughly when a
process started can narrow the seed to a small range and enumerate it. Clojure
backs `random-uuid` with `SecureRandom` for a reason — v4 UUIDs get used as
session ids, CSRF nonces and password-reset links, where guessable means
forgeable.

UUID bytes now come from the OS CSPRNG: `/dev/urandom` on posix,
`BCryptGenRandom` with `RtlGenRandom` as a fallback on Windows. The source is
resolved lazily and cached — never at load time, since top-level forms run
during heap build and a port opened there would be a stale descriptor shared by
every process started from the image. If a host offers no entropy source at all
the fallback writes to stderr rather than degrading quietly, and a smoke case
asserts that message never appears.

The UUID is now assembled from 16 entropy bytes with the RFC 4122 version and
variant bits overwritten, instead of being drawn a nibble at a time.

## SecureRandom

`java.security.SecureRandom` is implemented natively on the same source, with
the surface `java.util.Random` already had plus `generateSeed`, `setSeed` and
the `getInstance` / `getInstanceStrong` statics. `nextInt(bound)` rejection
samples — a bare modulo over a range that is not a multiple of the bound favours
the low residues, which matters for something used to pick tokens and salts.

It is also dropped from the `jolt-crypto` autoload list. It is a JDK class on
the JVM, and reaching for one should not oblige a program to declare a
dependency.

One caveat worth knowing: `jolt.crypto` re-registers `SecureRandom` when it
loads, and its shim carried only `nextBytes`/`generateSeed` — so requiring it
for an unrelated `Cipher` took `nextInt` and `nextLong` away again.
jolt-lang/jolt-crypto#2 fills that surface in; both paths are complete with the
two merged, and neither depends on the other's version.

## Testing

`make ci` green. 18 new unit rows (5 uuid, 13 securerandom), CLI smoke 116 → 118.
The Windows entropy path is written to the same shape as `jolt-foreign-proc-safe`
but I have no Windows host here, so it is untested — it degrades to the loud
fallback rather than failing if the DLL or symbol is missing.