### PR TITLE
Make print render like pr with quoting off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`print`/`println`/`print-str` now render like `pr` with quoting off, not like
+  `str`.** Previously `print` of a `2M` printed `2`, a regex printed `re`, and a
+  UUID printed the bare hex string. It now shares the readable renderer with `pr`
+  and only drops the string/char quoting, so those print as `2M`, `#"re"` and
+  `#uuid "…"`, and a mixed coll prints `[s a 2M]` instead of `[s \a 2M]` — the
+  JVM's `(binding [*print-readably* nil] (pr …))`. `str` is untouched (its
+  contract is `.toString`). The quoting-off flag rides a virtual register rather
+  than a per-value dynamic binding, which would have cost about 770ns a value.
+
+### Performance
+
+- **`pr`, `pr-str` and `print` skip the printer's arm registries for the value
+  types the runtime owns** — numbers, strings, chars, keywords, symbols, booleans
+  and nil now go straight to the renderer's base case instead of testing ~40
+  registered host-type predicates that cannot match them, and `print-method` is
+  resolved through a cached var cell instead of being looked up by name per
+  value. Measured over 200k values, A/B/A in one session: `pr-str` 220 ms → 162 ms
+  (1.36x), `print` 235 ms → 224 ms (parity — the delta is inside run-to-run
+  drift). A registered arm that could match one of those types is rejected at
+  registration, so the fast path cannot silently bypass a host shim's rendering.
+
 ## [0.5.18] - 2026-08-02
 
 Two things a program cannot work without: knowing where it broke, and getting

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ JOLT-TARGETS-NEEDING-DEPS := \
   devbootsmoke devirt directlink ffi fieldjoin fieldnum fieldread flarr grenadine \
   gateboot gatebootsmoke httpsfetch infer inline inline-body irvalidate \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
-  narrow numeric numwp oparity pic protoret remint sci selfhost shakelocal \
+  narrow numeric numwp oparity pic protoret printperf remint sci selfhost shakelocal \
   shakesmoke smoke staticnativesmoke test testbin transient unit unitcontext \
   values wp ci
 
@@ -474,3 +474,11 @@ aotfingerprint:
 # require. Needs Maven jars locally; NOT in the default ci gate (timing budget).
 aotcacheperf:
 	@sh test/chez/aot-cache-perf.sh
+
+# Perf probe for the print and pr value seams: 200000 values each through
+# with-out-str. Guards the per-value *print-readably* override and the printer's
+# fast path for runtime-owned types. Manual like aotcacheperf — the repo has no
+# wall-clock assertions in its default gates, and a timing floor would be flaky
+# on loaded CI. See the header of the script for how to read the numbers.
+printperf:
+	@$(CHEZ) --script test/chez/print-throughput.ss

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -396,8 +396,10 @@ fi
 # must not escape that file. Both the loader and the AOT'd binary bracket a
 # namespace's forms with a thread binding for the var (RT.load parity), so this
 # runs the app from source and as a built binary and expects the same answer.
+# The middle value is a widened bigint (jolt widens where the JVM throws) and
+# prints with the N suffix, as the JVM prints any bigint under print.
 umapp="$root/test/chez/unchecked-math-app"
-umwant="UNCHECKED-MATH -9223372036854775808 9223372036854775808 false"
+umwant="UNCHECKED-MATH -9223372036854775808 9223372036854775808N false"
 got_um_src="$(cd "$umapp" && JOLT_PWD="$umapp" "$joltabs" run -m umapp.main 2>&1 | tail -1)"
 if [ "$got_um_src" != "$umwant" ]; then
   echo "  FAIL: top-level (set! *unchecked-math* …) from source — want \`$umwant\`, got \`$got_um_src\`"; exit 1

--- a/host/chez/converters.ss
+++ b/host/chez/converters.ss
@@ -11,6 +11,7 @@
 ;; Newest registration is checked first (matches the old outermost-wins order).
 (define str-render-registry '())   ; list of (pred . render), checked front-to-back
 (define (register-str-render! pred render)
+  (pr-arm-reject-fast-type! 'register-str-render! pred)
   (set! str-render-registry (cons (cons pred render) str-render-registry)))
 
 ;; str: nil -> "", string raw, char bare (not \c), regex -> raw source, a
@@ -36,17 +37,33 @@
        (if (or (not ns) (jolt-nil? ns))
            (symbol-t-name v)
            (string-append ns "/" (symbol-t-name v)))))
