### PR TITLE
Gambit target G1: adapter, shims, hasheq, gambitcheck gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp depssmoke depsunit \
   fnform traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
-  certify
+  certify gambitcheck
 TEST-GATES := submodules selfhost ci
 
 GATE-RECEIPT := target/gate-receipt
@@ -560,6 +560,19 @@ certify:
 		clojure -M test/conformance/certify.clj; \
 	else \
 		echo "certify: clojure not on PATH — skipped"; \
+	fi
+
+# Gambit adapter gate (G1, jolt-mj95.2): loads host/gambit/{prelude-shims,
+# scheme-adapter-runtime,hasheq}.ss under native gsi and asserts the
+# CONTRACT.txt names + shim behavior. Detection-gated like certify — skips
+# cleanly when gambit-scheme is absent. NEVER bare gsc/gsi (gsc on PATH is
+# Ghostscript): always the brew-prefix binary.
+GAMBIT_GSI := $(shell brew --prefix gambit-scheme 2>/dev/null)/bin/gsi
+gambitcheck:
+	@if [ -x "$(GAMBIT_GSI)" ]; then \
+		"$(GAMBIT_GSI)" host/gambit/gambitcheck.ss; \
+	else \
+		echo "gambitcheck: gambit-scheme not installed (brew) — skipped"; \
 	fi
 
 # Re-mint the seed after changing a seed source (reader/analyzer/backend/core).

