### PR TITLE
Drop the unused root deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,0 @@
-{:mvn/local-repo ".cache/m2"
- :deps
- {cc.clojure/grenadine {:mvn/version "0.1.2"}}}


### PR DESCRIPTION
#522 added a root `deps.edn` declaring `cc.clojure/grenadine {:mvn/version "0.1.2"}` with `:mvn/local-repo ".cache/m2"`. Nothing loads it.

`host/chez/loader.ss` lists `vendor/grenadine/src` as a built-in source root and the binary embeds it, so the vendored copy always wins over the Maven jar. Checked by injecting a marker def into the extracted jar copy under `.cache/m2/.../grenadine-0.1.2.jar.jolt/grenadine/expander.cljc` — `(resolve 'grenadine.expander/JAR-MARKER)` returns nil.

What it cost:

- a network fetch plus jar extract on every in-repo jolt invocation with a cold `.cache/m2`. `/.cache/` is gitignored, so CI is always cold. A trivial probe script went 0.127s to 0.898s.
- relocated the local repo to `.cache/m2` for in-repo runs, so `mvnhttp` and `depssmoke` no longer share `~/.m2`.
- put a nonexistent `./src` on the classpath, since jolt defaults `:paths` to `["src"]` when deps.edn omits it.
- left the submodule pin and the declared Maven version free to diverge silently — the gates would keep testing the submodule while the file claimed 0.1.2.

`depsunit` (32/32), `grenadine`, `mvnhttp`, and `depssmoke` (88/0) all pass with the file gone.

If the intent was to move jolt off the submodule and onto the released artifact, that is a separate change — it needs the loader source root dropped too, or the Maven copy stays dead.

Closes jolt-e5ec.