+    ;; numbers and booleans reach the printer without an arm ever claiming them
+    ;; (pr-fast-type?, rt.ss); the cases above already cover the rest of that set.
+    ((pr-fast-type? v) (jolt-pr-str v))
     (else
      (let loop ((rs str-render-registry))
        (cond
          ((null? rs) (jolt-pr-str v))
          (((caar rs) v) ((cdar rs) v))
          (else (loop (cdr rs))))))))
-;; print/println render non-readably: a nested string is raw. jolt-str-render-one
-;; is exactly that (collections fall through to jolt-pr-str). The print family
-;; uses this seam, NOT the str fn — which renders readably (below). A top-level nil
-;; prints "nil" (str renders it ""), so the seam special-cases it.
-(define (jolt-print-one v) (if (jolt-nil? v) "nil" (jolt-str-render-one v)))
+;; print/println render via the SAME readable renderer as pr, with string/char
+;; quoting off: the JVM's print is (binding [*print-readably* nil] (pr ...)).
+;; jolt-pr-readable already consults *print-readably* for strings (printing.ss)
+;; and chars (jolt-char->string) at every nesting depth, so overriding it here
+;; makes (print ["s" \a 2M]) render [s a 2M] while numbers, regexes, uuids and
+;; the infinities keep their readable form — one renderer, not a per-type print
+;; registry. nil renders "nil" via the readable base. The override is a virtual
+;; register (rt.ss), not a thread binding: two ~1ns vreg writes per value instead
+;; of a pmap alloc + fold + two thread-parameter writes. Saved/restored so
+;; nesting composes, inside dynamic-wind so an un-restored override cannot leak
+;; non-readable rendering into every later pr in this thread if the renderer
+;; throws.
+(define (jolt-print-one v)
+  (let ((prev (virtual-register jolt-vreg-print-readably)))
+    (dynamic-wind
+      (lambda () (set-virtual-register! jolt-vreg-print-readably #f))
+      (lambda () (jolt-pr-readable v))
+      (lambda () (set-virtual-register! jolt-vreg-print-readably prev)))))
 (def-var! "clojure.core" "__print1" jolt-print-one)
 
 ;; str: a top-level string/scalar renders as jolt-str-render-one (raw string,

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -412,8 +412,13 @@
             (and (pair? ks) (or (jclass? (car ks)) (loop (cdr ks)))))))
   pm-has-class-keys?)
 
