### PR TITLE
deref: forward opts to a record implementing IBlockingDeref

### DIFF
--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -589,10 +589,19 @@
       ((jolt-delay? x) (jolt-delay-force x))
       ;; a record/reify implementing clojure.lang.IDeref: @x calls its `deref`
       ;; method with the value itself as the leading `this`.
+      ;;
+      ;; opts are forwarded, so a type implementing clojure.lang.IBlockingDeref
+      ;; gets (deref this timeout-ms timeout-value) rather than the blocking
+      ;; one-arity. Dropping them here did not fail loudly: the timed call
+      ;; silently became an untimed one, so (deref proc 1500 ::timeout) on a
+      ;; babashka.process record waited for the process to exit however long
+      ;; that took, and the caller's timeout branch was unreachable. That made
+      ;; every bounded subprocess call in a downstream harness unbounded, and
+      ;; leaked the processes it thought it was killing.
       ((and (jrec? x) (find-method-any-protocol (jrec-tag x) "deref"))
-       => (lambda (m) (jolt-invoke m x)))
+       => (lambda (m) (apply jolt-invoke m x opts)))
       ((and (reified-methods x) (hashtable-ref (reified-methods x) "deref" #f))
-       => (lambda (m) (jolt-invoke m x)))
+       => (lambda (m) (apply jolt-invoke m x opts)))
       (else (apply %pre-conc-deref x opts)))))
 
 ;; realized? for a future/promise/delay. Wrapped over the overlay version in


### PR DESCRIPTION
`jolt-deref` invoked a record's `deref` method with only the value itself and dropped any opts, so the timed three-arity `(deref ref timeout-ms timeout-value)` silently became the blocking one-arity for every record and reify. Futures and promises were unaffected, since earlier arms in the `cond` handle them.

```clojure
((and (jrec? x) (find-method-any-protocol (jrec-tag x) "deref"))
 => (lambda (m) (jolt-invoke m x)))        ;; opts dropped here
```

What makes this worth fixing rather than documenting is how quietly it fails. There is no error and no warning, and the value returned is the correct result of a call that merely took longer than the caller allowed. The caller's timeout branch is simply unreachable, and the code reads as though it works.

I found it through `babashka.process`, which implements `IBlockingDeref` exactly this way. `(deref proc 2000 ::timeout)` on a `sleep 60` waited the full sixty seconds and returned the real result instead of the timeout value. Downstream that turned every bounded subprocess call in a verification harness into an unbounded one and leaked the processes it believed it was killing: 28 orphaned `z3` processes on one machine, the oldest at seventeen hours. They degraded the machine enough that an unrelated Mathlib import measured about sixteen times its real cost, which sent me on a long detour before I found this.

The host side was already correct. `waitFor` with a timeout polls and returns `#f` properly, and `Process` implements both arities. Only the dispatch was losing the arguments.

Verified against a record implementing both arities: the timed deref returns its timeout value, the plain deref still blocks through, and futures are unchanged. `make unit` passes and `make cts` reports 6078 pass / 140 fail, matching baseline.
