### PR TITLE
Harden jolt.socket: broken-pipe throws, wildcard bind, class model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`jolt.socket`: `java.net.Socket` / `ServerSocket` / `InetSocketAddress` /
+  `InetAddress` over POSIX sockets** (`(require 'jolt.socket)` registers the
+  classes; IPv4, blocking I/O). Contributed in #542, hardened in the follow-up:
+  writes to a peer-closed socket throw `IOException` instead of silently
+  dropping (SIGPIPE guarded via `MSG_NOSIGNAL`/`SO_NOSIGPIPE`), `ServerSocket`
+  binds the wildcard address like Java (port 0 + `getLocalPort` report the
+  kernel-assigned port via `getsockname`), accepted sockets know their peer,
+  `class`/`instance?`/`str` answer as the mirrored classes, and
+  `InetAddress/getByName` resolves. Deliberate gaps are in
+  `known-divergences.edn`: `available()` is 0, a recv error reads as EOF,
+  connect timeouts are ignored.
+
 ## [0.6.5] - 2026-08-05
 
 Images now carry the two things 0.6.3 refused: anonymous functions and

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -686,6 +686,24 @@ else
   fails=$((fails + 1))
 fi
 
+# jolt.socket — the java.net.Socket/ServerSocket surface over real loopback TCP
+# (roundtrip, EOF, broken pipe, ephemeral ports, class model). Self-checks, one marker.
+# stderr goes into the capture: a run that dies before its first check must leave
+# the exception, not an empty log.
+sock_out="$($jolt run test/chez/socket-test.clj 2>&1)"
+if printf '%s' "$sock_out" | grep -q 'SOCKET-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.socket"
+  if printf '%s\n' "$sock_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$sock_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$sock_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$sock_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # jolt.process — the stdlib sub-process API against real programs (capture, pipes,
 # stdin, :dir/:env, exit codes, signals). The file self-checks and prints a marker.
 #

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -1,11 +1,16 @@
-#!/usr/bin/env jolt
 ;; java.net.Socket / ServerSocket / InetSocketAddress for Jolt via jolt.ffi.
 ;; POSIX sockets + jolt.host/tagged-table + ref-put!/ref-get for state.
 ;;
 ;; Usage: (require 'jolt.socket)  ;; registers classes globally
 
 (ns jolt.socket
-  "POSIX socket support. Registers Socket, ServerSocket, InetSocketAddress."
+  "POSIX socket support. Registers Socket, ServerSocket, InetSocketAddress,
+  InetAddress and the socket stream classes with the host class registry.
+
+  Deliberate divergences from the JVM (test/conformance/known-divergences.edn):
+  .available answers 0, a recv error reads as EOF (-1) rather than throwing,
+  .connect ignores its timeout argument (always blocking), and toString
+  formats are approximate. IPv4 only."
   (:require [jolt.ffi :as ffi]
             [clojure.string :as str]))
 
@@ -14,147 +19,235 @@
 (def ^:private AF-INET 2)
 (def ^:private SOCK-STREAM 1)
 
-(ffi/defcfn c-socket     "socket"     [:int :int :int] :int)
-(ffi/defcfn c-connect    "connect"    [:int :pointer :int] :int)
-(ffi/defcfn c-bind       "bind"       [:int :pointer :int] :int)
-(ffi/defcfn c-listen     "listen"     [:int :int] :int)
-(ffi/defcfn c-accept     "accept"     [:int :pointer :pointer] :int :blocking)
-(ffi/defcfn c-setsockopt "setsockopt" [:int :int :int :pointer :int] :int)
-(ffi/defcfn c-recv       "recv"       [:int :pointer :size_t :int] :ssize_t :blocking)
-(ffi/defcfn c-send       "send"       [:int :pointer :size_t :int] :ssize_t :blocking)
-(ffi/defcfn c-close      "close"      [:int] :int)
-(ffi/defcfn c-inet-addr  "inet_addr"  [:pointer] :uint)
-(ffi/defcfn c-gethostbyname "gethostbyname" [:pointer] :pointer)
+(ffi/defcfn c-socket      "socket"      [:int :int :int] :int)
+(ffi/defcfn c-connect     "connect"     [:int :pointer :int] :int :blocking)
+(ffi/defcfn c-bind        "bind"        [:int :pointer :int] :int)
+(ffi/defcfn c-listen      "listen"      [:int :int] :int)
+(ffi/defcfn c-accept      "accept"      [:int :pointer :pointer] :int :blocking)
+(ffi/defcfn c-setsockopt  "setsockopt"  [:int :int :int :pointer :int] :int)
+(ffi/defcfn c-getsockname "getsockname" [:int :pointer :pointer] :int)
+(ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-close       "close"       [:int] :int)
+(ffi/defcfn c-inet-addr   "inet_addr"   [:pointer] :uint)
+(ffi/defcfn c-gethostbyname "gethostbyname" [:pointer] :pointer :blocking)
 
-(def ^:private os-name    (str/lower-case (or (System/getProperty "os.name") "")))
-(def ^:private sol-socket (if (str/includes? os-name "mac") 0xffff 1))
-(def ^:private so-reuse   (if (str/includes? os-name "mac") 4 2))
+;; macOS carries BSD constants and a sin_len-led sockaddr; Linux has a 16-bit
+;; sin_family and needs MSG_NOSIGNAL on send — without it a write to a
+;; peer-closed socket raises SIGPIPE and kills the process (macOS suppresses
+;; the signal per-fd via the SO_NOSIGPIPE socket option instead).
+(def ^:private macos?
+  (str/includes? (str/lower-case (or (System/getProperty "os.name") "")) "mac"))
+(def ^:private sol-socket   (if macos? 0xffff 1))
+(def ^:private so-reuse     (if macos? 4 2))
+(def ^:private so-nosigpipe 0x1022)
+(def ^:private msg-nosignal (if macos? 0 0x4000))
 
-;; -- sockaddr helpers --------------------------------------------------------
-(defn- make-sockaddr-in [host port]
-  ;; Build sockaddr_in (16 bytes): sin_family(2) + sin_port(2) + sin_addr(4) + padding(8)
-  ;; Use inet_addr for numeric IPs, gethostbyname for hostnames.
-  (let [hb (.getBytes (str host) "UTF-8")
-        hp (ffi/alloc (inc (alength hb)))]
-    (ffi/write-array hp hb)
-    (let [addr (c-inet-addr hp)
-          ip (if (= addr 4294967295) ;; inet_addr returns 0xFFFFFFFF as unsigned for non-numeric
-               (let [he (c-gethostbyname hp)]
-                 (when (zero? he)
-                   (ffi/free hp)
-                   (throw (RuntimeException. (str "gethostbyname failed for " host))))
-                 (let [h-addr-list (ffi/read he :uptr 24)
-                       h-addr (ffi/read h-addr-list :uptr 0)]
-                   (ffi/read h-addr :uint 0)))
-               addr)
-          sa (ffi/alloc 16)]
-      (ffi/free hp)
-      (dotimes [i 16] (ffi/write sa :uint8 i 0))
-      (ffi/write sa :uint8 0 AF-INET) ;; sin_family
-      ;; sin_port in network byte order
-      (ffi/write sa :uint8 2 (bit-and (bit-shift-right port 8) 0xff))
-      (ffi/write sa :uint8 3 (bit-and port 0xff))
-      ;; sin_addr in network byte order (ip already in network order)
-      (ffi/write sa :uint 4 ip)
-      sa)))
+;; -- sockaddr helpers ---------------------------------------------------------
 
-(defn- make-loopback-sa [port]
+(defn- resolve-host [host]
+  ;; sin_addr (network byte order) for a numeric IP or hostname (IPv4 only).
+  ;; string->ptr NUL-terminates — a bare alloc+write-array leaves the
+  ;; terminator to whatever malloc hands back.
+  (let [hp (ffi/string->ptr (str host))]
+    (try
+      (let [addr (c-inet-addr hp)]
+        (if (= addr 4294967295) ;; INADDR_NONE: not a numeric IP, try DNS
+          (let [he (c-gethostbyname hp)]
+            (when (ffi/null? he)
+              (throw (java.io.IOException. (str "unknown host: " host))))
+            (let [h-addr-list (ffi/read he :uptr 24)
+                  h-addr (ffi/read h-addr-list :uptr 0)]
+              (ffi/read h-addr :uint 0)))
+          addr))
+      (finally (ffi/free hp)))))
+
+(defn- ip->str [ip]
+  ;; ip is sin_addr in network byte order read back as a native (little-endian)
+  ;; uint, so the low byte is the first octet.
+  (str (bit-and ip 0xff) "."
+       (bit-and (bit-shift-right ip 8) 0xff) "."
+       (bit-and (bit-shift-right ip 16) 0xff) "."
+       (bit-and (bit-shift-right ip 24) 0xff)))
+
+(defn- make-sockaddr [ip port]
+  ;; sockaddr_in (16 bytes): header(2) + sin_port(2, network order) +
+  ;; sin_addr(4) + padding(8). BSD's header is sin_len + one-byte sin_family;
+  ;; Linux's is a 16-bit little-endian sin_family.
   (let [sa (ffi/alloc 16)]
     (dotimes [i 16] (ffi/write sa :uint8 i 0))
-    ;; sin_family (2 bytes): AF_INET = 2, little-endian
-    (ffi/write sa :uint8 0 AF-INET)
-    ;; sin_port (2 bytes): network byte order (big-endian)
+    (if macos?
+      (do (ffi/write sa :uint8 0 16)          ;; sin_len
+          (ffi/write sa :uint8 1 AF-INET))
+      (ffi/write sa :uint8 0 AF-INET))
     (ffi/write sa :uint8 2 (bit-and (bit-shift-right port 8) 0xff))
     (ffi/write sa :uint8 3 (bit-and port 0xff))
-    ;; sin_addr (4 bytes): 127.0.0.1 in network byte order
-    (ffi/write sa :uint8 4 127)
-    (ffi/write sa :uint8 7 1) ;; 127.0.0.1
+    (ffi/write sa :uint 4 ip)
     sa))
+
+(defn- make-sockaddr-in [host port]
+  (make-sockaddr (resolve-host host) port))
+
+(defn- sa-port [sa]
+  (bit-or (bit-shift-left (ffi/read sa :uint8 2) 8) (ffi/read sa :uint8 3)))
+(defn- sa-addr [sa]
+  (ip->str (ffi/read sa :uint 4)))
+
+(defn- local-port [fd]
+  (let [sa (ffi/alloc 16) lenp (ffi/alloc 4)]
+    (try
+      (ffi/write lenp :int 0 16)
+      (if (neg? (c-getsockname fd sa lenp)) 0 (sa-port sa))
+      (finally (ffi/free sa) (ffi/free lenp)))))
+
+(defn- set-opt-1! [fd opt]
+  (let [p (ffi/alloc 4)]
+    (try
+      (ffi/write p :int 0 1)
+      (c-setsockopt fd sol-socket opt p 4)
+      (finally (ffi/free p)))))
+
+(defn- guard-fd! [fd]
+  ;; accepted fds don't reliably inherit socket options — set SO_NOSIGPIPE
+  ;; explicitly on every fd we hand out.
+  (when macos? (set-opt-1! fd so-nosigpipe)))
 
 (defn- new-fd! []
   (let [fd (c-socket AF-INET SOCK-STREAM 0)]
     (when (neg? fd) (throw (java.io.IOException. "socket() failed")))
-    (let [opt (ffi/alloc 4)]
-      (ffi/write opt :int 0 1)
-      (c-setsockopt fd sol-socket so-reuse opt 4)
-      (ffi/free opt))
+    (set-opt-1! fd so-reuse)
+    (guard-fd! fd)
     fd))
+
+;; -- tagged-table constructors ------------------------------------------------
+;; a "class" entry makes (class x) report the mirrored class name; instance?
+;; and str rendering are registered at the bottom of the file.
+
+(defn- tt [tag class]
+  (doto (jolt.host/tagged-table tag)
+    (jolt.host/ref-put! :class class)))
+
+(defn- make-inet-address [host addr]
+  (doto (tt :inet-address "java.net.Inet4Address")
+    (jolt.host/ref-put! :host host)
+    (jolt.host/ref-put! :address addr)))
+
+(defn- host-arg->str [h]
+  ;; Socket(InetAddress, port) / ServerSocket(..., bindAddr) pass the
+  ;; InetAddress table; take its literal before falling back to str.
+  (if (= :inet-address (jolt.host/ref-get h :jolt/type))
+    (str (or (jolt.host/ref-get h :address) (jolt.host/ref-get h :host)))
+    (str h)))
+
+(defn- connect-fd! [fd host port]
+  ;; resolve + connect; frees the sockaddr either way. Returns the resolved ip.
+  (let [ip (resolve-host host)
+        sa (make-sockaddr ip port)
+        r  (c-connect fd sa 16)]
+    (ffi/free sa)
+    (when (neg? r)
+      (throw (java.io.IOException. (str "connect failed: " host ":" port))))
+    ip))
 
 ;; -- Socket ------------------------------------------------------------------
 
 (defn- socket-ctor [& args]
-  (let [fd  (new-fd!)
-        cap (if (= 2 (count args))
-              (let [h (str (first args)) p (int (second args)) sa (make-sockaddr-in h p)]
-                (let [r (c-connect fd sa 16)]
-                  (ffi/free sa)
-                  (when (neg? r) (c-close fd) (throw (java.io.IOException. (str "connect failed: " h ":" p)))))
-                {:connected? true :host h :port p})
-              {:connected? false :host nil :port nil})
-        inst (jolt.host/tagged-table :socket)]
+  (let [fd   (new-fd!)
+        inst (tt :socket "java.net.Socket")]
     (jolt.host/ref-put! inst :fd fd)
     (jolt.host/ref-put! inst :closed? false)
-    (jolt.host/ref-put! inst :connected? (:connected? cap))
-    (when (:host cap) (jolt.host/ref-put! inst :host (:host cap)))
-    (when (:port cap) (jolt.host/ref-put! inst :port (:port cap)))
+    (jolt.host/ref-put! inst :connected? false)
+    (when (= 2 (count args))
+      (let [h  (host-arg->str (first args))
+            p  (int (second args))
+            ip (try (connect-fd! fd h p)
+                    (catch java.io.IOException e (c-close fd) (throw e)))]
+        (jolt.host/ref-put! inst :connected? true)
+        (jolt.host/ref-put! inst :host h)
+        (jolt.host/ref-put! inst :remote-addr (ip->str ip))
+        (jolt.host/ref-put! inst :port p)
+        (jolt.host/ref-put! inst :local-port (local-port fd))))
     inst))
+
+(defn- socket-close! [self]
+  (when-not (jolt.host/ref-get self :closed?)
+    (jolt.host/ref-put! self :closed? true)
+    (c-close (jolt.host/ref-get self :fd)))
+  nil)
+
+(defn- socket-connect! [self endpoint]
+  (when (jolt.host/ref-get self :closed?)
+    (throw (java.io.IOException. "Socket closed")))
+  (when (jolt.host/ref-get self :connected?)
+    (throw (java.io.IOException. "Already connected")))
+  (let [h  (str (jolt.host/ref-get endpoint :host))
+        p  (jolt.host/ref-get endpoint :port)
+        fd (jolt.host/ref-get self :fd)
+        ip (connect-fd! fd h p)]
+    (jolt.host/ref-put! self :connected? true)
+    (jolt.host/ref-put! self :host h)
+    (jolt.host/ref-put! self :remote-addr (ip->str ip))
+    (jolt.host/ref-put! self :port p)
+    (jolt.host/ref-put! self :local-port (local-port fd)))
+  nil)
+
+(defn- socket->str [self]
+  (if (jolt.host/ref-get self :connected?)
+    (str "Socket[addr=" (or (jolt.host/ref-get self :host) "")
+         "/" (or (jolt.host/ref-get self :remote-addr) "")
+         ",port=" (or (jolt.host/ref-get self :port) 0)
+         ",localport=" (or (jolt.host/ref-get self :local-port) 0) "]")
+    "Socket[unconnected]"))
 
 (def ^:private socket-methods
   {"connect"
-   (fn [self endpoint]
-     (when (jolt.host/ref-get self :closed?)
-       (throw (java.io.IOException. "Socket closed")))
-     (when (jolt.host/ref-get self :connected?)
-       (throw (java.io.IOException. "Already connected")))
-     (let [h  (jolt.host/ref-get endpoint :host)
-           p  (jolt.host/ref-get endpoint :port)
-           fd (jolt.host/ref-get self :fd)
-           sa (make-sockaddr-in h p)]
-       (let [r (c-connect fd sa 16)]
-         (ffi/free sa)
-         (when (neg? r) (throw (java.io.IOException. "connect() failed")))))
-     (jolt.host/ref-put! self :connected? true)
-     nil)
+   (fn
+     ([self endpoint] (socket-connect! self endpoint))
+     ;; Java's timeout is milliseconds-until-abort; this connect is always
+     ;; blocking (equivalent to timeout 0). Divergence, documented in the ns.
+     ([self endpoint _timeout] (socket-connect! self endpoint)))
 
    "getInputStream"
    (fn [self]
-     (let [inst (jolt.host/tagged-table :socket-input-stream)]
-       (jolt.host/ref-put! inst :fd (jolt.host/ref-get self :fd))
-       inst))
+     (doto (tt :socket-input-stream "java.net.SocketInputStream")
+       (jolt.host/ref-put! :fd (jolt.host/ref-get self :fd))
+       (jolt.host/ref-put! :socket self)))
 
    "getOutputStream"
    (fn [self]
-     (let [inst (jolt.host/tagged-table :socket-output-stream)]
-       (jolt.host/ref-put! inst :fd (jolt.host/ref-get self :fd))
-       inst))
+     (doto (tt :socket-output-stream "java.net.SocketOutputStream")
+       (jolt.host/ref-put! :fd (jolt.host/ref-get self :fd))
+       (jolt.host/ref-put! :socket self)))
 
-   "close"
+   "close"        socket-close!
+   "isConnected"  (fn [self] (boolean (jolt.host/ref-get self :connected?)))
+   "isClosed"     (fn [self] (boolean (jolt.host/ref-get self :closed?)))
+   "isBound"      (fn [self] (boolean (jolt.host/ref-get self :connected?)))
+   "getLocalPort" (fn [self] (or (jolt.host/ref-get self :local-port)
+                                 (local-port (jolt.host/ref-get self :fd))))
+   "getPort"      (fn [self] (or (jolt.host/ref-get self :port) 0))
+   "toString"     socket->str
+
+   "getInetAddress"
    (fn [self]
-     (when-not (jolt.host/ref-get self :closed?)
-       (jolt.host/ref-put! self :closed? true)
-       (c-close (jolt.host/ref-get self :fd)))
-     nil)
+     (make-inet-address (jolt.host/ref-get self :host)
+                        (jolt.host/ref-get self :remote-addr)))
 
-   "isConnected" (fn [self] (boolean (jolt.host/ref-get self :connected?)))
-   "isClosed"    (fn [self] (boolean (jolt.host/ref-get self :closed?)))
-   "isBound"     (fn [self] (boolean (jolt.host/ref-get self :connected?)))
-
-   "getLocalPort"
-   (fn [self] (or (jolt.host/ref-get self :local-port) 0))
-
-   "toString"
+   "getRemoteSocketAddress"
    (fn [self]
-     (str "Socket[connected=" (jolt.host/ref-get self :connected?)
-          " closed=" (jolt.host/ref-get self :closed?) "]"))
-
-   "getInetAddress"  (fn [self] (jolt.host/tagged-table :inet-address))
-   "getRemoteSocketAddress" (fn [self] (jolt.host/tagged-table :inet-socket-address))})
+     (doto (tt :inet-socket-address "java.net.InetSocketAddress")
+       (jolt.host/ref-put! :host (or (jolt.host/ref-get self :remote-addr)
+                                     (jolt.host/ref-get self :host)))
+       (jolt.host/ref-put! :port (jolt.host/ref-get self :port))))})
 
 ;; -- SocketInputStream -------------------------------------------------------
 (defn- do-recv [fd buf len]
+  ;; n <= 0 answers EOF: recv 0 is orderly shutdown; a negative return (error)
+  ;; also reads as EOF because errno isn't reachable to tell ECONNRESET from
+  ;; EINTR. Java throws SocketException there — documented divergence.
   (let [n (c-recv fd buf len 0)]
     (if (pos? n)
-      (let [rb (ffi/read-array buf n)] {:n n :bytes rb})
+      {:n n :bytes (ffi/read-array buf n)}
       {:n -1 :bytes nil})))
 
 (def ^:private socket-input-stream-methods
@@ -167,75 +260,103 @@
             (if (pos? n) (bit-and (ffi/read buf :uint8 0) 0xff) -1))
           (finally (ffi/free buf)))))
      ([self b]
-      (let [fd (jolt.host/ref-get self :fd) len (alength b) buf (ffi/alloc (max 1 len))]
-        (try
-          (let [{:keys [n bytes]} (do-recv fd buf len)]
-            (if (pos? n) (do (dotimes [i n] (aset b i (nth bytes i))) n) -1))
-          (finally (ffi/free buf)))))
+      (let [fd (jolt.host/ref-get self :fd) len (alength b)]
+        (if (zero? len) 0
+            (let [buf (ffi/alloc len)]
+              (try
+                (let [{:keys [n bytes]} (do-recv fd buf len)]
+                  (if (pos? n) (do (dotimes [i n] (aset b i (nth bytes i))) n) -1))
+                (finally (ffi/free buf)))))))
      ([self b off len]
-      (let [fd (jolt.host/ref-get self :fd) buf (ffi/alloc (max 1 len))]
-        (try
-          (let [{:keys [n bytes]} (do-recv fd buf len)]
-            (if (pos? n) (do (dotimes [i n] (aset b (+ off i) (nth bytes i))) n) -1))
-          (finally (ffi/free buf))))))
+      (let [fd (jolt.host/ref-get self :fd)]
+        (if (zero? len) 0
+            (let [buf (ffi/alloc len)]
+              (try
+                (let [{:keys [n bytes]} (do-recv fd buf len)]
+                  (if (pos? n) (do (dotimes [i n] (aset b (+ off i) (nth bytes i))) n) -1))
+                (finally (ffi/free buf))))))))
    "available" (fn [self] 0)
