### PR TITLE
PSL R10: close-out — strict lint, target-owned files, porting docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,7 +535,8 @@ manifestcheck:
 
 # PSL R1 portability lint gate: fails when a blocklisted Chez-only identifier
 # appears in a host file that is not allowlisted for it (and on stale allowlist
-# lines). Allowlist seeded from current reality; rounds R2-R9 shrink it to empty.
+# lines, and on any line naming a non-target-owned file). Allowlist seeded from
+# current reality; the R10 end state is the two target-owned files.
 portcheck:
 	@sh host/chez/portability-check.sh
 

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -16,6 +16,31 @@
 ;; only reaches these paths after `fixnum?` guards or type dispatch.
 ;;
 ;; Loaded from rt.ss BEFORE collections.ss so key-hash can use jolt-hasheq.
+;;
+;; TARGET-OWNED FILE (PSL R10): hasheq.ss is a per-target implementation a port
+;; REPLACES rather than migrates — the Chez-tuned hash engine. The #3% sites
+;; above are proven-sound unsafe variants (bounded intermediates, guarded
+;; entry); a target port supplies its own hasheq using safe ops or its own
+;; unsafe forms, keeping the SAME exported procedures. The portability gate
+;; allows this file's $primitive use only because the file is target-owned.
+;; Loaded by rt.ss as a plain top-level load, so the "exports" are the
+;; procedures the rest of the host actually calls from here (verified against
+;; call sites, not guessed). A target must reimplement exactly these:
+;;   jolt-hasheq                    entry point: fast paths + arms + fallback
+;;   murmur3-hash-long-flat         fixnum hashing (collections.ss key-hash)
+;;   murmur3-hash-int               int hashing (java/host-static-methods.ss)
+;;   murmur3-hash-long              long/bignum-in-range hashing
+;;   murmur3-hash-unencoded-chars   string-char hashing (host-static-methods)
+;;   big-integer-hashcode           bignum hash (java/bigdec.ss)
+;;   mix-coll-hash                  collection combine (collections/records/...)
+;;   hash-ordered                   seq hashing (seq.ss, reader.ss, ...)
+;;   hash-unordered                 map/set hashing (natives-misc, static-methods)
+;;   entry-hasheq                   (key . value) pair hash (collections/records)
+;;   hash-combine                   combiner (natives-reader, io, natives-str)
+;;   compute-keyword-hasheq         keyword hashing (values.ss)
+;;   symbol-hasheq / compute-symbol-hasheq   symbol hashing (records.ss)
+;; (string-hasheq, double-hasheq, jolt-hasheq-fallback and the caches stay
+;; INTERNAL — reached only through jolt-hasheq.)
 
 ;; ============================================================================
 ;; 32-bit signed integer helpers — all macros (syntax-rules) so they textually

--- a/host/chez/portability-blocklist.txt
+++ b/host/chez/portability-blocklist.txt
@@ -1,8 +1,13 @@
 # host/chez/portability-blocklist.txt — FORBIDDEN Chez-only identifiers the host
 # may not use directly, regardless of target. Rounds R4-R9 of the
 # portable-scheme-layer epic route each tier behind capability entry points in
-# host/scheme-adapter/chez.ss; the allowlist (portability-allowlist.txt) shrinks
-# to empty as they do, and this file grows with what the census finds.
+# host/scheme-adapter/chez.ss. The end state (R10) is structural, not zero
+# lines: the allowlist (portability-allowlist.txt) may only name TARGET-OWNED
+# files — per-target implementations a port replaces rather than migrates
+# (today: host/chez/scheme-adapter-runtime.ss and host/chez/hasheq.ss). An
+# allowlist line naming any other file fails the gate regardless of whether its
+# hit is real: a real forbidden-name use in a normal file is routed through the
+# adapter, never allowlisted. This file grows with what the census finds.
 #
 # Names every target's adapter must provide moved to
 # host/scheme-adapter/CONTRACT.txt in R2 (threads, system basics, and the misc

