### PR TITLE
examples-smoke: add image-dump-example row

### DIFF
--- a/ci/examples-smoke.sh
+++ b/ci/examples-smoke.sh
@@ -21,7 +21,9 @@
 # Build-only, and why:
 #   http-client-app  -main hits real HTTPS endpoints — a release must not depend
 #                    on third-party uptime.
-#   fps-demo, glimmer-app, glimmer-gl-app   GUI/GL; no headless test task.
+#   fps-demo, glimmer-app, glimmer-gl-app, image-dump-example   GUI/GL; no
+#                    headless test task. (image-dump-example's save/load path is
+#                    covered by the jolt-side stateimage gate.)
 #   hiccup/malli/markdown-app, ray-tracer*  no test task at all.
 set -eu
 
@@ -52,6 +54,7 @@ ray-tracer-multi rt.render      -
 fps-demo         fps-demo.core  -
 glimmer-app      app.core       -
 glimmer-gl-app   gl-demo.core   -
+image-dump-example app.core     -
 EOF
 
 fails=0


### PR DESCRIPTION
The examples gate cross-checks its manifest against the jolt-lang/examples
checkout in both directions, so merging the new example failed the v0.6.3
release run: `image-dump-example is in the checkout but has no
ci/examples-smoke.sh row` — publish and homebrew were skipped, release stayed
draft.

Build-only row, same as the other glimmer GUI apps (no headless test task; the
save/load machinery is covered by the jolt-side `stateimage` gate). Verified
`jolt build -m app.core` produces a standalone binary locally.

After merge: v0.6.3 gets re-tagged on the new main so the tag's copy of the
script carries the row.