-   "close"     (fn [self] nil)})
+   "close"     (fn [self] (socket-close! (jolt.host/ref-get self :socket)))})
 
 ;; -- SocketOutputStream ------------------------------------------------------
+(defn- send-fully! [fd buf len]
+  ;; loop over short sends; a non-positive return is a dead peer (EPIPE /
+  ;; ECONNRESET) — throw like Java rather than silently dropping the rest.
+  (loop [off 0]
+    (when (< off len)
+      (let [s (c-send fd (+ buf off) (- len off) msg-nosignal)]
+        (when-not (pos? s)
+          (throw (java.io.IOException. "Broken pipe")))
+        (recur (+ off s))))))
+
 (def ^:private socket-output-stream-methods
   {"write"
    (fn
      ([self b]
-      (let [fd (jolt.host/ref-get self :fd)
-            data (byte-array [(unchecked-byte b)])
-            n (alength data) buf (ffi/alloc n)]
-        (try (ffi/write-array buf data)
-             (loop [off 0]
-               (when (< off n)
-                 (let [s (c-send fd (+ buf off) (- n off) 0)]
-                   (when (pos? s) (recur (+ off s))))))
-             (finally (ffi/free buf)))))
-     ([self bytes off len]
-      (let [fd (jolt.host/ref-get self :fd) buf (ffi/alloc len)]
+      (let [fd (jolt.host/ref-get self :fd) buf (ffi/alloc 1)]
         (try
-          (dotimes [i len] (ffi/write buf :uint8 i (aget bytes (+ off i))))
-          (loop [t 0]
-            (when (< t len)
-              (let [s (c-send fd (+ buf t) (- len t) 0)]
-                (when (pos? s) (recur (+ t s))))))
-          (finally (ffi/free buf))))))
+          (ffi/write buf :uint8 0 (bit-and (int b) 0xff))
+          (send-fully! fd buf 1)
+          (finally (ffi/free buf)))))
+     ([self bytes off len]
+      (when (pos? len)
+        (let [fd (jolt.host/ref-get self :fd) buf (ffi/alloc len)]
+          (try
+            (dotimes [i len]
+              (ffi/write buf :uint8 i (bit-and (aget bytes (+ off i)) 0xff)))
+            (send-fully! fd buf len)
+            (finally (ffi/free buf)))))))
    "flush" (fn [self] nil)