--- a/host/chez/portability-check.ss
+++ b/host/chez/portability-check.ss
@@ -117,6 +117,16 @@
 (define allowlist-file (rooted "host/chez/portability-allowlist.txt"))
 (define census-file (rooted ".dirge/psl-census.md"))
 
+(define target-owned-files
+  ;; A target-owned file is a per-target implementation a port REPLACES rather
+  ;; than migrates: today the adapter runtime (the sanctioned home of the
+  ;; forbidden names) and the Chez-tuned hash implementation. PSL R10 strict
+  ;; lint: the allowlist may ONLY name these files. A real forbidden-name use
+  ;; in any other file is a signal to route through the adapter, never to
+  ;; allowlist.
+  '("host/chez/scheme-adapter-runtime.ss"
+    "host/chez/hasheq.ss"))
+
 ;; ---------------------------------------------------------------------------
 ;; blocklist: identifier symbol -> tier name (tier headers are "# tier: NAME")
 ;; ---------------------------------------------------------------------------
@@ -430,6 +440,16 @@
        #t)
       (else (loop (cdr l))))))
 
+(define (not-target-owned-files lines)
+  ;; Allowlist lines whose file is not target-owned. The rule is STRUCTURAL:
+  ;; it fires even when the line's hit is real, because a real forbidden-name
+  ;; use in a normal file is exactly what must be routed through the adapter.
+  (let loop ((l lines) (bad '()))
+    (cond
+      ((null? l) (reverse bad))
+      ((member (car (car l)) target-owned-files) (loop (cdr l) bad))
+      (else (loop (cdr l) (cons (car (car l)) bad))))))
+
 (define (run-gate results errors)
   (let ((allow (read-allowlist allowlist-file)))
     (define fail 0)
@@ -455,6 +475,14 @@
           (printf "  STALE ~a ~a\n" (car line) (cdr line))
           (set! stale (+ stale 1))))
       allow)
+    ;; STRICT LINT (PSL R10): the allowlist may only name target-owned files.
+    ;; This fails STRUCTURALLY — a real hit in a non-target-owned file is
+    ;; exactly what must be routed through the adapter, not allowlisted.
+    (for-each
+      (lambda (f)
+        (printf "  NOT-TARGET-OWNED ~a: not target-owned; route through the adapter instead of allowlisting\n" f)
+        (set! fail (+ fail 1)))
+      (not-target-owned-files allow))
     (for-each (lambda (e) (printf "  READ-ERROR ~a: ~a\n" (car e) (cadr e))) errors)
     (printf "portability check: scanned ~a files\n" (length results))
     (if (and (= fail 0) (= stale 0) (null? errors))
@@ -501,11 +529,21 @@
                             (and (string=? (car a) (car b))
                                  (string<? (symbol->string (cadr a))
                                            (symbol->string (cadr b)))))))))
-    (write-allowlist sorted)
-    (printf "portability check: regenerated ~a lines\n" (length sorted))
-    (printf "portability check: scanned ~a files\n" (length results))
-    (for-each (lambda (e) (printf "  READ-ERROR ~a: ~a\n" (car e) (cadr e))) errors)
-    (if (null? errors) 0 1)))
+    (let ((bad (not-target-owned-files sorted)))
+      (if (null? bad)
+          (begin
+            (write-allowlist sorted)
+            (printf "portability check: regenerated ~a lines\n" (length sorted))
+            (printf "portability check: scanned ~a files\n" (length results))
+            (for-each (lambda (e) (printf "  READ-ERROR ~a: ~a\n" (car e) (cadr e))) errors)
+            (if (null? errors) 0 1))
+          (begin
+            (for-each
+              (lambda (f)
+                (printf "  NOT-TARGET-OWNED ~a: not target-owned; route through the adapter instead of allowlisting\n" f))
+              bad)
+            (printf "portability check: regen aborted — allowlist may only name target-owned files\n")
+            1)))))
 
 ;; ---------------------------------------------------------------------------
 ;; census: emit .dirge/psl-census.md

