### PR TITLE
Follow-ups from the jolt-gmvj round

### DIFF
--- a/bench/printing.clj
+++ b/bench/printing.clj
@@ -1,0 +1,78 @@
+;; printing — a PRINT-PATH stress test. The suite otherwise has no print axis,
+;; so the per-item work the printers do between values (resolving the dynamic
+;; vars that steer them) never showed up in a measurement.
+;;
+;; Three regimes, all of which reach the printer once per VALUE rather than once
+;; per call, so per-item overhead dominates:
+;;   - pr-str over scalars: hits *print-readably* per string/char
+;;   - print-str into a rebound *out*: hits the *out* lookup per write
+;;   - pr-str over namespaced maps: hits *print-namespace-maps* per map
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh printing 300
+(ns printing)
+
+(defn build-scalars [n]
+  (mapv (fn [i]
+          (case (mod i 5)
+            0 (str "s" i)
+            1 (keyword (str "k" i))
+            2 (char (+ 97 (mod i 26)))
+            3 (symbol (str "sym" i))
+            (long i)))
+        (range n)))
+
+(defn build-ns-maps [n]
+  (mapv (fn [i]
+          {:app/id i :app/name (str "n" i) :app/tag (keyword (str "t" (mod i 7)))})
+        (range n)))
+
+;; one printer entry per element, not one per collection
+(defn pr-scalars [xs]
+  (loop [s (seq xs) n 0]
+    (if s
+      (recur (next s) (+ n (count (pr-str (first s)))))
+      n)))
+
+(defn print-into-writer [xs]
+  (let [w (java.io.StringWriter.)]
+    (binding [*out* w]
+      (loop [s (seq xs)]
+        (when s
+          (print (first s))
+          (recur (next s)))))
+    (count (str w))))
+
+(defn pr-ns-maps [ms]
+  (loop [s (seq ms) n 0]
+    (if s
+      (recur (next s) (+ n (count (pr-str (first s)))))
+      n)))
+
+(defn run [iters scalars ns-maps]
+  (loop [i 0 acc 0]
+    (if (< i iters)
+      (recur (inc i)
+             (+ acc
+                (pr-scalars scalars)
+                (print-into-writer scalars)
+                (pr-ns-maps ns-maps)))
+      acc)))
+
+(defn -main [& args]
+  (let [iters (if (seq args) (Integer/parseInt (first args)) 300)
+        scalars (build-scalars 500)
+        ns-maps (build-ns-maps 200)]
+    (dotimes [_ 2] (run (max 1 (quot iters 4)) scalars ns-maps))   ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run iters scalars ns-maps)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "printing iters" iters "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/host/chez/printing.ss
+++ b/host/chez/printing.ss
@@ -49,9 +49,14 @@
 ;; *print-namespace-maps* shared-ns detector: returns the namespace string when
 ;; the map is non-empty, the var is true, every key is a namespace-qualified
 ;; keyword, and they all share the same (non-nil) namespace. Otherwise #f.
+;; resolved once — see pr-readably-cell (rt.ss) for why the cached cell is safe
+(define ns-maps-cell #f)
 (define (pr-ns-maps-shared-ns pairs)
   (and (pair? pairs)
-       (jolt-truthy? (jolt-var-get (jolt-var "clojure.core" "*print-namespace-maps*")))
+       (begin
+         (unless ns-maps-cell
+           (set! ns-maps-cell (jolt-var "clojure.core" "*print-namespace-maps*")))
+         (jolt-truthy? (jolt-var-get ns-maps-cell)))
        (keyword? (caar pairs))
        (let ((ns (keyword-t-ns (caar pairs))))
          (and ns (not (string=? ns ""))
@@ -181,6 +186,7 @@
 ;; suppressed while __with-out-str captures output to a string port: there the
 ;; redirect, not *out*, defines where text goes (pr-str / print-str rely on it).
 (define jolt-pprint-hook-suppressed (make-thread-parameter #f))
+(define out-cell #f)
 (define (jolt-write s)
   (cond ((and (not (jolt-nil? jolt-pprint-write-hook))
               (not (jolt-pprint-hook-suppressed))
@@ -192,7 +198,13 @@
         ;; which is why this tests for a write METHOD rather than for jhost:
         ;; keying on the representation silently skipped every reify Writer.
         ;; The default port-writer over stdout keeps the fast port path below.
-        ((let ((w (var-deref "clojure.core" "*out*")))
+        ;; resolved once — see pr-readably-cell (rt.ss). var-cell-deref, NOT
+        ;; var-cell-root: *out* is what with-out-str rebinds, so the read has to
+        ;; stay on the binding stack.
+        ((let ((w (begin
+                    (unless out-cell
+                      (set! out-cell (jolt-var "clojure.core" "*out*")))
+                    (var-cell-deref out-cell))))
            (and (or (iface-method w "write" #f)
                     (and (jhost? w)
                          (not (and (string=? (jhost-tag w) "port-writer")

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -836,19 +836,11 @@
 (define pr-fast-probes
   (list 0 (expt 2 70) 1/2 1.5 "s" jolt-nil #t #f #\a
         (keyword #f "k") (jolt-symbol #f "s")))
+;; Shares reject-fast-type-claim! (values.ss) with the eq and hash registries,
+;; which enforce the same invariant over their own — narrower — fast paths.
 (define (pr-arm-reject-fast-type! who pred)
-  (for-each
-   (lambda (v)
-     ;; A predicate that throws on an unexpected type is not claiming it.
-     (when (guard (e (#t #f)) (and (pred v) #t))
-       (error who
-              (string-append
-               "arm predicate matches a runtime-owned value type, which the "
-               "printer fast path renders without consulting the arms (see "
-               "pr-fast-type? in rt.ss). Narrow the predicate to the type this "
-               "arm actually owns.")
-              v)))
-   pr-fast-probes))
+  (reject-fast-type-claim! who pred pr-fast-probes
+                           "the printer fast path (see pr-fast-type? in rt.ss)"))
 
 ;; A host shim registers a type's str-style rendering via register-pr-str-arm! (or
 ;; register-pr-arm! in printing.ss for both printers at once) instead of

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -275,10 +275,21 @@
 ;; binding — and only consults the var when the slot is unset. A fresh thread
 ;; starts the slot at fixnum 0, so a stored #f (readably off) stays distinct from
 ;; "unset"; jolt-var/-get resolve at call time (vars.ss / rt.ss load later).
+;; Resolved once and reused: jolt-var rebuilds "clojure.core/*print-readably*"
+;; with string-append and hashes it on every call, which on a per-item path is
+;; the whole cost of the lookup. The cell is stable under redefinition —
+;; def-var! mutates the root in place — and jolt-var-get still consults the
+;; binding stack, so a (binding [*print-readably* …]) is honoured. Lazily, since
+;; vars.ss/rt.ss finish loading after this point. Same shape as pm-cell
+;; (io-streams.ss) and the cells the backend emits for compiled code.
+(define pr-readably-cell #f)
 (define (jolt-pr-readable?)
   (let ((o (virtual-register jolt-vreg-print-readably)))
     (if (eq? o 0)
-        (jolt-truthy? (jolt-var-get (jolt-var "clojure.core" "*print-readably*")))
+        (begin
+          (unless pr-readably-cell
+            (set! pr-readably-cell (jolt-var "clojure.core" "*print-readably*")))
+          (jolt-truthy? (jolt-var-get pr-readably-cell)))
         (jolt-truthy? o))))
 (define (jolt-trace-ring) (let ((h (virtual-register jolt-vreg-trace-ring))) (and (vector? h) h)))
 (define (jolt-trace-ring-set! h) (set-virtual-register! jolt-vreg-trace-ring h))

--- a/host/chez/values.ss
+++ b/host/chez/values.ss
@@ -66,14 +66,52 @@
 
 ;; chars/strings: Chez natives (strings treated immutable).
 
+;; --- fast-path invariant for the arm registries ------------------------------
+;; jolt=2, jolt-hash and the printers all answer their commonest types before
+;; walking their arms. The correctness condition is that NO registered arm may
+;; claim one of those, or the fast path would silently skip it. That is enforced
+;; here at registration rather than left to a comment, so a shim registering a
+;; too-broad predicate fails loudly at the point of registration instead of
+;; being quietly ignored at some later call.
+;;
+;; Each registry passes its OWN probes: the fast paths are not the same set, and
+;; a guard wider than the fast path it protects would reject arms that are
+;; perfectly legal. jolt-hash, for one, walks the arms for chars, symbols,
+;; flonums and bignums, all of which the printer answers directly.
+(define (reject-fast-type-claim! who claims? probes what)
+  (for-each
+   (lambda (probe)
+     ;; A predicate that throws on an unexpected type is not claiming it.
+     (when (guard (e (#t #f)) (and (claims? probe) #t))
+       (error who
+              (string-append
+               "arm predicate matches a runtime-owned value type, which " what
+               " answers without consulting the arms. Narrow the predicate to "
+               "the type this arm actually owns.")
+              probe)))
+   probes))
+
 ;; --- jolt equality (Clojure =) — scalars + collections ----------------------
 ;; A host shim registers a type's equality via register-eq-arm! instead of
 ;; set!-wrapping jolt=2 (cf. register-hash-arm!). An arm is (pred . handler), both
 ;; (a b): the arm applies when pred holds (typically either arg is the type), and
 ;; handler returns the #t/#f result. Arms are checked before the base scalar/coll
 ;; cases; the entry is stable.
+;;
+;; Only the fixnum and flonum pairs are subject to the invariant. jolt=2's third
+;; fast clause — (eq? a b) on a non-number — legitimately short-circuits every
+;; type including records, so the usual either-arg-is-my-type predicate stays
+;; legal even though it matches those. Probes pair DISTINCT values so they land
+;; on the numeric clauses rather than that identity one.
+(define eq-fast-probes (list (cons 0 1) (cons 1.5 2.5)))
+(define (eq-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who
+                           (lambda (probe) (pred (car probe) (cdr probe)))
+                           eq-fast-probes
+                           "the jolt=2 fixnum/flonum fast path"))
 (define jolt-eq-arms '())
 (define (register-eq-arm! pred handler)
+  (eq-arm-reject-fast-type! 'register-eq-arm! pred)
   (set! jolt-eq-arms (cons (cons pred handler) jolt-eq-arms)))
 (define (jolt=2-base a b)
   (cond
@@ -114,8 +152,17 @@
 ;; register-hash-arm! instead of set!-wrapping jolt-hash — the arms are disjoint
 ;; types, checked before the base cases, so the full behavior is gathered here plus
 ;; the registry rather than scattered across a set! chain (cf. register-str-render!).
+;; Narrower than the printer's set: only nil, keywords, fixnums and strings are
+;; answered before the arm walk, so chars, symbols, flonums, bignums and ratios
+;; all still reach the arms and an arm claiming one of those is legal.
+;; Built on demand, not at load: interning a keyword needs hasheq.ss, which
+;; rt.ss loads after this file. Every arm registers later still.
+(define (hash-fast-probes) (list jolt-nil (keyword #f "k") 0 "s"))
+(define (hash-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred (hash-fast-probes) "the jolt-hash fast path"))
 (define jolt-hash-arms '())
 (define (register-hash-arm! pred handler)
+  (hash-arm-reject-fast-type! 'register-hash-arm! pred)
   (set! jolt-hash-arms (cons (cons pred handler) jolt-hash-arms)))
 (define (jolt-hash-base x)
   ;; Delegate to jolt-hasheq for all scalars; sequential/coll handled by

--- a/test/chez/values-test.ss
+++ b/test/chez/values-test.ss
@@ -64,5 +64,50 @@
 (ok "hash +nan ok"  (number? (jolt-hash +nan.0)))
 (ok "hash inf != exact" (not (= (jolt-hash +inf.0) (jolt-hash 0))))
 
+;; --- arm registries reject arms their fast path would skip ------------------
+;; jolt-hash answers nil/keyword/fixnum/string, and jolt=2 answers fixnum and
+;; flonum pairs, before consulting the arms. An arm claiming one of those would
+;; be silently skipped, so registration rejects it rather than leaving the
+;; invariant to a comment. Each registry guards its OWN fast path — the
+;; printer's is wider, and reusing it here would reject legitimate arms.
+(define (raises? thunk) (guard (e (#t #t)) (thunk) #f))
+
+(define-record-type armtest-t (fields v) (nongenerative armtest-v1))
+
+(ok "hash arm rejects fixnum"  (raises? (lambda () (register-hash-arm! fixnum? (lambda (x) 0)))))
+(ok "hash arm rejects string"  (raises? (lambda () (register-hash-arm! string? (lambda (x) 0)))))
+(ok "hash arm rejects keyword" (raises? (lambda () (register-hash-arm! keyword-t? (lambda (x) 0)))))
+(ok "hash arm rejects nil"     (raises? (lambda () (register-hash-arm! jolt-nil? (lambda (x) 0)))))
+
+;; an arm claiming BOTH sides of a fast pair is what jolt=2 would skip
+(ok "eq arm rejects fixnum pair"
+    (raises? (lambda () (register-eq-arm! (lambda (a b) (and (fixnum? a) (fixnum? b)))
+                                          (lambda (a b) #t)))))
+(ok "eq arm rejects flonum pair"
+    (raises? (lambda () (register-eq-arm! (lambda (a b) (and (flonum? a) (flonum? b)))
+                                          (lambda (a b) #t)))))
+
+;; hash's fast path is NARROWER than the printer's: chars, symbols, flonums and
+;; bignums all reach the arms, so the hash guard must let them through
+(ok "hash guard allows char"   (not (raises? (lambda () (hash-arm-reject-fast-type! 'test char?)))))
+(ok "hash guard allows flonum" (not (raises? (lambda () (hash-arm-reject-fast-type! 'test flonum?)))))
+(ok "hash guard allows symbol" (not (raises? (lambda () (hash-arm-reject-fast-type! 'test symbol-t?)))))
+(ok "pr guard still rejects char" (raises? (lambda () (pr-arm-reject-fast-type! 'test char?))))
+
+;; eq's identity clause legitimately short-circuits every non-number type, so a
+;; single-sided claim on one is not subject to the invariant
+(ok "eq guard allows either-arg shape"
+    (not (raises? (lambda () (eq-arm-reject-fast-type!
+                              'test (lambda (a b) (or (string? a) (string? b))))))))
+
+;; and a real arm on a type off the fast path still registers and is consulted
+(ok "hash arm on a plain type registers"
+    (not (raises? (lambda () (register-hash-arm! armtest-t? (lambda (x) 4242))))))
+(ok "registered hash arm is consulted" (= 4242 (jolt-hash (make-armtest-t 1))))
+(ok "eq arm on a plain type registers"
+    (not (raises? (lambda () (register-eq-arm! (lambda (a b) (or (armtest-t? a) (armtest-t? b)))
+                                               (lambda (a b) #t))))))
+(ok "registered eq arm is consulted" (jolt=2 (make-armtest-t 1) (make-armtest-t 2)))
+
 (printf "values-test: ~a/~a passed\n" (- total fails) total)
 (exit (if (> fails 0) 1 0))


### PR DESCRIPTION
Three beads from the survey round, plus the grenadine bump now that upstream merged.

### jolt-i0qr — enforce the fast-path invariant on the eq and hash arm registries

`jolt=2` and `jolt-hash` both answer their commonest types before walking their arms, so an arm claiming one of those is silently skipped. Only the printer registries enforced that; here it was a comment.

Each registry guards its **own** fast path rather than sharing the printer's probe set — the sets genuinely differ. `jolt-hash` walks the arms for chars, symbols, flonums and bignums, all of which the printer answers directly, so reusing the printer's probes would reject arms that are perfectly legal. For eq only the fixnum and flonum pairs are subject to it: the `(eq? a b)` on a non-number clause legitimately short-circuits every type including records, so the usual either-arg-is-my-type predicate stays legal.

Every existing arm in the runtime passes the new guards. Test registers a bad arm and asserts the rejection, and asserts the hash guard lets char/symbol/flonum through.

The bead's "assess the rest" half is done and filed as jolt-18ps with the survey: six registries have the same latent gap (get, count, contains, empty, seq, compare) and four don't apply (invoke and class check arms first; instance-check and num have a different arm shape).

### jolt-71m2 — cache resolved var cells on the printer's per-item paths

`var-deref`/`jolt-var` rebuild `"clojure.core/<name>"` with `string-append` and hash it on every call. Three per-item sites converted: `*out*` in `jolt-write`, `*print-readably*`, `*print-namespace-maps*`.

Reads stay on the binding stack (`var-cell-deref`/`jolt-var-get`, never `var-cell-root`), so `with-out-str` and `(binding [*print-readably* …])` still take effect — verified explicitly, since that is the trap #266 hit.

`bench/printing.clj` is new: the suite had no print axis, so this cost could not be seen. Two A/B/A sessions at `printing:1000`, 7 runs each:

```
A1 2928.9  B 2827.3  A2 2933.4   -> 3.5%, A drift 0.15%
A1 2946.4  B 2789.9  A2 2956.1   -> 5.5%, A drift 0.33%
```

3.5–5.5%: consistent in direction and well above drift, but the spread between sessions is wider than the drift within either, and the benchmark is print-saturated by design — a real program prints far less, so expect less than that.

**The two multimethod sites are not converted.** `isa?`/`parents` resolve once per dispatch cache *miss*, and the cache memoizes per distinct dispatch value: 400k dispatches over 4 values take 4 misses, so the whole saving is ~336ns against 173ms. The bead's premise ("per dispatch on a cache miss") is where it breaks — a miss happens once per value, not per dispatch. No measurable win, so no change.

### jolt-p93a — not shipped

I implemented two candidate fixes and both failed, which is worth more than a rushed third. Recorded on the bead:

1. **Intersect the history with the live continuation.** Does not work — in this very repro the continuation yields *no* jolt frames at all (`JOLT_TRACE=0` prints no trace whatsoever, TCO erased the spine). It cannot bound what it does not contain.
2. **Give each rib a parent link and walk that instead of ring order.** Implemented; output byte-identical. The parent can only be recorded as "the rib current when this one was pushed", and since the head never rewinds on return, after `(println …)` completes that is println's *last* rib, not `-main`'s. The link inherits exactly the defect it was meant to fix.

So the live spine is not derivable from entry-only records. A correct fix needs a rewind on non-tail return — a second write per call, which the virtual-register design explicitly avoided (those writes were ~70% of tracing overhead) — or emitter support, or dropping precision to just mark the boundary. None is small, and it is P4, so it stays open with the analysis attached rather than being guessed at here.

### Bump grenadine to fd5b47f

Restores the version-conflict warning jolt printed before #522 moved the expander out. Verified byte-identical to pre-#522:

```
[jolt.deps] version conflict for demo/libc: keeping #:local{:root "…"} over #:mvn{:version "1.0.0"} (Unable to compare versions for demo/libc: …)
```

Also picks up the portable catch in the expander (Glojure resolves neither `Exception` nor `Throwable`; doesn't affect jolt, same commit).

---

Local: `make ci` green, plus `values` 52/52, `unit`, `corpus`, `depsunit` 32/32, `grenadine`, `mvnhttp`.