-   "close" (fn [self] nil)})
+   "close" (fn [self] (socket-close! (jolt.host/ref-get self :socket)))})
 
 ;; -- ServerSocket ------------------------------------------------------------
 (defn- server-ctor [& args]
-  (let [port (if (pos? (count args)) (int (first args)) 0)
-        fd   (new-fd!)
-        sa   (make-loopback-sa port)]
+  ;; [] [port] [port backlog] [port backlog bindAddr] — binds the wildcard
+  ;; address unless bindAddr says otherwise, like Java. Port 0 asks the kernel
+  ;; for an ephemeral port; getsockname recovers the real one.
+  (let [port      (if (pos? (count args)) (int (first args)) 0)
+        backlog   (if (>= (count args) 2) (int (second args)) 50)
+        bind-host (if (>= (count args) 3) (host-arg->str (nth args 2)) "0.0.0.0")
+        fd        (new-fd!)
+        sa        (make-sockaddr-in bind-host port)]
     (when (neg? (c-bind fd sa 16))
       (c-close fd) (ffi/free sa)
       (throw (java.io.IOException. (str "bind failed on port " port))))
     (ffi/free sa)
-    (when (neg? (c-listen fd 50))
-      (c-close fd) (throw (java.io.IOException. "listen() failed")))
-    (let [inst (jolt.host/tagged-table :server-socket)]
-      (jolt.host/ref-put! inst :fd fd)
-      (jolt.host/ref-put! inst :closed? false)
-      (jolt.host/ref-put! inst :port port)
-      inst)))
+    (when (neg? (c-listen fd backlog))
+      (c-close fd)
+      (throw (java.io.IOException. "listen() failed")))
+    (doto (tt :server-socket "java.net.ServerSocket")
+      (jolt.host/ref-put! :fd fd)
+      (jolt.host/ref-put! :closed? false)
+      (jolt.host/ref-put! :bind-addr bind-host)
+      (jolt.host/ref-put! :port (if (zero? port) (local-port fd) port)))))
+
+(defn- server->str [self]
+  (let [ba (or (jolt.host/ref-get self :bind-addr) "0.0.0.0")]
+    (str "ServerSocket[addr=" ba "/" ba
+         ",localport=" (or (jolt.host/ref-get self :port) 0) "]")))
 
 (def ^:private server-socket-methods
   {"accept"
    (fn [self]
      (when (jolt.host/ref-get self :closed?)
        (throw (java.io.IOException. "ServerSocket closed")))
-     (let [cfd (c-accept (jolt.host/ref-get self :fd) ffi/null ffi/null)]
-       (when (neg? cfd) (throw (java.io.IOException. "accept() failed")))
-       (let [inst (jolt.host/tagged-table :socket)]
-         (jolt.host/ref-put! inst :fd cfd)
-         (jolt.host/ref-put! inst :closed? false)
-         (jolt.host/ref-put! inst :connected? true)
-         inst)))
+     (let [sa (ffi/alloc 16) lenp (ffi/alloc 4)]
+       (try
+         (ffi/write lenp :int 0 16)
+         (let [cfd (c-accept (jolt.host/ref-get self :fd) sa lenp)]
+           (when (neg? cfd) (throw (java.io.IOException. "accept() failed")))
+           (guard-fd! cfd)
+           (doto (tt :socket "java.net.Socket")
+             (jolt.host/ref-put! :fd cfd)
+             (jolt.host/ref-put! :closed? false)
+             (jolt.host/ref-put! :connected? true)
+             (jolt.host/ref-put! :host (sa-addr sa))
+             (jolt.host/ref-put! :remote-addr (sa-addr sa))
+             (jolt.host/ref-put! :port (sa-port sa))
+             (jolt.host/ref-put! :local-port (local-port cfd))))
+         (finally (ffi/free sa) (ffi/free lenp)))))
 
    "close"
    (fn [self]
@@ -247,37 +368,71 @@
    "isClosed"     (fn [self] (boolean (jolt.host/ref-get self :closed?)))
    "isBound"      (fn [self] (not (jolt.host/ref-get self :closed?)))
    "getLocalPort" (fn [self] (or (jolt.host/ref-get self :port) 0))
-   "toString"     (fn [self]
-                    (str "ServerSocket[port=" (jolt.host/ref-get self :port)
-                         " closed=" (jolt.host/ref-get self :closed?) "]"))})
+   "toString"     server->str})
 
 ;; -- InetSocketAddress -------------------------------------------------------
 (defn- isa-ctor [& args]
-  (let [h (if (= 1 (count args)) "127.0.0.1" (str (first args)))
-        p (int (if (= 1 (count args)) (first args) (second args)))
-        inst (jolt.host/tagged-table :inet-socket-address)]
-    (jolt.host/ref-put! inst :host h)
-    (jolt.host/ref-put! inst :port p)
-    inst))
+  ;; (InetSocketAddress. port) is the wildcard address, like Java.
+  (let [h (if (= 1 (count args)) "0.0.0.0" (host-arg->str (first args)))
+        p (int (if (= 1 (count args)) (first args) (second args)))]
+    (doto (tt :inet-socket-address "java.net.InetSocketAddress")
+      (jolt.host/ref-put! :host h)
+      (jolt.host/ref-put! :port p))))
+
+(defn- isa->str [self]
+  (str (or (jolt.host/ref-get self :host) "0.0.0.0")
+       ":" (or (jolt.host/ref-get self :port) 0)))
 
 (def ^:private inet-socket-address-methods
-  {"getHostName" (fn [self] (or (jolt.host/ref-get self :host) "127.0.0.1"))
-   "getPort"     (fn [self] (or (jolt.host/ref-get self :port) 0))
-   "toString"    (fn [self]
-                   (let [h (or (jolt.host/ref-get self :host) "127.0.0.1")
-                         p (or (jolt.host/ref-get self :port) 0)]
-                     (str h ":" p)))})
+  {"getHostName"   (fn [self] (or (jolt.host/ref-get self :host) "0.0.0.0"))
+   "getHostString" (fn [self] (or (jolt.host/ref-get self :host) "0.0.0.0"))
+   "getPort"       (fn [self] (or (jolt.host/ref-get self :port) 0))
+   "isUnresolved"  (fn [self] false)
+   "getAddress"
+   (fn [self]
+     (let [h (or (jolt.host/ref-get self :host) "0.0.0.0")]
+       (make-inet-address h (try (ip->str (resolve-host h))
+                                 (catch java.io.IOException _ nil)))))
+   "toString"      isa->str})
 
