### PR TITLE
Expose the portable dependency facade

### DIFF
--- a/jolt-core/clojurestar/deps.cljc
+++ b/jolt-core/clojurestar/deps.cljc
@@ -1,0 +1,17 @@
+(ns clojurestar.deps
+  "Dialect-neutral dynamic dependency loading."
+  (:require
+   #?(:bb [babashka.deps :as implementation]
+      :glj [glojure.deps :as implementation]
+      :jolt [jolt.deps :as implementation]
+      :lg [let-go.deps :as implementation]
+      :clj [grenadine.jvm :as implementation])))
+
+(defn add-deps
+  "Add the Maven dependencies in a deps.edn map to the running dialect.
+
+  This portable facade deliberately returns nil. Use the dialect-specific
+  dependency namespace when backend-specific options or results are needed."
+  [deps-map]
+  (implementation/add-deps deps-map)
+  nil)

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -7,6 +7,7 @@
 
 (ns deps-expand-test
   (:require [clojure.string :as str]
+            [clojurestar.deps :as portable-deps]
             [grenadine.version :as version]
             [jolt.deps :as deps]
             [jolt.deps.ext :as ext]))
@@ -47,6 +48,8 @@
     (println "  FAIL:" label)
     (println "    expected:" (pr-str expected))
     (println "    got:     " (pr-str actual))))
+
+(is= "portable facade returns nil" nil (portable-deps/add-deps {}))
 
 ;;;; the repo from tools.deps test_deps.clj
 


### PR DESCRIPTION
Provide clojurestar.deps/add-deps as a dialect-neutral wrapper around jolt.deps while preserving Jolt's richer native API. Verify the common facade returns nil for portable callers.