### PR TITLE
PSL R8: eval/compile/AOT isolation behind adapter entry points

### DIFF
--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1235,7 +1235,7 @@
 ;; raising ((take nil coll) must throw, not walk off a nil count). Level 2
 ;; keeps every check with nearly all of the optimization.
 (define bld-chez-params
-  `(("optimized" (optimize-level 2)
+  '(("optimized" (optimize-level 2)
                  (generate-inspector-information #f)
                  (generate-procedure-source-information #f)
                  (fasl-compressed #t))
@@ -1257,17 +1257,19 @@
           "" (cdr params))
         "")))
 
-;; Compile one flat source file under the mode's Chez parameters.
+;; Compile one flat source file under the mode's Chez parameters. The mode->params
+;; table stays as jolt build policy; this is a thin translation of those params
+;; into the target-neutral profile sa-compile-file consumes.
 (define (bld-chez-compile-file mode src so)
   (let ((params (assoc mode bld-chez-params)))
     (if params
         (let ((pv (lambda (k) (cadr (assq k (cdr params))))))
-          (parameterize ((optimize-level (pv 'optimize-level))
-                         (generate-inspector-information (pv 'generate-inspector-information))
-                         (generate-procedure-source-information (pv 'generate-procedure-source-information))
-                         (fasl-compressed (pv 'fasl-compressed)))
-            (compile-file src so)))
-        (compile-file src so))))
+          (sa-compile-file src so
+            `((optimize . ,(pv 'optimize-level))
+              (inspector-info . ,(pv 'generate-inspector-information))
+              (source-info . ,(pv 'generate-procedure-source-information))
+              (compressed . ,(pv 'fasl-compressed)))))
+        (sa-compile-file src so #f))))
 
 ;; --- runtime-half fasl cache -------------------------------------------------
 ;; The runtime half of the flat source (rt.ss + the clojure.core prelude +
@@ -1385,10 +1387,10 @@
     ;; foreign-procedure at runtime, but every defcfn in the image was
     ;; AOT-compiled, so the FFI is unaffected.
     ;; The unit fasls go in after the Chez boots, in the order they were compiled.
-    (apply make-boot-file boot '()
-           (append (list petite)
-                   (if petite-only? '() (list scheme))
-                   (map cadr units)))
+    (sa-make-boot-file boot
+      (append (list petite)
+              (if petite-only? '() (list scheme))
+              (map cadr units)))
     (ei-mark! "make-boot-file")
     ;; The stub is the native launcher the boot is appended to. With no :static
     ;; natives it's the prebuilt one bundled in jolt (no cc needed); with :static

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -477,8 +477,7 @@
 (define (aot-runtime-fingerprint)
   (when (eq? aot-fingerprint-memo 'unset)
     (set! aot-fingerprint-memo
-      (or (and (top-level-bound? 'jolt-baked-runtime-fingerprint)
-               (top-level-value 'jolt-baked-runtime-fingerprint))
+      (or (sa-baked-global 'jolt-baked-runtime-fingerprint)
           (aot-source-fingerprint))))
   aot-fingerprint-memo)
 ;; …-tr when the tail-frame history is on. Whether tracing is enabled changes the
@@ -754,7 +753,7 @@
             ;; current-output-port by default — swallow it so a cache miss can't
             ;; corrupt the running program's stdout.
             (parameterize ((current-output-port (open-output-string)))
-              (compile-file scm tmp-so))
+              (sa-compile-file scm tmp-so #f))
             (rename-file tmp-so so))
           (unless (file-exists? so)
             (aot-info (string-append "no .so produced for " name))))))))
@@ -983,7 +982,7 @@
       ;; compile-file narrates to current-output-port by default — swallow it so a
       ;; compile can't corrupt the running program's stdout.
       (parameterize ((current-output-port (open-output-string)))
-        (compile-file (cpath-scm-file base) tmp-so))
+        (sa-compile-file (cpath-scm-file base) tmp-so #f))
       (delete-file (cpath-so-file base) #f)
       (cpath-write-meta! (cpath-meta-file base) (cpath-meta-lines name deps))
       (rename-file tmp-so (cpath-so-file base)))

--- a/host/chez/portability-allowlist.txt
+++ b/host/chez/portability-allowlist.txt
@@ -2,25 +2,15 @@
 # Regenerate with: sh host/chez/portability-check.sh --regen
 # Lines: <file> <identifier>. A line whose hit disappears is STALE and fails the gate.
 # srfi-portable tier hits and CONTRACT names are never listed here.
-host/chez/build.ss compile-file
-host/chez/build.ss make-boot-file
-host/chez/compile-eval.ss interaction-environment
 host/chez/hasheq.ss $primitive
-host/chez/loader.ss compile-file
-host/chez/loader.ss top-level-bound?
-host/chez/loader.ss top-level-value
-host/chez/rt.ss top-level-bound?
-host/chez/rt.ss top-level-value
-host/chez/run-contagion.ss interaction-environment
-host/chez/run-devirt.ss interaction-environment
-host/chez/run-fieldread.ss interaction-environment
-host/chez/run-narrow.ss interaction-environment
-host/chez/run-pic.ss interaction-environment
 host/chez/scheme-adapter-runtime.ss bytes-allocated
 host/chez/scheme-adapter-runtime.ss collect
 host/chez/scheme-adapter-runtime.ss collect-maximum-generation
 host/chez/scheme-adapter-runtime.ss collect-trip-bytes
+host/chez/scheme-adapter-runtime.ss compile-file
 host/chez/scheme-adapter-runtime.ss current-memory-bytes
+host/chez/scheme-adapter-runtime.ss fasl-read
+host/chez/scheme-adapter-runtime.ss fasl-write
 host/chez/scheme-adapter-runtime.ss file-modification-time
 host/chez/scheme-adapter-runtime.ss foreign-alloc
 host/chez/scheme-adapter-runtime.ss foreign-callable-entry-point
@@ -35,11 +25,11 @@ host/chez/scheme-adapter-runtime.ss inspect/object
 host/chez/scheme-adapter-runtime.ss load-shared-object
 host/chez/scheme-adapter-runtime.ss lock-object
 host/chez/scheme-adapter-runtime.ss machine-type
+host/chez/scheme-adapter-runtime.ss make-boot-file
 host/chez/scheme-adapter-runtime.ss maximum-memory-bytes
 host/chez/scheme-adapter-runtime.ss open-process-ports
 host/chez/scheme-adapter-runtime.ss real-time
 host/chez/scheme-adapter-runtime.ss statistics
+host/chez/scheme-adapter-runtime.ss top-level-bound?
+host/chez/scheme-adapter-runtime.ss top-level-value
 host/chez/scheme-adapter-runtime.ss unlock-object
-host/chez/state-image.ss fasl-read
-host/chez/state-image.ss fasl-write
-host/chez/state-image.ss top-level-value

--- a/host/chez/portability-blocklist.txt
+++ b/host/chez/portability-blocklist.txt
@@ -49,7 +49,10 @@ compile-to-file
 compile-file
 compile-whole-program
 make-boot-file
-interaction-environment
+optimize-level
+generate-inspector-information
+generate-procedure-source-information
+fasl-compressed
 top-level-value
 set-top-level-value!
 top-level-bound?

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -144,8 +144,7 @@
 ;; has no baked define and falls back to $JOLT_VERSION (bin/jolt sets it from
 ;; `git describe`), then "dev".
 (define (jolt-version-string)
-  (or (and (top-level-bound? 'jolt-baked-version-early)
-           (top-level-value 'jolt-baked-version-early))
+  (or (sa-baked-global 'jolt-baked-version-early)
       (let ((v (getenv "JOLT_VERSION"))) (and v (> (string-length v) 0) v))
       "dev"))
 

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -331,3 +331,69 @@
 ;; callable registry hands to C. Contract: the entry address of a callable.
 ;; Degradation: none.
 (define (sa-foreign-callable-entry-point co) (foreign-callable-entry-point co))
+
+;; ---- R8: eval/compile/AOT (capabilities: native-compile, image) --------------
+
+;; (sa-baked-global sym) -> value | #f
+;; The top-level value of SYM, or #f when unbound. Callers probe optionally-
+;; baked globals (jolt-baked-runtime-fingerprint, jolt-baked-version-early,
+;; jolt-compile-eval-form) whose values are never #f, so #f is a safe absent
+;; sentinel. Contract: reflect on the running top level by symbol. Degradation:
+;; none — every target has SOME notion of its global environment; a target that
+;; truly cannot reflect returns #f always (all three callers tolerate absent).
+(define (sa-baked-global sym)
+  (guard (e (#t #f))
+    (and (top-level-bound? sym) (top-level-value sym))))
+
+;; (sa-compile-file src so profile) -> void
+;; Compile the Scheme source file SRC to the native object SO under PROFILE:
+;; #f = target defaults, or an alist with TARGET-NEUTRAL keys
+;; (optimize . 0..3), (inspector-info . bool), (source-info . bool),
+;; (compressed . bool). The Chez impl parameterizes optimize-level /
+;; generate-inspector-information / generate-procedure-source-information /
+;; fasl-compressed and calls compile-file; a target maps the keys it has and
+;; ignores the rest. Contract: native compilation of SRC to SO. Degradation:
+;; raise a message-carrying condition ((error 'sa-compile-file "...")), never a
+;; bare raise — the AOT cache (loader.ss) treats the raise as a cache disable
+;; and falls back to loading from source (verified with the entry point forced
+;; to raise: programs run correctly from source); `jolt build` surfaces it as a
+;; jolt-level error whose message is the condition's.
+(define (sa-compile-file src so profile)
+  (if profile
+      (let ((pv (lambda (k) (cdr (assq k profile)))))
+        (parameterize ((optimize-level (pv 'optimize))
+                       (generate-inspector-information (pv 'inspector-info))
+                       (generate-procedure-source-information (pv 'source-info))
+                       (fasl-compressed (pv 'compressed)))
+          (compile-file src so)))
+      (compile-file src so)))
+
+;; (sa-make-boot-file out base-boots) -> void
+;; Assemble the boot file OUT from the base boot files BASE-BOOTS — exactly the
+;; shape build.ss:1388 uses, (apply make-boot-file out '() base-boots), with the
+;; boot program '() (the running executable loads the boots directly). Contract:
+;; write a boot file the target's runtime can boot from. Degradation: raise —
+;; same story as sa-compile-file.
+(define (sa-make-boot-file out base-boots)
+  (apply make-boot-file out '() base-boots))
+
+;; (sa-fasl-write obj port [externals-pred]) -> void
+;; fasl-serialize OBJ to PORT, optionally under the externals predicate
+;; state-image.ss passes so refused objects are COLLECTED as externals instead
+;; of failing the write (jolt.image's dump path). Contract: serialize a value
+;; graph to a byte image, honoring the externals hook. Degradation: raise — a
+;; target without fasl serialization surfaces jolt.image's dump as a clean
+;; jolt-level unsupported error carrying the condition's message — so the raise
+;; must be a message-carrying condition ((error 'sa-fasl-write "...")), never a
+;; bare raise, whose ex-message is nil (verified both ways with the entry point
+;; forced to raise).
+(define (sa-fasl-write obj port . rest)
+  (apply fasl-write obj port rest))
+
+;; (sa-fasl-read port [who exts]) -> value
+;; Deserialize the next object from PORT; the (sa-fasl-read port 'load exts)
+;; shape restores a body whose externals were resolved by the caller (jolt.image's
+;; restore path). Contract: read back what sa-fasl-write wrote, resolving
+;; externals through EXTS. Degradation: raise — same story as sa-fasl-write.
+(define (sa-fasl-read port . rest)
+  (apply fasl-read port rest))

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -460,7 +460,7 @@
 ;; dropped the compiler has no binding at all: refuse by name instead of
 ;; surfacing an unbound-variable error mid-restore.
 (define (image-compile-eval-seam)
-  (let ((ce (guard (e (#t #f)) (top-level-value 'jolt-compile-eval-form))))
+  (let ((ce (sa-baked-global 'jolt-compile-eval-form)))
     (and (procedure? ce) ce)))
 
 ;; Rebuild one fn source record into a live closure: compile
@@ -1126,7 +1126,7 @@
     ;; cannot be written ahead of the body.
     (let ((body (call-with-bytevector-output-port
                   (lambda (p)
-                    (fasl-write (vector v* (image-collect-meta v*)) p
+                    (sa-fasl-write (vector v* (image-collect-meta v*)) p
                       (lambda (x)
                         (and (image-external? x)
                              (begin
@@ -1162,9 +1162,9 @@
                                        "image: a resource handler returned a value that is not plain data"
                                        jolt-nil))))
                     (lambda () (call-with-bytevector-output-port
-                                 (lambda (p) (fasl-write descs p)))))))))
+                                 (lambda (p) (sa-fasl-write descs p)))))))))
           (let ((port (open-file-output-port path (file-options no-fail))))
-            (fasl-write (image-header) port)
+            (sa-fasl-write (image-header) port)
             (put-bytevector port desc-bytes)
             (put-bytevector port body)
             (close-port port)))))
@@ -1177,11 +1177,11 @@
   (unless (file-exists? path)
     (jolt-throw (jolt-ex-info (string-append "image: no such file: " path) jolt-nil)))
   (let ((port (open-file-input-port path)))
-    (let* ((h (fasl-read port))
+    (let* ((h (sa-fasl-read port))
            (_ (image-check-header! h path))
-           (descs (fasl-read port))
+           (descs (sa-fasl-read port))
            (exts (list->vector (map image-decode-external descs)))
-           (b (fasl-read port 'load exts)))
+           (b (sa-fasl-read port 'load exts)))
       (close-port port)
       (unless (and (vector? b) (fx=? (vector-length b) 2))
         (jolt-throw (jolt-ex-info (string-append "image: malformed body in " path) jolt-nil)))

--- a/host/scheme-adapter/CONTRACT.txt
+++ b/host/scheme-adapter/CONTRACT.txt
@@ -182,6 +182,41 @@ sa-foreign-procedure-runtime
 sa-foreign-procedure
 sa-foreign-procedure-blocking
 #
+# tier: eval
+# interaction-environment: R7RS (scheme repl), not Chez-only. The ONLY host
+# call shape is the standard (eval expr (interaction-environment)) — jolt's
+# compile spine evals emitted Scheme in the top-level environment (rt.ss's
+# runtime procedures live there), so jolt's top level IS the interaction
+# environment (def-var! targets it). A target adapter must provide an
+# interaction environment whose eval sees the target's top level.
+interaction-environment
+#
+# tier: capability-native-compile
+# OUR OWN definitions in host/chez/scheme-adapter-runtime.ss — the eval/compile
+# tier's compile-file / make-boot-file / compile parameters behind one entry
+# surface. sa-compile-file compiles a Scheme source file to a native object
+# under a TARGET-NEUTRAL profile alist: ((optimize . 0..3) (inspector-info .
+# bool) (source-info . bool) (compressed . bool)); #f means target defaults. A
+# target maps the keys it has and ignores the rest. Permitted degradation:
+# sa-compile-file and sa-make-boot-file must RAISE on targets that cannot
+# compile to native code — the AOT cache (loader.ss) treats the raise as a
+# cache disable and loads from source, and `jolt build` must surface it as a
+# clean jolt-level error, not a Scheme backtrace.
+sa-baked-global
+sa-compile-file
+sa-make-boot-file
+#
+# tier: capability-image
+# OUR OWN definitions in host/chez/scheme-adapter-runtime.ss — the fasl/image
+# tier's fasl-write/fasl-read behind one entry surface. Shapes mirror the real
+# call sites in state-image.ss exactly: (sa-fasl-write obj port [externals-pred])
+# and (sa-fasl-read port [who exts]). Permitted degradation: must RAISE on
+# targets without fasl serialization — jolt.image's dump/restore entry points
+# surface a clean unsupported jolt-level error (verified: they already guard
+# the write/read and convert a raise into a jolt-level message).
+sa-fasl-write
+sa-fasl-read
+#
 # tier: misc
 # format is the Chez/Guile ~a ~s ~d subset (SRFI-28); printf/fprintf are
 # format to the current/given output port. pretty-print is the standard


### PR DESCRIPTION
PSL round 8 of #446 (epic jolt-867l): eval/compile/AOT behind the adapter. The allowlist is now hasheq's `$primitive` plus the adapter's own 34 sanctioned lines — no other host file uses a forbidden name.

## Reclassified, not migrated

`interaction-environment` is R7RS `(scheme repl)`, not Chez-only, and every host site is the standard `(eval expr (interaction-environment))` shape. It moves from the blocklist to the contract with the semantic note that jolt's top level IS the interaction environment (`def-var!` targets it). Clears six allowlist lines with zero code change.

## Capability: native-compile

- `sa-compile-file src so profile` — the profile is a target-neutral alist (`optimize` / `inspector-info` / `source-info` / `compressed`); Chez maps it onto its four compile parameters, which join the blocklist (they were never inventoried). `bld-chez-compile-file` becomes a thin translation from the mode table (which stays put as build policy) to the profile.
- `sa-make-boot-file` mirrors the one real call shape.
- Driver scripts (make-devboot/make-gateboot/build-jolt) turn out to use the compile parameters only inside emitted strings — driver text for a fresh Chez process, correctly invisible to the lint and legitimately Chez-flavored.

## Capability: image

`sa-fasl-write` / `sa-fasl-read` mirror state-image.ss's exact shapes (externals predicate on the dump, `'load exts` on the restore).

## Micro-seam

`sa-baked-global sym` → value or #f: the three optionally-baked top-level probes (runtime fingerprint, early version, the compile-eval seam) collapse onto it; `top-level-bound?`/`top-level-value` leave the per-file allowlist.

## Degradation, actually proven

Both proofs ran with the entry points forced to raise:
- `sa-compile-file` raising → the AOT cache quietly disables and programs load from source, correct output (`clojure.string` require + call ran green in the degraded state).
- `sa-fasl-write` raising → `jolt.image/dump!` surfaces a catchable jolt-level error. Found while proving it: a bare `(raise 'unsupported)` gives `ex-message` = nil; the contract now requires a message-carrying condition (`(error 'sa-fasl-write "...")`), which surfaces intact.

## Verification

portcheck (101 files) / adaptercheck (67 contract names) / manifestcheck green; state-image 135/135 (incl. the v0.6.5 cross-version fixture); aot-cache smoke 16/0; buildsmoke full matrix (release/optimized/direct-link/tree-shake/petite-only/...); injected `fasl-write` fails the lint naming the file; full 55-target gate green on the final tree (MAKE_EXIT=0).