--- a/host/gambit/gambitcheck.ss
+++ b/host/gambit/gambitcheck.ss
@@ -1,0 +1,412 @@
+;; gambitcheck.ss — the G1 gate for the Gambit adapter (jolt-mj95.2).
+;;
+;; Run via `make gambitcheck` (detection-gated: skips when gambit-scheme is
+;; absent, and always uses $(brew --prefix gambit-scheme)/bin/gsi — NEVER bare
+;; gsc/gsi, which is Ghostscript on this machine). Run from the repo root.
+;;
+;; Loads the three gambit target files (prelude-shims, scheme-adapter-runtime,
+;; hasheq), then:
+;;   (a) asserts every host/scheme-adapter/CONTRACT.txt name is bound
+;;       (or shimmed — variables via eval, syntax shims via the explicit list,
+;;       each ALSO verified behaviorally by the unit tests below),
+;;   (b) unit-tests every shim group: record round-trip incl. the parent
+;;       clause family, hashtable CRUD + entries + weak-eq, fx + bitwise
+;;       aliases, condition accessors on a caught error, condvar wait/signal,
+;;       parameter fork-inheritance, with-mutex, hasheq known-answer rows
+;;       (captured from the Chez build via bin/jolt), and the sa-* raise
+;;       surface (message-carrying conditions).
+;;
+;; The hasheq known-answer rows pin VALUE PARITY with the Chez build: each row
+;; is a pure hasheq function whose output was captured from `bin/jolt` on the
+;; Chez runtime (the jolt-level (hash ...) routes through exactly these
+;; functions). Rows for the vector/map shapes compute the hash-ordered /
+;; hash-unordered combinator math directly — the cseq/pmap iteration over them
+;; is G2 scope (the full runtime), the murmur3 + combinator math is G1.
+;;
+;; NO import here: the prelude's (import (except (gambit) define-record-type))
+;; is the single import point for the whole boot path. A file-level import in
+;; THIS file would create a module boundary and the loaded shim macros
+;; (define-record-type, fx aliases, with-mutex, the sa-foreign-* syntaxes)
+;; would not resolve here — the (gambit) names come from the prelude's import,
+;; which loads into the same top level.
+
+;; ---- splice the three target files ------------------------------------------
+;;
+;; ##include (NOT load): each loaded file is a SEPARATE compilation unit, and a
+;; define-syntax inside a loaded file registers only in its own unit's macro
+;; environment — the loading file's LATER forms never see it (defines leak at
+;; runtime into the shared global, macros don't). The prelude's record/fx/
+;; with-mutex shims are macros, so gambitcheck must expand in the SAME unit as
+;; the prelude: ##include textually splices the three files here, exactly the
+;; "compile the boot files together" flow the G2 build uses.
+
+(##include "prelude-shims.ss")
+(##include "scheme-adapter-runtime.ss")
+
+;; hasheq's seq/symbol arms test jolt-nil? — a values.ss kernel name that only
+;; boots in G2. A sentinel stub stands in for this gate; the known-answer rows
+;; below never construct jolt-nil, so the stub is only ever asked "is this
+;; ordinary value nil" (answer: no). G2's boot manifest loads the real one.
+(define %gambitcheck-nil-sentinel (list 'nil))
+(define (jolt-nil? x) (eq? x %gambitcheck-nil-sentinel))
+
+(##include "hasheq.ss")
+
+;; ---- test harness ------------------------------------------------------------
+
+(define failures 0)
+
+(define (check label actual expected)
+  (if (equal? actual expected)
+      (begin (printf "  ok     ~a\n" label) #t)
+      (begin (printf "  FAIL   ~a: got ~s expected ~s\n" label actual expected)
+             (set! failures (+ failures 1))
+             #f)))
+
+(define (check-true label v)
+  (if v
+      (begin (printf "  ok     ~a\n" label) #t)
+      (begin (printf "  FAIL   ~a: got #f\n" label)
+             (set! failures (+ failures 1))
+             #f)))
+
+(define (check-raise-message label thunk expected-msg)
+  (let ((m (guard (e (#t (condition-message e)))
+             (thunk)
+             "NO-RAISE")))
+    (check (string-append label " -> " expected-msg)
+           m expected-msg)))
+
+;; ---- (a) contract-name assertion pass ----------------------------------------
+
+;; minimal line parsing, self-contained (mirrors host/scheme-adapter/chez.ss)
+(define (char-ws? c)
+  (or (char=? c #\space) (char=? c #\tab) (char=? c #\newline)
+      (char=? c #\return)))
+
+(define (string->tokens s)
+  (let ((n (string-length s)))
+    (let loop ((i 0) (acc '()))
+      (cond
+        ((>= i n) (reverse acc))
+        ((char-ws? (string-ref s i)) (loop (+ i 1) acc))
+        (else
+         (let scan ((j i))
+           (if (and (< j n) (not (char-ws? (string-ref s j))))
+               (scan (+ j 1))
+               (loop j (cons (substring s i j) acc)))))))))
+
+(define (strip-comment s)
+  (let ((n (string-length s)))
+    (let loop ((i 0))
+      (cond
+        ((>= i n) s)
+        ((or (char=? (string-ref s i) #\#) (char=? (string-ref s i) #\;))
+         (substring s 0 i))
+        (else (loop (+ i 1)))))))
+
+(define (contract-file-path)
+  ;; #f when unreachable — the js-compiled gate has no repo cwd (Gambit-js
+  ;; current-directory is not the node process cwd, and command-line carries
+  ;; no script path), so the contract-name pass SKIPS there; the unit tests
+  ;; are the behavioral proof. Under gsi via make, the repo-root path exists
+  ;; and the pass is mandatory.
+  (if (file-exists? "host/scheme-adapter/CONTRACT.txt")
+      "host/scheme-adapter/CONTRACT.txt"
+      (let* ((cl (command-line))
+             (sp (and (pair? cl) (pair? (cdr cl)) (cadr cl))))
+        (if (and sp (file-exists? sp))
+            (let* ((dir (substring sp 0 (- (string-length sp)
+                                           (string-length "gambitcheck.ss"))))
+                   (root (substring dir 0 (- (string-length dir)
+                                             (string-length "host/gambit/")))))
+              (string-append root "host/scheme-adapter/CONTRACT.txt"))
+            #f))))
+
+(define (read-contract-names path)
+  (let ((p (open-input-file path)))
+    (let loop ((acc '()))
+      (let ((l (get-line p)))
+        (if (eof-object? l)
+            (begin (close-port p) (reverse acc))
+            (let ((toks (string->tokens (strip-comment l))))
+              (if (or (null? toks)
+                      (and (>= (length toks) 2)
+                           (string=? (car toks) "#")
+                           (string=? (cadr toks) "tier:")))
+                  (loop acc)
+                  (loop (cons (string->symbol (car toks)) acc)))))))))
+
+;; Syntax shims the variable-probe below cannot see (eval of a macro name is
+;; implementation-defined). Each of these is ALSO verified behaviorally by the
+;; unit-test sections — this list is only the CONTRACT-name side of the check.
+(define contract-syntax-shims
+  '(with-mutex
+    sa-foreign-procedure sa-foreign-procedure-blocking
+    sa-foreign-callable sa-foreign-callable-collect-safe))
+
+(define (bound? s)
+  (or (guard (e (#t #f)) (eval s (interaction-environment)) #t)
+      (memq s contract-syntax-shims)))
+
+(define (assert-contract-names)
+  (printf "== CONTRACT.txt names (bound or shimmed) ==\n")
+  (let ((path (contract-file-path)))
+    (if (not path)
+        (printf "  skip   CONTRACT.txt not reachable (js target has no repo cwd); the unit tests below are the behavioral proof\n")
+        (assert-contract-names* path))))
+
+(define (assert-contract-names* path)
+  (let ((names (read-contract-names path)))
+    (let ((missing (filter (lambda (s) (not (bound? s))) names)))
+      (for-each (lambda (s) (printf "  NOT-BOUND ~a\n" s)) missing)
+      (printf "  ~a contract names checked against the combined env\n"
+              (length names))
+      (if (null? missing)
+          (printf "  ok     all contract names bound-or-shimmed\n")
+          (begin (printf "  FAIL   ~a contract name(s) not bound\n"
+                         (length missing))
+                 (set! failures (+ failures 1)))))))
+
+;; ---- (b) unit tests ----------------------------------------------------------
+
+(define (test-records)
+  (define-record-type animal (fields name) (nongenerative gambitcheck-animal-v1))
+  (define-record-type dog (parent animal) (fields (mutable age)) (nongenerative gambitcheck-dog-v1))
+  (printf "== records: define-record-type round-trip incl. parent clause ==\n")
+  (check "ctor + accessors" (let ((d (make-dog "rex" 3))) (list (animal-name d) (dog-age d)))
+         '("rex" 3))
+  (check "predicate on child" (dog? (make-dog "rex" 3)) #t)
+  (check "base predicate inclusive of child" (animal? (make-dog "rex" 3)) #t)
+  (check "child predicate excludes base instance" (dog? (make-animal "rex")) #f)
+  (check "parent accessor on child" (animal-name (make-dog "rex" 3)) "rex")
+  (check "mutable field set!" (let ((d (make-dog "rex" 3))) (dog-age-set! d 4) (dog-age d)) 4)
+  (check "immutable field has no setter (unbound)" (not (guard (e (#t #f)) (eval 'animal-name-set! (interaction-environment)) #t)) #t)
+  (check "wrong-arity ctor raises" (guard (e (#t (condition-message e))) (make-dog "rex") "no-raise") "wrong number of arguments"))
+
+(define (test-hashtables)
+  (printf "== hashtable shim over tables ==\n")
+  (let ((h (make-eq-hashtable)))
+    (hashtable-set! h 'a 1)
+    (check "ref after set!" (hashtable-ref h 'a #f) 1)
+    (check "missing ref -> default" (hashtable-ref h 'zzz #f) #f)
+    (check "contains? after set!" (hashtable-contains? h 'a) #t)
+    (check "size" (hashtable-size h) 1)
+    (hashtable-delete! h 'a)
+    (check "contains? after delete!" (hashtable-contains? h 'a) #f)
+    (check "size after delete!" (hashtable-size h) 0))
+  (let ((h (make-eq-hashtable)))
+    (hashtable-set! h 'a 1)
+    (hashtable-set! h 'b 2)
+    (check "keys is a vector" (vector? (hashtable-keys h)) #t)
+    ;; iteration order is unspecified on BOTH hosts — compare as a sorted set
+    (check "keys contents" (list-sort (lambda (a b) (string<? (symbol->string a) (symbol->string b))) (vector->list (hashtable-keys h))) '(a b))
+    (check "entries -> two parallel vectors (order-independent, aligned)"
+           (call-with-values (lambda () (hashtable-entries h))
+             (lambda (ks vs)
+               (list-sort (lambda (x y) (< (cdr x) (cdr y)))
+                          (map cons (vector->list ks) (vector->list vs)))))
+           '((a . 1) (b . 2))))
+  (let ((h (make-eq-hashtable)))
+    (hashtable-set! h 'a 1)
+    (hashtable-set! h 'b 2)
+    (check "CONTRACT misc hashtable-values" (list-sort < (vector->list (hashtable-values h))) '(1 2))
+    (check "CONTRACT misc hashtable-cells" (length (hashtable-cells h)) 2))
+  (let ((h (make-hashtable string-hash string=?)))
+    (hashtable-set! h "k" 1)
+    (check "make-hashtable (hash+equiv dropped, equal? test)" (hashtable-ref h "k" #f) 1))
+  (let ((w (make-weak-eq-hashtable)))
+    (let ((k (list 1)))
+      (hashtable-set! w k 'v)
+      (check "weak-eq set!/ref" (hashtable-ref w k #f) 'v))))
+
+(define (test-fx-aliases)
+  (printf "== fx + bitwise spelling aliases ==\n")
+  (check "fx=? alias" (fx=? 1 1) #t)
+  (check "fx<? alias" (fx<? 1 2) #t)
+  (check "fx>? alias" (fx>? 2 1) #t)
+  (check "fxsll alias" (fxsll 1 4) 16)
+  (check "fxsra alias" (fxsra 8 1) 4)
+  (check "native fx+ still bound" (fx+ 1 2) 3)
+  (check "bitwise-arithmetic-shift-left (natives-num.ss spelling)" (bitwise-arithmetic-shift-left 1 40) 1099511627776)
+  (check "bitwise-arithmetic-shift-right floor on negative" (bitwise-arithmetic-shift-right -7 1) -4))
+
+(define (test-conditions)
+  (printf "== Chez condition accessors over error objects ==\n")
+  (let ((c (guard (e (#t e)) (error 'who "boom" 1 2))))
+    (check "condition? on error object" (condition? c) #t)
+    (check "message-condition? on error object" (message-condition? c) #t)
+    (check "condition-message" (condition-message c) "boom")
+    (check "condition-irritants" (condition-irritants c) '(1 2)))
+  (check "condition? on non-error" (condition? 42) #f)
+  (check "message-condition? on non-error" (message-condition? 42) #f)
+  (check "condition-message on non-error -> #f" (condition-message 42) #f)
+  (check "condition-irritants on non-error -> '()" (condition-irritants 42) '()))
+
+(define (test-threads)
+  (printf "== thread mappings ==\n")
+  ;; condvar wait/signal round-trip. got is a SHARED mutable cell — a
+  ;; thread-parameter would be wrong here: the worker's set lands in its own
+  ;; dynamic environment (inheritance copies parent->child at fork, never
+  ;; back), the main thread never observes it, and the wait deadlocks.
+  (let ((m (make-mutex))
+        (cv (make-condition))
+        (got (vector #f)))
+    (define w (fork-thread
+               (lambda ()
+                 (mutex-lock! m)
+                 (vector-set! got 0 #t)
+                 (condition-signal cv)
+                 (mutex-unlock! m))))
+    (mutex-lock! m)
+    (if (not (vector-ref got 0)) (condition-wait cv m))
+    (mutex-unlock! m)
+    (thread-join! w)
+    (check "condvar wait/signal round-trip" (vector-ref got 0) #t))
+  ;; condition-wait with a future timeout returns (mutex re-acquired)
+  (let ((m (make-mutex))
+        (cv (make-condition))
+        (t0 (sa-real-time-ms)))
+    (mutex-lock! m)
+    (condition-wait cv m (+ (time->seconds (current-time)) 0.05))
+    (mutex-unlock! m)
+    (check-true "condition-wait timeout returns, mutex re-acquired"
+                (< (- (sa-real-time-ms) t0) 5000)))
+  ;; with-mutex macro: body value + no deadlock
+  (check "with-mutex returns body value"
+         (with-mutex (make-mutex) 42) 42)
+  ;; parameter fork-inheritance (the G0 pin)
+  (let ((p (make-thread-parameter 1))
+        (result (make-thread-parameter #f)))
+    (p 2)
+    (let ((t (fork-thread (lambda () (result (p))))))
+      (thread-join! t)
+      (check "parameter fork-inheritance: child sees parent's current value" (result) 2)))
+  ;; get-thread-id: distinct numbers for live threads
+  (let ((ids (make-table test: eq?)))
+    (let ((id1 (get-thread-id))
+          (t2 (fork-thread (lambda () (table-set! ids 't2 (get-thread-id))))))
+      (thread-join! t2)
+      (check "get-thread-id is a number" (and (number? id1) (number? (table-ref ids 't2 #f))) #t)
+      (check "get-thread-id distinct per thread" (not (= id1 (table-ref ids 't2 #f))) #t))))
+
+(define (test-hasheq-known-answers)
+  (printf "== hasheq known answers (captured from the Chez build via bin/jolt) ==\n")
+  ;; fixnums -> murmur3-hash-long-flat (jolt-hasheq fixnum arm)
+  (check "hash 42  (Chez 1871679806)" (murmur3-hash-long-flat 42) 1871679806)
+  (check "hash -7  (Chez -1703207563)" (murmur3-hash-long-flat -7) -1703207563)
+  (check "hash 1000000000000  (Chez -1510912948)" (murmur3-hash-long-flat 1000000000000) -1510912948)
+  (check "murmur3-hash-long agrees with flat on fixnum" (murmur3-hash-long 1000000000000) -1510912948)
+  ;; strings -> string-hasheq (java-string-hashcode + murmur3-hash-int)
+  (check "hash \"hello\"  (Chez 1715862179)" (string-hasheq "hello") 1715862179)
+  (check "hash long string  (Chez 237270814)" (string-hasheq "abcdefghijklmnopqrstuvwxyz0123456789") 237270814)
+  (check "hash longer string  (Chez 1189256432)"
+         (string-hasheq "a-really-long-string-that-is-definitely-more-than-fifteen-characters-long-for-sure")
+         1189256432)
+  ;; keywords -> compute-keyword-hasheq (the keyword-t khash field)
+  (check "hash :kw  (Chez 1158308175)" (compute-keyword-hasheq #f "kw") 1158308175)
+  (check "hash :a/b  (Chez 1482224565)" (compute-keyword-hasheq "a" "b") 1482224565)
+  ;; symbols -> compute-symbol-hasheq
+  (check "hash 'sym  (Chez 195671222)" (compute-symbol-hasheq '() "sym") 195671222)
+  (check "hash 'foo/bar  (Chez 254379989)" (compute-symbol-hasheq "foo" "bar") 254379989)
+  ;; doubles -> double-hasheq
+  (check "hash 0.5  (Chez 1071644672)" (double-hasheq 0.5) 1071644672)
+  (check "hash 2.5  (Chez 1074003968)" (double-hasheq 2.5) 1074003968)
+  (check "hash 0.0  (Chez 0)" (double-hasheq 0.0) 0)
+  (check "hash -0.0  (Chez 0)" (double-hasheq -0.0) 0)
+  ;; bignum / ratio -> big-integer-hashcode
+  (check "hash 123456789012345678901234567890  (Chez 1915528825)"
+         (big-integer-hashcode 123456789012345678901234567890) 1915528825)
+  (check "hash 1/3  (Chez 2: bigint(1) ^ bigint(3))"
+         (bitwise-xor (big-integer-hashcode 1) (big-integer-hashcode 3)) 2)
+  ;; collection combinators: the hash-ordered / hash-unordered math behind
+  ;; [1 2 3] and {:a 1} (cseq/pmap iteration is G2; the murmur3 + combinator
+  ;; math is exactly what this port owns)
+  (check "hash [1 2 3]  (Chez 736442005)"
+         (let* ((h1 (i32 (+ 31 (murmur3-hash-long-flat 1))))
+                (h2 (i32 (+ (* 31 h1) (murmur3-hash-long-flat 2))))
+                (h3 (i32 (+ (* 31 h2) (murmur3-hash-long-flat 3)))))
+           (mix-coll-hash h3 3))
+         736442005)
+  (check "hash {:a 1}  (Chez 1772842048)"
+         (let* ((ka (compute-keyword-hasheq #f "a"))
+                (h1 (i32 (+ 31 ka)))
+                (h2 (i32 (+ (* 31 h1) (murmur3-hash-long-flat 1))))
+                (e (mix-coll-hash h2 2)))
+           (mix-coll-hash e 1))
+         1772842048))
+
+(define (test-sa-surface)
+  (printf "== sa-* runtime surface ==\n")
+  (check "sa-host-tag" (sa-host-tag) "gambit")
+  (check "sa-os-family (documented else-default)" (sa-os-family) 'linux)
+  (check "sa-arch (degraded)" (sa-arch) 'other)
+  (check "sa-endian" (sa-endian) 'little)
+  (check "sa-real-time-ms is an exact integer" (exact-integer? (sa-real-time-ms)) #t)
+  (check "sa-real-time-ms advances"
+         (let ((a (sa-real-time-ms)))
+           (thread-sleep! 0.01)
+           (>= (sa-real-time-ms) a)) #t)
+  ;; mtime needs a real file; under the js exe there is no repo cwd (same
+  ;; detection as the contract pass), so these two rows skip there
+  (if (contract-file-path)
+      (begin
+        (check "sa-file-mtime-ms on an existing file"
+               (exact-integer? (sa-file-mtime-ms "host/scheme-adapter/CONTRACT.txt")) #t)
+        (check "sa-file-mtime-ms is a plausible epoch-ms (> 1e12)"
+               (> (sa-file-mtime-ms "host/scheme-adapter/CONTRACT.txt") 1000000000000) #t))
+      (printf "  skip   sa-file-mtime-ms rows (no repo cwd under the js exe)\n"))
+  (check "sa-introspect-enabled? fixed #f" (sa-introspect-enabled?) #f)
+  (check "sa-continuation-frames -> '()" (sa-continuation-frames #f) '())
+  (check "sa-procedure-info -> #f" (sa-procedure-info (lambda () 1)) #f)
+  (check "sa-stats zero vector" (sa-stats) #(0 0 0 0 0 0))
+  (check "sa-baked-global -> #f always" (sa-baked-global 'jolt-baked-version-early) #f)
+  (check "sa-gc-collect no-ops" (sa-gc-collect) #f)
+  (check "sa-gc-max-generation 0" (sa-gc-max-generation) 0)
+  ;; the ffi tier: EVERY entry raises a message-carrying condition
+  (check-raise-message "sa-foreign-alloc" (lambda () (sa-foreign-alloc 16))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-foreign-procedure (syntax)" (lambda () (sa-foreign-procedure "f" (int) int))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-foreign-procedure-blocking (syntax)" (lambda () (sa-foreign-procedure-blocking "f" (int) int))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-foreign-callable (syntax)" (lambda () (sa-foreign-callable (lambda () 1) (int) int))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-foreign-callable-collect-safe (syntax)" (lambda () (sa-foreign-callable-collect-safe (lambda () 1) (int) int))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-load-shared-object" (lambda () (sa-load-shared-object "libx"))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-lock-object" (lambda () (sa-lock-object (list 1)))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-foreign-entry?" (lambda () (sa-foreign-entry? "f"))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-foreign-entry-address" (lambda () (sa-foreign-entry-address "f"))
+                       "ffi is unsupported on the gambit target")
+  (check-raise-message "sa-compile-file" (lambda () (sa-compile-file "a.ss" "a.so" #f))
+                       "native compilation is unsupported on the gambit target")
+  (check-raise-message "sa-make-boot-file" (lambda () (sa-make-boot-file "out.boot" '()))
+                       "native compilation is unsupported on the gambit target")
+  (check-raise-message "sa-fasl-write" (lambda () (sa-fasl-write 42 (open-output-string)))
+                       "fasl serialization is unsupported on the gambit target")
+  (check-raise-message "sa-fasl-read" (lambda () (sa-fasl-read (open-input-string "")))
+                       "fasl serialization is unsupported on the gambit target")
+  (check-raise-message "sa-run-process" (lambda () (sa-run-process "echo hi" #f))
+                       "subprocess support is unsupported on the gambit target"))
+
+;; ---- main --------------------------------------------------------------------
+
+(assert-contract-names)
+(test-records)
+(test-hashtables)
+(test-fx-aliases)
+(test-conditions)
+(test-threads)
+(test-hasheq-known-answers)
+(test-sa-surface)
+
+(printf "\ngambitcheck: ~a failure(s)\n" failures)
+(if (= failures 0)
+    (begin (printf "gambitcheck: PASS — gambit adapter + shims verified on native gsi\n")
+           (exit 0))
+    (begin (printf "gambitcheck: FAILED\n")
+           (exit 1)))

--- a/host/gambit/hasheq.ss
+++ b/host/gambit/hasheq.ss
@@ -1,0 +1,442 @@
+;; JVM-compatible hash engine for Jolt — Gambit target (native gsi), safe ops.
+;;
+;; Safe-ops port of host/chez/hasheq.ss (PSL R10 target-owned file): the SAME
+;; exported 14-procedure surface, the SAME murmur3 constants and algorithm,
+;; expressed with plain R7RS/Gambit arithmetic (bitwise-and masks, arithmetic-
+;; shift) instead of Chez's #3% fixnum tricks. Correctness first, tuning never
+;; (demo target).
+;;
+;; The 14 exported procedures (the rest of the host calls exactly these):
+;;   jolt-hasheq                    entry point: fast paths + arms + fallback
+;;   murmur3-hash-long-flat         fixnum hashing (collections.ss key-hash)
+;;   murmur3-hash-int               int hashing (java/host-static-methods.ss)
+;;   murmur3-hash-long              long/bignum-in-range hashing
+;;   murmur3-hash-unencoded-chars   string-char hashing (host-static-methods)
+;;   big-integer-hashcode           bignum hash (java/bigdec.ss)
+;;   mix-coll-hash                  collection combine (collections/records/...)
+;;   hash-ordered                   seq hashing (seq.ss, reader.ss, ...)
+;;   hash-unordered                 map/set hashing (natives-misc, static-methods)
+;;   entry-hasheq                   (key . value) pair hash (collections/records)
+;;   hash-combine                   combiner (natives-reader, io, natives-str)
+;;   compute-keyword-hasheq         keyword hashing (values.ss)
+;;   symbol-hasheq / compute-symbol-hasheq   symbol hashing (records.ss)
+;; (string-hasheq, double-hasheq, jolt-hasheq-fallback and the caches stay
+;; INTERNAL — reached only through jolt-hasheq.)
+;;
+;; HASH VALUE PARITY: jolt hash values must match the Chez build's — corpus
+;; rows compare them in G2. gambitcheck pins this with known-answer rows
+;; captured from the Chez build via bin/jolt (see the rows in gambitcheck.ss).
+;;
+;; Shift semantics: Gambit does not bind the R6RS bitwise-arithmetic-shift-*
+;; names; arithmetic-shift with a NEGATIVE count is the arithmetic right shift
+;; (floor semantics, identical to R6RS). urs32 masks back to unsigned 32 bits,
+;; which is the Java >>> on a 32-bit value.
+
+;; ============================================================================
+;; 32-bit signed integer helpers — all macros (syntax-rules) so they inline at
+;; every call site with zero procedure-call overhead.
+;; ============================================================================
+
+;; Mask to unsigned 32 bits (0 .. 2^32-1).
+(define-syntax u32
+  (syntax-rules ()
+    ((_ x) (bitwise-and x #xFFFFFFFF))))
+
+;; Interpret an unsigned 32-bit value as signed 32-bit (-2^31 .. 2^31-1).
+;; Input must already be ≤ 32 bits (u32-masked); already-signed values pass
+;; through unchanged — same semantics as the Chez i32.
+(define-syntax i32
+  (syntax-rules ()
+    ((_ x) (let ((u (u32 x)))
+             (if (>= u #x80000000) (- u #x100000000) u)))))
+
+;; 32-bit wrapping multiply via a 16-bit split. Plain arithmetic throughout;
+;; every intermediate is ≤ 2^48, far inside Gambit's 62-bit fixnum range.
+(define-syntax mul32
+  (syntax-rules ()
+    ((_ a b)
+     (let* ((a* (i32 a))
+            (b* (i32 b))
+            (hi (bitwise-and (arithmetic-shift b* -16) #xFFFF))
+            (lo (bitwise-and b* #xFFFF))
+            (hi-part (arithmetic-shift (bitwise-and (* a* hi) #xFFFF) 16))
+            (lo-part (* a* lo)))
+       (i32 (bitwise-and (+ hi-part lo-part) #xFFFFFFFF))))))
+
+;; 32-bit wrapping add. a and b each evaluated once.
+(define-syntax add32
+  (syntax-rules ()
+    ((_ a b) (i32 (+ (i32 a) (i32 b))))))
+
+;; Unsigned right shift (Java >>>): mask to unsigned 32 FIRST, then shift —
+;; shifting a negative value first drags infinite sign bits through the mask
+;; (that ordering bug corrupted every hash). Same order as the Chez build.
+(define-syntax urs32
+  (syntax-rules ()
+    ((_ x n) (arithmetic-shift (u32 x) (- n)))))
+
+;; Rotate left (Java Integer.rotateLeft). x and n each evaluated once.
+(define-syntax rotl32
+  (syntax-rules ()
+    ((_ x n)
+     (let ((n* (remainder n 32))
+           (x* x))
+       (i32 (bitwise-ior (arithmetic-shift (u32 x*) n*)
+                         (urs32 x* (- 32 n*))))))))
+
+;; ============================================================================
+;; Murmur3 — exact port of clojure.lang.Murmur3.
+;; ============================================================================
+
+(define murmur3-seed 0)
+(define murmur3-C1   #xcc9e2d51)   ;; -862048943
+(define murmur3-C2   #x1b873593)   ;; 461845907
+
+(define (murmur3-mix-k1 k1)
+  (let* ((k1 (mul32 k1 murmur3-C1))
+         (k1 (rotl32 k1 15))
+         (k1 (mul32 k1 murmur3-C2)))
+    k1))
+
+(define (murmur3-mix-h1 h1 k1)
+  (let* ((h1 (bitwise-xor h1 k1))
+         (h1 (rotl32 h1 13))
+         (h1 (add32 (mul32 h1 5) #xe6546b64)))
+    h1))
+
+(define (murmur3-fmix h1 len)
+  (let* ((h1 (bitwise-xor h1 len))
+         (h1 (bitwise-xor h1 (urs32 h1 16)))
+         (h1 (mul32 h1 #x85ebca6b))
+         (h1 (bitwise-xor h1 (urs32 h1 13)))
+         (h1 (mul32 h1 #xc2b2ae35))
+         (h1 (bitwise-xor h1 (urs32 h1 16))))
+    h1))
+
+;; Flat-inlined murmur3-hash-long for fixnums (Java Long.hasheq: two 32-bit
+;; halves, count=8; input 0 → 0).
+(define (murmur3-hash-long-flat input)
+  (if (= input 0) 0
+      (let* ((low (i32 input))
+             (high (i32 (arithmetic-shift input -32)))
+             ;; --- mixK1(low): mul32(low, C1) ---
+             (k1 (mul32 low murmur3-C1))
+             (k1 (rotl32 k1 15))
+             (k1 (mul32 k1 murmur3-C2))
+             ;; --- mixH1(seed, k1) ---
+             (h1 (bitwise-xor murmur3-seed k1))
+             (h1 (rotl32 h1 13))
+             (h1 (add32 (mul32 h1 5) #xe6546b64))
+             ;; --- mixK1(high) ---
+             (k1 (mul32 high murmur3-C1))
+             (k1 (rotl32 k1 15))
+             (k1 (mul32 k1 murmur3-C2))
+             ;; --- mixH1(h1 from low, k1 from high) ---
+             (h1 (bitwise-xor h1 k1))
+             (h1 (rotl32 h1 13))
+             (h1 (add32 (mul32 h1 5) #xe6546b64))
+             ;; --- fmix(h1, 8) ---
+             (h1 (bitwise-xor h1 8))
+             (h1 (bitwise-xor h1 (urs32 h1 16)))
+             (h1 (mul32 h1 #x85ebca6b))
+             (h1 (bitwise-xor h1 (urs32 h1 13)))
+             (h1 (mul32 h1 #xc2b2ae35)))
+        (i32 (bitwise-xor h1 (urs32 h1 16))))))
+
+;; murmur3-hash-int for int32-range values (Java Murmur3.hashInt, count=4).
+(define (murmur3-hash-int input)
+  (if (= (i32 input) 0) 0
+      (let* ((k1 (murmur3-mix-k1 (i32 input)))
+             (h1 (murmur3-mix-h1 murmur3-seed k1)))
+        (murmur3-fmix h1 4))))
+
+;; murmur3-hash-long for any exact integer within 64 bits; the >64-bit bignum
+;; fallback keeps the low 64 bits (Java long semantics) before mixing.
+(define (murmur3-hash-long input)
+  (if (= input 0) 0
+      (if (fixnum? input)
+          (murmur3-hash-long-flat input)
+          (let* ((u64 (bitwise-and input #xFFFFFFFFFFFFFFFF))
+                 (low (i32 u64))
+                 (high (i32 (arithmetic-shift u64 -32)))
+                 (k1 (murmur3-mix-k1 low))
+                 (h1 (murmur3-mix-h1 murmur3-seed k1))
+                 (k1 (murmur3-mix-k1 high))
+                 (h1 (murmur3-mix-h1 h1 k1)))
+            (murmur3-fmix h1 8)))))
+
+;; ============================================================================
+;; String hash — Java String.hashCode() over UTF-16 code units.
+;; ============================================================================
+
+;; Java String.hashCode(): s[0]*31^(n-1) + ... + s[n-1] with int32 wrapping at
+;; every step (the i32 wrap is exact: + and * commute with mod 2^32). Iterates
+;; the string's codepoints directly (jolt/Gambit strings hold astral chars as a
+;; single position), computing surrogate pairs inline for codepoints >= #x10000.
+(define (java-string-hashcode s)
+  (let ((len (string-length s)))
+    (let loop ((i 0) (h 0))
+      (if (>= i len)
+          (i32 h)
+          (let ((cp (char->integer (string-ref s i))))
+            (if (< cp #x10000)
+                (loop (+ i 1) (i32 (+ (* 31 h) cp)))
+                (let* ((cp2 (- cp #x10000))
+                       (high (bitwise-ior #xD800 (arithmetic-shift cp2 -10)))
+                       (low  (bitwise-ior #xDC00 (bitwise-and cp2 #x3FF))))
+                  (let ((h* (i32 (+ (* 31 h) high))))
+                    (loop (+ i 1) (i32 (+ (* 31 h*) low)))))))))))
+
+(define (murmur3-hash-unencoded-chars s)
+  ;; Java's Murmur3.hashUnencodedChars(CharSequence) over the UTF-16 code-unit
+  ;; sequence: processes 2 code units at a time, mixing each pair as
+  ;; k1 = c1 | (c2 << 16); a single trailing unit is mixed alone. Count tracks
+  ;; complete code units so the final fmix length is 2 * total code units.
+  (let ((len (string-length s)))
+    (let loop ((i 0) (h1 murmur3-seed) (pending #f) (count 0))
+      (if (>= i len)
+          (if pending
+              ;; One unpaired unit left — mix and finalize
+              (let* ((k1 (murmur3-mix-k1 pending))
+                     (h1 (bitwise-xor h1 k1)))
+                (murmur3-fmix h1 (* 2 (+ count 1))))
+              (murmur3-fmix h1 (* 2 count)))
+          (let ((cp (char->integer (string-ref s i))))
+            (if (< cp #x10000)
+                ;; BMP: one code unit
+                (if pending
+                    ;; Pair pending + this unit; both consumed
+                    (let* ((k1 (murmur3-mix-k1
+                                (bitwise-ior pending
+                                             (arithmetic-shift cp 16))))
+                           (h1 (murmur3-mix-h1 h1 k1)))
+                      (loop (+ i 1) h1 #f (+ count 2)))
+                    ;; Hold as pending (not counted yet)
+                    (loop (+ i 1) h1 cp count))
+                ;; Astral: surrogate pair (high, low) — always 2 units
+                (let* ((cp2 (- cp #x10000))
+                       (high (bitwise-ior #xD800 (arithmetic-shift cp2 -10)))
+                       (low  (bitwise-ior #xDC00 (bitwise-and cp2 #x3FF))))
+                  (if pending
+                      ;; Pair pending + high (consumed), low becomes new pending
+                      (let* ((k1 (murmur3-mix-k1
+                                  (bitwise-ior pending
+                                               (arithmetic-shift high 16))))
+                             (h1 (murmur3-mix-h1 h1 k1)))
+                        (loop (+ i 1) h1 low (+ count 2)))
+                      ;; High + low consumed together
+                      (let* ((k1 (murmur3-mix-k1
+                                  (bitwise-ior high
+                                               (arithmetic-shift low 16))))
+                             (h1 (murmur3-mix-h1 h1 k1)))
+                        (loop (+ i 1) h1 #f (+ count 2)))))))))))
+
+;; ============================================================================
+;; Bignum / double hashing.
+;; ============================================================================
+
+;; Java BigInteger.hashCode over the magnitude limbs (big-endian 32-bit):
+;; h = 31*h + limb with int32 wrapping, then * signum.
+(define (big-integer-hashcode x)
+  (let* ((signum (cond ((< x 0) -1) ((= x 0) 0) (else 1)))
+         (mag (abs x)))
+    (if (= mag 0)
+        0
+        (let ((nbits (integer-length mag)))
+          (let* ((nlimbs (+ (quotient (- nbits 1) 32) 1))
+                 (shift0 (* (- nlimbs 1) 32)))
+            (let loop ((i 0) (h 0) (shift shift0))
+              (if (>= i nlimbs)
+                  (* h signum)
+                  (let ((limb (u32 (arithmetic-shift mag (- shift)))))
+                    (loop (+ i 1) (i32 (+ (* 31 h) limb)) (- shift 32))))))))))
+
+;; Extract the 64-bit IEEE-754 bit pattern of a double. Gambit binds no R6RS
+;; bytevector-ieee accessors; ##flonum->ieee754-64 returns the pattern
+;; directly as an exact integer (probed 4.9.7: 1.5 -> #x3FF8000000000000).
+(define (double-to-raw-bits x)
+  (##flonum->ieee754-64 x))
+
+;; Double hasheq — Numbers.hasheq for Double.class: ±0.0 → 0 (Gambit's fl=?
+;; equates 0.0 and -0.0, so both hit the special case, matching the Chez
+;; build), else Double.hashCode = (int)(bits ^ (bits >>> 32)).
+(define (double-hasheq x)
+  (if (and (flonum? x) (fl=? x 0.0) (fl=? (fl/ x 1.0) -0.0))
+      0
+      (let ((bits (double-to-raw-bits x)))
+        (i32 (bitwise-xor bits (arithmetic-shift bits -32))))))
+
+;; ============================================================================
+;; Collection hash mixers — exact ports of the Murmur3 Java methods.
+;; ============================================================================
+
+(define (mix-coll-hash hash count)
+  (let* ((k1 (murmur3-mix-k1 hash))
+         (h1 (murmur3-mix-h1 murmur3-seed k1)))
+    (murmur3-fmix h1 count)))
+
+;; hash-ordered and hash-unordered operate over a Jolt seq (cseq/nil).
+;; Called from seq.ss (seq-hash) and collections.ss (jolt-coll-hash).
+
+(define (hash-ordered xs)
+  (let loop ((xs xs) (n 0) (h 1))
+    (if (jolt-nil? xs)
+        (mix-coll-hash h n)
+        (loop (jolt-seq (seq-more xs))
+              (+ n 1)
+              (i32 (+ (* 31 h) (jolt-hasheq (seq-first xs))))))))
+
+;; hash-ordered of a 2-element sequence [k v] — MapEntry-as-vector on the JVM.
+(define (entry-hasheq k v)
+  (let* ((h1 (i32 (+ 31 (jolt-hasheq k))))
+         (h2 (i32 (+ (* 31 h1) (jolt-hasheq v)))))
+    (mix-coll-hash h2 2)))
+
+(define (hash-unordered xs)
+  (let loop ((xs xs) (n 0) (h 0))
+    (if (jolt-nil? xs)
+        (mix-coll-hash h n)
+        (let ((e (seq-first xs)))
+          (loop (jolt-seq (seq-more xs))
+                (+ n 1)
+                ;; add32: APersistentMap.mapHasheq/APersistentSet.setHasheq sum
+                ;; in a Java int (32-bit wrap), matching the native pmap/pset
+                ;; paths — so a custom coll that hashes via hash-unordered hashes
+                ;; equal to a plain map/set with the same elements.
+                (add32 h (if (pair? e)
+                             (entry-hasheq (car e) (cdr e))
+                             (jolt-hasheq e))))))))
+
+;; ============================================================================
+;; Util.hashCombine — exact port of clojure.lang.Util.hashCombine.
+;; ============================================================================
+
+(define (hash-combine seed hash)
+  ;; a la boost: seed ^= hash + 0x9e3779b9 + (seed << 6) + (seed >> 2)
+  ;; Java's >> is arithmetic (sign-extending), NOT >>> (logical/unsigned).
+  (let* ((seed (i32 seed))
+         (hash (i32 hash))
+         (sl   (i32 (arithmetic-shift seed 6)))
+         (sr   (arithmetic-shift seed -2))
+         (sum  (i32 (+ (i32 (+ hash #x9e3779b9)) (i32 (+ sl sr)))))
+         (result (bitwise-xor seed sum)))
+    (i32 result)))
+
+;; ============================================================================
+;; Keyword / Symbol hasheq (mirrors Keyword.java / Symbol.java).
+;; ============================================================================
+
+;; Keyword hasheq = symbol.hasheq() + 0x9e3779b9. Stored in the keyword-t's
+;; khash field at construction time (values.ss).
+(define (compute-keyword-hasheq ns name)
+  ;; sym.hasheq() = hashCombine(murmur3.hashUnencodedChars(name), hash(ns))
+  ;; hash(ns) = ns.hashCode() = java-string-hashcode(ns) or 0 if absent.
+  ;; Then keyword hasheq = sym.hasheq() + 0x9e3779b9.
+  (let ((ns-hash (if (or (not ns) (eq? ns '()))
+                     0
+                     (java-string-hashcode ns))))
+    (i32 (+ (hash-combine (murmur3-hash-unencoded-chars name) ns-hash)
+            #x9e3779b9))))
+
+;; Symbol hasheq = Util.hashCombine(Murmur3.hashUnencodedChars(name), hash(ns)).
+(define symbol-hasheq-cache (make-weak-eq-hashtable))
+
+(define (compute-symbol-hasheq ns name)
+  (let ((ns-hash (if (or (jolt-nil? ns) (not ns) (eq? ns '()))
+                     0
+                     (java-string-hashcode ns))))
+    (hash-combine (murmur3-hash-unencoded-chars name) ns-hash)))
+
+(define (symbol-hasheq sym)
+  (or (hashtable-ref symbol-hasheq-cache sym #f)
+      (let ((h (compute-symbol-hasheq (symbol-t-ns sym) (symbol-t-name sym))))
+        (hashtable-set! symbol-hasheq-cache sym h)
+        h)))
+
+;; String hasheq cache — same pattern as the symbol cache.
+(define string-hasheq-cache (make-weak-eq-hashtable))
+
+(define (compute-string-hasheq s)
+  (murmur3-hash-int (java-string-hashcode s)))
+
+(define (string-hasheq s)
+  (or (hashtable-ref string-hasheq-cache s #f)
+      (let ((h (compute-string-hasheq s)))
+        (hashtable-set! string-hasheq-cache s h)
+        h)))
+
+;; ============================================================================
+;; jolt-hasheq — the top-level dispatch (mirrors Util.hasheq).
+;; ============================================================================
+
+;; Per-type arms registered by host shims (records, dates, etc.). An arm is
+;; (pred . handler); pred takes the value, handler returns int.
+(define jolt-hasheq-arms '())
+
+;; Dispatch: fast-path types first, then registered arms, then fallback.
+(define (jolt-hasheq x)
+  (cond
+    ((jolt-nil? x) 0)
+    ((keyword? x) (keyword-t-khash x))
+    ;; Fixnum: all fixnums use hashLong (count=8) matching JVM's Long.hasheq.
+    ((fixnum? x) (murmur3-hash-long-flat x))
+    ((string? x) (string-hasheq x))
+    (else
+     ;; New hasheq arms (jrec via records.ss, etc.)
+     (let loop ((as jolt-hasheq-arms))
+       (cond ((null? as)
+              ;; Fall through to old jolt-hash arms (backward-compat for types
+              ;; that still register via register-hash-arm!).
+              (let loop2 ((bs jolt-hash-arms))
+                (cond ((null? bs) (jolt-hasheq-fallback x))
+                      (((caar bs) x) (i32 ((cdar bs) x)))
+                      (else (loop2 (cdr bs))))))
+             (((caar as) x) ((cdar as) x))
+             (else (loop (cdr as))))))))
+
+(define (jolt-hasheq-fallback x)
+  ;; All types not covered by the fast path or arms.
+  ;; Mirrors Util.hasheq: Number → Numbers.hasheq,
+  ;; IHashEq → .hasheq(), else .hashCode().
+  (cond
+    ;; Numbers (excluding fixnums, already handled in fast path)
+    ((number? x)
+     (cond
+       ((flonum? x) (double-hasheq x))
+       ;; Ratio: exact non-integer. hasheq = BigInteger.hashCode(numer) ^
+       ;; BigInteger.hashCode(denom)
+       ((and (exact? x) (not (integer? x)))
+        (i32 (bitwise-xor (big-integer-hashcode (numerator x))
+                          (big-integer-hashcode (denominator x)))))
+       ;; BigInt / bignum: if fits in long → hashLong, else BigInteger.hashCode
+       ((and (exact? x) (integer? x)
+             (>= x -9223372036854775808) (<= x 9223372036854775807))
+        (murmur3-hash-long x))
+       ;; Bignum > 64-bit: BigInteger.hashCode (JVM parity).
+       (else (big-integer-hashcode x))))
+    ((boolean? x) (if x 1231 1237))
+    ((char? x) (char->integer x))    ;; Character.hashCode = (int) charValue
+    ((jolt-symbol? x) (symbol-hasheq x))
+    ;; Sequential (vector/list/seq) → hashOrdered (Murmur3.hashOrdered)
+    ((jolt-sequential? x) (hash-ordered (jolt-seq x)))
+    ;; Collections (map/set) → hashUnordered (Murmur3.hashUnordered)
+    ((pmap? x)
+     (or (and (not (= 0 (pmap-hasheq x))) (pmap-hasheq x))
+         (let* ((result (pmap-fold x
+                         (lambda (k v acc)
+                           (cons (add32 (car acc) (entry-hasheq k v))
+                                 (+ (cdr acc) 1)))
+                         (cons 0 0)))
+                (h (mix-coll-hash (car result) (cdr result))))
+           (pmap-hasheq-set! x h)
+           h)))
+    ((pset? x)
+     (or (and (not (= 0 (pset-hasheq x))) (pset-hasheq x))
+         (let* ((result (pset-fold x
+                         (lambda (e acc) (cons (+ (car acc) (jolt-hasheq e))
+                                               (+ (cdr acc) 1)))
+                         (cons 0 0)))
+                (h (mix-coll-hash (car result) (cdr result))))
+           (pset-hasheq-set! x h)
+           h)))
+    (else (equal-hash x))))

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -1,0 +1,463 @@
+;; prelude-shims.ss — the Gambit target's syntax/API shims, loaded FIRST in every
+;; boot path (rt.ss owns the load; gambitcheck loads it directly).
+;;
+;; G1 (jolt-mj95.2): the syntax/API layer for native gsi (Gambit 4.9.7). Every
+;; shim here exists because the curated host subset (the G2 boot manifest) uses
+;; an R6RS/Chez spelling that Gambit does not provide under that name — see
+;; .dirge/gambit-spike-findings.md for the probe verdicts this builds on, and
+;; the census lists below for exactly what is shimmed (grep as data, not by eye).
+;;
+;; DESIGN NOTES
+;; ------------
+;; - Gambit's plain-script top level lacks several (gambit) module names
+;;   (format/printf/system/...), so the prelude starts by importing the (gambit)
+;;   module. Gambit's native define-record-type is renamed out of the way
+;;   (%gambit-native-record, unused) because it is the define-type sugar with
+;;   keyword syntax — NOT the R6RS form the host writes.
+;; - Records: Gambit has NO record mechanism with parent support and inclusive
+;;   predicates (the findings doc's "R7RS define-record-type works" verdict is
+;;   wrong: the (scheme base) version IS Gambit's native macro, which rejects the
+;;   R6RS field-spec form; probe 2026-08-07). The host needs both — the jrec
+;;   family (records.ss define-jrec-family) generates parent clauses, and
+;;   collections.ss dispatches on (jrec? x) as a GENERIC record test, which
+;;   requires the base predicate to be true of child instances. So the shim
+;;   implements define-record-type itself over native vectors: an instance is
+;;   #(type-id field0 field1 ...) with parent fields laid out first, a load-time
+;;   registry maps type-name -> rtd (id parent-name nfields field-names), and
+;;   constructor/accessor/setter/predicate bindings are eval'd into the
+;;   interaction environment (the same mechanism def-var! relies on — the G0
+;;   pin that eval'd defines are visible to later evals).
+;;   DIVERGENCE (documented): a gambit record IS a native vector, so (vector? r)
+;;   is #t where Chez gives #f. Host dispatch never tests raw vector? on records
+;;   (jolt-vector? = pvec?, and pvec is itself a record), so the jolt-level
+;;   classification is unaffected. Accessor/predicate type checks use the same
+;;   ancestor-chain logic as R6RS.
+;; - nongenerative uids are accepted and IGNORED (no image capability on this
+;;   target). protocol/parent in record clauses: parent IS supported (the jrec
+;;   family needs it); protocol is an error.
+
+;; Gambit's plain-script top level lacks several (gambit) module names
+;; (format/printf/system/...), so the prelude imports the (gambit) module —
+;; EXCEPT its native define-record-type (the define-type sugar with keyword
+;; syntax, NOT the R6RS form the host writes), which this file replaces with
+;; its own translator below.
+(import (except (gambit) define-record-type))
+
+;; ============================================================================
+;; interaction environment — the eval target for record bindings and, later,
+;; def-var!. R7RS (scheme repl) interaction-environment if bound, else Gambit's
+;; repl-environment. Either way (interaction-environment) returns THE top-level
+;; environment where define lands (G0 pin).
+;; ============================================================================
+
+(define %jolt-interaction-environment
+  (guard (e (#t (repl-environment)))
+    (interaction-environment)))
+
+(define (interaction-environment)
+  %jolt-interaction-environment)
+
+;; ============================================================================
+;; R6RS define-record-type translator
+;; ============================================================================
+
+(define jolt-record-table (make-table test: eq?))     ;; type-name sym -> rtd
+(define jolt-record-id-table (make-table test: eqv?)) ;; id fixnum -> rtd
+(define jolt-record-counter 0)
+
+;; rtd = #(id parent-name nfields field-name-list)
+(define (jolt-record-id-of name)
+  (let ((rtd (table-ref jolt-record-table name #f)))
+    (and rtd (vector-ref rtd 0))))
+
+(define (jolt-record-nfields id)
+  (vector-ref (table-ref jolt-record-id-table id #f) 2))
+
+(define (register-jolt-record-type! name parent-name fields)
+  (let* ((parent-id (and parent-name (jolt-record-id-of parent-name)))
+         (parent-n (if parent-id (jolt-record-nfields parent-id) 0))
+         (n (+ parent-n (length fields)))
+         (id (begin (set! jolt-record-counter (+ jolt-record-counter 1))
+                    jolt-record-counter))
+         (rtd (vector id parent-name n fields)))
+    (table-set! jolt-record-table name rtd)
+    (table-set! jolt-record-id-table id rtd)
+    id))
+
+;; Is ID a descendant-or-self of ANCESTOR-ID? Inclusive predicate semantics.
+(define (jolt-record-ancestor? id ancestor-id)
+  (or (= id ancestor-id)
+      (let* ((rtd (table-ref jolt-record-id-table id #f))
+             (pn (and rtd (vector-ref rtd 1))))
+        (and pn (jolt-record-ancestor? (jolt-record-id-of pn) ancestor-id)))))
+
+(define (make-jolt-record-ctor id n)
+  (lambda args
+    (if (not (= (length args) n))
+        (error 'record-constructor "wrong number of arguments" n (length args))
+        (let ((v (make-vector (+ n 1))))
+          (vector-set! v 0 id)
+          (let loop ((i 0) (args args))
+            (if (< i n)
+                (begin (vector-set! v (+ i 1) (car args))
+                       (loop (+ i 1) (cdr args)))
+                v))))))
+
+(define (make-jolt-record-pred id)
+  (lambda (x)
+    (and (vector? x)
+         (>= (vector-length x) 1)
+         (fixnum? (vector-ref x 0))
+         (jolt-record-ancestor? (vector-ref x 0) id))))
+
+(define (make-jolt-record-field id parent-n own-index)
+  (+ 1 parent-n own-index))
+
+(define (make-jolt-record-accessor id parent-n own-index)
+  (let ((off (make-jolt-record-field id parent-n own-index)))
+    (lambda (r)
+      (if (not (and (vector? r) (> (vector-length r) off)
+                    (jolt-record-ancestor? (vector-ref r 0) id)))
+          (error 'record-accessor "not an instance of this record type" id r))
+      (vector-ref r off))))
+
+(define (make-jolt-record-setter id parent-n own-index)
+  (let ((off (make-jolt-record-field id parent-n own-index)))
+    (lambda (r v)
+      (if (not (and (vector? r) (> (vector-length r) off)
+                    (jolt-record-ancestor? (vector-ref r 0) id)))
+          (error 'record-setter "not an instance of this record type" id r))
+      (vector-set! r off v))))
+
+;; Build the record type and eval its ctor/pred/accessor/setter bindings into
+;; the interaction environment (names computed from the record name exactly as
+;; Chez generates them: make-<name>/<name>?/<name>-<field>/<name>-<field>-set!
+;; for a bare name-spec, or the explicit ctor/pred from (name ctor pred)).
+(define (make-jolt-record-type name ctor pred parent-name fields)
+  (let* ((parent-id (and parent-name (jolt-record-id-of parent-name)))
+         (parent-n (if parent-id (jolt-record-nfields parent-id) 0))
+         (id (register-jolt-record-type! name parent-name fields))
+         (env (interaction-environment))
+         (nstr (symbol->string name))
+         (ctor-name (or ctor (string->symbol (string-append "make-" nstr))))
+         (pred-name (or pred (string->symbol (string-append nstr "?")))))
+    (eval (list 'define ctor-name (list 'make-jolt-record-ctor id
+                                        (+ parent-n (length fields))))
+          env)
+    (eval (list 'define pred-name (list 'make-jolt-record-pred id)) env)
+    (let loop ((j 0) (fs fields))
+      (if (pair? fs)
+          (let* ((spec (car fs))               ; (kind . name), kind ∈ mutable|immutable
+                 (f (cdr spec))
+                 (acc (string->symbol (string-append nstr "-" (symbol->string f))))
+                 (setn (string->symbol (string-append (symbol->string acc) "-set!"))))
+            (eval (list 'define acc (list 'make-jolt-record-accessor
+                                          id parent-n j))
+                  env)
+            ;; R6RS: only (mutable f) fields have a mutator binding.
+            (when (eq? (car spec) 'mutable)
+              (eval (list 'define setn (list 'make-jolt-record-setter
+                                             id parent-n j))
+                    env))
+            (loop (+ j 1) (cdr fs)))
+          #f))
+    id))
+
+;; field-spec extraction: (kind . name) pairs. R6RS semantics: a PLAIN spec is
+;; IMMUTABLE — only (mutable f) fields get a setter binding.
+(define-syntax jolt-record-field-names
+  (syntax-rules (mutable immutable)
+    ((_ ()) '())
+    ((_ ((mutable f) rest ...)) (cons (cons 'mutable 'f) (jolt-record-field-names (rest ...))))
+    ((_ ((immutable f) rest ...)) (cons (cons 'immutable 'f) (jolt-record-field-names (rest ...))))
+    ((_ (f rest ...)) (cons (cons 'immutable 'f) (jolt-record-field-names (rest ...))))))
+
+(define-syntax define-record-type
+  (syntax-rules (fields mutable immutable nongenerative parent protocol)
+    ((_ (name ctor pred) (parent p) (fields spec ...) (nongenerative uid))
+     (define name (make-jolt-record-type 'name 'ctor 'pred 'p
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ (name ctor pred) (fields spec ...) (nongenerative uid))
+     (define name (make-jolt-record-type 'name 'ctor 'pred #f
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ (name ctor pred) (parent p) (fields spec ...))
+     (define name (make-jolt-record-type 'name 'ctor 'pred 'p
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ (name ctor pred) (fields spec ...))
+     (define name (make-jolt-record-type 'name 'ctor 'pred #f
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ name (fields spec ...) (nongenerative uid))
+     (define name (make-jolt-record-type 'name #f #f #f
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ name (fields spec ...))
+     (define name (make-jolt-record-type 'name #f #f #f
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ name (parent p) (fields spec ...) (nongenerative uid))
+     (define name (make-jolt-record-type 'name #f #f 'p
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ name (parent p) (fields spec ...))
+     (define name (make-jolt-record-type 'name #f #f 'p
+                                         (jolt-record-field-names (spec ...)))))
+    ((_ (name ctor pred) (nongenerative uid))
+     (define name (make-jolt-record-type 'name 'ctor 'pred #f '())))
+    ((_ name (nongenerative uid))
+     (define name (make-jolt-record-type 'name #f #f #f '())))
+    ((_ name (protocol p) rest ...)
+     (error 'define-record-type "protocol clauses are unsupported on the gambit target" 'name))))
+
+;; ============================================================================
+;; R6RS hashtable API over Gambit tables.
+;;
+;; CENSUS (curated subset, 2026-08-07): make-hashtable 53, hashtable-ref 170,
+;; hashtable-set! 97, hashtable-keys 22, hashtable-delete! 17, make-weak-eq-
+;; hashtable 10, make-eq-hashtable 6, hashtable-contains? 6, hashtable-values 5
+;; (CONTRACT misc), hashtable-entries 4, hashtable-size 3, make-eqv-hashtable 1,
+;; hashtable-cells 0 (CONTRACT misc). hashtable-update!/copy/mutable?/symbol-
+;; hashtable? are NOT used in the subset — deliberately not shimmed.
+;;
+;; make-hashtable is always called with a hash function + equiv predicate
+;; (e.g. (make-hashtable string-hash string=?)). Gambit tables hash internally
+;; (equal?-consistent), so the hash argument is accepted and DROPPED — every
+;; table operation is behaviorally identical; the hash function is only an
+;; internal implementation detail. string-hash is provided so the argument
+;; expression evaluates.
+;; ============================================================================
+
+(define (string-hash s) (equal?-hash s))
+
+(define (make-eq-hashtable . rest) (make-table test: eq?))
+(define (make-eqv-hashtable . rest) (make-table test: eqv?))
+(define (make-weak-eq-hashtable) (make-table test: eq? weak-keys: #t))
+(define (make-hashtable hash-fn equiv) (make-table test: equiv))
+
+(define (hashtable-ref t k d) (table-ref t k d))
+(define (hashtable-set! t k v) (table-set! t k v))
+;; Gambit deletion is (table-set! t k) with no value (G0 probe: delete = set!
+;; with no value; there is no table-delete!).
+(define (hashtable-delete! t k) (table-set! t k))
+(define (hashtable-size t) (table-length t))
+
+(define %hashtable-missing (gensym 'hashtable-missing))
+(define (hashtable-contains? t k)
+  (not (eq? (table-ref t k %hashtable-missing) %hashtable-missing)))
+
+;; R6RS hashtable-keys returns a VECTOR.
+(define (hashtable-keys t)
+  (list->vector (map car (table->list t))))
+
+;; R6RS hashtable-entries returns TWO values: keys vector, values vector.
+(define (hashtable-entries t)
+  (let ((cells (table->list t)))
+    (values (list->vector (map car cells))
+            (list->vector (map cdr cells)))))
+
+;; CONTRACT misc: hashtable-values (vector of values), hashtable-cells (list of
+;; (key . value) pairs).
+(define (hashtable-values t)
+  (list->vector (map cdr (table->list t))))
+
+(define (hashtable-cells t)
+  (table->list t))
+
+;; ============================================================================
+;; fx spelling aliases.
+;;
+;; CENSUS: fx+ 146, fx- 56, fx=? 55, fx<? 47, fx>? 31, fxand 26, fx* 10, fxsra 7,
+;; fxsll 6, fxmax 5, fxior 5, fxnot 2, fxmin 2, fxremainder 1, fxquotient 1.
+;; fl=? 1 (hasheq's -0.0 arm) -> Gambit fl=.
+;; Gambit binds fx+ fx- fx* fxand fxior fxnot fxmax fxmin fxquotient fxremainder
+;; natively; fx=?/fx<?/fx>? need the trailing-? spellings, and fxsll/fxsra map to
+;; fxarithmetic-shift-left/right. fx<=? fx>=? fx1+ fx1- fxsrl: zero uses in the
+;; subset — not aliased.
+;; ============================================================================
+
+(define-syntax fx=?
+  (syntax-rules () ((_ a ...) (fx= a ...))))
+(define-syntax fx<?
+  (syntax-rules () ((_ a ...) (fx< a ...))))
+(define-syntax fx>?
+  (syntax-rules () ((_ a ...) (fx> a ...))))
+(define-syntax fl=?
+  (syntax-rules () ((_ a ...) (fl= a ...))))
+(define-syntax fxsll
+  (syntax-rules () ((_ a b) (fxarithmetic-shift-left a b))))
+(define-syntax fxsra
+  (syntax-rules () ((_ a b) (fxarithmetic-shift-right a b))))
+
+;; R6RS bitwise shift spellings (natives-num.ss is the one user in the subset:
+;; jolt-bit-shift-left/right, bit-mask, jolt-bit-test — 6 call sites) → Gambit's
+;; arithmetic-shift. Gambit does not bind the R6RS bitwise-arithmetic-shift-*
+;; names; arithmetic-shift with a NEGATIVE count is the arithmetic right shift
+;; (floor semantics — identical to R6RS bitwise-arithmetic-shift-right).
+(define-syntax bitwise-arithmetic-shift-left
+  (syntax-rules () ((_ x n) (arithmetic-shift x n))))
+(define-syntax bitwise-arithmetic-shift-right
+  (syntax-rules () ((_ x n) (arithmetic-shift x (- n)))))
+
+;; ============================================================================
+;; Chez condition accessors over Gambit error objects.
+;;
+;; CENSUS: condition-message 7, condition? 7, message-condition? 2,
+;; condition-irritants 1. Gambit's (error 'who "msg" irr...) folds exactly like
+;; Chez: error-object-message -> "msg", error-object-irritants -> (irr...).
+;; Non-error raised values: condition? -> #f, message/irritants -> #f / '().
+;; ============================================================================
+
+;; Chez's (error who "msg" irritant ...) keeps WHO out of the message and the
+;; irritants. Gambit's native error is message-first (a symbol who would BECOME
+;; the message and push "msg" into the irritants — probed 4.9.7), so the shim
+;; re-shapes: message = the string, irritants = the rest, who dropped (Gambit
+;; has no who slot; the host's five error sites read message + irritants only).
+(define %gambit-error error)
+(define (error who . rest)
+  (if (and (pair? rest) (string? (car rest)))
+      (apply %gambit-error (car rest) (cdr rest))
+      (apply %gambit-error who rest)))
+
+(define (condition? x) (error-object? x))
+(define (message-condition? x) (error-object? x))
+(define (condition-message c)
+  (if (error-object? c) (error-object-message c) #f))
+(define (condition-irritants c)
+  (if (error-object? c) (error-object-irritants c) '()))
+
+;; ============================================================================
+;; thread-name mappings (G0 verdicts: the PIN holds — parameters fork-inherit
+;; into SRFI-18 threads; mutexes are non-recursive; condvar wait shape differs
+;; from Chez condition-wait and is mapped here).
+;; ============================================================================
+
+(define (mutex-acquire m . rest)
+  (if (pair? rest) (mutex-lock! m (car rest)) (mutex-lock! m)))
+(define (mutex-release m) (mutex-unlock! m))
+
+(define-syntax with-mutex
+  (syntax-rules ()
+    ((_ m body ...)
+     (dynamic-wind (lambda () (mutex-lock! m))
+                   (lambda () body ...)
+                   (lambda () (mutex-unlock! m))))))
+
+(define (make-thread-parameter init) (make-parameter init))
+
+;; SRFI-18 spellings: make-condition-variable / condition-variable-signal! /
+;; condition-variable-broadcast.
+(define (make-condition) (make-condition-variable))
+(define (condition-signal cv) (condition-variable-signal! cv))
+(define (condition-broadcast cv) (condition-variable-broadcast! cv))
+
+;; (condition-wait cv m [timeout]) — the SRFI-18 idiom is a single
+;; (mutex-unlock! m cv [timeout]) call: it releases M, waits on CV (or times
+;; out), and RE-ACQUIRES M before returning. Unit-tested in gambitcheck.
+(define (condition-wait cv m . rest)
+  ;; SRFI-18's (mutex-unlock! m cv [timeout]) releases M and waits, but does
+  ;; NOT re-acquire on wake — Chez's condition-wait DOES, and every host wait
+  ;; loop assumes it (unlock follows the loop). Re-lock before returning.
+  ;; A NUMBER timeout is normalized to a time object: the js runtime treats a
+  ;; raw absolute-seconds real as a setTimeout DELAY (32-bit-overflow warnings,
+  ;; infinite reschedule loop — probed under node); a time object works on
+  ;; both targets.
+  (let ((r (if (pair? rest)
+               (let ((t (car rest)))
+                 (mutex-unlock! m cv (if (number? t) (seconds->time t) t)))
+               (mutex-unlock! m cv))))
+    (mutex-lock! m)
+    r))
+
+(define (fork-thread thunk) (thread-start! (make-thread thunk)))
+
+;; CONTRACT: get-thread-id is a NUMBER, distinct per live thread. Gambit has no
+;; native thread ids, so a weak table maps thread objects to a monotonic
+;; counter. Weak keys so a dead thread's slot (and id) can be reclaimed.
+(define thread-id-table (make-table test: eq? weak-keys: #t))
+(define thread-id-mutex (make-mutex))
+(define thread-id-counter 0)
+
+(define (get-thread-id)
+  (let ((t (current-thread)))
+    (or (table-ref thread-id-table t #f)
+        (begin
+          (mutex-lock! thread-id-mutex)
+          (let ((id (or (table-ref thread-id-table t #f)
+                        (begin (set! thread-id-counter (+ thread-id-counter 1))
+                               (table-set! thread-id-table t thread-id-counter)
+                               thread-id-counter))))
+            (mutex-unlock! thread-id-mutex)
+            id)))))
+
+;; ============================================================================
+;; CONTRACT misc names (system/sort/time helpers the host spells differently).
+;; ============================================================================
+
+;; Chez sort shape is (sort predicate list); Gambit's native is list-sort with
+;; the same (less? list) order.
+(define (sort pred lst) (list-sort pred lst))
+
+(define (list-head lst n)
+  (let loop ((lst lst) (n n) (acc '()))
+    (if (<= n 0)
+        (reverse acc)
+        (loop (cdr lst) (- n 1) (cons (car lst) acc)))))
+
+;; iota / vector-copy / box / unbox / set-box! / void / gensym / pretty-print /
+;; getenv / system come from (gambit) natively; format/printf/fprintf are shimmed below.
+
+;; R6RS sleep takes a TIME object; Gambit's thread-sleep! takes real seconds.
+(define (sleep t)
+  (if (number? t)
+      (thread-sleep! t)
+      (thread-sleep! (time->seconds t))))
+
+;; CONTRACT: current-time accepts the R6RS one-arg time-type form AND the Chez
+;; zero-arg form. Gambit's native is zero-arg only; the type argument is ignored
+;; (a utc time object is monotonic enough for elapsed deltas within a process).
+(define %gambit-current-time current-time)
+(define (current-time . rest) (%gambit-current-time))
+
+;; make-time is not bound natively (and unused in the curated subset — the
+;; CONTRACT comment mentions the host passing make-time results to sleep).
+;; R6RS order: (make-time type nanosecond second).
+(define (make-time type nanosecond second)
+  (seconds->time (+ second (/ nanosecond 1000000000))))
+
+;; CONTRACT misc: system is the shell-out; Gambit spells it shell-command.
+(define (system cmd) (shell-command cmd))
+
+(define (scheme-version)
+  (guard (e (#t "Gambit Scheme"))
+    (##version-string)))
+
+;; Chez's equal-hash (used by the hasheq fallback) maps onto Gambit's equal?-hash.
+(define (equal-hash x) (equal?-hash x))
+
+;; CONTRACT: format is the ~a ~s ~d ~% ~~ subset (SRFI-28); printf/fprintf are
+;; format to the current/given output port. Gambit binds NONE of these natively
+;; (probed 4.9.7) — the earlier note claiming they come from (gambit) was wrong.
+(define (%format-to port fmt args)
+  (let ((n (string-length fmt)))
+    (let loop ((i 0) (args args))
+      (when (< i n)
+        (let ((c (string-ref fmt i)))
+          (if (and (char=? c #\~) (< (+ i 1) n))
+              (let ((d (string-ref fmt (+ i 1))))
+                (case d
+                  ((#\a #\A) (display (car args) port) (loop (+ i 2) (cdr args)))
+                  ((#\s #\S) (write (car args) port) (loop (+ i 2) (cdr args)))
+                  ((#\d #\D) (display (car args) port) (loop (+ i 2) (cdr args)))
+                  ((#\%) (newline port) (loop (+ i 2) args))
+                  ((#\~) (display #\~ port) (loop (+ i 2) args))
+                  (else (display c port) (loop (+ i 1) args))))
+              (begin (display c port) (loop (+ i 1) args))))))))
+
+;; R6RS get-line over Gambit's read-line.
+(define (get-line port) (read-line port))
+
+(define (format fmt . args)
+  (call-with-output-string
+    (lambda (p) (%format-to p fmt args))))
+
+(define (printf fmt . args)
+  (%format-to (current-output-port) fmt args))
+
+(define (fprintf port fmt . args)
+  (%format-to port fmt args))

--- a/host/gambit/scheme-adapter-runtime.ss
+++ b/host/gambit/scheme-adapter-runtime.ss
@@ -1,0 +1,341 @@
+;; scheme-adapter-runtime.ss — the RUNTIME half of the portable-scheme-layer
+;; adapter (PSL R3, epic jolt-867l) — GAMBIT TARGET (native gsi, G1 demo).
+;;
+;; The Chez adapter (host/chez/scheme-adapter-runtime.ss) owns the system-tier
+;; FORBIDDEN names and exposes them through named capability entry points; a
+;; non-Chez target implements (or explicitly degrades) this one small surface
+;; instead of chasing call sites. This file is the Gambit implementation:
+;; same sa-* names, same call shapes, same doc discipline, with the G1 demo
+;; degradations below. Loaded FIRST in every boot path, after prelude-shims.ss
+;; (which owns the (gambit) import) — so this file needs no import of its own.
+;;
+;; G1 degradation summary (each is documented at its entry point):
+;;   - real:  sa-real-time-ms, sa-file-mtime-ms, sa-host-tag and the identity
+;;            derived values. Everything else that can be honest is honest.
+;;   - ffi:   the ENTIRE tier raises a message-carrying condition
+;;            ((error 'sa-foreign-alloc "ffi is unsupported on the gambit
+;;            target")) — never a bare raise (jolt surfaces ex-message, and a
+;;            bare raise surfaces nil; that lesson is paid for). The G2 boot
+;;            manifest excludes java/ffi.ss entirely, so these are only
+;;            reached if jolt-level ffi is attempted.
+;;   - native-compile / image: raise, message-carrying — the AOT cache and
+;;            jolt.image treat the raise as a clean cache disable / unsupported.
+;;   - introspect: off (sa-introspect-enabled? is #f) — frames '() / proc-info
+;;            #f / zero-vector stats; backtraces render from the compile-time
+;;            tables alone, exactly the documented degraded mode.
+;;   - subprocess: sa-run-process raises (demo target; Gambit's open-process
+;;            ports exist but the demo scope does not ship a process tier).
+
+;; ---- system tier (capability: system) --------------------------------------
+
+;; (sa-run-process cmd transcoder) -> (values stdin stdout stderr pid)
+;; Spawn CMD (a shell string) with block buffering and the given transcoder
+;; (#f = binary), returning the four process ports and the pid. Contract: a
+;; target must provide exactly this shape. Degradation: a target without
+;; subprocess support must raise 'unsupported — every caller genuinely needs
+;; the subprocess, so none of them may be silently degraded. The G1 demo
+;; raises with a message-carrying condition.
+(define (sa-run-process cmd transcoder)
+  (error 'sa-run-process "subprocess support is unsupported on the gambit target" cmd))
+
+;; (sa-gc-collect) -> void
+;; A full collection hint (every generation) — what the Runtime.gc /
+;; System.gc callers mean: weak references clear and guardians fire.
+;; Contract: perform a full collection. Degradation: may no-op — callers
+;; already guard the call and the JVM semantic is only a hint. Gambit's
+;; collector runs on its own schedule; no-op.
+(define (sa-gc-collect)
+  #f)
+
+;; (sa-gc-max-generation) -> exact integer
+;; The deepest collectable generation, for callers mapping JVM generations.
+;; Contract: return the maximum generation argument sa-gc-collect accepts.
+;; Degradation: a single-generation collector returns 0.
+(define (sa-gc-max-generation)
+  0)
+
+;; (sa-bytes-allocated) -> exact integer
+;; Live-heap bytes — the "used" reading under current-memory-bytes that
+;; Runtime.freeMemory is built from. Contract: bytes currently allocated and
+;; live. Degradation: an approximation is acceptable; callers only subtract it
+;; from total to compute free memory. Gambit's ##bytes-allocated is used when
+;; bound (gsi native); 0 otherwise.
+(define (sa-bytes-allocated)
+  (guard (e (#t 0))
+    (##bytes-allocated)))
+
+;; (sa-total-memory-bytes) -> exact integer
+;; Total process heap bytes — what the collector has reserved from the OS
+;; (the JVM's totalMemory; Runtime.freeMemory is the difference against
+;; sa-bytes-allocated). Contract: total heap bytes. Degradation: an
+;; approximation is fine — callers only display it or subtract
+;; sa-bytes-allocated from it. A large constant is the documented fallback
+;; (the JVM arm already maps an unbounded heap to Long/MAX_VALUE).
+(define (sa-total-memory-bytes)
+  9223372036854775807)
+
+;; (sa-max-memory-bytes) -> exact integer
+;; Upper bound on the heap the runtime may use — the JVM's maxMemory, which
+;; jolt maps to Long/MAX_VALUE when the heap is unbounded. Contract: an upper
+;; bound on heap bytes. Degradation: a large constant is acceptable — the JVM
+;; arm already falls back to Long.MAX_VALUE semantics.
+(define (sa-max-memory-bytes)
+  9223372036854775807)
+
+;; (sa-real-time-ms) -> exact integer
+;; Wall-clock milliseconds, monotonic within a process — used for elapsed
+;; deltas (build profiling) and unique temp-file stamps. Contract: an
+;; exact-integer ms clock usable for both. Gambit's (real-time) returns a
+;; monotonic elapsed-seconds FLONUM (millisecond precision); convert to an
+;; exact ms count.
+(define (sa-real-time-ms)
+  (inexact->exact (floor (* (real-time) 1000))))
+
+;; ---- R5: io remainder (mtime) + the last GC hook -----------------------------
+
+;; (sa-file-mtime-ms path) -> exact integer
+;; Epoch milliseconds of PATH's last modification. Contract: a per-file mtime
+;; usable for newer-than comparisons (build freshness, AOT cache keys, the
+;; gate-boot staleness predicate). Degradation: none — stat is universal on
+;; real targets; do not fake. Gambit's file-info-modification-time returns a
+;; time object (converted via the bound time->seconds) or seconds directly.
+(define (sa-file-mtime-ms path)
+  ;; Gambit spells it file-info-last-modification-time (returns a time object);
+  ;; time->seconds gives fractional epoch seconds.
+  (let ((t (time->seconds (file-info-last-modification-time (file-info path)))))
+    (if (number? t)
+        (inexact->exact (floor (* t 1000)))
+        (inexact->exact (floor (* (time->seconds t) 1000))))))
+
+;; (sa-gc-trip-bytes! n) -> void
+;; Set the allocation threshold at which a trip collection triggers — the
+;; dev-cache CLI's GC tuning knob. Contract: honor N as a collection-trip
+;; hint. Degradation: may no-op — the call tunes a dev cache only; collection
+;; still happens on its own schedule.
+(define (sa-gc-trip-bytes! n)
+  #f)
+
+;; ---- R6: introspection tier (capability: introspect) -------------------------
+
+;; sa-introspect-enabled? — dynamic parameter, FIXED #f on this target. The
+;; degraded-backtrace gate flips it to #f on Chez to prove that throw surfaces
+;; still carry type+message while every introspect entry point returns
+;; empty/#f; the gambit target IS that mode, permanently.
+(define sa-introspect-enabled? (make-parameter #f))
+
+;; (sa-host-tag) -> string
+;; The runtime's host tag. NAMING ONLY: release/fasl directory names, image
+;; headers, telemetry strings, error text. No logic may branch on it — logic
+;; branches use sa-os-family / sa-arch / sa-endian. Contract: an opaque,
+;; per-build-stable host string.
+(define (sa-host-tag)
+  "gambit")
+
+;; (sa-os-family) -> 'macos | 'windows | 'linux
+;; The OS family every host OS branch derives. Contract: one of the three
+;; symbols. Degradation: none — the sites have no safe assumed default; an
+;; unrecognized host falls back to 'linux, matching the Chez adapter's
+;; else-branches. The G1 demo runs no OS branches, so 'linux is documented as
+;; the else-default, not probed.
+(define (sa-os-family)
+  'linux)
+
+;; (sa-arch) -> 'x86-64 | 'arm64 | 'i386 | 'other
+;; The machine architecture. Contract: the architecture symbol. Degradation:
+;; 'other for an unrecognized host; callers treat it as unverified.
+(define (sa-arch)
+  'other)
+
+;; (sa-endian) -> 'little | 'big | #f
+;; Byte order of the host. Contract: the byte order. The gambit target's
+;; double-to-raw-bits byte layout (hasheq.ss) assumes little-endian; both
+;; supported platforms (arm64/x86-64 macOS and linux) are little-endian.
+(define (sa-endian)
+  'little)
+
+;; (sa-stats) -> #(cpu-nanos real-nanos gc-count gc-cpu-nanos gc-real-nanos
+;;                gc-bytes)
+;; One statistics snapshot as the six exact-integer fields rt.ss reads into
+;; the jolt.host telemetry vars (time fields pre-converted to nanos). Contract:
+;; the six fields in this order. Degradation: a zero vector — the OTel layer
+;; maps zeros to absent metrics.
+(define (sa-stats)
+  (vector 0 0 0 0 0 0))
+
+;; (sa-continuation-frames k) -> list of frame inspectors | '()
+;; The continuation's frames, innermost first. Contract: stepping a throw
+;; continuation. Degradation: '() — the backtrace then renders from the
+;; compile-time tables alone (jolt-backwalk) or reports no frames.
+(define (sa-continuation-frames k)
+  '())
+
+;; (sa-procedure-info x) -> (name . ((free-name . value) ...)) | #f
+;; A procedure's inspector name and live free-variable captures. Contract:
+;; name + captured values. Degradation: #f — the image writer refuses the
+;; closure ('image-no), the same verdict as today's no-inspector builds.
+(define (sa-procedure-info x)
+  #f)
+
+;; ---- R7: ffi tier (capability: ffi) — entirely unsupported, all raise -------
+
+;; (sa-ffi-raise who) -> never returns
+;; The single raising helper the whole ffi tier lowers to. ALWAYS a
+;; message-carrying condition — jolt surfaces the message through ex-message,
+;; and a bare raise surfaces nil.
+(define (sa-ffi-raise who)
+  (error who "ffi is unsupported on the gambit target"))
+
+;; (sa-foreign-procedure name args res) -> foreign procedure
+;; SYNTAX: compile-time-typed foreign-procedure creation. Contract: build a
+;; foreign procedure for a statically-known signature. Degradation: the gambit
+;; target has no ffi tier — expands to a call of the raising helper, so any
+;; attempt surfaces the documented jolt-level unsupported error.
+(define-syntax sa-foreign-procedure
+  (syntax-rules ()
+    ((_ name args res) (sa-ffi-raise 'sa-foreign-procedure))
+    ((_ conv name args res) (sa-ffi-raise 'sa-foreign-procedure))))
+
+;; (sa-foreign-procedure-blocking name args res) -> foreign procedure
+;; SYNTAX: like sa-foreign-procedure, but the call is __collect_safe. Contract:
+;; mark the call so a blocking foreign invocation does not stop other threads'
+;; GC. Degradation: no ffi tier on this target — raise, like the rest.
+(define-syntax sa-foreign-procedure-blocking
+  (syntax-rules ()
+    ((_ name args res) (sa-ffi-raise 'sa-foreign-procedure-blocking))
+    ((_ conv name args res) (sa-ffi-raise 'sa-foreign-procedure-blocking))))
+
+;; (sa-foreign-callable proc args res) -> foreign callable
+;; SYNTAX: compile-time-typed foreign-callable creation, mirroring
+;; sa-foreign-procedure. Contract: build a foreign callable around a Scheme
+;; procedure for a statically-known signature. Degradation: raise, like the rest.
+(define-syntax sa-foreign-callable
+  (syntax-rules ()
+    ((_ proc args res) (sa-ffi-raise 'sa-foreign-callable))))
+
+;; (sa-foreign-callable-collect-safe proc args res) -> foreign callable
+;; SYNTAX: like sa-foreign-callable, but the callable entry uses the
+;; __collect_safe convention. Degradation: raise, like the rest.
+(define-syntax sa-foreign-callable-collect-safe
+  (syntax-rules ()
+    ((_ proc args res) (sa-ffi-raise 'sa-foreign-callable-collect-safe))))
+
+;; (sa-foreign-procedure-runtime name args res blocking?) -> foreign procedure | #f
+;; Construct a foreign procedure from a RUNTIME-known signature. Contract:
+;; create a foreign procedure for a runtime signature. Degradation: raise —
+;; callers only ask when sa-foreign-entry? has said yes, which never happens
+;; on this target.
+(define (sa-foreign-procedure-runtime name args res blocking?)
+  (sa-ffi-raise 'sa-foreign-procedure-runtime))
+
+;; (sa-foreign-alloc n) -> pointer
+;; Allocate N raw bytes of foreign memory. Contract: malloc-style foreign
+;; allocation. Degradation: raise — jolt.ffi surfaces that as a clean
+;; jolt-level error.
+(define (sa-foreign-alloc n)
+  (sa-ffi-raise 'sa-foreign-alloc))
+
+;; (sa-foreign-free p) -> void
+;; Release foreign memory allocated by sa-foreign-alloc. Degradation: raise.
+(define (sa-foreign-free p)
+  (sa-ffi-raise 'sa-foreign-free))
+
+;; (sa-foreign-ref type addr off) -> value
+;; Typed read of one value at byte offset OFF of the foreign block at ADDR.
+;; Degradation: raise.
+(define (sa-foreign-ref type addr off)
+  (sa-ffi-raise 'sa-foreign-ref))
+
+;; (sa-foreign-set! type addr off v) -> void
+;; Typed write of V at byte offset OFF of the foreign block at ADDR.
+;; Degradation: raise.
+(define (sa-foreign-set! type addr off v)
+  (sa-ffi-raise 'sa-foreign-set!))
+
+;; (sa-foreign-sizeof type) -> exact integer
+;; Size in bytes of a foreign type. Degradation: raise.
+(define (sa-foreign-sizeof type)
+  (sa-ffi-raise 'sa-foreign-sizeof))
+
+;; (sa-lock-object x) -> void
+;; Pin X against the collector while C holds a reference to it. Contract: keep
+;; X address-stable and live. Degradation: the CONTRACT permits no-oping BOTH
+;; sa-lock-object and sa-unlock-object on a non-moving collector; here the
+;; ffi tier is entirely unsupported so no foreign reference can exist — a
+;; consistent raise is the honest degradation (never one without the other).
+(define (sa-lock-object x)
+  (sa-ffi-raise 'sa-lock-object))
+
+;; (sa-unlock-object x) -> void
+;; Release a sa-lock-object pin. Degradation: raise, exactly alongside
+;; sa-lock-object.
+(define (sa-unlock-object x)
+  (sa-ffi-raise 'sa-unlock-object))
+
+;; (sa-load-shared-object name-or-#f) -> void
+;; dlopen of the named shared object. Degradation: raise — and jolt.ffi/
+;; load-library must surface that as a clean jolt-level error, not a VM abort.
+(define (sa-load-shared-object name)
+  (sa-ffi-raise 'sa-load-shared-object))
+
+;; (sa-foreign-entry? name) -> boolean
+;; Does the named C entry resolve. Contract: an existence probe for C symbols.
+;; Degradation: the CONTRACT allows #f for anything unresolved, but the ffi
+;; tier is entirely unsupported here — raise carries the unsupported story
+;; through jolt.ffi's single load-library choke point.
+(define (sa-foreign-entry? name)
+  (sa-ffi-raise 'sa-foreign-entry?))
+
+;; (sa-foreign-entry-address name) -> pointer
+;; The address of the named C entry. Degradation: raise — callers only ask
+;; for symbols they know exist, which never happens here.
+(define (sa-foreign-entry-address name)
+  (sa-ffi-raise 'sa-foreign-entry-address))
+
+;; (sa-foreign-callable-entry-point co) -> pointer
+;; A foreign-callable code object's C-visible entry-point address.
+;; Degradation: raise.
+(define (sa-foreign-callable-entry-point co)
+  (sa-ffi-raise 'sa-foreign-callable-entry-point))
+
+;; ---- R8: eval/compile/AOT (capabilities: native-compile, image) --------------
+
+;; (sa-baked-global sym) -> value | #f
+;; The top-level value of SYM, or #f when unbound. Callers probe optionally-
+;; baked globals (jolt-baked-runtime-fingerprint, jolt-baked-version-early,
+;; jolt-compile-eval-form) whose values are never #f, so #f is a safe absent
+;; sentinel. Contract: reflect on the running top level by symbol. Degradation:
+;; #f always — the gambit target has no baked-image globals; all three callers
+;; tolerate absent (documented degradation).
+(define (sa-baked-global sym)
+  #f)
+
+;; (sa-compile-file src so profile) -> void
+;; Compile the Scheme source file SRC to the native object SO under PROFILE.
+;; Contract: native compilation of SRC to SO. Degradation: raise a
+;; message-carrying condition, never a bare raise — the AOT cache (loader.ss)
+;; treats the raise as a cache disable and falls back to loading from source;
+;; `jolt build` surfaces it as a jolt-level error whose message is the
+;; condition's.
+(define (sa-compile-file src so profile)
+  (error 'sa-compile-file "native compilation is unsupported on the gambit target" src))
+
+;; (sa-make-boot-file out base-boots) -> void
+;; Assemble the boot file OUT from the base boot files BASE-BOOTS. Contract:
+;; write a boot file the target's runtime can boot from. Degradation: raise —
+;; same story as sa-compile-file.
+(define (sa-make-boot-file out base-boots)
+  (error 'sa-make-boot-file "native compilation is unsupported on the gambit target" out))
+
+;; (sa-fasl-write obj port [externals-pred]) -> void
+;; Serialize OBJ to PORT. Contract: serialize a value graph to a byte image.
+;; Degradation: raise — jolt.image's dump surfaces as a clean jolt-level
+;; unsupported error carrying the condition's message; the raise must be
+;; message-carrying, never a bare raise.
+(define (sa-fasl-write obj port . rest)
+  (error 'sa-fasl-write "fasl serialization is unsupported on the gambit target"))
+
+;; (sa-fasl-read port [who exts]) -> value
+;; Deserialize the next object from PORT. Contract: read back what
+;; sa-fasl-write wrote. Degradation: raise — same story as sa-fasl-write.
+(define (sa-fasl-read port . rest)
+  (error 'sa-fasl-read "fasl serialization is unsupported on the gambit target"))


### PR DESCRIPTION
Round G1 of the Gambit JS backend epic (jolt-mj95): the second target's adapter layer, verified on native gsi AND compiled to js under node — the same gambitcheck source passes 92/0 and 89/0 respectively (the js run self-skips the three rows needing a repo cwd).

## What's in host/gambit/

- **prelude-shims.ss** — an R6RS define-record-type translator: records as tagged vectors over an rtd registry with ancestor-chain inclusive predicates (records.ss's jrec family generates parent clauses in its macro expansion, which Gambit's native forms cannot express; plain fields are immutable per R6RS — no setter). Plus the R6RS hashtable API over Gambit tables (deletion is set!-with-no-value), fx/fl trailing-? aliases, Chez condition accessors + the Chez error shape over Gambit error objects, format/printf/fprintf (Gambit binds none), and thread mappings.
- **scheme-adapter-runtime.ss** — the sa-* surface: system tier real, identity strings, introspection off, and ffi / native-compile / image all raising message-carrying conditions.
- **hasheq.ss** — safe-ops port of the target-owned hash surface; all 19 known-answer rows captured from the Chez build match exactly.
- **make gambitcheck** — detection-gated (brew-prefix gsi only; bare gsc is Ghostscript here), wired into ci with a clean skip when Gambit is absent.

## The bugs review caught in the draft

urs32 masked to u32 AFTER the arithmetic shift — negative intermediates dragged infinite sign bits through the mask and corrupted every hash (one fix flipped all 19 rows). Immutable fields got setters. condition-wait didn't re-acquire the mutex (Chez's does; every host wait loop assumes it). Two js-runtime discoveries now hardened in the shims: a raw absolute-seconds timeout is treated as a setTimeout DELAY under node (32-bit overflow + infinite reschedule — numbers normalize to time objects), and an uncaught error in a js exe drops into a stdin REPL instead of exiting.

## Verification

gambitcheck 92/0 (gsi) and 89/0 (node, same source); portcheck/adaptercheck untouched-and-green; full gate green — 56 ci targets including the new one (MAKE_EXIT=0). Zero changes to host/chez or jolt-core.