+;; Resolved once: var-deref rebuilds "clojure.core/print-method" and hashes it on
+;; every call, which this pays per printed value. The cell is stable — def-var!
+;; mutates the root in place — so caching it is sound under redefinition.
+(define pm-cell #f)
 (define (user-print-method x)
-  (let ((mf (var-deref "clojure.core" "print-method")))
+  (unless pm-cell (set! pm-cell (jolt-var "clojure.core" "print-method")))
+  (let ((mf (var-cell-deref pm-cell)))
     (and (jolt-multifn? mf)
          (let ((tbl (jolt-multifn-methods mf)))
            (or (hashtable-ref tbl (jolt-type x) #f)

--- a/host/chez/printing.ss
+++ b/host/chez/printing.ss
@@ -31,6 +31,7 @@
 ;; inst, uuid, record, var, …). Disjoint types, checked before the base cases.
 (define jolt-pr-readable-arms '())
 (define (register-pr-readable-arm! pred render)
+  (pr-arm-reject-fast-type! 'register-pr-readable-arm! pred)
   (set! jolt-pr-readable-arms (cons (cons pred render) jolt-pr-readable-arms)))
 (define (register-pr-arm! pred render)
   (register-pr-str-arm! pred render)
@@ -66,9 +67,11 @@
   (cond
     ;; *print-readably* nil makes pr print a string like print does — bare, no
     ;; quotes or escapes — at every nesting level. Chars already honored it
-    ;; (jolt-char->string); strings were escaping unconditionally.
+    ;; (jolt-char->string); strings were escaping unconditionally. The print
+    ;; family's override (jolt-pr-readable?, rt.ss) is checked before the var,
+    ;; so its per-value path skips this lookup entirely.
     ((string? x)
-     (if (jolt-truthy? (jolt-var-get (jolt-var "clojure.core" "*print-readably*")))
+     (if (jolt-pr-readable?)
          (string-append "\"" (jolt-str-escape x) "\"")
          x))
     ;; pr renders the infinities / NaN in READABLE form (##Inf reads back), unlike
@@ -124,12 +127,17 @@
     ;; passing readable? so that if it reaches the #object[…] fallback the content
     ;; is QUOTED, which is the (pr x) vs (print x) difference on the JVM.
     (else (jolt-pr-str/readable x #t))))
+;; A user print-method still outranks everything, including for a fast-path type —
+;; (defmethod print-method String …) is legal on the JVM — so the fast path skips
+;; only the arm walk, never the user-method check.
 (define (jolt-pr-readable-dispatch x)
   (or (and pr-user-method-render (pr-user-method-render x))
-      (let loop ((as jolt-pr-readable-arms))
-        (cond ((null? as) (jolt-pr-readable-base x))
-              (((caar as) x) ((cdar as) x))
-              (else (loop (cdr as)))))))
+      (if (pr-fast-type? x)
+          (jolt-pr-readable-base x)
+          (let loop ((as jolt-pr-readable-arms))
+            (cond ((null? as) (jolt-pr-readable-base x))
+                  (((caar as) x) ((cdar as) x))
+                  (else (loop (cdr as))))))))
 
 ;; *print-meta* support. The var is def'd after this file loads, so capture its
 ;; cell lazily; jolt-var-get (patched by dyn-binding.ss) honors a `binding`.

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -260,7 +260,7 @@
 ;; kept tracing opt-in. Reads are ~2.4ns vs ~3.3ns, a smaller but free win.
 ;;
 ;; Virtual registers are a fixed global resource: (virtual-register-count) slots for
-;; the whole process (16 on every platform jolt targets). jolt claims four, allocated
+;; the whole process (16 on every platform jolt targets). jolt claims five, allocated
 ;; here so the assignment is in one place; nothing else in the runtime uses them.
 ;; A freshly forked thread starts every slot at fixnum 0, NOT #f — so "no ring yet"
 ;; is tested with vector?, never with a truthiness check, and line 0 means "unknown".
@@ -268,6 +268,18 @@
 (define jolt-vreg-trace-tail 1)
 (define jolt-vreg-line 2)        ; line currently executing in traced code
 (define jolt-vreg-catch-line 3)  ; line at the throw a catch clause is handling
+(define jolt-vreg-print-readably 4)  ; the print family's *print-readably* override; 0 = unset
+;; Effective *print-readably* for the readable renderer's string/char cases. The
+;; print family stashes its override in the slot above — a virtual-register write
+;; is ~1ns vs a pmap alloc + fold + two thread-parameter writes per dynamic
+;; binding — and only consults the var when the slot is unset. A fresh thread
+;; starts the slot at fixnum 0, so a stored #f (readably off) stays distinct from
+;; "unset"; jolt-var/-get resolve at call time (vars.ss / rt.ss load later).
+(define (jolt-pr-readable?)
+  (let ((o (virtual-register jolt-vreg-print-readably)))
+    (if (eq? o 0)
+        (jolt-truthy? (jolt-var-get (jolt-var "clojure.core" "*print-readably*")))
+        (jolt-truthy? o))))
 (define (jolt-trace-ring) (let ((h (virtual-register jolt-vreg-trace-ring))) (and (vector? h) h)))
 (define (jolt-trace-ring-set! h) (set-virtual-register! jolt-vreg-trace-ring h))
 (define (jolt-trace-tail?) (eq? (virtual-register jolt-vreg-trace-tail) #t))
@@ -733,7 +745,7 @@
   (cond ((null? strs) "") ((null? (cdr strs)) (car strs))
         (else (string-append (car strs) ", " (jolt-str-join-comma (cdr strs))))))
 (define (jolt-char->string c)
-  (if (jolt-truthy? (jolt-var-get (jolt-var "clojure.core" "*print-readably*")))
+  (if (jolt-pr-readable?)
       (string-append "\\" (case c ((#\newline) "newline") ((#\space) "space") ((#\tab) "tab")
                                   ((#\return) "return") ((#\backspace) "backspace") ((#\page) "formfeed")
                                   (else (string c))))
@@ -797,11 +809,53 @@
                       (parameterize ((jolt-print-depth (fx+ (jolt-print-depth) 1))) body ...)
                       (begin body ...)))))
 
+;; The value types the runtime itself owns: Chez immediates plus the two value
+;; records (keyword, symbol) no host shim can model. Every printer base case
+;; renders these directly, so walking the arm registries for one is dead work —
+;; and in print-heavy code they are nearly every value. Both printers and the str
+;; renderer skip straight to their base case for a value that answers true here.
+;;
+;; The correctness condition is that NO registered arm may match one of these, or
+;; the fast path would silently bypass it. That is enforced at registration
+;; (pr-arm-reject-fast-type!) rather than left to a comment, so a library shim
+;; registering through __register-pr! / __register-str! cannot introduce an arm
+;; the fast path would skip: it fails loudly at the point of registration instead
+;; of rendering wrongly at some later print.
+(define (pr-fast-type? x)
+  (or (number? x)
+      (string? x)
+      (jolt-nil? x)
+      (eq? x #t)
+      (eq? x #f)
+      (char? x)
+      (keyword? x)
+      (jolt-symbol? x)))
+
+;; One representative per fast-path type, covering the numeric tower (fixnum,
+;; bignum, ratio, flonum) since an arm could plausibly claim only one of those.
+(define pr-fast-probes
+  (list 0 (expt 2 70) 1/2 1.5 "s" jolt-nil #t #f #\a
+        (keyword #f "k") (jolt-symbol #f "s")))
+(define (pr-arm-reject-fast-type! who pred)
+  (for-each
+   (lambda (v)
+     ;; A predicate that throws on an unexpected type is not claiming it.
+     (when (guard (e (#t #f)) (and (pred v) #t))
+       (error who
+              (string-append
+               "arm predicate matches a runtime-owned value type, which the "
+               "printer fast path renders without consulting the arms (see "
+               "pr-fast-type? in rt.ss). Narrow the predicate to the type this "
+               "arm actually owns.")
+              v)))
+   pr-fast-probes))
+
 ;; A host shim registers a type's str-style rendering via register-pr-str-arm! (or
 ;; register-pr-arm! in printing.ss for both printers at once) instead of
 ;; set!-wrapping jolt-pr-str. Disjoint types, checked before the base cases.
 (define jolt-pr-str-arms '())
 (define (register-pr-str-arm! pred render)
+  (pr-arm-reject-fast-type! 'register-pr-str-arm! pred)
   (set! jolt-pr-str-arms (cons (cons pred render) jolt-pr-str-arms)))
 ;; Fallback rendering for a value no printer branch claims. The JVM prints an
 ;; unknown object as #object[<class> <hash> <toString>]; jolt used to hand the
@@ -869,10 +923,12 @@
     (else (jolt-object-repr x readable?))))
 (define (jolt-pr-str x) (jolt-pr-str/readable x #f))
 (define (jolt-pr-str/readable x readable?)
-  (let loop ((as jolt-pr-str-arms))
-    (cond ((null? as) (jolt-pr-str-base/readable x readable?))
-          (((caar as) x) ((cdar as) x))
-          (else (loop (cdr as))))))
+  (if (pr-fast-type? x)
+      (jolt-pr-str-base/readable x readable?)
+      (let loop ((as jolt-pr-str-arms))
+        (cond ((null? as) (jolt-pr-str-base/readable x readable?))
+              (((caar as) x) ((cdar as) x))
+              (else (loop (cdr as)))))))
 
 ;; converters + string ops: str/subs/vec/keyword/symbol/compare/int/
 ;; double/gensym — host-coupled seed natives def-var!'d into clojure.core. Loaded

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -967,6 +967,35 @@
   {:suite "io / print family (overlay)" :label "pr writes no newline" :expected "\"\\\\a\"" :actual "(with-out-str (pr \\a))" :portability :common}
   {:suite "io / print family (overlay)" :label "print nil arg" :expected "\"nil\"" :actual "(with-out-str (print nil))" :portability :common}
   {:suite "io / print family (overlay)" :label "prn keyword" :expected "\":k\\n\"" :actual "(with-out-str (prn :k))" :portability :common}
+  ;; print is pr rendering with *print-readably* nil: numbers, regexes, uuids and
+  ;; tagged literals render identically under print and pr — only strings and
+  ;; chars lose their quoting. Rows below pin the whole [print pr] matrix.
+  {:suite "io / print family (overlay)" :label "print of 2M keeps the M suffix like pr" :expected "\"2M\"" :actual "(with-out-str (print 2M))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of 2M keeps the M suffix" :expected "\"2M\"" :actual "(with-out-str (pr 2M))" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of 1.5M keeps the M suffix like pr" :expected "\"1.5M\"" :actual "(with-out-str (print 1.5M))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of 1.5M keeps the M suffix" :expected "\"1.5M\"" :actual "(with-out-str (pr 1.5M))" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of a regex is readable like pr" :expected "\"#\\\"re\\\"\"" :actual "(with-out-str (print #\"re\"))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of a regex is readable" :expected "\"#\\\"re\\\"\"" :actual "(with-out-str (pr #\"re\"))" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of ##Inf is readable like pr" :expected "\"##Inf\"" :actual "(with-out-str (print ##Inf))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of ##Inf is readable" :expected "\"##Inf\"" :actual "(with-out-str (pr ##Inf))" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of ##NaN is readable like pr" :expected "\"##NaN\"" :actual "(with-out-str (print ##NaN))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of ##NaN is readable" :expected "\"##NaN\"" :actual "(with-out-str (pr ##NaN))" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of a UUID has the #uuid prefix like pr" :expected "\"#uuid \\\"0d1e9c62-9e35-4dd9-9cef-7db2e5c5e7a1\\\"\"" :actual "(with-out-str (print (parse-uuid \"0d1e9c62-9e35-4dd9-9cef-7db2e5c5e7a1\")))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of a UUID has the #uuid prefix" :expected "\"#uuid \\\"0d1e9c62-9e35-4dd9-9cef-7db2e5c5e7a1\\\"\"" :actual "(with-out-str (pr (parse-uuid \"0d1e9c62-9e35-4dd9-9cef-7db2e5c5e7a1\")))" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of a mixed coll renders strings and chars bare, numbers readable" :expected "\"[s a 2M]\"" :actual "(with-out-str (print [\"s\" \\a 2M]))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of a mixed coll quotes strings and chars" :expected "\"[\\\"s\\\" \\\\a 2M]\"" :actual "(with-out-str (pr [\"s\" \\a 2M]))" :portability :common}
+  ;; str is a different contract from print (.toString, not a printer) — pins.
+  {:suite "io / print family (overlay)" :label "str of 2M drops the M suffix" :expected "\"2\"" :actual "(str 2M)" :portability :common}
+  {:suite "io / print family (overlay)" :label "str of a regex is the bare source" :expected "\"re\"" :actual "(str #\"re\")" :portability :common}
+  {:suite "io / print family (overlay)" :label "str of a char is bare" :expected "\"a\"" :actual "(str \\a)" :portability :common}
+  {:suite "io / print family (overlay)" :label "str of a string is bare" :expected "\"s\"" :actual "(str \"s\")" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of a string is quoted" :expected "\"\\\"s\\\"\"" :actual "(with-out-str (pr \"s\"))" :portability :common}
+  ;; a bigint beyond long range prints with the N suffix under BOTH print and pr
+  ;; (the JVM's BigInt print-method ignores *print-readably*); str of one drops it.
+  {:suite "io / print family (overlay)" :label "print of a bigint keeps the N suffix like pr" :expected "\"9223372036854775808N\"" :actual "(with-out-str (print 9223372036854775808))" :portability :common}
+  {:suite "io / print family (overlay)" :label "pr of a bigint keeps the N suffix" :expected "\"9223372036854775808N\"" :actual "(with-out-str (pr 9223372036854775808))" :portability :common}
+  {:suite "io / print family (overlay)" :label "str of a bigint drops the N suffix" :expected "\"9223372036854775808\"" :actual "(str 9223372036854775808)" :portability :common}
+  {:suite "io / print family (overlay)" :label "print of a bigint nested in a coll keeps the N" :expected "\"[9223372036854775808N]\"" :actual "(with-out-str (print [9223372036854775808]))" :portability :common}
   {:suite "io / print-method multimethod" :label "records print canonically" :expected "\"#user.Pt{:x 1, :y 2}\"" :actual "(do (defrecord Pt [x y]) (pr-str (->Pt 1 2)))" :portability :common}
   {:suite "io / print-method multimethod" :label "records nested in colls" :expected "\"[#user.Pt{:x 1, :y 2}]\"" :actual "(do (defrecord Pt [x y]) (pr-str [(->Pt 1 2)]))" :portability :common}
   {:suite "io / print-method multimethod" :label "defmethod overrides a record, top level" :expected "\"#user.Pt{:x 3, :y 4}\"" :actual "(do (defrecord Pt [x y]) (defmethod print-method (quote user.Pt) [r w] (.write w (str \"<\" (:x r) \",\" (:y r) \">\"))) (pr-str (->Pt 3 4)))" :portability :jvm}
@@ -1611,6 +1640,16 @@
   {:suite "numbers / n-ary primitive arithmetic" :label "1 operand: +/*/min/max are the operand, - negates (^long)" :expected "[5 5 5 5 -5]" :actual "(do (defn nary1 [^long a] [(+ a) (* a) (min a) (max a) (- a)]) (nary1 5))" :portability :common}
   {:suite "numbers / n-ary primitive arithmetic" :label "1 operand over ^double, and / reciprocates" :expected "[4.0 4.0 4.0 4.0 -4.0 0.25]" :actual "(do (defn dnary1 [^double a] [(+ a) (* a) (min a) (max a) (- a) (/ a)]) (dnary1 4.0))" :portability :common}
   {:suite "numbers / arithmetic" :label "mod/rem/quot over BigDecimal operands" :expected "[2M 2M 2M 2M]" :actual "[(mod 8M 3M) (rem 8M 3M) (quot 8M 3M) (mod -1M 3M)]" :portability :common}
+  ;; BigDecimal x Double contagion: a double operand makes the result a Double
+  ;; (3.0, not 3.0M). An audit once called these divergences; they are JVM-correct
+  ;; and pinned here so the claim cannot resurface. (byte 300) throwing and the
+  ;; 61-bit fixnum behavior are the other verified-correct "divergences" — not
+  ;; pinned here because their jolt model differs in shape, not value.
+  {:suite "numbers / BigDecimal x Double contagion" :label "quot of double and BigDecimal is a Double" :expected "3.0" :actual "(quot 10.0 3M)" :portability :common}
+  {:suite "numbers / BigDecimal x Double contagion" :label "rem of double and BigDecimal is a Double" :expected "1.0" :actual "(rem 10.0 3M)" :portability :common}
+  {:suite "numbers / BigDecimal x Double contagion" :label "+ of BigDecimal and double is a Double" :expected "3.0" :actual "(+ 1.0M 2.0)" :portability :common}
+  {:suite "numbers / BigDecimal x Double contagion" :label "its class is java.lang.Double" :expected "\"java.lang.Double\"" :actual "(.getName (class (+ 1.0M 2.0)))" :portability :jvm}
+  {:suite "numbers / BigDecimal x Double contagion" :label "the Double result is not = to the BigDecimal" :expected "false" :actual "(= (quot 10.0 3M) 3.0M)" :portability :common}
   {:suite "numbers / comparison" :label "less than" :expected "true" :actual "(< 1 2 3)" :portability :common}
   {:suite "numbers / comparison" :label "less than false" :expected "false" :actual "(< 1 3 2)" :portability :common}
   {:suite "numbers / comparison" :label "greater than" :expected "true" :actual "(> 3 2 1)" :portability :common}

--- a/test/chez/print-throughput.ss
+++ b/test/chez/print-throughput.ss
@@ -1,0 +1,56 @@
+;; print-throughput.ss — perf probe for the print/pr value seams, 200000 values
+;; each. Run: chez --script test/chez/print-throughput.ss (or `make printperf`).
+;;
+;; Values are INTEGERS, deliberately. A string short-circuits in the first cond
+;; arm of the readable renderer, so a string loop measures almost none of the
+;; dispatch this guards and reads well under a real print-heavy program; an
+;; integer walks the base cases and, before the fast path, both arm registries.
+;; An earlier version of this probe printed strings and reported a number a real
+;; `jolt run` did not reproduce.
+;;
+;; Two regressions this stands guard over, both over 200k values:
+;;   - binding *print-readably* per value through the dynamic-var machinery
+;;     (~770ns/value): print 235ms -> 404ms.
+;;   - routing print through the readable renderer without the fast path, so
+;;     every value tests ~40 host-type arm predicates that cannot match it:
+;;     print 235ms -> 272ms.
+;; Current shape: print ~224ms, pr-str ~162ms. The bounds are generous because
+;; absolute numbers drift ~7% between sessions and more on loaded CI — they catch
+;; an order-of-magnitude regression, not a few percent. To judge a change, A/B/A
+;; it in ONE session against a real `jolt run` program rather than trusting the
+;; absolute number here.
+(import (chezscheme))
+(load "host/chez/rt.ss")
+(set-chez-ns! "clojure.core")
+(load "host/chez/seed/prelude.ss")
+(load "host/chez/post-prelude.ss")
+(set-chez-ns! "user")
+(load "host/chez/host-contract.ss")
+(load "host/chez/seed/image.ss")
+(load "host/chez/compile-eval.ss")
+
+(define (now-ms)
+  (let ((t (current-time 'time-monotonic)))
+    (+ (* 1000.0 (time-second t)) (/ (time-nanosecond t) 1000000.0))))
+
+(define runs 3)
+(define (best-ms expr)
+  (let loop ((i 0) (best +inf.0))
+    (if (fx>= i runs)
+        best
+        (let ((t0 (now-ms)))
+          (jolt-compile-eval expr "user")
+          (loop (fx+ i 1) (min best (- (now-ms) t0)))))))
+
+(define failed? #f)
+(define (report! label expr bound)
+  (let ((ms (best-ms expr)))
+    (printf "~a 200000 values: ~a ms (best of ~a)\n"
+            label (/ (round (* 100 ms)) 100.0) runs)
+    (when (> ms bound)
+      (set! failed? #t)
+      (printf "  FAIL: over the ~a ms guard\n" bound))))
+
+(report! "print " "(with-out-str (dotimes [i 200000] (print i)))" 700)
+(report! "pr-str" "(with-out-str (dotimes [i 200000] (pr-str i)))" 600)
+(when failed? (exit 1))


### PR DESCRIPTION
`print`/`println`/`print-str` were implemented as `str` rendering, so `2M` printed
as `2`, a regex as `re`, a UUID as bare hex, `##Inf` as `Infinity`, and a char
nested in a collection kept its backslash. The JVM's `print` is `pr` with
`*print-readably*` nil, and readably affects only strings and chars — at every
nesting depth.

They now share the one readable renderer rather than a second per-type table,
which is how the two drifted apart to begin with. The quoting-off flag rides a
virtual register; carrying it through the dynamic-var machinery cost ~770ns a
value and made print-heavy code 1.6x slower.

While in there, both printers and the `str` renderer skip their arm registries
for the types the runtime owns — numbers, strings, chars, keywords, symbols,
booleans, nil — which no host shim can claim, and `print-method` resolves through
a cached var cell instead of a lookup by name per value. `values.ss` already does
this for `jolt=2`/`jolt-hash`; the printer was the one that had been missed.

Registering an arm whose predicate matches one of those types is rejected at
registration, so the fast path cannot silently bypass a shim's rendering. Booting
jolt is what proves no existing arm claims one.

## Measured

A/B/A in one session, 200k values through a real `jolt run`:

| | print | pr-str |
| --- | --- | --- |
| fast path | 224 ms | **162 ms** |
| baseline | 235 ms | 220 ms |
| fast path again | 224 ms | **162 ms** |

`pr-str` 1.36x faster. `print` is parity — the delta is inside run-to-run drift
(±7%), not a win.

## Verification

- Differentials against reference Clojure 1.12: print-vs-pr 17/17, BigDecimal
  contagion 29/29.
- `make test` green, `make certify` 0 new / 0 stale, `cts` matches baseline.
- 39 corpus rows pin the print/pr/str matrix, the bigint `N` suffix, and the
  BigDecimal × Double contagion results — an audit called those divergences, but
  the differential says they already match the JVM.
- `make printperf` probe rewritten to print integers; the old one printed
  strings, which short-circuit in the renderer's first cond arm and reported a
  number a real `jolt run` did not reproduce.

One behaviour change beyond `print` itself: `build-smoke.sh` expects
`9223372036854775808N`, since a bigint now carries its `N` under `print` as it
does on the JVM.