--- a/host/scheme-adapter/CONTRACT.txt
+++ b/host/scheme-adapter/CONTRACT.txt
@@ -225,7 +225,12 @@ sa-fasl-read
 # so adapters wrap. iota/list-head are SRFI-1 (take). vector-copy is SRFI-43.
 # hashtable-values returns a vector of the table's values, hashtable-cells a
 # list of (key . value) pairs (adapters build both from the R6RS
-# hashtable-keys/for-each API).
+# hashtable-keys/for-each API). scheme-version (added R10): zero-arg, a
+# human-readable version string of the target Scheme implementation — the
+# exact format is target-specific (Chez's native returns "Chez Scheme Version
+# 10.4.1"; a Guile adapter would wrap its (version)). Naming/telemetry only:
+# no host logic may parse it except target-owned build machinery (release
+# dirs, image headers), which knows its own target's format.
 gensym
 format
 printf
@@ -241,3 +246,4 @@ list-head
 vector-copy
 hashtable-values
 hashtable-cells
+scheme-version

--- a/host/scheme-adapter/TARGET-CONTRACT.md
+++ b/host/scheme-adapter/TARGET-CONTRACT.md
@@ -1,0 +1,122 @@
+# TARGET-CONTRACT.md — porting jolt's host layer to a new Scheme
+
+This is the porting document. It says what a target must provide, what it may
+degrade and how, which files it replaces outright, and how the gates hold the
+boundary. The machine-readable inventory is CONTRACT.txt (names, shapes,
+tiers) — this file is the narrative that makes it actionable. The design
+history is RFC 0010 on the site.
+
+## The shape of a port
+
+1. **Satisfy the contract names** (CONTRACT.txt, tiers `threads` through
+   `misc`). Most exist in any serious Scheme under some spelling; the work is
+   matching the PINNED SEMANTICS below, not finding the functions.
+2. **Implement or degrade the capability entry points** (`sa-*`,
+   CONTRACT.txt `capability-*` tiers). Each has a documented degradation; an
+   absent capability raises or returns empty — it never fakes.
+3. **Replace the two target-owned files**: `scheme-adapter-runtime.ss` (your
+   adapter IS this file for your target) and `hasheq.ss` (see below).
+4. **Add a backend primitive-table entry** (jolt-core/jolt/backend_scheme.clj
+   `target-prims`): your spelling for the unsafe-op prefix (empty string =
+   checked ops, safe and slower) — and make the four `sa-foreign-*` syntaxes
+   expand to your FFI forms.
+5. **Start from `guile.ss`** — the structural stub mirrors the Chez adapter
+   section by section and marks every place where "the target has this" still
+   needs "and it behaves the same" verified.
+
+## Pinned semantics (behavior a standard does not give you)
+
+These are load-bearing. Each was audited against real call sites (the R4
+threads table covered 280 of them); getting one wrong produces silent
+misbehavior, not a crash.
+
+- **Thread-parameters fork-inherit.** A child thread starts with the parent's
+  current bindings for every `make-thread-parameter`. jolt's dynamic-binding
+  conveyance into agent/async/future workers relies on this ALONE.
+- **Mutexes are non-recursive.** jolt implements reentrancy itself (monitors
+  are (mutex, owner, count) with IllegalMonitorStateException on non-owner
+  exit). If your locks are recursive, that must not become load-bearing.
+- **`condition-wait` may wake spuriously.** Every wait site loops on its
+  predicate; your implementation may wake threads freely but must not LOSE
+  wakeups.
+- **Blocking foreign calls must not stop other threads' GC.** Chez spells
+  this `__collect_safe`; `sa-foreign-procedure-blocking` /
+  `sa-foreign-callable-collect-safe` carry the requirement. A target whose
+  collector never stops other threads may collapse blocking to plain.
+- **The interaction environment is jolt's top level.** `def-var!` targets it
+  and `(eval expr (interaction-environment))` must see it.
+- **Degradation raises are message-carrying conditions** — `(error 'who
+  "message")`, never a bare raise: jolt surfaces the message through
+  ex-message, and a bare raise surfaces nil.
+
+## Capability degradations, by tier
+
+- **system**: `sa-run-process` raises without subprocess support (callers
+  genuinely need the child). GC hooks (`sa-gc-collect`, `sa-gc-trip-bytes!`)
+  may no-op. Clocks (`sa-real-time-ms`) and `sa-file-mtime-ms` are required —
+  do not fake them.
+- **introspect**: `sa-continuation-frames` → `'()`, `sa-procedure-info` → #f,
+  `sa-stats` → zero vector. The runtime keeps working: backtraces carry type
+  and message without frames (the degradedbacktrace gate proves this mode),
+  static frame reconstruction from callsite tables still works, and the image
+  writer refuses closures instead of guessing.
+- **ffi**: without dlopen/FFI, `sa-load-shared-object` raises and jolt.ffi
+  surfaces it as a jolt-level error at `load-library` — the one user-facing
+  choke point. `sa-lock-object`/`sa-unlock-object` may BOTH no-op on a
+  non-moving collector (never just one). `sa-foreign-procedure-runtime`
+  constructs an FP from a runtime signature — Chez needs eval for this; a
+  target with native runtime construction (Guile `pointer->procedure`) does
+  it directly.
+- **native-compile**: `sa-compile-file` takes a target-neutral profile
+  ((optimize . 0..3) (inspector-info . bool) (source-info . bool)
+  (compressed . bool)); map what you have, ignore the rest. On raise, the AOT
+  cache disables silently and everything loads from source — an
+  interpretation-only target runs jolt fine, it just cannot `jolt build`.
+- **image**: `sa-fasl-write`/`sa-fasl-read` raise → `jolt.image` dump/restore
+  report unsupported. A target with its own serializer can implement them,
+  but note the format contract: raw-traveling nongenerative record layouts
+  are image-format surface.
+- **threads**: absence is a designed mode, not a raise — THREADS.md specifies
+  synchronous agents/futures per construct: what stays observably honest,
+  what must raise instead of faking concurrency.
+
+## Platform identity
+
+Logic branches on derived properties only: `sa-os-family` ('macos | 'windows
+| 'linux), `sa-arch`, `sa-endian`. The raw `sa-host-tag` string appears in
+NAMES only (release dirs, image headers, telemetry) — a port chooses any
+stable identifier; nothing parses it except target-owned build machinery.
+
+## Target-owned files
+
+The lint's allowlist may only name these; everything else routes through the
+adapter (portcheck enforces this structurally):
+
+- `host/chez/scheme-adapter-runtime.ss` — the adapter itself; a port writes
+  its own.
+- `host/chez/hasheq.ss` — the Chez-tuned hash implementation (proven-sound
+  `#3%` unsafe variants in the hot loops). A port reimplements its exported
+  surface with safe ops first; tune later. The surface is listed in the
+  file's header.
+
+## Emitted code
+
+The backend emits through the same boundary: unsafe primitives via the
+per-target table (meaning-keyed; the chez entry reproduces today's output
+byte-exactly — the minted seed prelude is the proof), FFI lowerings via the
+`sa-foreign-*` syntaxes. Generated code is as portable as handwritten code;
+your adapter loads first in every boot path (rt.ss owns the load), so emitted
+references resolve by construction.
+
+## The gates
+
+- `make portcheck` — no forbidden name outside target-owned files; stale
+  lines fail; allowlist lines naming other files fail structurally.
+- `make adaptercheck` — every contract name and `sa-*` entry bound (syntax
+  bindings included).
+- `make census` — regenerates the per-tier inventory (.dirge/psl-census.md).
+- `make degradedbacktrace` — the introspect-off mode actually runs.
+
+A port is credible when: adaptercheck passes against YOUR adapter, the
+corpus and unit gates pass in interpretation mode, and every degraded
+capability fails the documented way rather than faking.

--- a/host/scheme-adapter/guile.ss
+++ b/host/scheme-adapter/guile.ss
@@ -1,0 +1,186 @@
+;; host/scheme-adapter/guile.ss — the hypothetical Guile target's adapter STUB
+;; for the portable Scheme layer (PSL R10 close-out).
+;;
+;; DESIGN ARTIFACT — NOT LOADABLE CODE. This file does not run: every entry is
+;; marked UNIMPLEMENTED. Its value is proving the CONTRACT is target-shaped,
+;; not chez-shaped: each contract name below is annotated with the Guile-native
+;; candidate where one is obvious and `??` where the mapping needs research. A
+;; real Guile port starts by filling this file in (implementing the entries,
+;; deleting the annotations), then wiring the gate-time half — a guile.ss
+;; assertion pass probing the (guile) environment like chez.ss probes
+;; (chezscheme), and a Guile scheme-adapter-runtime.ss providing the sa-* names.
+;;
+;; Structure mirrors host/scheme-adapter/chez.ss: one section per CONTRACT.txt
+;; tier, in contract order, with every name of that tier. Chez semantics PINNED
+;; in CONTRACT.txt (thread-parameter fork-inheritance, non-recursive mutexes,
+;; numeric thread ids, spurious-wakeup conditions) are noted "must verify" — a
+;; candidate is never asserted as matching without checking the target.
+;;
+;; Guile reference: 3.0.x. Module names follow Guile's (rnrs ...) / (srfi srfi-NN)
+;; conventions. Do NOT guess semantics beyond what is written here.
+
+;; ---------------------------------------------------------------------------
+;; tier: threads (SRFI-18 / (rnrs) threads)
+;; ---------------------------------------------------------------------------
+;;   fork-thread            UNIMPLEMENTED  Guile: SRFI-18 fork-thread.
+;;                                        must verify: contract pins THREAD-PARAMETER
+;;                                        FORK-INHERITANCE (child starts with creator's
+;;                                        current values); Guile's SRFI-39 parameters
+;;                                        default fresh per thread — inheritance must be
+;;                                        reproduced explicitly, like the host relies on.
+;;   make-mutex             UNIMPLEMENTED  Guile: SRFI-18 make-mutex.
+;;   mutex-acquire          UNIMPLEMENTED  Guile: (rnrs) mutex-acquire (SRFI-18 mutex-lock!).
+;;                                        must verify: contract pins NON-RECURSIVE mutexes
+;;                                        (same-thread re-acquire blocks) — SRFI-18 matches.
+;;   mutex-release          UNIMPLEMENTED  Guile: (rnrs) mutex-release.
+;;   with-mutex             UNIMPLEMENTED  Guile: (rnrs) with-mutex.
+;;   make-condition         UNIMPLEMENTED  Guile: (rnrs) make-condition.
+;;   condition-wait         UNIMPLEMENTED  Guile: (rnrs) condition-wait.
+;;                                        must verify: contract permits SPURIOUS wakeups
+;;                                        (every host wait re-checks its predicate).
+;;   condition-signal       UNIMPLEMENTED  Guile: (rnrs) condition-signal.
+;;   condition-broadcast    UNIMPLEMENTED  Guile: (rnrs) condition-broadcast.
+;;   make-thread-parameter  UNIMPLEMENTED  Guile: make-thread-parameter (SRFI-18 style).
+;;                                        must verify: fork-inheritance, same note as
+;;                                        fork-thread (host conveys dyn-binding-stack and
+;;                                        *txn* through these).
+;;   get-thread-id          UNIMPLEMENTED  ?? Guile has no numeric per-thread id;
+;;                                        current-thread returns an object.
+;;                                        must verify: contract pins a NUMBER distinct per
+;;                                        live thread (host keys an eqv?-hashtable by it and
+;;                                        multiplies it into the random seed) — needs a
+;;                                        numeric mapping.
+
+;; ---------------------------------------------------------------------------
+;; tier: system
+;; ---------------------------------------------------------------------------
+;;   getenv                 UNIMPLEMENTED  Guile: (getenv "NAME") -> string or #f (posix).
+;;   sleep                  UNIMPLEMENTED  ?? Guile's sleep is SRFI-18 seconds; contract
+;;                                        shape is R6RS (rnrs time) sleep taking a time
+;;                                        object. must verify which shape satisfies both.
+;;   current-time           UNIMPLEMENTED  Guile: (srfi srfi-19) current-time — zero-arg,
+;;                                        time-utc object; matches the pinned zero-arg shape.
+;;   system                 UNIMPLEMENTED  Guile: (system "cmd") — POSIX, exit status
+;;                                        as exact integer.
+
+;; ---------------------------------------------------------------------------
+;; tier: capability-system (sa-* names are OUR contract; Guile adapter supplies them)
+;; ---------------------------------------------------------------------------
+;;   sa-run-process         UNIMPLEMENTED  ?? Guile subprocess: (system ...) loses stdout;
+;;                                        open-pipe/open-process candidates.
+;;                                        must verify: contract requires raise 'unsupported
+;;                                        on targets without subprocess support.
+;;   sa-gc-collect          UNIMPLEMENTED  Guile: (gc) — may no-op (contract allows).
+;;   sa-gc-max-generation   UNIMPLEMENTED  ?? Guile uses Boehm GC — no generations.
+;;   sa-bytes-allocated     UNIMPLEMENTED  ?? (gc-stats) candidate; must verify field/shape.
+;;   sa-total-memory-bytes  UNIMPLEMENTED  ?? (gc-stats) candidate; must verify.
+;;   sa-max-memory-bytes    UNIMPLEMENTED  Large constant permitted by contract.
+;;   sa-real-time-ms        UNIMPLEMENTED  ?? (get-internal-real-time) — must verify units;
+;;                                        may use any monotonic ms clock, never a constant.
+;;   sa-file-mtime-ms       UNIMPLEMENTED  Guile: (stat:mtim (stat path)) — posix; must
+;;                                        verify unit (time object -> ms conversion).
+;;   sa-gc-trip-bytes!      UNIMPLEMENTED  ?? Guile exposes no GC trip threshold; no-op
+;;                                        candidate — must verify callers tolerate it.
+
+;; ---------------------------------------------------------------------------
+;; tier: capability-introspect
+;; ---------------------------------------------------------------------------
+;;   sa-host-tag            UNIMPLEMENTED  Guile: (version) -> "3.0.9" — naming/telemetry
+;;                                        only; all logic consumes the derived properties.
+;;   sa-os-family           UNIMPLEMENTED  ?? (uname) from (ice-9 posix) candidate.
+;;   sa-arch                UNIMPLEMENTED  ?? (uname) machine field candidate.
+;;   sa-endian              UNIMPLEMENTED  Guile: (native-endianness) — R6RS (rnrs bytevectors).
+;;   sa-stats               UNIMPLEMENTED  ?? (gc-stats); contract permits a zero vector.
+;;   sa-introspect-enabled? UNIMPLEMENTED  #f — degraded-backtrace gate (contract's
+;;                                        documented degradation path).
+;;   sa-continuation-frames UNIMPLEMENTED  ?? Guile's call-with-prompt does not expose
+;;                                        frames; '() permitted (backtrace renders bare).
+;;   sa-procedure-info      UNIMPLEMENTED  #f permitted by contract.
+
+;; ---------------------------------------------------------------------------
+;; tier: capability-ffi
+;; ---------------------------------------------------------------------------
+;;   sa-foreign-procedure   UNIMPLEMENTED  Guile: (pointer->procedure ret (dynamic-func name
+;;                                        lib) args) — (system foreign). must verify call
+;;                                        shape translation; SYNTAX on Chez (lowering).
+;;   sa-foreign-procedure-blocking UNIMPLEMENTED  ?? must verify collect-safety; may
+;;                                        collapse to plain sa-foreign-procedure only if the
+;;                                        collector never stops other threads.
+;;   sa-foreign-alloc       UNIMPLEMENTED  ?? (system foreign) make-c-struct / bytevector
+;;                                        candidates.
+;;   sa-foreign-free        UNIMPLEMENTED  ?? same.
+;;   sa-foreign-ref         UNIMPLEMENTED  ?? (parse-c-struct ...) candidate.
+;;   sa-foreign-set!        UNIMPLEMENTED  ?? (make-c-struct ...) candidate.
+;;   sa-foreign-sizeof      UNIMPLEMENTED  ?? (sizeof) — must verify (Guile has (sizeof)).
+;;   sa-lock-object         UNIMPLEMENTED  may BOTH no-op on a non-moving collector; Guile's
+;;   sa-unlock-object       UNIMPLEMENTED  Boehm GC is non-moving — no-op candidate;
+;;                                        must verify (never just one, or it leaks/crashes).
+;;   sa-load-shared-object  UNIMPLEMENTED  Guile: (dynamic-link "lib") — (system foreign).
+;;   sa-foreign-entry?      UNIMPLEMENTED  ?? (dynamic-func ...) failure shape; must verify.
+;;   sa-foreign-entry-address UNIMPLEMENTED Guile: (dynamic-func name lib).
+;;   sa-foreign-callable-entry-point UNIMPLEMENTED Guile: (procedure->pointer ret proc args).
+;;   sa-foreign-procedure-runtime UNIMPLEMENTED ?? internal plumbing; must verify shape.
+
+;; ---------------------------------------------------------------------------
+;; tier: eval
+;; ---------------------------------------------------------------------------
+;;   interaction-environment UNIMPLEMENTED ?? Guile idiom: (eval expr (current-module));
+;;                                        contract pins an env whose eval sees the target's
+;;                                        top level (jolt's compile spine evals emitted
+;;                                        Scheme there). must verify against (resolve-module ...)
+;;                                        / R7RS (environment ...).
+
+;; ---------------------------------------------------------------------------
+;; tier: capability-native-compile
+;; ---------------------------------------------------------------------------
+;;   sa-baked-global        UNIMPLEMENTED  ?? baked-runtime fingerprint plumbing.
+;;   sa-compile-file        UNIMPLEMENTED  Guile: compile-file (Guile native, emits .go).
+;;                                        must verify profile-alist mapping and AOT-cache
+;;                                        contract; may RAISE (cache disables, loads source).
+;;   sa-make-boot-file      UNIMPLEMENTED  ?? Guile has no boot files (different build
+;;                                        model); raise candidate — must verify.
+
+;; ---------------------------------------------------------------------------
+;; tier: capability-image
+;; ---------------------------------------------------------------------------
+;;   sa-fasl-write          UNIMPLEMENTED  ?? Guile: (ice-9 serialize) / (write ...) sexp
+;;                                        candidates; must verify externals hook contract;
+;;                                        may RAISE (jolt.image surfaces a clean unsupported
+;;                                        error — the raise must carry a message).
+;;   sa-fasl-read           UNIMPLEMENTED  ?? same, must verify externals resolution shape.
+
+;; ---------------------------------------------------------------------------
+;; tier: misc
+;; ---------------------------------------------------------------------------
+;;   gensym                 UNIMPLEMENTED  Guile: (gensym) native.
+;;   format                 UNIMPLEMENTED  Guile: SRFI-28 (format #f ...) — ~a ~s ~d subset;
+;;                                        (ice-9 format) is the full superset.
+;;   printf                 UNIMPLEMENTED  Guile: SRFI-28 (format #t ...).
+;;   fprintf                UNIMPLEMENTED  Guile: SRFI-28 (format port ...).
+;;   pretty-print           UNIMPLEMENTED  Guile: (pretty-print obj [port]) — (ice-9 pretty-print).
+;;   void                   UNIMPLEMENTED  ?? Guile: (void) exists in recent versions; must
+;;                                        verify; trivial either way (unspecified value).
+;;   box                    UNIMPLEMENTED  Guile: (srfi srfi-111) box/unbox/set-box!.
+;;   unbox                  UNIMPLEMENTED  Guile: (srfi srfi-111).
+;;   set-box!               UNIMPLEMENTED  Guile: (srfi srfi-111).
+;;   sort                   UNIMPLEMENTED  Guile: (srfi srfi-132) sort; must verify ARGUMENT
+;;                                        ORDER — contract pins Chez shape (sort pred lis),
+;;                                        SRFI-132 has the opposite; adapter wraps.
+;;   iota                   UNIMPLEMENTED  Guile: (srfi srfi-1) iota.
+;;   list-head              UNIMPLEMENTED  Guile: (srfi srfi-1) list-head.
+;;   vector-copy            UNIMPLEMENTED  Guile: (srfi srfi-43) vector-copy.
+;;   hashtable-values       UNIMPLEMENTED  build from (rnrs) hashtable-keys + ref/for-each.
+;;   hashtable-cells        UNIMPLEMENTED  build from (rnrs) hashtable-keys + ref/for-each.
+;;   scheme-version         UNIMPLEMENTED  Guile: (version) -> "3.0.9" — zero-arg, naming/
+;;                                        telemetry only; nothing may parse it.
+
+;; ===========================================================================
+;; gate-time half (mirrors chez.ss's assertion pass) — UNIMPLEMENTED
+;; ===========================================================================
+;; A Guile port replaces chez.ss's pass with one probing the (guile) environment:
+;;   - read CONTRACT.txt (same "# tier:" format);
+;;   - probe each name via (module-bound? ... (resolve-module '(guile))) plus the
+;;     sa-* definitions from the Guile scheme-adapter-runtime;
+;;   - report ALL missing names at once, exit non-zero.
+;; The chez.ss helpers (char-ws?, string->tokens, strip-comment, script-arg,
+;; contract-file) port verbatim — they are R6RS and target-neutral.


### PR DESCRIPTION
PSL round 10 of #446 (epic jolt-867l): the close-out. The portable-Scheme-layer boundary is now structural, documented, and enforced.

## Strict lint

The allowlist end state is a rule, not a number: it may only name TARGET-OWNED files — per-target implementations a port replaces rather than migrates. Today that is exactly two: `scheme-adapter-runtime.ss` (the sanctioned home of forbidden names) and `hasheq.ss` (the Chez-tuned hash engine; its 14-procedure exported surface, verified against call sites, is listed in its header). portcheck fails an allowlist line naming any other file even when its hit is real — a real forbidden-name use in a normal file is routed through the adapter, never allowlisted — and `--regen` is subject to the same rule, so it cannot launder a new file in. All three failure directions demoed: forbidden call in a normal file, structurally-rejected allowlist line, stale line.

## Porting docs

- `host/scheme-adapter/TARGET-CONTRACT.md` — the porting document: the shape of a port, the pinned semantics a standard doesn't give you (thread-parameter fork-inheritance, non-recursive mutexes, spurious wakeups, blocking-FFI collect-safety, message-carrying degradation raises), per-capability degradations, target-owned files, the backend primitive table, and what makes a port credible.
- `host/scheme-adapter/guile.ss` — a structural stub mirroring the Chez adapter tier by tier, every entry unimplemented, with Guile-native candidates where obvious and must-verify notes where the pinned semantics need checking (notably: SRFI-39 parameters do not fork-inherit — the one place Guile likely diverges from a load-bearing pin).
- RFC 0010 on the site (separate repo, publishing with this merge).

## Contract

`scheme-version` joins the misc tier: zero-arg, human-readable, naming/telemetry only, format target-specific. Review caught and removed a broken adapter wrapper that shadowed Chez's native with a call to the nonexistent `version` — the native is the contract implementation on Chez (assert-only, like every contract name), and `jolt.host/scheme-version` + build.ss's parse verified working.

## Verification

portcheck / adaptercheck (68 contract names) / census / manifestcheck green; the three lint failure demos captured and reverted; full 55-target gate green on the final tree (MAKE_EXIT=0).
