### PR TITLE
Refs travel in images by value; jolt-ref layout unfrozen

### DIFF
--- a/bench/image_refs.clj
+++ b/bench/image_refs.clj
@@ -1,0 +1,35 @@
+;; image-refs — jolt.image dump + restore of a ref-heavy graph: n refs holding
+;; small vectors inside one map. Times the write-side walk (descriptor
+;; substitution), fasl, and the restore-side re-mint — the cold path the
+;; refs-travel-by-value work touches directly.
+;;
+;; jolt-only (jolt.host image seam).
+;;   bench/run.sh image-refs 10000
+(ns image-refs)
+
+(def path "/tmp/jolt-bench-image-refs.jimg")
+
+(defn run [n]
+  (let [g (loop [i 0 acc {}]
+            (if (< i n)
+              (recur (inc i) (assoc acc i (ref [i (inc i)])))
+              acc))]
+    (jolt.host/image-write! path g)
+    (let [r (jolt.host/image-read path)]
+      @(get r (dec n)))))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 10000)]
+    (dotimes [_ 1] (run (quot n 4)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "image-refs n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/stm.clj
+++ b/bench/stm.clj
@@ -1,0 +1,44 @@
+;; stm — ref/STM throughput: ref creation, transactional ref-set/alter, and
+;; plain deref in a tight loop. Isolates the ref record allocation and the
+;; txn log/commit path; the image-format work (refs travel by value) must not
+;; move any of these.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh stm 200000
+(ns stm)
+
+(defn run [n]
+  ;; creation: n fresh refs, keep a few alive so allocation is real
+  (let [rs (loop [i 0 acc []]
+             (if (< i 32) (recur (inc i) (conj acc (ref 0))) acc))
+        r (first rs)]
+    (loop [i 0]
+      (when (< i n)
+        (ref 0)
+        (recur (inc i))))
+    ;; txn writes: one ref-set + one alter per iteration
+    (loop [i 0]
+      (when (< i n)
+        (dosync (ref-set r i) (alter r inc))
+        (recur (inc i))))
+    ;; reads: plain deref (no txn) over the batch
+    (loop [i 0 acc 0]
+      (if (< i n)
+        (recur (inc i) (+ acc @r @(peek rs)))
+        acc))))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 200000)]
+    (dotimes [_ 2] (run (quot n 4)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "stm n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/host/chez/refs.ss
+++ b/host/chez/refs.ss
@@ -10,17 +10,16 @@
 ;; atom/var/agent.  Loaded after atoms.ss (shares jolt-iref-state-throw and
 ;; the iref tables).
 
-;; The lock field is DEAD at runtime (stm-lock serializes every commit; no code
-;; reads it) but it is FROZEN in the record layout: refs travel in images as
-;; raw nongenerative records, so jolt-ref-v1's field list is image-format
-;; surface — a 0.6.5 image holding a ref fails to restore against a changed
-;; layout with "incompatible record type jolt-ref". Removing the field needs
-;; state-image to walk refs by value (like walk-atom) and a compat story for
-;; existing images first: bead jolt-867l tracks it. Verified 2026-08-06 by
-;; dumping {ref} with the v0.6.5 release binary and restoring here.
+;; Refs travel in state images by VALUE (state-image.ss substitutes an
+;; image-ref descriptor on dump and re-mints through make-jolt-ref on
+;; restore), so this layout is NOT image-format surface and may change
+;; freely. The uid jolt-ref-v1 is RETIRED: format-2 images carry refs as raw
+;; nongenerative jolt-ref-v1 records (fields: val lock), and the legacy
+;; restore arm depends on materializing that rtd from the fasl without a
+;; live conflict — never reuse the v1 uid for a different layout.
 (define-record-type jolt-ref
-  (fields (mutable val) lock)
-  (nongenerative jolt-ref-v1))
+  (fields (mutable val))
+  (nongenerative jolt-ref-v2))
 
 ;; IRef arm: refs are watchable/validatable through the iref tables.
 (register-iref-arm! jolt-ref?)
@@ -102,7 +101,7 @@
   (let loop ((o opts) (validator jolt-nil) (m #f))
     (cond
       ((or (null? o) (null? (cdr o)))
-       (let ((r (make-jolt-ref v (make-mutex))))
+       (let ((r (make-jolt-ref v)))
          ;; validate init via iref validator table
          (when (and (not (jolt-nil? validator)) (jolt-not (jolt-invoke validator v)))
            (jolt-iref-state-throw))

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -22,7 +22,14 @@
 ;; 2: closures travel as source records (image-fnsrc), sorted colls as
 ;; image-sorted, unhandled resources as image-stub. A version-1 reader
 ;; refuses these images by the header check instead of misreading records.
-(define jolt-image-format-version 2)
+;; 3: refs travel as image-ref descriptors instead of raw jolt-ref records,
+;; so the ref record layout is no longer image-format surface. A version-2
+;; reader refuses these images by the header check — on a runtime without
+;; the descriptor a ref would restore as an inert record, silently wrong.
+;; This build still READS version 2: everything a v2 image can contain
+;; (including raw jolt-ref-v1 records) restores here via the legacy arm.
+(define jolt-image-format-version 3)
+(define jolt-image-read-versions '(2 3))
 
 ;; --- classification -----------------------------------------------------------
 ;; An eq hashtable is the ONE hashtable kind Chez can fasl; eqv/equal/string-hash
@@ -232,6 +239,32 @@
 (define-record-type image-sorted
   (fields kind cmp-fn entries)
   (nongenerative image-sorted-v1))
+
+;; A ref travels by VALUE: the write side substitutes this descriptor for the
+;; live jolt-ref, restore re-mints a fresh ref through make-jolt-ref and copies
+;; meta — so the ref record's layout is not image-format surface (refs.ss can
+;; change it freely; the v1 lock-field freeze is lifted). val is mutable so a
+;; self-referencing ref memoizes its descriptor before its val walks, exactly
+;; like walk-atom. Watches and validators live in the weak iref side tables and
+;; do not travel — the same as when refs rode raw. Images older than format 3
+;; carry refs as raw jolt-ref-v1 records instead; see image-legacy-ref? below.
+(define-record-type image-ref
+  (fields (mutable val))
+  (nongenerative image-ref-v1))
+
+;; A raw jolt-ref record in a format-2 image (v0.6.5/v0.6.6). The live runtime
+;; type is jolt-ref-v2, so the fasl's nongenerative jolt-ref-v1 rtd (fields:
+;; val lock) materializes from the image without conflict and its instances
+;; arrive as inert records of that type — NOT jolt-ref? — which the restore
+;; walk re-mints into live refs, reading val through the materialized rtd's
+;; own accessor. The jolt-ref-v1 uid is RETIRED: it must never be reused for
+;; a record with a different layout, or these images stop reading.
+(define (image-legacy-ref? x)
+  (and (record? x)
+       (record-rtd x)
+       (eq? (record-type-uid (record-rtd x)) 'jolt-ref-v1)))
+(define (legacy-ref-val x)
+  ((record-accessor (record-rtd x) 0) x))
 
 ;; A resource the dump could not write (port, thread, non-eq hashtable,
 ;; unregistered closure) that stub mode substitutes in place of a refusal. id
@@ -563,6 +596,13 @@
                       (walk-handled-restore x path))
                      ((and (eq? mode 'restore) (image-sorted? x))
                       (walk-sorted-restore x path))
+                     ;; a ref descriptor re-mints a live ref; a raw jolt-ref-v1
+                     ;; record from a format-2 image re-mints through the
+                     ;; legacy arm (same construction, val read via its own rtd)
+                     ((and (eq? mode 'restore) (image-ref? x))
+                      (walk-ref-restore (image-ref-val x) x path))
+                     ((and (eq? mode 'restore) (image-legacy-ref? x))
+                      (walk-ref-restore (legacy-ref-val x) x path))
                      ;; a stub with a matching resolver becomes the live value it
                      ;; stands for; without one it stays the inert record — the
                      ;; per-restore table (populated by restore-world!) lists it
@@ -654,6 +694,7 @@
                              ((htable-sorted? x) (walk-sorted x path))
                              ((var-cell? x) (walk-var-cell x path))
                              ((jolt-atom? x) (walk-atom x path))
+                             ((jolt-ref? x) (walk-ref x path))
                              ((pair? x) (walk-pair x path))
                              ((vector? x) (walk-vector x path))
                              ((and (hashtable? x) (hashtable-mutable? x))
@@ -831,6 +872,35 @@
                                 (jolt-atom-watches x))
                       (walk (jolt-atom-validator x) (cons "@validator" path))
                       #t))))
+             ;; cover val — the ref's only traveling state. Watches/validators
+             ;; live in the weak iref side tables and do not travel (identical
+             ;; to the raw-record days); the STM lock is global, nothing else
+             ;; to carry. Write side substitutes the descriptor; memoize BEFORE
+             ;; walking val so a self-referencing ref closes its cycle on the
+             ;; descriptor.
+             (walk-ref
+              (lambda (x path)
+                (if (image-rebuild-mode? mode)
+                    (let ((nx (make-image-ref jolt-nil)))
+                      (hashtable-set! memo x nx)
+                      (image-meta-copy! x nx)
+                      (image-ref-val-set! nx (walk (jolt-ref-val x) (cons "ref" path)))
+                      nx)
+                    (begin
+                      (hashtable-set! memo x #t)
+                      (walk (jolt-ref-val x) (cons "ref" path))
+                      #t))))
+             ;; read side: re-mint a live ref from a descriptor's (or a legacy
+             ;; raw record's) val — the caller passes the val read the right
+             ;; way for x's representation. Memoize before walking val, same
+             ;; cycle discipline as walk-atom.
+             (walk-ref-restore
+              (lambda (v x path)
+                (let ((nx (make-jolt-ref jolt-nil)))
+                  (hashtable-set! memo x nx)
+                  (image-meta-copy! x nx)
+                  (jolt-ref-val-set! nx (walk v (cons "ref" path)))
+                  nx)))
              (walk-pair
               (lambda (x path)
                 (if (image-rebuild-mode? mode)
@@ -1044,11 +1114,10 @@
 (define (image-check-header! h path)
   (unless (and (vector? h) (fx=? (vector-length h) 4) (eq? (vector-ref h 0) 'jolt-image))
     (jolt-throw (jolt-ex-info (string-append "image: " path " is not a jolt image") jolt-nil)))
-  (unless (equal? (vector-ref h 1) jolt-image-format-version)
+  (unless (member (vector-ref h 1) jolt-image-read-versions)
     (jolt-throw (jolt-ex-info
                   (string-append "image: " path " has format version "
-                                 (jolt-str-one (vector-ref h 1)) ", this build reads version "
-                                 (number->string jolt-image-format-version))
+                                 (jolt-str-one (vector-ref h 1)) ", this build reads versions 2 and 3")
                   jolt-nil)))
   ;; The fasl version moves with Chez, and a mismatch otherwise surfaces as an
   ;; opaque fasl-read error, so name it here instead.
@@ -1385,6 +1454,10 @@
         ((jolt-atom? x)
          (hashtable-set! memo x x)
          (jolt-atom-val-set! x (sub (jolt-atom-val x)))
+         x)
+        ((jolt-ref? x)
+         (hashtable-set! memo x x)
+         (jolt-ref-val-set! x (sub (jolt-ref-val x)))
          x)
         ((pair? x)
          (hashtable-set! memo x x)

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -751,6 +751,28 @@
                           (jolt-keyword "log") jolt-nil)))
     (ok "stubs empties after resolve" (fx=? 0 (jolt-count (jolt-image-stubs))))))
 
+;; a stub inside a REF's val resolves through the in-place substitution walk
+;; (the walk previously passed refs through untouched — resolved stubs never
+;; landed inside a ref)
+(let ((sp (open-file-output-port "/tmp/jolt-image-refstub.txt" (file-options no-fail))))
+  (jolt-compile-eval "(def holder nil)" "r11.world")
+  (let ((cell (jolt-var "r11.world" "holder")))
+    (var-cell-root-set! cell (jolt-ref-new sp)))
+  (jolt-image-dump-world! tmp (jolt-vector "r11.world"))
+  (jolt-compile-eval "(def holder :clobbered)" "r11.world")
+  (jolt-image-restore-world! tmp)
+  (let ((ss (jolt-image-stubs)))
+    (ok "stub inside a ref's val is listed"
+        (fx=? 1 (jolt-count ss)))
+    (when (fx=? 1 (jolt-count ss))
+      (let ((id (jolt-get (jolt-nth ss 0) (jolt-keyword "id") jolt-nil)))
+        (ok "resolve-stub! replaces the slot inside the ref"
+            (and (fx=? 1 (jolt-image-resolve-stub! id "PORT-AGAIN"))
+                 (equal? "PORT-AGAIN"
+                         (jolt-ref-val (var-cell-root (jolt-var "r11.world" "holder")))))))))
+  (close-port sp)
+  (delete-file "/tmp/jolt-image-refstub.txt"))
+
 ;; resolver pre-registered: the stub never materializes
 ;; kind strings match the STUBBED OBJECT's class (a port's, here), so a
 ;; catch-all predicate is the simplest fixture
@@ -770,17 +792,64 @@
 (close-port stub-port)
 (delete-file stub-probe-file)
 
-;; --- PSL R4: cross-version restore — a v0.6.5-made world image holding a ref
-;; and an atom must restore against today's runtime. jolt-ref-v1's field list is
-;; image-format surface (refs travel as raw nongenerative records), so a layout
-;; change fails HERE, not in someone's app at restore time. The proper
-;; versioned-reconstruction fix is bead jolt-867l.11; this pins the regression
-;; until it lands.
+;; --- cross-version restore: the LEGACY-FORMAT proof. A v0.6.5-made (format-2)
+;; world image carries its ref as a raw nongenerative jolt-ref-v1 record; the
+;; live type is jolt-ref-v2, so the v1 rtd materializes from the fasl and the
+;; legacy restore arm re-mints a live ref from it. This fixture is permanent:
+;; it is the only thing proving old ref-carrying images keep restoring.
 (ok "v0.6.5 fixture present" (file-exists? "test/chez/fixtures/image-v0.6.5-ref-atom.image"))
 (jolt-image-restore-world! "test/chez/fixtures/image-v0.6.5-ref-atom.image")
 (is "v0.6.5 fixture: imgtest/plain" "imgtest/plain" "7")
 (is "v0.6.5 fixture: imgtest/my-atom deref" "(deref imgtest/my-atom)" "42")
 (is "v0.6.5 fixture: imgtest/my-ref deref" "(deref imgtest/my-ref)" "99")
+;; the legacy-restored ref is a LIVE v2 ref, not an inert v1 record: STM works
+(is "v0.6.5 fixture: legacy ref participates in dosync"
+    "(do (dosync (ref-set imgtest/my-ref 100)) (deref imgtest/my-ref))" "100")
+
+;; --- refs travel by value (format 3, jolt-867l.11): descriptor on dump,
+;; re-mint on restore. Value, meta, shared identity, cycles, and STM liveness
+;; all survive; the raw jolt-ref record never enters the fasl, so its layout
+;; is no longer image-format surface.
+(is "ref round-trip: value + meta + identity + cycle + dosync"
+    (string-append
+      "(let [r (ref 99 :meta {:tag :hot})"
+      "      shared (ref [1 2])"
+      "      cyc (ref nil)"
+      "      _ (dosync (ref-set cyc {:self cyc}))"
+      "      _ (jolt.host/image-write! \"" tmp "\" {:a r :b shared :c shared :cyc cyc})"
+      "      g (jolt.host/image-read \"" tmp "\")]"
+      "  [(deref (:a g)) (:tag (meta (:a g)))"
+      "   (identical? (:b g) (:c g))"
+      "   (identical? (:cyc g) (:self (deref (:cyc g))))"
+      "   (do (dosync (ref-set (:a g) 100)) (deref (:a g)))])")
+    "[99 :hot true true 100]")
+;; format discipline: the new image writes header version 3, and its bytes
+;; carry the descriptor rtd, never the live ref rtd
+(define (bv-contains? bv s)
+  (let* ((sb (string->utf8 s)) (m (bytevector-length sb)) (n (bytevector-length bv)))
+    (let scan ((i 0))
+      (cond ((fx>? (fx+ i m) n) #f)
+            ((let cmp ((j 0))
+               (or (fx=? j m)
+                   (and (fx=? (bytevector-u8-ref bv (fx+ i j)) (bytevector-u8-ref sb j))
+                        (cmp (fx+ j 1))))) #t)
+            (else (scan (fx+ i 1)))))))
+(ok "ref-carrying image is format 3 with no raw jolt-ref rtd"
+    (let ((port (open-file-input-port tmp)))
+      (let* ((h (fasl-read port))
+             (rest (get-bytevector-all port)))
+        (close-port port)
+        (and (fx=? 3 (vector-ref h 1))
+             (bv-contains? rest "image-ref")
+             (not (bv-contains? rest "jolt-ref-v2"))))))
+;; an unknown format version refuses with a clean error naming both versions
+(let ((vport (open-file-output-port tmp (file-options no-fail))))
+  (fasl-write (vector 'jolt-image 99 (jolt-image-runtime-version) (sa-host-tag)) vport)
+  (close-port vport))
+(ok "future format version refuses cleanly"
+    (call/cc (lambda (k)
+      (with-exception-handler (lambda (e) (k #t))
+        (lambda () (jolt-image-read tmp) #f)))))
 
 (cleanup!)
 (when (file-exists? (string-append tmp ".txt")) (delete-file (string-append tmp ".txt")))


### PR DESCRIPTION
Closes the last child of the portable-scheme-layer epic (jolt-867l.11, from #446's R4): refs now travel in state images **by value**, so the `jolt-ref` record layout stops being image-format surface and the dead `lock` field finally goes.

## Mechanism

- Dump substitutes an `image-ref` descriptor for each live ref (memoized before its val walks — shared refs keep identity, a self-referencing ref closes its cycle on the descriptor; meta copies through). The raw ref record never enters the fasl.
- Restore re-mints through `make-jolt-ref`, same construction discipline as `walk-atom`.
- `jolt-ref` drops the dead lock field and moves to `nongenerative jolt-ref-v2`; the v1 uid is retired. Each `(ref x)` also stops allocating a mutex.

## Compat, both directions

- **Old images on this build**: format version 2 stays readable. A v2 image's raw `jolt-ref-v1` records materialize their rtd from the fasl (no conflict with the live v2 type) and a legacy restore arm converts them to live refs. The v0.6.5-dumped fixture is the permanent proof, extended with a row showing the legacy-restored ref participates in `dosync`.
- **New images on old builds**: the format version bumps to 3, so a ≤0.6.6 runtime refuses with its exact-match header check — a clean error instead of silently restoring refs as inert records.

## Found along the way

The `resolve-stub!` substitution walk passed refs through untouched, so a resolved stub inside a ref's val never landed. Refs now substitute in place like atoms, with a gate row (placed before the suite's catch-all resolver registration, which otherwise claims the stub inline).

## Performance (A/B/A vs main, 5 runs/leg, `--direct-link --opt` builds)

| bench | A1 (main) | B | A2 (main) |
|---|---|---|---|
| stm (ref create + dosync ref-set/alter + deref, 200k) | 122.0 ms | 102.0 ms | 118.9 ms |
| image-refs (dump+restore 10k refs) | 82.2 ms | 67.0 ms | 81.5 ms |
| fib 30 (canary) | 9.2 ms | 9.4 ms | 9.1 ms |
| collections 30k (canary) | 22.2 ms | 22.3 ms | 22.5 ms |

STM ~1.17x faster (no per-ref mutex allocation), ref-heavy image round-trip ~1.22x faster (dedicated descriptor arm replaces the generic record-field walk, no mutex bytes). Canaries within the A1/A2 drift band. `stm` and `image-refs` are new benches following the local protocol.

## Verification

state-image gate extended 135 → 141 assertions (round-trip value/meta/identity/cycle/dosync, format-3-writes with no raw ref rtd in the bytes, future-format clean refusal, ref-wrapped stub resolution, the v0.6.5 fixture); stm-test green; full 55-target gate green on the final tree (MAKE_EXIT=0).
