### PR TITLE
Enforce the fast-path invariant on the remaining arm registries

### DIFF
--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -480,8 +480,29 @@
 ;; A host shim registers a type's get via register-get-arm! (handler: (coll k d) ->
 ;; value) instead of set!-wrapping jolt-get — disjoint coll types, checked before the
 ;; base map/set/vec/string cases (cf. register-hash-arm!).
+;; Shared probe values for the collection fast paths. Built on demand, not at
+;; load: jolt-empty-list and list->cseq come from seq.ss and make-jrec from
+;; records.ss, both of which rt.ss loads after this file. Every arm registers
+;; later still. See reject-fast-type-claim! (values.ss) for why each registry
+;; passes its own subset rather than sharing one list — jolt-get answers records
+;; but not strings, count/empty/seq answer strings but not records.
+(define (probe-pvec) (jolt-vector))
+(define (probe-pmap) (jolt-hash-map))
+(define (probe-pset) empty-pset)
+(define (probe-cseq) (list->cseq (list 1)))
+;; Spliced, not listed: records.ss builds jrec-fast-type-probe well after
+;; transients.ss has already registered a get arm, so before that point there is
+;; simply no record to probe against.
+(define (probe-jrecs)
+  (probe-if-available (lambda () jrec-fast-type-probe)))
+
+(define (get-fast-probes)
+  (append (list (probe-pmap) (probe-pvec) (probe-pset)) (probe-jrecs)))
+(define (get-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred (get-fast-probes) "the jolt-get fast path"))
 (define jolt-get-arms '())
 (define (register-get-arm! pred handler)
+  (get-arm-reject-fast-type! 'register-get-arm! pred)
   (set! jolt-get-arms (cons (cons pred handler) jolt-get-arms)))
 (define (jolt-get-base coll k d)
   (cond ((pmap? coll) (pmap-get coll k d))
@@ -552,8 +573,13 @@
 ;; extension types. jolt-seq / jolt-empty? / jolt-conj1 / jolt-nth /
 ;; jolt-contains? still use set! chains — migrate them to this registry the
 ;; same way when touched (each needs its own bench guard; seq is the hottest).
+(define (count-fast-probes)
+  (list (probe-pvec) (probe-pmap) (probe-pset) "s" jolt-nil jolt-empty-list (probe-cseq)))
+(define (count-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred (count-fast-probes) "the jolt-count fast path"))
 (define jolt-count-arms '())
 (define (register-count-arm! pred handler)
+  (count-arm-reject-fast-type! 'register-count-arm! pred)
   (set! jolt-count-arms (cons (cons pred handler) jolt-count-arms)))
 (define (jolt-count-base coll)
   ;; arms exhausted: a deftype/record counts through its declared method.
@@ -633,15 +659,32 @@
                       (else (loop (cdr as))))))))
 
 ;; ---- contains? arms: host types register here instead of set!-wrapping jolt-contains? ---
+;; Widest of the four: contains? not only answers the collection types, it THROWS
+;; for the scalars (a number, boolean, keyword, symbol or char is not
+;; associative) before any arm is consulted. An arm claiming one of those would
+;; never run.
+(define (contains-fast-probes)
+  (append (list (probe-pmap) (probe-pset) (probe-pvec) jolt-nil "s"
+                (probe-cseq) jolt-empty-list 0 #t #f
+                (keyword #f "k") (jolt-symbol #f "s") #\a)
+          (probe-jrecs)))
+(define (contains-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred (contains-fast-probes) "the jolt-contains? fast path"))
 (define jolt-contains-arms '())
 (define (register-contains-arm! pred handler)
+  (contains-arm-reject-fast-type! 'register-contains-arm! pred)
   (set! jolt-contains-arms (cons (cons pred handler) jolt-contains-arms)))
 
 ;; ---- empty? arms: host types register here instead of set!-wrapping jolt-empty? ---
 ;; Arms dispatch newest-registration-first, matching the set!-chain precedence.
 ;; The built-in types stay inline; arms checked before the seq-based fallback.
+(define (empty-fast-probes)
+  (list jolt-nil (probe-pvec) (probe-pmap) (probe-pset) "s" jolt-empty-list (probe-cseq)))
+(define (empty-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred (empty-fast-probes) "the jolt-empty? fast path"))
 (define jolt-empty-arms '())
 (define (register-empty-arm! pred handler)
+  (empty-arm-reject-fast-type! 'register-empty-arm! pred)
   (set! jolt-empty-arms (cons (cons pred handler) jolt-empty-arms)))
 
 (define (jolt-empty? coll)

--- a/host/chez/converters.ss
+++ b/host/chez/converters.ss
@@ -205,8 +205,23 @@
 ;; pred holds (typically either arg is the type) and handler returns -1/0/1.
 ;; Arms are the last resort before the "cannot compare" error, so a library can
 ;; make its own values Comparable without editing this file.
+;; Only the SAME-TYPE pairs are subject to the invariant. jolt-compare's nil
+;; clauses are single-sided — (compare nil x) is -1 for every x — so the fast
+;; path answering them is correct for any type, and the usual
+;; either-arg-is-my-type predicate stays legal even though it matches them. Same
+;; distinction register-eq-arm! makes for its identity clause.
+(define (compare-fast-probes)
+  (list (cons 0 1) (cons "a" "b") (cons (keyword #f "a") (keyword #f "b"))
+        (cons (jolt-symbol #f "a") (jolt-symbol #f "b")) (cons #t #f)
+        (cons #\a #\b) (cons (probe-pvec) (probe-pvec))))
+(define (compare-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who
+                           (lambda (probe) (pred (car probe) (cdr probe)))
+                           (compare-fast-probes)
+                           "the jolt-compare same-type fast path"))
 (define jolt-compare-arms '())
 (define (register-compare-arm! pred handler)
+  (compare-arm-reject-fast-type! 'register-compare-arm! pred)
   (set! jolt-compare-arms (cons (cons pred handler) jolt-compare-arms)))
 (define (jolt-compare a b)
   (cond

--- a/host/chez/records.ss
+++ b/host/chez/records.ss
@@ -152,6 +152,14 @@
     (if (fx<= n 8)
         (apply (vector-ref jrec-ctor-vec n) desc ext (vector->list vals))
         (make-jrec* desc ext vals))))
+;; One throwaway record, built here at load and reused, for the arm registries to
+;; probe a candidate predicate against (reject-fast-type-claim!, values.ss).
+;; Built ONCE rather than per registration: registrations also happen at runtime,
+;; as user code defines records, and calling make-jrec from that context resolves
+;; differently. collections.ss reaches it through probe-if-available, since it
+;; loads before this file and the earliest arms register before it too.
+(define jrec-fast-type-probe (make-jrec 'fast-type-probe (vector) jolt-nil))
+
 ;; compatibility accessor: rebuilds a fresh field vector from the inline slots.
 ;; Read-only — never set! through this, it returns a copy.
 (define (jrec-vals r)
@@ -509,10 +517,12 @@
 ;; compiled to (get inst :field), never recurse); a NON-field key on a deftype that
 ;; implements clojure.lang.ILookup routes to its valAt (core.match's pattern types
 ;; compute ::tag in valAt), else the default.
-;; jrec is the hottest get target (every record field read); jolt-get-dispatch
-;; (collections.ss) checks jrec? directly and calls jrec-ref, skipping the get-arm
-;; walk. This registration is the equivalent fallback for any other caller.
-(register-get-arm! jrec? jrec-ref)
+;; jrec is the hottest get target (every record field read), so jolt-get-dispatch
+;; (collections.ss) checks jrec? directly and calls jrec-ref before the arm walk.
+;; There is NO get-arm registration for jrec: jolt-get-arms has exactly one
+;; consumer — the else branch of that same cond — so an arm on jrec? could never
+;; run. register-get-arm! now rejects one at registration rather than accepting a
+;; handler it would silently never call.
 ;; A jrec is a defrecord (map of fields) by default, BUT a deftype that
 ;; implements a clojure.lang collection interface carries the op as an inline
 ;; method — prefer that method, else fall back to the field/map behavior. (jrec-cl

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -141,8 +141,16 @@
 ;; Arms dispatch newest-registration-first (cons front, walk head-first), matching
 ;; the precedence the set! chains produced. The built-in types stay inline in
 ;; jolt-seq itself.
+;; Records are NOT on this fast path — jolt-seq walks the arms for them — so the
+;; probe list deliberately omits jrec even though jolt-get's includes it. See
+;; reject-fast-type-claim! (values.ss).
+(define (seq-fast-probes)
+  (list jolt-nil jolt-empty-list (probe-cseq) (probe-pvec) (probe-pmap) (probe-pset) "s"))
+(define (seq-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred (seq-fast-probes) "the jolt-seq fast path"))
 (define jolt-seq-arms '())
 (define (register-seq-arm! pred handler)
+  (seq-arm-reject-fast-type! 'register-seq-arm! pred)
   (set! jolt-seq-arms (cons (cons pred handler) jolt-seq-arms)))
 
 (define (jolt-seq x)

--- a/host/chez/values.ss
+++ b/host/chez/values.ss
@@ -78,6 +78,14 @@
 ;; a guard wider than the fast path it protects would reject arms that are
 ;; perfectly legal. jolt-hash, for one, walks the arms for chars, symbols,
 ;; flonums and bignums, all of which the printer answers directly.
+;; A probe whose type is not constructible yet, as a 0-or-1 element list to
+;; splice in. Registries load in rt.ss order but so do the types they probe —
+;; transients.ss registers a get arm before records.ss defines make-jrec — and a
+;; probe that cannot be built is simply one this registration is not checked
+;; against, which is strictly better than failing to boot.
+(define (probe-if-available thunk)
+  (guard (e (#t '())) (list (thunk))))
+
 (define (reject-fast-type-claim! who claims? probes what)
   (for-each
    (lambda (probe)

--- a/test/chez/values-test.ss
+++ b/test/chez/values-test.ss
@@ -109,5 +109,46 @@
                                                (lambda (a b) #t))))))
 (ok "registered eq arm is consulted" (jolt=2 (make-armtest-t 1) (make-armtest-t 2)))
 
+;; --- the collection and compare registries guard their own fast paths --------
+;; Same invariant as eq/hash, same trap: the sets are all different, so each
+;; registry has to probe its OWN. jolt-get answers records but not strings;
+;; count/empty/seq answer strings but not records; contains? throws for scalars
+;; before ever reaching an arm.
+(ok "get arm rejects pmap"    (raises? (lambda () (register-get-arm! pmap? (lambda (c k d) d)))))
+(ok "get arm rejects jrec"    (raises? (lambda () (register-get-arm! jrec? (lambda (c k d) d)))))
+(ok "count arm rejects string" (raises? (lambda () (register-count-arm! string? (lambda (c) 0)))))
+(ok "count arm rejects cseq"  (raises? (lambda () (register-count-arm! cseq? (lambda (c) 0)))))
+(ok "contains arm rejects number"
+    (raises? (lambda () (register-contains-arm! number? (lambda (c k) #f)))))
+(ok "contains arm rejects keyword"
+    (raises? (lambda () (register-contains-arm! keyword? (lambda (c k) #f)))))
+(ok "empty arm rejects string" (raises? (lambda () (register-empty-arm! string? (lambda (c) #t)))))
+(ok "seq arm rejects pvec"    (raises? (lambda () (register-seq-arm! pvec? (lambda (x) x)))))
+(ok "seq arm rejects string"  (raises? (lambda () (register-seq-arm! string? (lambda (x) x)))))
+(ok "compare arm rejects string pair"
+    (raises? (lambda () (register-compare-arm! (lambda (a b) (and (string? a) (string? b)))
+                                               (lambda (a b) 0)))))
+(ok "compare arm rejects char pair"
+    (raises? (lambda () (register-compare-arm! (lambda (a b) (and (char? a) (char? b)))
+                                               (lambda (a b) 0)))))
+
+;; the sets really do differ — a guard wider than its own fast path would reject
+;; arms that are perfectly legal
+(ok "get guard allows string"   (not (raises? (lambda () (get-arm-reject-fast-type! 'test string?)))))
+(ok "count guard allows jrec"   (not (raises? (lambda () (count-arm-reject-fast-type! 'test jrec?)))))
+(ok "seq guard allows jrec"     (not (raises? (lambda () (seq-arm-reject-fast-type! 'test jrec?)))))
+;; compare's nil clauses are single-sided and answer correctly for EVERY type, so
+;; the usual either-arg predicate must stay legal even though it matches them
+(ok "compare guard allows either-arg shape"
+    (not (raises? (lambda () (compare-arm-reject-fast-type!
+                              'test (lambda (a b) (or (armtest-t? a) (armtest-t? b))))))))
+
+;; and real arms on a type off the fast path still register and are consulted
+(ok "seq arm on a plain type registers"
+    (not (raises? (lambda () (register-seq-arm! armtest-t? (lambda (x) jolt-nil))))))
+(ok "count arm on a plain type registers"
+    (not (raises? (lambda () (register-count-arm! armtest-t? (lambda (x) 7))))))
+(ok "registered count arm is consulted" (= 7 (jolt-count (make-armtest-t 1))))
+
 (printf "values-test: ~a/~a passed\n" (- total fails) total)
 (exit (if (> fails 0) 1 0))


### PR DESCRIPTION
Closes jolt-18ps. Finishes the survey jolt-i0qr started — that one did eq and hash, this is `get`, `count`, `contains?`, `empty?`, `seq` and `compare`.

Each registry front-loads a fast path past its arm walk, so an arm claiming one of those types is silently skipped and its handler never runs.

## Each registry probes its own fast path

This is the whole difficulty, and the trap jolt-i0qr already hit once between the printer and hash sets: the sets genuinely differ, and a guard wider than the path it protects rejects arms that are perfectly legal.

| registry | answers before the arms |
|---|---|
| `get` | pmap, pvec, pset, **jrec** — but *not* strings |
| `count` | pvec, pmap, pset, **string**, nil, empty-list, cseq |
| `contains?` | the collections, **plus throws** for number, boolean, keyword, symbol, char |
| `empty?` | nil, pvec, pmap, pset, **string**, empty-list, cseq |
| `seq` | nil, empty-list, cseq, pvec, pmap, pset, **string** — records reach the arms |
| `compare` | same-type pairs only (see below) |

For `compare`, only the same-type pairs are subject to the invariant. Its nil clauses are single-sided — `(compare nil x)` is -1 for every `x` — so the fast path answering them is correct for any type, and the usual either-arg-is-my-type predicate stays legal. Same distinction `register-eq-arm!` makes for its identity clause.

## Four registries deliberately left alone

`invoke` and `class` check their arms **first**, so there is nothing to skip. `type` only has a `:type` meta override ahead of the walk, which is value-level rather than a type fast path. `instance-check` and `num` take a different arm shape than pred+handler.

## It found a real violation immediately

`records.ss` registered `(register-get-arm! jrec? jrec-ref)`. That arm could never fire: `jolt-get-arms` has exactly one consumer — the `else` branch of the same `cond` whose `((jrec? coll) (jrec-ref coll k d))` clause runs first. Removed, along with the stale comment claiming it was a fallback "for any other caller".

## Probe construction

Probes are built on demand, because the types outlive the load order — `seq.ss` supplies the cseq and empty-list values after `collections.ss`, and `records.ss` the record. `probe-if-available` drops one that cannot be built yet (`transients.ss` registers a get arm before `records.ss` exists), so an early registration is simply unchecked against that probe rather than failing the boot.

The record probe is built **once** at `records.ss` load, not per registration. Registrations also happen at runtime as user code defines records, and calling `make-jrec` from that context resolves differently — I hit that as a `Call error` on a plain `(defrecord R [a b])` before pinning it down.

## Verification

`values` gate 55 → 70 checks; the 15 new ones fail before the change and pass after. `make test` green, cts unchanged at 6079/139/2. Spot-checked records and collections directly — field get, assoc/dissoc, count/seq, contains?/empty?, equality/hash, transients, sorted-map — all unaffected by dropping the dead arm.