+;; -- InetAddress --------------------------------------------------------------
 (defn- inet-address-ctor [& _]
-  (let [inst (jolt.host/tagged-table :inet-address)]
-    (jolt.host/ref-put! inst :address "127.0.0.1")
-    inst))
+  (make-inet-address "localhost" "127.0.0.1"))
+
+(defn- inet-address->str [self]
+  (str (or (jolt.host/ref-get self :host) "")
+       "/" (or (jolt.host/ref-get self :address) "")))
 
 (def ^:private inet-address-methods
   {"getHostAddress" (fn [self] (or (jolt.host/ref-get self :address) "127.0.0.1"))
-   "toString"       (fn [self] (or (jolt.host/ref-get self :address) "127.0.0.1"))})
+   "getHostName"    (fn [self] (or (jolt.host/ref-get self :host)
+                                   (jolt.host/ref-get self :address)))
+   "toString"       inet-address->str})
 
-;; -- Registration ------------------------------------------------------------
+(def ^:private inet-address-statics
+  {"getByName"
+   (fn [h] (make-inet-address (str h) (ip->str (resolve-host h))))
+   "getLoopbackAddress"
+   (fn [] (make-inet-address "localhost" "127.0.0.1"))})
+
+;; -- value-semantics + registration -------------------------------------------
+
+(def ^:private tag->classes
+  {:socket               #{"Socket" "java.net.Socket"}
+   :server-socket        #{"ServerSocket" "java.net.ServerSocket"}
+   :socket-input-stream  #{"InputStream" "java.io.InputStream"}
+   :socket-output-stream #{"OutputStream" "java.io.OutputStream"}
+   :inet-socket-address  #{"InetSocketAddress" "java.net.InetSocketAddress"
+                           "SocketAddress" "java.net.SocketAddress"}
+   :inet-address         #{"InetAddress" "java.net.InetAddress"
+                           "Inet4Address" "java.net.Inet4Address"}})
+
+(def ^:private tag->render
+  {:socket              socket->str
+   :server-socket       server->str
+   :inet-socket-address isa->str
+   :inet-address        inet-address->str})
+
 (def ^:private registered? (atom false))
 
 (defn register-all! []
@@ -294,6 +449,8 @@
 
     (clojure.core/__register-class-ctor! "InetAddress" inet-address-ctor)
     (clojure.core/__register-class-ctor! "java.net.InetAddress" inet-address-ctor)
+    (clojure.core/__register-class-statics! "InetAddress" inet-address-statics)
+    (clojure.core/__register-class-statics! "java.net.InetAddress" inet-address-statics)
 
     (clojure.core/__register-class-ctor! "Socket" socket-ctor)
     (clojure.core/__register-class-ctor! "java.net.Socket" socket-ctor)
@@ -301,7 +458,17 @@
     (clojure.core/__register-class-ctor! "ServerSocket" server-ctor)
     (clojure.core/__register-class-ctor! "java.net.ServerSocket" server-ctor)
 
-    (println "[jolt.socket] Registered Socket, ServerSocket, InetSocketAddress")
+    ;; (instance? java.net.Socket s) etc.; only ever asserts true — anything
+    ;; else defers to the next check and the built-ins.
+    (clojure.core/__register-instance-check!
+      (fn [cn val]
+        (let [cs (tag->classes (jolt.host/ref-get val :jolt/type))]
+          (when (and cs (contains? cs cn)) true))))
+
+    ;; (str sock) renders through toString like Java; pred is two cheap lookups.
+    (clojure.core/__register-str!
+      (fn [x] (contains? tag->render (jolt.host/ref-get x :jolt/type)))
+      (fn [x] ((tag->render (jolt.host/ref-get x :jolt/type)) x)))
     true))
 
 (register-all!)

