### PR TITLE
Add whole-world image dump and restore

### DIFF
--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -89,10 +89,15 @@ gc-real-nanos
 getenv
 host-class-name?
 host-intern!
+image-add-after-restore-hook!
+image-add-before-dump-hook!
+image-dump-world!
 image-read
 image-register-handler!
+image-restore-world!
 image-runtime-version
 image-scan
+image-scan-world
 image-write!
 inference-enabled?
 inline-enabled?

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -338,6 +338,124 @@
       (image-reattach-meta! (vector-ref b 1))
       (vector-ref b 0))))
 
+;; --- whole-world image ----------------------------------------------------------
+;; The Smalltalk/Common Lisp shape: don't ask which variable to save, save the
+;; world. Walk the var table and write every var's root, so restoring brings the
+;; program's whole state back rather than one value the caller remembered to name.
+;;
+;; What makes this affordable on Chez is that CODE does not have to travel. A var
+;; whose root is a procedure is skipped outright: the restoring process is the
+;; same build, so it already has that function: `defn` bodies, protocol impls and
+;; multimethod tables are all present before the image is read. Only DATA moves.
+;; That is also why an image is pinned to its build — see the header check.
+;;
+;; Namespaces owned by the language are skipped by default. clojure.core holds
+;; mutable vars (*ns*, *warn-on-reflection*, printer state) that belong to the
+;; process being restored INTO, not to the image; carrying them over would make a
+;; restore quietly reconfigure the reader and printer.
+;; `user` is deliberately NOT skipped: at a REPL it is where the work lives, and
+;; an image that quietly dropped it would lose exactly what the user typed.
+(define image-system-ns-prefixes '("clojure." "jolt."))
+
+(define (image-system-ns? ns)
+  (or (string=? ns "clojure.core")
+      (let loop ((ps image-system-ns-prefixes))
+        (and (pair? ps)
+             (or (and (>= (string-length ns) (string-length (car ps)))
+                      (string=? (substring ns 0 (string-length (car ps))) (car ps)))
+                 (loop (cdr ps)))))))
+
+;; Hooks, the *save-hooks* / *init-hooks* pair. An application quiesces in
+;; before-dump (stop pools, park threads) and rebuilds whatever it could not
+;; carry in after-restore (reopen resources, re-derive computed cells).
+(define image-before-dump-hooks '())
+(define image-after-restore-hooks '())
+(define (jolt-image-add-before-dump-hook! f)
+  (set! image-before-dump-hooks (append image-before-dump-hooks (list f))) jolt-nil)
+(define (jolt-image-add-after-restore-hook! f)
+  (set! image-after-restore-hooks (append image-after-restore-hooks (list f))) jolt-nil)
+(define (image-run-hooks! hs) (for-each (lambda (f) (jolt-invoke f)) hs) jolt-nil)
+
+;; A var root a handler claimed, replaced by the handler's plain-data payload.
+;; Substituting HERE rather than through the fasl externals mechanism is what
+;; lets the payload be ordinary state: it rides in the body, so a function inside
+;; it becomes a fn-ref and a keyword inside it gets re-interned, exactly as if the
+;; application had stored that data directly. Routing it through a descriptor
+;; instead would put it in the one part of the file that cannot carry either.
+(define-record-type image-handled (fields payload) (nongenerative image-handled-v1))
+
+;; ns-list is a jolt seq of namespace-name strings, or nil for "every namespace
+;; that isn't the language's own".
+(define (image-world-vars ns-list)
+  (let ((want (if (jolt-nil? ns-list)
+                  #f
+                  (let loop ((s (jolt-seq ns-list)) (acc '()))
+                    (if (jolt-nil? s) acc
+                        (loop (jolt-next s) (cons (jolt-first s) acc))))))
+        (out '()))
+    (let-values (((ks vs) (hashtable-entries var-table)))
+      (let loop ((i 0))
+        (when (fx<? i (vector-length ks))
+          (let* ((cell (vector-ref vs i))
+                 (ns (var-cell-ns cell))
+                 (nm (var-cell-name cell))
+                 (root (var-cell-root cell)))
+            (when (and (if want (member ns want) (not (image-system-ns? ns)))
+                       ;; code is already in the restoring build; only data moves
+                       (not (procedure? root))
+                       (not (jolt-var-unbound? root)))
+              (let ((h (image-handler-for root)))
+                (set! out (cons (cons (string-append ns "/" nm)
+                                      (if h
+                                          (make-image-handled (jolt-invoke (cadr h) root))
+                                          root))
+                                out)))))
+          (loop (fx+ i 1)))))
+    out))
+
+(define (jolt-image-dump-world! path ns-list)
+  (image-run-hooks! image-before-dump-hooks)
+  (jolt-image-write! path (vector 'jolt-world (image-world-vars ns-list))))
+
+(define (jolt-image-scan-world ns-list)
+  (jolt-image-scan (vector 'jolt-world (image-world-vars ns-list))))
+
+(define (jolt-image-restore-world! path)
+  (let ((w (jolt-image-read path)))
+    (unless (and (vector? w) (fx=? (vector-length w) 2) (eq? (vector-ref w 0) 'jolt-world))
+      (jolt-throw (jolt-ex-info
+                    (string-append "image: " path
+                                   " is a value image, not a world image — read it with read-image")
+                    jolt-nil)))
+    (let ((n 0))
+      (for-each
+        (lambda (p)
+          (let* ((k (car p))
+                 (slash (let scan ((i 0))
+                          (cond ((fx>=? i (string-length k)) #f)
+                                ((char=? (string-ref k i) #\/) i)
+                                (else (scan (fx+ i 1))))))
+                 (ns (substring k 0 slash))
+                 (nm (substring k (fx+ slash 1) (string-length k))))
+            (let ((cell (jolt-var ns nm))
+                  (v (cdr p)))
+              ;; a handler claimed this var on the way out; hand the payload back
+              ;; to whichever registered handler accepts it
+              (var-cell-root-set! cell (if (image-handled? v)
+                                           (image-decode-external
+                                             (list 'handler (image-handled-payload v)))
+                                           v))
+              (var-cell-defined?-set! cell #t)
+              (set! n (fx+ n 1)))))
+        (vector-ref w 1))
+      (image-run-hooks! image-after-restore-hooks)
+      n)))
+
+(def-var! "jolt.host" "image-dump-world!" jolt-image-dump-world!)
+(def-var! "jolt.host" "image-restore-world!" jolt-image-restore-world!)
+(def-var! "jolt.host" "image-scan-world" jolt-image-scan-world)
+(def-var! "jolt.host" "image-add-before-dump-hook!" jolt-image-add-before-dump-hook!)
+(def-var! "jolt.host" "image-add-after-restore-hook!" jolt-image-add-after-restore-hook!)
 (def-var! "jolt.host" "image-write!" jolt-image-write!)
 (def-var! "jolt.host" "image-read" jolt-image-read)
 (def-var! "jolt.host" "image-scan" jolt-image-scan)

--- a/stdlib/jolt/image.clj
+++ b/stdlib/jolt/image.clj
@@ -66,3 +66,52 @@
   it."
   []
   (host/image-runtime-version))
+
+;; --- the whole world ----------------------------------------------------------
+;; The Smalltalk / Common Lisp shape: instead of naming the one value you
+;; remembered to save, save the program. `dump-world!` walks the var table and
+;; writes every var's root, so a restore brings back the whole of your state.
+;;
+;; Code does not travel. A var whose root is a function is skipped, because the
+;; restoring process is the same build and already has it — every `defn`,
+;; protocol impl and multimethod is there before the image is read. Only data
+;; moves, which is what keeps this affordable on a runtime with no heap dump.
+
+(defn dump-world!
+  "Write every data var in the application's namespaces to PATH.
+
+  With no NAMESPACES, dumps every namespace that is not the language's own —
+  clojure.*, jolt.* and user are skipped, because their vars (*ns*, printer and
+  reader settings) belong to the process being restored into, not to the image.
+  Pass a seq of namespace-name strings to be explicit.
+
+  Runs the before-dump hooks first. Vars holding functions are skipped: the
+  restoring build already has the code."
+  ([path] (dump-world! path nil))
+  ([path namespaces] (host/image-dump-world! path namespaces)))
+
+(defn restore-world!
+  "Read a world image and rebind every var it holds. Returns the number of vars
+  restored, then runs the after-restore hooks.
+
+  Throws if PATH holds a value image rather than a world image."
+  [path]
+  (host/image-restore-world! path))
+
+(defn scan-world
+  "What `dump-world!` would refuse, without writing anything. Same shape as
+  `scan`. Use it to find the vars holding closures before you try."
+  ([] (scan-world nil))
+  ([namespaces] (host/image-scan-world namespaces)))
+
+(defn add-before-dump-hook!
+  "Run F before a world dump. Where an application quiesces — stop pools, park
+  worker threads, flush what should be in the image."
+  [f]
+  (host/image-add-before-dump-hook! f))
+
+(defn add-after-restore-hook!
+  "Run F after a world restore. Where an application rebuilds what could not be
+  carried — reopen resources, re-derive computed cells, restart threads."
+  [f]
+  (host/image-add-after-restore-hook! f))

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -196,6 +196,47 @@
     "true")
 
 
+;; --- whole-world image -----------------------------------------------------------
+;; The Smalltalk/CL shape: save the program, not one named value. Code is skipped
+;; (the restoring build already has it), so only data moves.
+(define world-tmp (string-append tmp ".world"))
+(ev "(ns imgtest.app)")
+(jolt-compile-eval "(def board {:tasks [{:id 1 :text \"a\"}] :filter :all})" "imgtest.app")
+(jolt-compile-eval "(def counter 41)" "imgtest.app")
+(jolt-compile-eval "(defn helper [x] (* 2 x))" "imgtest.app")
+
+(is "world scan is clean for data-only namespaces"
+    "(count (jolt.host/image-scan-world [\"imgtest.app\"]))" "0")
+(ev (string-append "(jolt.host/image-dump-world! \"" world-tmp "\" [\"imgtest.app\"])"))
+;; clobber the world
+(jolt-compile-eval "(def board {:tasks [] :filter :done})" "imgtest.app")
+(jolt-compile-eval "(def counter 0)" "imgtest.app")
+(is "world restore reports how many vars it rebound"
+    (string-append "(jolt.host/image-restore-world! \"" world-tmp "\")") "2")
+(is "data vars come back"
+    "(str (:filter imgtest.app/board) \" \" imgtest.app/counter)" ":all 41")
+(is "restored data keeps working keyword lookup"
+    "(count (:tasks imgtest.app/board))" "1")
+(is "code vars are untouched by a restore"
+    "(imgtest.app/helper 21)" "42")
+(is "a value image is refused by restore-world!"
+    (string-append "(do (jolt.host/image-write! \"" tmp "\" {:a 1})"
+                   " (try (jolt.host/image-restore-world! \"" tmp "\") :no-throw"
+                   " (catch Exception e (if (re-find #\"value image\" (ex-message e)) :named :other))))")
+    ":named")
+(is "a world image is refused by plain read"
+    (string-append "(let [w (jolt.host/image-read \"" world-tmp "\")] (vector? w))") "false")
+;; hooks fire in order around the operation
+(jolt-compile-eval "(def hooklog (atom []))" "user")
+(is "before-dump and after-restore hooks fire"
+    (string-append "(do (jolt.host/image-add-before-dump-hook! (fn [] (swap! user/hooklog conj :before)))"
+                   " (jolt.host/image-add-after-restore-hook! (fn [] (swap! user/hooklog conj :after)))"
+                   " (jolt.host/image-dump-world! \"" world-tmp "\" [\"imgtest.app\"])"
+                   " (jolt.host/image-restore-world! \"" world-tmp "\")"
+                   " (pr-str @user/hooklog))")
+    "[:before :after]")
+(when (file-exists? world-tmp) (delete-file world-tmp))
+
 (cleanup!)
 (when (file-exists? (string-append tmp ".txt")) (delete-file (string-append tmp ".txt")))
 


### PR DESCRIPTION
Follow-up to #533. Adds the whole-world half: `dump-world!` / `restore-world!`.

The value-level API meant you had to name what to save, which for plain data is
what EDN already does. This is the Smalltalk / `save-lisp-and-die` shape instead:
walk the var table, write every var's root, and get the program back. Nothing in
an application has to list what its state consists of — add a `def` tomorrow and
it is in the image.

## Why this is affordable without a heap dump

Code does not travel. A var whose root is a procedure is skipped: the restoring
process is the same build, so every `defn`, protocol impl and multimethod is
already there. Only data moves.

`clojure.*` and `jolt.*` are skipped by default — their vars (`*ns*`, printer and
reader settings) belong to the process being restored *into*, and carrying them
over would quietly reconfigure it. `user` is deliberately kept: at a REPL that is
where the work is.

## Handlers are substituted at the var root

Worth a look during review. A handler's payload is ordinary application state —
in the example app it is the todo board, which holds a live function and
keywords. So the payload has to ride in the **body**, where a function becomes a
fn-ref and a keyword gets re-interned. Routing it through the externals
descriptor table would put it in the one part of the file that can carry
neither — the same layering problem that makes sorted maps unwritable.

So `image-world-vars` substitutes a handler-claimed root with an `image-handled`
record carrying the payload, before the write.

## Hooks

`add-before-dump-hook!` / `add-after-restore-hook!`, the `*save-hooks*` /
`*init-hooks*` pair. What lets an application quiesce on the way out and rebuild
what could not travel on the way in.

## Testing

`make stateimage` — 60 assertions. New coverage: world round-trip, that code vars
are untouched by a restore, that a value image and a world image each refuse the
other's reader, and that hooks fire in order. `make corpus` and `make unit` pass.

Exercised end to end against the example app (jolt-lang/examples#24): a restore
brings back records as records, a function stored in state as the same var, and
one Task object shared between the board, its index and an undo snapshot as a
single object.