--- a/test/chez/socket-test.clj
+++ b/test/chez/socket-test.clj
@@ -1,0 +1,171 @@
+;; jolt.socket gate — the java.net.Socket/ServerSocket surface over real
+;; loopback TCP. Run: bin/jolt run test/chez/socket-test.clj (smoke.sh greps
+;; for "SOCKET-TEST OK"). Every server binds port 0 (kernel-assigned), so
+;; parallel gates never collide on a port.
+(ns socket-test
+  (:require [clojure.string :as str]))
+
+(require 'jolt.socket)
+
+(def failures (atom []))
+
+;; announce BEFORE evaluating, and flush: a check that blocks (accept/recv
+;; with no peer) must name itself in the log rather than hang silently.
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; connect lands in the listen backlog, so single-threaded connect-then-accept
+;; is safe; every helper closes what it opens.
+(defn with-pair [f]
+  (let [server (java.net.ServerSocket. 0)
+        client (java.net.Socket. "127.0.0.1" (.getLocalPort server))
+        conn   (.accept server)]
+    (try (f server client conn)
+         (finally (.close conn) (.close client) (.close server)))))
+
+;; roundtrip both directions
+(with-pair
+  (fn [server client conn]
+    (let [msg (.getBytes "hello over tcp" "UTF-8")]
+      (.write (.getOutputStream client) msg 0 (alength msg)))
+    (let [buf (byte-array 64)
+          n   (.read (.getInputStream conn) buf 0 64)]
+      (check-eq "roundtrip client->server" (String. buf 0 n "UTF-8") "hello over tcp"))
+    (let [msg (.getBytes "pong" "UTF-8")]
+      (.write (.getOutputStream conn) msg 0 (alength msg)))
+    (let [buf (byte-array 16)
+          n   (.read (.getInputStream client) buf 0 16)]
+      (check-eq "roundtrip server->client" (String. buf 0 n "UTF-8") "pong"))))
+
+;; hostname resolution (gethostbyname path)
+(let [server (java.net.ServerSocket. 0)
+      client (java.net.Socket. "localhost" (.getLocalPort server))]
+  (check-eq "hostname connect" (.isConnected client) true)
+  (.close client) (.close server))
+
+;; binary-safe bytes above 127
+(with-pair
+  (fn [server client conn]
+    (let [data (byte-array [(unchecked-byte 0) (unchecked-byte 127)
+                            (unchecked-byte 128) (unchecked-byte 200)
+                            (unchecked-byte 255)])]
+      (.write (.getOutputStream client) data 0 5)
+      (let [buf (byte-array 8)
+            n   (.read (.getInputStream conn) buf 0 8)]
+        (check-eq "binary bytes" [n (mapv #(bit-and % 0xff) (take n buf))]
+                  [5 [0 127 128 200 255]])))))
+
+;; single-byte write/read arities; zero-length read answers 0 like Java
+(with-pair
+  (fn [server client conn]
+    (.write (.getOutputStream client) 65)
+    (check-eq "single byte" (.read (.getInputStream conn)) 65)
+    (check-eq "zero-length read" (.read (.getInputStream client) (byte-array 0)) 0)))
+
+;; read into an offset
+(with-pair
+  (fn [server client conn]
+    (let [msg (.getBytes "ab" "UTF-8")]
+      (.write (.getOutputStream client) msg 0 2))
+    (let [buf (byte-array [(byte 45) (byte 45) (byte 45) (byte 45)])
+          n   (.read (.getInputStream conn) buf 1 2)]
+      (check-eq "offset read" [n (String. buf 0 4 "UTF-8")] [2 "-ab-"]))))
+
+;; EOF after peer close
+(with-pair
+  (fn [server client conn]
+    (.close client)
+    (check-eq "eof read" (.read (.getInputStream conn)) -1)))
+
+;; refused connect throws (bind an ephemeral port, close it, dial it)
+(let [server (java.net.ServerSocket. 0)
+      port   (.getLocalPort server)]
+  (.close server)
+  (check-eq "refused connect throws"
+            (try (java.net.Socket. "127.0.0.1" port) "no-throw"
+                 (catch java.io.IOException e "threw"))
+            "threw"))
+
+;; bind conflict throws
+(let [server (java.net.ServerSocket. 0)]
+  (check-eq "bind conflict throws"
+            (try (java.net.ServerSocket. (.getLocalPort server)) "no-throw"
+                 (catch java.io.IOException e "threw"))
+            "threw")
+  (.close server))
+
+;; write to a peer-closed socket throws instead of silently dropping — and the
+;; process must survive it (SIGPIPE guarded via MSG_NOSIGNAL / SO_NOSIGPIPE).
+(let [server (java.net.ServerSocket. 0)
+      client (java.net.Socket. "127.0.0.1" (.getLocalPort server))
+      conn   (.accept server)
+      out    (.getOutputStream client)
+      msg    (.getBytes "x" "UTF-8")]
+  (.close conn)
+  (Thread/sleep 100)
+  ;; the first write may itself draw the RST (timing differs by platform), so
+  ;; both live inside the try: what's asserted is that SOME write throws.
+  (check-eq "broken pipe throws"
+            (try (.write out msg 0 1)
+                 (Thread/sleep 100)
+                 (.write out msg 0 1)
+                 "no-throw"
+                 (catch java.io.IOException e "threw"))
+            "threw")
+  (.close client) (.close server))
+
+;; port 0 reports the kernel-assigned port; connected sockets know both ends
+(with-pair
+  (fn [server client conn]
+    (check-eq "server ephemeral port" (pos? (.getLocalPort server)) true)
+    (check-eq "client local port" (pos? (.getLocalPort client)) true)
+    (check-eq "client remote port" (.getPort client) (.getLocalPort server))
+    (check-eq "accepted peer port" (.getPort conn) (.getLocalPort client))
+    (check-eq "accepted peer addr" (.getHostAddress (.getInetAddress conn)) "127.0.0.1")))
+
+;; class model: class / instance? / str-through-toString
+(with-pair
+  (fn [server client conn]
+    (check-eq "class Socket" (.getName (class client)) "java.net.Socket")
+    (check-eq "class ServerSocket" (.getName (class server)) "java.net.ServerSocket")
+    (check-eq "instance? Socket" (instance? java.net.Socket client) true)
+    (check-eq "instance? cross-class" (instance? java.net.ServerSocket client) false)
+    (check-eq "instance? InputStream" (instance? java.io.InputStream (.getInputStream client)) true)
+    (check-eq "str routes toString" (str/starts-with? (str client) "Socket[addr=") true)
+    (check-eq "unconnected toString" (str (java.net.Socket.)) "Socket[unconnected]")))
+
+;; InetAddress / InetSocketAddress
+(check-eq "getByName localhost" (.getHostAddress (java.net.InetAddress/getByName "localhost")) "127.0.0.1")
+(check-eq "getByName class" (.getName (class (java.net.InetAddress/getByName "localhost"))) "java.net.Inet4Address")
+(let [isa (java.net.InetSocketAddress. "127.0.0.1" 8080)]
+  (check-eq "isa port" (.getPort isa) 8080)
+  (check-eq "isa host" (.getHostName isa) "127.0.0.1")
+  (check-eq "isa getAddress" (.getHostAddress (.getAddress isa)) "127.0.0.1"))
+
+;; no-arg Socket + .connect(endpoint)
+(let [server (java.net.ServerSocket. 0)
+      client (java.net.Socket.)]
+  (.connect client (java.net.InetSocketAddress. "127.0.0.1" (.getLocalPort server)))
+  (check-eq "connect endpoint" (.isConnected client) true)
+  (.close client) (.close server))
+
+;; ServerSocket(port, backlog, bindAddr) restricts the bind
+(let [lb (java.net.ServerSocket. 0 5 (java.net.InetAddress/getByName "127.0.0.1"))]
+  (check-eq "bindAddr honored" (str/includes? (str lb) "addr=127.0.0.1") true)
+  (.close lb))
+
+;; closing a stream closes the socket, like Java
+(with-pair
+  (fn [server client conn]
+    (.close (.getInputStream conn))
+    (check-eq "stream close closes socket" (.isClosed conn) true)))
+
+(if (empty? @failures)
+  (println "SOCKET-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "SOCKET-TEST FAILED:" (count @failures))))

--- a/test/chez/socket-test.clj
+++ b/test/chez/socket-test.clj
@@ -144,7 +144,10 @@
 (check-eq "getByName class" (.getName (class (java.net.InetAddress/getByName "localhost"))) "java.net.Inet4Address")
 (let [isa (java.net.InetSocketAddress. "127.0.0.1" 8080)]
   (check-eq "isa port" (.getPort isa) 8080)
-  (check-eq "isa host" (.getHostName isa) "127.0.0.1")
+  ;; getHostString, not getHostName: the JVM reverse-resolves a literal to
+  ;; "localhost" (nameservice-dependent); getHostString answers the literal
+  ;; on both. jolt's getHostName skips the reverse lookup — known divergence.
+  (check-eq "isa host" (.getHostString isa) "127.0.0.1")
   (check-eq "isa getAddress" (.getHostAddress (.getAddress isa)) "127.0.0.1"))
 
 ;; no-arg Socket + .connect(endpoint)

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -324,7 +324,36 @@
    :behavior "java.lang.management.ManagementFactory/getMemoryMXBean and the MXBean API"
    :jvm "returns a MemoryMXBean reporting heap/non-heap usage, GC counts, and more"
    :jolt "absent; the call raises \"No matching method getMemoryMXBean\""
-   :note "Runtime.totalMemory/freeMemory/maxMemory ARE present over Chez's collector accounting. What is missing is JMX itself. Affects criterium's benchmark reporting, not its timing."}]
+   :note "Runtime.totalMemory/freeMemory/maxMemory ARE present over Chez's collector accounting. What is missing is JMX itself. Affects criterium's benchmark reporting, not its timing."}
+  ;; jolt.socket (stdlib, require-gated): java.net.Socket over POSIX fds. The
+  ;; stream's available() would need ioctl(FIONREAD), and ioctl is variadic —
+  ;; variadic C calls through the FFI are unsafe on arm64 — so it answers 0.
+  ;; InputStream.available()=0 is a legal Java answer callers must handle anyway.
+  {:category :host-model
+   :behavior "(.available (.getInputStream socket)) — requires (require 'jolt.socket)"
+   :jvm "the number of bytes readable without blocking"
+   :jolt "always 0"
+   :note "FIONREAD needs ioctl, which is variadic and so FFI-unsafe on arm64. Loop-on-read code is unaffected; code that polls available() to avoid blocking will block."}
+  ;; A recv error reads as EOF: errno is not reachable through the FFI, so
+  ;; ECONNRESET (Java: SocketException) cannot be told from EINTR (Java: retry).
+  {:category :host-model
+   :behavior "(.read (.getInputStream socket)) on a reset connection — requires (require 'jolt.socket)"
+   :jvm "throws java.net.SocketException (\"Connection reset\")"
+   :jolt "-1 (EOF)"
+   :note "No errno through the FFI, so error and orderly shutdown collapse to EOF. Writes DO throw (send's return distinguishes); only the read side is permissive."}
+  ;; connect's timeout argument is accepted and ignored — the underlying
+  ;; connect(2) is always blocking (equivalent to Java's timeout 0).
+  {:category :host-model
+   :behavior "(.connect socket endpoint 5000) — requires (require 'jolt.socket)"
+   :jvm "aborts with SocketTimeoutException after 5000 ms"
+   :jolt "blocks until the OS-level connect resolves"
+   :note "A timed connect needs non-blocking mode + poll; not modeled. The no-timeout arity behaves identically on both."}
+  ;; InetSocketAddress.toString is host:port; the JVM renders hostname/ip:port.
+  {:category :host-model
+   :behavior "(str (java.net.InetSocketAddress. \"127.0.0.1\" 80)) — requires (require 'jolt.socket)"
+   :jvm "\"/127.0.0.1:80\" (hostname null for a literal; \"localhost/127.0.0.1:80\" for a name)"
+   :jolt "\"127.0.0.1:80\""
+   :note "jolt does not resolve in the InetSocketAddress constructor (the JVM does), so the hostname/ip split doesn't exist to render. Socket/ServerSocket toString follow the JVM shape."}]
  :entries
  [;; SimpleDateFormat with no Locale answers for ROOT in jolt but the machine's
   ;; DEFAULT locale on the JVM ("March|Mar|Saturday|Sat" under en), so this row's

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -348,6 +348,16 @@
    :jvm "aborts with SocketTimeoutException after 5000 ms"
    :jolt "blocks until the OS-level connect resolves"
    :note "A timed connect needs non-blocking mode + poll; not modeled. The no-timeout arity behaves identically on both."}
+  ;; getHostName does no reverse lookup. The JVM reverse-resolves a
+  ;; literal-address InetSocketAddress ("127.0.0.1" answers "localhost" when
+  ;; the nameservice maps it), which makes its value machine-dependent —
+  ;; the same reason the locale rows are uncertifiable. getHostString answers
+  ;; the literal on both and is the portable accessor.
+  {:category :host-model
+   :behavior "(.getHostName (java.net.InetSocketAddress. \"127.0.0.1\" 80)) — requires (require 'jolt.socket)"
+   :jvm "\"localhost\" — reverse lookup through the nameservice (machine-dependent)"
+   :jolt "\"127.0.0.1\" — the literal; no reverse lookup"
+   :note "Reverse DNS would need getnameinfo and makes the answer environment-dependent; the JVM's own javadoc flags the lookup. Use .getHostString for the literal on both. Caught certifying test/chez/socket-test.clj against the JVM."}
   ;; InetSocketAddress.toString is host:port; the JVM renders hostname/ip:port.
   {:category :host-model
    :behavior "(str (java.net.InetSocketAddress. \"127.0.0.1\" 80)) — requires (require 'jolt.socket)"


### PR DESCRIPTION
Follow-up to #542 (thanks @allen-munsch). Review found a few real bugs and some Java-semantics gaps; this fixes them and adds a smoke gate.

## Bugs

- **Silent data loss on send error.** The write loop exited quietly when `send` returned an error, so a write to a peer-closed socket dropped the rest of the buffer. It now throws `IOException` like Java. SIGPIPE is guarded (`MSG_NOSIGNAL` on Linux, `SO_NOSIGPIPE` on macOS) — without that a Linux server writing to a disconnected client dies on the signal.
- **Host strings weren't reliably NUL-terminated.** `resolve-host` allocated `len+1` bytes and wrote `len`, leaving the terminator to whatever malloc handed back; `inet_addr`/`gethostbyname` read past the string on dirty memory. Now goes through `ffi/string->ptr`.
- **sockaddr_in leaned on XNU leniency.** The family byte was written at offset 0 on macOS, where the BSD layout has `sin_len` there and `sin_family` at 1. Worked because XNU ignores the field; now writes the real layout.

## Java semantics

- `ServerSocket` binds the wildcard address like Java (was loopback-only), and takes the `(port)`, `(port backlog)`, `(port backlog bindAddr)` arities.
- `(ServerSocket. 0)` + `.getLocalPort` reports the kernel-assigned port (`getsockname` is now bound); connected sockets also answer `.getLocalPort`/`.getPort`.
- Accepted sockets record their peer, so `.getInetAddress`/`.getPort`/`.getRemoteSocketAddress` work server-side.
- `class` / `instance?` / `str` answer as the mirrored classes (`:class` entries + `__register-instance-check!` + `__register-str!`); previously `(class sock)` was `:object` and `instance?` false.
- `InetAddress/getByName` and `getLoopbackAddress` statics; `InetSocketAddress.getAddress`/`getHostString`; closing a socket stream closes the socket; zero-length reads answer 0; `Socket[unconnected]`-style toStrings.

## Deliberate divergences, recorded in known-divergences.edn

`available()` answers 0 (FIONREAD needs variadic ioctl, unsafe on arm64), a recv error reads as EOF rather than `SocketException` (no errno through the FFI), connect timeouts are ignored, `InetSocketAddress.toString` is `host:port`.

## Tests

`test/chez/socket-test.clj` — roundtrip, hostname resolution, binary bytes, EOF, refused/conflict throws, broken pipe, ephemeral ports, peer info, class model — wired into smoke.sh. All servers bind port 0, so parallel gates never collide.
