### PR TITLE
Gambit target G2: the jolt kernel boots on gsi — 39 files, reader/printer at Chez parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Gambit target groundwork** (second Scheme target, toward a browser
+  REPL): the adapter/shim layer and the full jolt kernel manifest boot on
+  native Gambit with reader/printer at parity, gated by `make gambitcheck`
+  and `make gambitkernel`.
+
 ## [0.6.8] - 2026-08-07
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -575,6 +575,16 @@ gambitcheck:
 		echo "gambitcheck: gambit-scheme not installed (brew) — skipped"; \
 	fi
 
+# G2 kernel-test gate (jolt-mj95.4): the full booted manifest on native gsi,
+# driven through the real natives. Same detection-gated shape as gambitcheck;
+# NOT in the ci list. Run from the repo root (boot's irregex load is cwd-relative).
+gambitkernel:
+	@if [ -x "$(GAMBIT_GSI)" ]; then \
+		"$(GAMBIT_GSI)" host/gambit/kernel-test.ss; \
+	else \
+		echo "gambitkernel: gambit-scheme not installed (brew) — skipped"; \
+	fi
+
 # Re-mint the seed after changing a seed source (reader/analyzer/backend/core).
 remint:
 	@sh host/chez/remint.sh

--- a/host/gambit/boot.ss
+++ b/host/gambit/boot.ss
@@ -65,6 +65,15 @@
 (##include "../chez/lazy-bridge.ss")
 (##include "../chez/natives-transduce.ss")
 (##include "../chez/vars.ss")
+(##include "../chez/natives-misc.ss")
+(##include "../chez/natives-format.ss")
+(##include "../chez/extensions.ss")
+(##include "../chez/ns.ss")
+(##include "../chez/dyn-binding.ss")
+(##include "../chez/natives-reader.ss")
+(##include "../chez/reader.ss")
+(##include "../chez/syntax-quote.ss")
+(##include "../chez/host-contract.ss")
 
 ;; ---- smoke ---------------------------------------------------------------
 ;; Must exercise a LAZY seq (jolt-concat / jolt-map), not just jolt-first on a

--- a/host/gambit/boot.ss
+++ b/host/gambit/boot.ss
@@ -1,0 +1,91 @@
+;; boot.ss — the G2 boot: the curated jolt runtime subset loads on native gsi
+;; (Gambit 4.9.7). jolt-mj95.3.
+;;
+;; ONE compilation unit: everything is ##include-spliced (NOT load'd) so the
+;; shim macros from prelude-shims.ss (define-record-type, fx aliases,
+;; with-mutex, ...) expand in the SAME unit as every manifest file — the
+;; "compile the boot files together" flow (see gambitcheck.ss's splice note).
+;;
+;; LOAD SHIM: rt.ss orchestrates its own loads ((load "host/chez/...") for the
+;; whole manifest plus the excluded java tail). Under this boot every manifest
+;; file is spliced in here and the excluded ones are deliberately skipped, so
+;; a runtime (load "host/chez/...") must be a no-op — re-loading the Chez
+;; copies would clobber the gambit sa-runtime/hasheq and pull in Chez-only
+;; java interop. vendor/irregex is NOT under host/chez and loads normally.
+(define %gambit-load load)
+(define (load path . rest)
+  (if (and (string? path) (string-prefix? "host/chez/" path))
+      #f
+      (apply %gambit-load path rest)))
+
+(##include "prelude-shims.ss")
+(##include "scheme-adapter-runtime.ss")
+
+;; ---- manifest, in rt.ss load order (findings doc, curated) ----------------
+;;
+;; G2-booted: values, hasheq(gambit), collections, seq, then rt-core (the gambit
+;; kernel — the rt.ss port; its port-log is in the file header). STOPS at the
+;; first file whose blocker is class (c) (a genuine Chez-only construct with no
+;; gambit seam) — see REPORT.
+
+;; lazy-bridge forward-shared flags: seq.ss's force path reads jolt-mt? and
+;; seq-more dispatches on it, but lazy-bridge.ss (loaded much later) is what
+;; defines them. Pre-declare so seq.ss's references are bound; lazy-bridge.ss
+;; REDEFINES them with its real implementation (the #f default and the
+;; mark-mt! flip are identical, so the redefinition is a no-op in practice).
+(define jolt-mt? #f)
+(define (jolt-mark-mt!) (set! jolt-mt? #t))
+
+(##include "../chez/values.ss")
+(##include "hasheq.ss")
+(##include "../chez/collections.ss")
+(##include "../chez/seq.ss")
+(##include "rt-core.ss")
+
+;; regex needs regex-translate.ss (pure; rt.ss used to preload it from java/).
+(##include "../chez/java/regex-translate.ss")
+(##include "../chez/regex.ss")
+(##include "../chez/atoms.ss")
+(##include "../chez/refs.ss")
+(##include "../chez/predicates.ss")
+(##include "../chez/converters.ss")
+(##include "../chez/transients.ss")
+(##include "../chez/natives-seq.ss")
+(##include "../chez/printing.ss")
+(##include "../chez/natives-coll.ss")
+(##include "../chez/natives-num.ss")
+(##include "../chez/multimethods.ss")
+(##include "../chez/java/class-hierarchy.ss")
+(##include "records-gambit.ss")  ;; GENERATED from records.ss (make gambitgen) — phase wall, see gen-records.ss
+(##include "../chez/java/records-interop.ss")
+(##include "../chez/natives-meta.ss")
+(##include "../chez/java/host-class.ss")
+(##include "../chez/dynamic-var-defaults.ss")
+(##include "../chez/host-table.ss")
+(##include "../chez/lazy-bridge.ss")
+(##include "../chez/natives-transduce.ss")
+(##include "../chez/vars.ss")
+
+;; ---- smoke ---------------------------------------------------------------
+;; Must exercise a LAZY seq (jolt-concat / jolt-map), not just jolt-first on a
+;; vector — the lazy force path is where jolt-mt? and the cseq tail thunks live.
+
+(write (jolt-vector 1 2 3))
+(newline)
+(write (jolt-hash-map 'a 1 'b 2))
+(newline)
+(write (jolt-hash-set 1 2 3))
+(newline)
+(write (jolt= (jolt-vector 1 2) (jolt-vector 1 2)))
+(newline)
+(write (jolt-first (jolt-vector 10 20 30)))
+(newline)
+;; lazy: a string seq is built from cseq-lazy tail thunks (str->seq); forcing
+;; it walks seq-more's (not jolt-mt?) path. jolt-concat/map wrap everything in
+;; jolt-make-lazy-seq (lazy-bridge.ss) and land in the kernel-test once that
+;; file boots.
+(write (jolt-count (jolt-seq "abcde")))
+(newline)
+(write (jolt-seq (jolt-seq "abcde")))
+(newline)
+(display "boot: values+hasheq+collections+seq+rt-core OK\n")

--- a/host/gambit/gen-records.ss
+++ b/host/gambit/gen-records.ss
@@ -1,0 +1,68 @@
+;; gen-records.ss — generate host/gambit/records-gambit.ss from
+;; host/chez/records.ss. Run on CHEZ via `make gambitgen`:
+;;   chez --script host/gambit/gen-records.ss
+;;
+;; WHY: records.ss's define-jrec-family is a PROCEDURAL transformer whose body
+;; calls helper procedures at expansion time. Gambit expands a whole ##include
+;; unit before evaluating any of it, so those helpers are unbound when the
+;; expander reaches the macro's use — the same phase wall as with-syntax. The
+;; expansion itself is pure data, so this script produces it ON CHEZ: it reads
+;; records.ss as data, evals the transformer lambda, applies it to the use
+;; form, and writes every records.ss form verbatim with the macro definition
+;; dropped and each use replaced by its expansion. records-gambit.ss is
+;; GENERATED, DERIVED single-source output (the seed-mint pattern) — never
+;; hand-edit it; regenerate when records.ss changes.
+
+(import (chezscheme))
+
+;; Gambit does not read Chez-style brackets — emit parens only.
+(print-brackets #f)
+
+(define src "host/chez/records.ss")
+(define out "host/gambit/records-gambit.ss")
+
+(define (read-all f)
+  (with-input-from-file f
+    (lambda ()
+      (let loop ((acc '()))
+        (let ((x (read)))
+          (if (eof-object? x) (reverse acc) (loop (cons x acc))))))))
+
+(define forms (read-all src))
+
+;; the transformer lambda from (define-syntax define-jrec-family (lambda (x) ...))
+(define transformer
+  (let loop ((fs forms))
+    (cond
+      ((null? fs) (error 'gen-records "define-jrec-family not found in" src))
+      ((and (pair? (car fs))
+            (eq? (caar fs) 'define-syntax)
+            (eq? (cadar fs) 'define-jrec-family))
+       (eval (caddar fs)))
+      (else (loop (cdr fs))))))
+
+(define (expand-use form)
+  ;; apply the transformer to the use as a syntax object; syntax->datum of the
+  ;; result is the clean (begin (define-record-type ...) ...) — no lowering.
+  (syntax->datum (transformer (datum->syntax #'here form))))
+
+(define port (open-output-file out 'replace))
+(put-string port ";; records-gambit.ss — GENERATED from host/chez/records.ss by\n")
+(put-string port ";; host/gambit/gen-records.ss (make gambitgen). Do not edit; regenerate\n")
+(put-string port ";; when records.ss changes. The define-jrec-family transformer is\n")
+(put-string port ";; expansion-phase-hostile on Gambit; its uses are pre-expanded here.\n\n")
+(for-each
+  (lambda (f)
+    (cond
+      ((and (pair? f) (eq? (car f) 'define-syntax) (eq? (cadr f) 'define-jrec-family))
+       (put-string port ";; (define-syntax define-jrec-family ...) — pre-expanded below\n\n"))
+      ((and (pair? f) (eq? (car f) 'define-jrec-family))
+       (put-string port ";; expansion of ")
+       (write f port)
+       (put-string port "\n")
+       (for-each (lambda (g) (pretty-print g port) (newline port))
+                 (cdr (expand-use f))))   ; drop the begin head
+      (else (pretty-print f port) (newline port))))
+  forms)
+(close-port port)
+(display (string-append "gen-records: wrote " out "\n"))

--- a/host/gambit/kernel-test.ss
+++ b/host/gambit/kernel-test.ss
@@ -1,0 +1,303 @@
+;; kernel-test.ss — the G2 kernel-test gate (jolt-mj95.4).
+;;
+;; Run via `make gambitkernel` (detection-gated: skips when gambit-scheme is
+;; absent, and always uses $(brew --prefix gambit-scheme)/bin/gsi — NEVER bare
+;; gsc/gsi, which is Ghostscript on this machine). Run from the repo root (the
+;; irregex load inside the boot is cwd-relative).
+;;
+;; ONE compilation unit with the boot: (##include "boot.ss") textually splices
+;; the whole 39-file manifest here (prelude-shims + scheme-adapter-runtime +
+;; hasheq + the curated chez kernel files), exactly the G2 build flow — the
+;; shim macros expand in the same top level, and NO file-level import appears
+;; in this file (a module boundary would hide them; see gambitcheck.ss's splice
+;; note).
+;;
+;; The rows drive the REAL native fns (jolt-vector, jolt-conj, jolt-assoc,
+;; jolt-get, jolt-dissoc, jolt-count, jolt-nth, jolt-first, jolt-next, jolt-seq,
+;; jolt-take, jolt-map, jolt-partition, jolt-pr-readable, jolt-read-string,
+;; jolt-hasheq, jolt-with-meta, jolt-meta, jolt=, def-var!, var-deref,
+;; def-dynvar!) — all defined in the booted chez sources (names verified
+;; against host/chez before writing).
+;;
+;; Every expected STRING / hasheq value below was captured from the Chez build
+;; via bin/jolt — the paste-command is in a comment beside each row. Maps and
+;; sets with 2+ entries render in HAMT-iteration order (not stable insertion
+;; order), so those are compared via jolt= / accessors, never printed form
+;; (single-entry ones print deterministically and ARE rendered).
+
+(##include "boot.ss")
+
+;; ---- test harness (mirrors gambitcheck.ss) -----------------------------------
+
+(define failures 0)
+
+(define (check label actual expected)
+  (if (equal? actual expected)
+      (begin (printf "  ok     ~a\n" label) #t)
+      (begin (printf "  FAIL   ~a: got ~s expected ~s\n" label actual expected)
+             (set! failures (+ failures 1))
+             #f)))
+
+(define (check-true label v)
+  (if v
+      (begin (printf "  ok     ~a\n" label) #t)
+      (begin (printf "  FAIL   ~a: got #f\n" label)
+             (set! failures (+ failures 1))
+             #f)))
+
+;; ---- collection construction + count -----------------------------------------
+
+(define (test-construction)
+  (printf "== construction: jolt-vector / jolt-list / jolt-hash-map / jolt-hash-set / jolt-count ==\n")
+  ;; Chez: bin/jolt -e "(pr-str [1 2 3])" -> "[1 2 3]"
+  (check "vector 1 2 3" (jolt-pr-readable (jolt-vector 1 2 3)) "[1 2 3]")
+  ;; Chez: bin/jolt -e "(pr-str (list 1 2 3))" -> "(1 2 3)"
+  (check "list 1 2 3" (jolt-pr-readable (jolt-list 1 2 3)) "(1 2 3)")
+  ;; Chez: bin/jolt -e "(pr-str {:a 1})" -> "{:a 1}"
+  (check "map {:a 1}" (jolt-pr-readable (jolt-hash-map (keyword #f "a") 1)) "{:a 1}")
+  ;; Chez: bin/jolt -e "(pr-str #{7})" -> "#{7}"
+  (check "set #{7}" (jolt-pr-readable (jolt-hash-set 7)) "#{7}")
+  (check "count vector" (jolt-count (jolt-vector 1 2 3)) 3)
+  (check "count list" (jolt-count (jolt-list 1 2 3 4)) 4)
+  (check "count map" (jolt-count (jolt-hash-map (keyword #f "a") 1 (keyword #f "b") 2)) 2)
+  (check "count set" (jolt-count (jolt-hash-set 1 2 3)) 3)
+  (check "count string" (jolt-count "hello") 5)
+  (check "count empty vector" (jolt-count (jolt-vector)) 0)
+  (check "count empty map" (jolt-count (jolt-hash-map)) 0)
+  (check "count empty set" (jolt-count (jolt-hash-set)) 0)
+  (check "count empty list" (jolt-count (jolt-list)) 0)
+  ;; Chez: bin/jolt -e "(pr-str [])" -> "[]"
+  (check "empty vector render" (jolt-pr-readable (jolt-vector)) "[]")
+  ;; Chez: bin/jolt -e "(pr-str {})" -> "{}"
+  (check "empty map render" (jolt-pr-readable (jolt-hash-map)) "{}")
+  ;; Chez: bin/jolt -e "(pr-str #{})" -> "#{}"
+  (check "empty set render" (jolt-pr-readable (jolt-hash-set)) "#{}")
+  ;; Chez: bin/jolt -e "(pr-str (list))" -> "()"
+  (check "empty list render" (jolt-pr-readable (jolt-list)) "()"))
+
+;; ---- conj / assoc / dissoc ---------------------------------------------------
+
+(define (test-conj-assoc-dissoc)
+  (printf "== jolt-conj / jolt-assoc / jolt-dissoc ==\n")
+  ;; Chez: bin/jolt -e "(pr-str (conj [1 2] 3))" -> "[1 2 3]"
+  (check "conj on vector" (jolt-pr-readable (jolt-conj (jolt-vector 1 2) 3)) "[1 2 3]")
+  ;; Chez: bin/jolt -e "(pr-str (conj (list 1 2) 3))" -> "(3 1 2)"
+  (check "conj on list prepends" (jolt-pr-readable (jolt-conj (jolt-list 1 2) 3)) "(3 1 2)")
+  ;; Chez: bin/jolt -e "(pr-str (conj nil 1 2))" -> "(2 1)"
+  (check "conj on nil builds a list" (jolt-pr-readable (jolt-conj jolt-nil 1 2)) "(2 1)")
+  (check "conj [k v] pair into map -> get" (jolt-get (jolt-conj (jolt-hash-map (keyword #f "a") 1) (jolt-vector (keyword #f "b") 2)) (keyword #f "b")) 2)
+  (check "conj [k v] pair into map -> count" (jolt-count (jolt-conj (jolt-hash-map (keyword #f "a") 1) (jolt-vector (keyword #f "b") 2))) 2)
+  (check "assoc new key -> get" (jolt-get (jolt-assoc (jolt-hash-map (keyword #f "a") 1) (keyword #f "b") 2) (keyword #f "b")) 2)
+  (check "assoc new key -> count" (jolt-count (jolt-assoc (jolt-hash-map (keyword #f "a") 1) (keyword #f "b") 2)) 2)
+  ;; Chez: bin/jolt -e "(pr-str (assoc [0 0 0] 1 9))" -> "[0 9 0]"
+  (check "assoc on vector by index" (jolt-pr-readable (jolt-assoc (jolt-vector 0 0 0) 1 9)) "[0 9 0]")
+  (check "assoc on nil -> map" (jolt-get (jolt-assoc jolt-nil (keyword #f "a") 1) (keyword #f "a")) 1)
+  (check "dissoc removes key" (jolt-nil? (jolt-get (jolt-dissoc (jolt-hash-map (keyword #f "a") 1 (keyword #f "b") 2) (keyword #f "a")) (keyword #f "a"))) #t)
+  (check "dissoc shrinks count" (jolt-count (jolt-dissoc (jolt-hash-map (keyword #f "a") 1 (keyword #f "b") 2) (keyword #f "a"))) 1)
+  (check "dissoc absent key is a no-op" (jolt-count (jolt-dissoc (jolt-hash-map (keyword #f "a") 1) (keyword #f "zzz"))) 1))
+
+;; ---- get / nth ---------------------------------------------------------------
+
+(define (test-get-nth)
+  (printf "== jolt-get / jolt-nth ==\n")
+  (check "get vector by index" (jolt-get (jolt-vector 10 20) 1) 20)
+  (check "get vector out of range -> nil" (jolt-nil? (jolt-get (jolt-vector 10 20) 9)) #t)
+  (check "get map present key" (jolt-get (jolt-hash-map (keyword #f "a") 1) (keyword #f "a")) 1)
+  (check "get map missing key -> default" (jolt-get (jolt-hash-map (keyword #f "a") 1) (keyword #f "zzz") 99) 99)
+  (check "get set membership returns key" (jolt-get (jolt-hash-set 7) 7) 7)
+  (check "get set absent -> nil" (jolt-nil? (jolt-get (jolt-hash-set 7) 8)) #t)
+  (check "nth vector" (jolt-nth (jolt-vector 10 20 30) 1) 20)
+  (check "nth list" (jolt-nth (jolt-list 5 6 7) 2) 7)
+  (check "nth string" (jolt-nth "abc" 1) #\b)
+  (check "nth out of range -> not-found" (jolt-nth (jolt-vector 10 20) 5 99) 99)
+  (check-true "nth out of range raises jolt-throw"
+    (guard (e (#t (jolt-throw-condition? e)))
+      (jolt-nth (jolt-vector 10 20) 5)
+      #f))
+  (check "nth oob exception class"
+    (jolt-ex-info-record-class-name
+      (jolt-throw-condition-value
+        (guard (e (#t e)) (jolt-nth (jolt-vector 10 20) 5) #f)))
+    "java.lang.IndexOutOfBoundsException"))
+
+;; ---- seq walking -------------------------------------------------------------
+
+(define (test-seq-walking)
+  (printf "== jolt-first / jolt-next / jolt-seq ==\n")
+  (check "first vector" (jolt-first (jolt-vector 10 20 30)) 10)
+  ;; Chez: bin/jolt -e "(pr-str (next [10 20 30]))" -> "(20 30)"
+  (check "next vector" (jolt-pr-readable (jolt-next (jolt-vector 10 20 30))) "(20 30)")
+  (check "first of next" (jolt-first (jolt-next (jolt-vector 10 20 30))) 20)
+  (check-true "next of single-element list is nil" (jolt-nil? (jolt-next (jolt-list 1))))
+  ;; Chez: bin/jolt -e "(pr-str (seq [10 20]))" -> "(10 20)"
+  (check "seq vector" (jolt-pr-readable (jolt-seq (jolt-vector 10 20))) "(10 20)")
+  ;; Chez: bin/jolt -e "(pr-str (seq (list 1 2 3)))" -> "(1 2 3)"
+  (check "seq list" (jolt-pr-readable (jolt-seq (jolt-list 1 2 3))) "(1 2 3)")
+  ;; Chez: bin/jolt -e "(pr-str (seq \"abc\"))" -> "(\\a \\b \\c)"
+  (check "seq string" (jolt-pr-readable (jolt-seq "abc")) "(\\a \\b \\c)")
+  (check "count seq string" (jolt-count (jolt-seq "abcde")) 5)
+  (check "first of seq list" (jolt-first (jolt-seq (jolt-list 1 2 3))) 1)
+  (check "count seq of 2-entry map" (jolt-count (jolt-seq (jolt-hash-map (keyword #f "a") 1 (keyword #f "b") 2))) 2)
+  (check-true "seq of map yields entry vectors" (pvec? (jolt-first (jolt-seq (jolt-hash-map (keyword #f "a") 1)))))
+  ;; Chez: bin/jolt -e "(pr-str (seq {:a 1}))" -> "([:a 1])"
+  (check "seq single-entry map" (jolt-pr-readable (jolt-seq (jolt-hash-map (keyword #f "a") 1))) "([:a 1])")
+  (check-true "seq of empty vector is nil" (jolt-nil? (jolt-seq (jolt-vector)))))
+
+;; ---- lazy seqs (real natives-seq producers, forced through the printer) ------
+
+(define (test-lazy)
+  (printf "== lazy seqs: jolt-take / jolt-map / jolt-partition forced through jolt-pr-readable ==\n")
+  ;; Chez: bin/jolt -e "(pr-str (take 3 [1 2 3 4 5]))" -> "(1 2 3)"
+  (check "take 3 vector" (jolt-pr-readable (jolt-take 3 (jolt-vector 1 2 3 4 5))) "(1 2 3)")
+  (check "count take 3" (jolt-count (jolt-take 3 (jolt-vector 1 2 3 4 5))) 3)
+  (check "first of take" (jolt-first (jolt-take 3 (jolt-vector 9 8 7 6))) 9)
+  ;; Chez: bin/jolt -e "(pr-str (take 1 (list 7 8 9)))" -> "(7)"
+  (check "take 1 list" (jolt-pr-readable (jolt-take 1 (jolt-list 7 8 9))) "(7)")
+  ;; Chez: bin/jolt -e "(pr-str (map inc [1 2 3]))" -> "(2 3 4)"
+  (check "map inc vector" (jolt-pr-readable (jolt-map jolt-inc (jolt-vector 1 2 3))) "(2 3 4)")
+  ;; Chez: bin/jolt -e "(pr-str (partition 2 [1 2 3 4 5 6]))" -> "((1 2) (3 4) (5 6))"
+  (check "partition 2 vector" (jolt-pr-readable (jolt-partition 2 (jolt-vector 1 2 3 4 5 6))) "((1 2) (3 4) (5 6))")
+  (check "count partition 2" (jolt-count (jolt-partition 2 (jolt-vector 1 2 3 4 5 6))) 3))
+
+;; ---- rendering (jolt-pr-readable) --------------------------------------------
+
+(define (test-rendering)
+  (printf "== rendering: jolt-pr-readable (captures from bin/jolt on Chez) ==\n")
+  ;; Chez: bin/jolt -e "(pr-str [[1 2] (list 3 4)])" -> "[[1 2] (3 4)]"
+  (check "nested vector+list" (jolt-pr-readable (jolt-vector (jolt-vector 1 2) (jolt-list 3 4))) "[[1 2] (3 4)]")
+  ;; Chez: bin/jolt -e "(pr-str [1 {:a [2 3]} (list 4 5)])" -> "[1 {:a [2 3]} (4 5)]"
+  (check "deep nesting" (jolt-pr-readable (jolt-vector 1 (jolt-hash-map (keyword #f "a") (jolt-vector 2 3)) (jolt-list 4 5))) "[1 {:a [2 3]} (4 5)]")
+  ;; Chez: bin/jolt -e "(pr-str [1 nil true false])" -> "[1 nil true false]"
+  (check "nil and booleans" (jolt-pr-readable (jolt-vector 1 jolt-nil #t #f)) "[1 nil true false]")
+  ;; Chez: bin/jolt -e "(pr-str [\"a\\\"b\" \"c\\\\d\" \"tab\\there\" \"nl\\nx\"])" -> "[\"a\\\"b\" \"c\\\\d\" \"tab\\there\" \"nl\\nx\"]"
+  (check "strings with escapes" (jolt-pr-readable (jolt-vector "a\"b" "c\\d" "tab\there" "nl\nx")) "[\"a\\\"b\" \"c\\\\d\" \"tab\\there\" \"nl\\nx\"]")
+  ;; Chez: bin/jolt -e "(pr-str [\\a \\b \\newline \\space \\tab])" -> "[\\a \\b \\newline \\space \\tab]"
+  (check "chars incl named" (jolt-pr-readable (jolt-vector #\a #\b #\newline #\space #\tab)) "[\\a \\b \\newline \\space \\tab]")
+  ;; Chez: bin/jolt -e "(pr-str [##Inf ##-Inf ##NaN])" -> "[##Inf ##-Inf ##NaN]"
+  (check "infinities and NaN" (jolt-pr-readable (jolt-vector +inf.0 -inf.0 +nan.0)) "[##Inf ##-Inf ##NaN]")
+  ;; Chez: bin/jolt -e "(pr-str [9223372036854775808 -9223372036854775809])" -> "[9223372036854775808N -9223372036854775809N]"
+  (check "bigints with N suffix" (jolt-pr-readable (jolt-vector 9223372036854775808 -9223372036854775809)) "[9223372036854775808N -9223372036854775809N]")
+  ;; Chez: bin/jolt -e "(pr-str [2/3 1/100])" -> "[2/3 1/100]"
+  (check "ratios" (jolt-pr-readable (jolt-vector 2/3 1/100)) "[2/3 1/100]")
+  ;; Chez: bin/jolt -e "(pr-str [:a/b :c/d])" -> "[:a/b :c/d]"
+  (check "namespaced keywords" (jolt-pr-readable (jolt-vector (keyword "a" "b") (keyword "c" "d"))) "[:a/b :c/d]")
+  ;; Chez: bin/jolt -e "(pr-str (list (quote foo/bar) (quote sym)))" -> "(foo/bar sym)"
+  (check "symbols incl namespaced" (jolt-pr-readable (jolt-list (jolt-symbol "foo" "bar") (jolt-symbol #f "sym"))) "(foo/bar sym)"))
+
+;; ---- reader round-trips -------------------------------------------------------
+
+(define (test-reader-roundtrip)
+  (printf "== jolt-read-string round-trips (jolt= to constructed + re-render) ==\n")
+  ;; Chez: bin/jolt -e "(pr-str (read-string \"[1 :kw {\\\"s\\\" 2/3} #{sym}]\"))" -> "[1 :kw {\"s\" 2/3} #{sym}]"
+  (check "corpus re-render" (jolt-pr-readable (jolt-read-string "[1 :kw {\"s\" 2/3} #{sym}]")) "[1 :kw {\"s\" 2/3} #{sym}]")
+  (check-true "corpus jolt= to constructed"
+    (jolt= (jolt-read-string "[1 :kw {\"s\" 2/3} #{sym}]")
+           (jolt-vector 1 (keyword #f "kw") (jolt-hash-map "s" 2/3) (jolt-hash-set (jolt-symbol #f "sym")))))
+  ;; Chez: bin/jolt -e "(pr-str (read-string \"[\\\"a\\\\\\\"b\\\" \\\\newline]\"))" -> "[\"a\\\"b\" \\newline]"
+  (check "escapes round-trip re-render" (jolt-pr-readable (jolt-read-string "[\"a\\\"b\" \\newline]")) "[\"a\\\"b\" \\newline]")
+  (check-true "escapes round-trip jolt="
+    (jolt= (jolt-read-string "[\"a\\\"b\" \\newline]") (jolt-vector "a\"b" #\newline)))
+  ;; Chez: bin/jolt -e "(pr-str (read-string \"[##Inf ##NaN]\"))" -> "[##Inf ##NaN]"
+  (check "inf/NaN round-trip re-render" (jolt-pr-readable (jolt-read-string "[##Inf ##NaN]")) "[##Inf ##NaN]")
+  (check-true "inf round-trip jolt=" (jolt= (jolt-read-string "[##Inf]") (jolt-vector +inf.0)))
+  ;; Chez: bin/jolt -e "(pr-str (read-string \"\\\\a\"))" -> "\\a"
+  (check "char round-trip" (jolt-pr-readable (jolt-read-string "\\a")) "\\a")
+  ;; Chez: bin/jolt -e "(pr-str (read-string \"{:a 1}\"))" -> "{:a 1}"
+  (check-true "map round-trip jolt=" (jolt= (jolt-read-string "{:a 1}") (jolt-hash-map (keyword #f "a") 1)))
+  (check-true "set round-trip jolt=" (jolt= (jolt-read-string "#{1 2 3}") (jolt-hash-set 1 2 3)))
+  (check-true "list round-trip jolt=" (jolt= (jolt-read-string "(1 2 3)") (jolt-list 1 2 3)))
+  (check-true "integer round-trip jolt=" (jolt= (jolt-read-string "42") 42))
+  (check-true "keyword round-trip jolt=" (jolt= (jolt-read-string ":kw") (keyword #f "kw")))
+  (check-true "symbol round-trip jolt=" (jolt= (jolt-read-string "foo/bar") (jolt-symbol "foo" "bar"))))
+
+;; ---- hasheq (real collections vs Chez-captured (hash ...)) -------------------
+
+(define (test-hasheq)
+  (printf "== hasheq: jolt-hasheq on real collections, pinned to Chez (hash ...) ==\n")
+  ;; Chez: bin/jolt -e "(hash [1 2 3])" -> 736442005
+  (check "hash [1 2 3]" (jolt-hasheq (jolt-vector 1 2 3)) 736442005)
+  ;; Chez: bin/jolt -e "(hash (list 1 2 3))" -> 736442005
+  (check "hash (list 1 2 3) == hash [1 2 3]" (jolt-hasheq (jolt-list 1 2 3)) 736442005)
+  ;; Chez: bin/jolt -e "(hash [])" -> -2017569654
+  (check "hash []" (jolt-hasheq (jolt-vector)) -2017569654)
+  ;; Chez: bin/jolt -e "(hash {})" -> -15128758
+  (check "hash {}" (jolt-hasheq (jolt-hash-map)) -15128758)
+  ;; Chez: bin/jolt -e "(hash #{})" -> -15128758
+  (check "hash #{} == hash {}" (jolt-hasheq (jolt-hash-set)) -15128758)
+  ;; Chez: bin/jolt -e "(hash {:a 1})" -> 1772842048
+  (check "hash {:a 1}" (jolt-hasheq (jolt-hash-map (keyword #f "a") 1)) 1772842048)
+  ;; Chez: bin/jolt -e "(hash {:a 1 :b 2})" -> 161871944
+  (check "hash {:a 1 :b 2}" (jolt-hasheq (jolt-hash-map (keyword #f "a") 1 (keyword #f "b") 2)) 161871944)
+  ;; Chez: bin/jolt -e "(hash #{1 2})" -> 460223544
+  (check "hash #{1 2}" (jolt-hasheq (jolt-hash-set 1 2)) 460223544)
+  ;; Chez: bin/jolt -e "(hash [1 :a \"s\" 2/3])" -> 262523492
+  (check "hash mixed vector" (jolt-hasheq (jolt-vector 1 (keyword #f "a") "s" 2/3)) 262523492)
+  ;; Chez: bin/jolt -e "(hash 9223372036854775808)" -> -2147483648
+  (check "hash bigint" (jolt-hasheq 9223372036854775808) -2147483648)
+  ;; Chez: bin/jolt -e "(hash 2/3)" -> 1
+  (check "hash ratio" (jolt-hasheq 2/3) 1)
+  ;; Chez: bin/jolt -e "(hash (with-meta [1 2] {:k 1}))" -> 156247261 == (hash [1 2])
+  (check "hash ignores meta" (jolt-hasheq (jolt-with-meta (jolt-vector 1 2) (jolt-hash-map (keyword #f "k") 1))) 156247261))
+
+;; ---- meta round-trip ---------------------------------------------------------
+
+(define (test-meta)
+  (printf "== jolt-with-meta / jolt-meta ==\n")
+  (check-true "meta round-trip"
+    (jolt= (jolt-meta (jolt-with-meta (jolt-vector 1 2) (jolt-hash-map (keyword #f "k") 1)))
+           (jolt-hash-map (keyword #f "k") 1)))
+  ;; Chez: bin/jolt -e "(pr-str (with-meta [1 2] {:k 1}))" -> "[1 2]"
+  (check "meta not printed" (jolt-pr-readable (jolt-with-meta (jolt-vector 1 2) (jolt-hash-map (keyword #f "k") 1))) "[1 2]")
+  (check-true "meta of a number is nil" (jolt-nil? (jolt-meta 42)))
+  (check-true "meta of a bare symbol is nil" (jolt-nil? (jolt-meta (jolt-symbol #f "s")))))
+
+;; ---- def-var! / var-deref / def-dynvar! (rt-core) ----------------------------
+
+(define (test-vars)
+  (printf "== def-var! / var-deref / def-dynvar! through rt-core ==\n")
+  (def-var! "kernel.test" "x" 42)
+  (check "def-var! then var-deref" (var-deref "kernel.test" "x") 42)
+  (def-var! "kernel.test" "x" 43)
+  (check "re-def-var! mutates root" (var-deref "kernel.test" "x") 43)
+  (check-true "never-defined var is unbound sentinel" (jolt-var-unbound? (var-deref "kernel.test" "never-defined")))
+  (def-dynvar! "kernel.test" "*dx*" 7)
+  (check "def-dynvar! then var-deref" (var-deref "kernel.test" "*dx*") 7)
+  (check-true "dynvar carries :dynamic meta"
+    (jolt= (jolt-get (jolt-meta (jolt-var "kernel.test" "*dx*")) (keyword #f "dynamic")) #t))
+  (check-true "def-var! returns the var cell" (var-cell? (def-var! "kernel.test" "y" 1))))
+
+;; ---- jolt= structural equality, mixed nesting --------------------------------
+
+(define (test-equality)
+  (printf "== jolt= structural equality ==\n")
+  (check-true "vectors equal" (jolt= (jolt-vector 1 2) (jolt-vector 1 2)))
+  (check-true "deep nesting equal" (jolt= (jolt-vector 1 (jolt-vector 2 (jolt-vector 3))) (jolt-vector 1 (jolt-vector 2 (jolt-vector 3)))))
+  (check-true "map of vector equal" (jolt= (jolt-hash-map (keyword #f "a") (jolt-vector 1 2)) (jolt-hash-map (keyword #f "a") (jolt-vector 1 2))))
+  (check-true "set order-insensitive" (jolt= (jolt-hash-set 1 2 3) (jolt-hash-set 3 2 1)))
+  ;; Chez: bin/jolt -e "(= (list 1 2) [1 2])" -> true — jolt= is SEQUENTIAL
+  ;; equality: a seq and a vector with the same elements are equal (a known
+  ;; jolt/CHEZ-parity quirk vs Clojure's false). Pin the parity, not Clojure.
+  (check-true "seq == vector (sequential equality, matches Chez)" (jolt= (jolt-list 1 2) (jolt-vector 1 2)))
+  (check-true "map key mismatch" (not (jolt= (jolt-hash-map (keyword #f "a") 1) (jolt-hash-map (keyword #f "b") 1))))
+  (check-true "vector element mismatch" (not (jolt= (jolt-vector 1 2) (jolt-vector 1 3)))))
+
+;; ---- main --------------------------------------------------------------------
+
+(test-construction)
+(test-conj-assoc-dissoc)
+(test-get-nth)
+(test-seq-walking)
+(test-lazy)
+(test-rendering)
+(test-reader-roundtrip)
+(test-hasheq)
+(test-meta)
+(test-vars)
+(test-equality)
+
+(printf "\nkernel-test: ~a failure(s)\n" failures)
+(if (= failures 0)
+    (begin (printf "kernel-test: PASS — booted kernel + natives verified on native gsi\n")
+           (exit 0))
+    (begin (printf "kernel-test: FAILED\n")
+           (exit 1)))

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -304,6 +304,27 @@
 (define-syntax fxsra
   (syntax-rules () ((_ a b) (fxarithmetic-shift-right a b))))
 
+;; Chez fxlogbit? (i fx): #t when bit i of fixnum fx is set. Gambit 4.9.7 has
+;; no bit-test primitive (no bitwise-bit-set? / fixnum bit-test in any module);
+;; decompose via fxand + shift. Used by seq.ss's jolt-invoke* arity pre-checks
+;; and the procedure-arity-mask probes below.
+(define (fxlogbit? i fx)
+  (not (fx=? 0 (fxand fx (fxarithmetic-shift-left 1 i)))))
+
+;; Chez procedure-arity-mask: bitmask of the arg counts a procedure accepts.
+;; Gambit 4.9.7 has NO arity introspection at all (procedure-arity exists in no
+;; module — grep of the installed library confirms). Return the all-bits mask so
+;; jolt-invoke*'s (fxlogbit? n (procedure-arity-mask f)) pre-check always passes
+;; and the call proceeds — Gambit's own runtime raises on a real arity mismatch.
+;; The Chez build keeps precise masks; this is a port-of-convenience shim.
+(define (procedure-arity-mask f) -1)
+
+;; R6RS bitwise-bit-set? (n i): #t when bit i of n is set. Gambit 4.9.7 lacks
+;; it (records-gambit.ss's satisfies? path is the one user in the subset).
+;; Same fx decomposition as fxlogbit? — the only caller passes a fixnum mask.
+(define (bitwise-bit-set? n i)
+  (not (fx=? 0 (fxand n (fxarithmetic-shift-left 1 i)))))
+
 ;; R6RS bitwise shift spellings (natives-num.ss is the one user in the subset:
 ;; jolt-bit-shift-left/right, bit-mask, jolt-bit-test — 6 call sites) → Gambit's
 ;; arithmetic-shift. Gambit does not bind the R6RS bitwise-arithmetic-shift-*

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -550,3 +550,26 @@
   (let ((p (or (table-ref %vreg-table n #f)
                (let ((q (make-parameter 0))) (table-set! %vreg-table n q) q))))
     (p v)))
+
+;; parse-int-str / parse-int-or-throw — ported from java/host-static.ss (G2
+;; EXCLUDES the java/ tree; natives-misc.ss's jolt-bigint calls them). String
+;; -> integer in RADIX, #f on failure; parse-int-or-throw raises a jolt
+;; NumberFormatException. str-trim is String.trim (java/natives-str.ss): chars
+;; at or below space.
+(define (str-trim s)
+  (let ((len (string-length s)))
+    (let scan-l ((i 0))
+      (cond ((fx=? i len) "")
+            ((char<=? (string-ref s i) #\space) (scan-l (fx+ i 1)))
+            (else (let scan-r ((j (fx- len 1)))
+                    (if (char<=? (string-ref s j) #\space)
+                        (scan-r (fx- j 1))
+                        (substring s i (fx+ j 1)))))))))
+(define (parse-int-str s radix)
+  (let ((n (string->number (str-trim (if (string? s) s (jolt-str-render-one s))) radix)))
+    (and n (integer? n) n)))
+(define (parse-int-or-throw s radix what)
+  (or (parse-int-str s radix)
+      (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                    (string-append "For input string: \""
+                                   (if (string? s) s (jolt-str-render-one s)) "\"")))))

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -163,6 +163,20 @@
           #f))
     id))
 
+;; R6RS record runtime introspection over the shim registry. CENSUS (boot
+;; manifest, 2026-08-11): record-constructor + record-type-descriptor only, the
+;; make-pmap/make-pset raw-constructor fast paths in collections.ss. Under the
+;; shim a record type NAME is bound to its registered id (make-jolt-record-type
+;; returns it), so the descriptor is the registry rtd and the raw constructor
+;; is rebuilt from it.
+(define (record-type-descriptor name)
+  (if (fixnum? name) (table-ref jolt-record-id-table name #f) #f))
+(define (record-constructor rtd)
+  (if (vector? rtd)
+      (let ((id (vector-ref rtd 0)) (n (vector-ref rtd 2)))
+        (make-jolt-record-ctor id n))
+      (error 'record-constructor "not a jolt record descriptor" rtd)))
+
 ;; field-spec extraction: (kind . name) pairs. R6RS semantics: a PLAIN spec is
 ;; IMMUTABLE — only (mutable f) fields get a setter binding.
 (define-syntax jolt-record-field-names
@@ -234,6 +248,8 @@
 (define (hashtable-set! t k v) (table-set! t k v))
 ;; Gambit deletion is (table-set! t k) with no value (G0 probe: delete = set!
 ;; with no value; there is no table-delete!).
+(define (hashtable-clear! t)
+  (for-each (lambda (kv) (table-set! t (car kv))) (table->list t)))
 (define (hashtable-delete! t k) (table-set! t k))
 (define (hashtable-size t) (table-length t))
 
@@ -277,6 +293,10 @@
   (syntax-rules () ((_ a ...) (fx< a ...))))
 (define-syntax fx>?
   (syntax-rules () ((_ a ...) (fx> a ...))))
+(define-syntax fx<=?
+  (syntax-rules () ((_ a ...) (fx<= a ...))))
+(define-syntax fx>=?
+  (syntax-rules () ((_ a ...) (fx>= a ...))))
 (define-syntax fl=?
   (syntax-rules () ((_ a ...) (fl= a ...))))
 (define-syntax fxsll
@@ -313,6 +333,17 @@
   (if (and (pair? rest) (string? (car rest)))
       (apply %gambit-error (car rest) (cdr rest))
       (apply %gambit-error who rest)))
+
+;; Chez syntax-case has with-syntax; Gambit's (gambit) module exposes
+;; syntax-case but not with-syntax. rt.ss's jolt-foreign-proc-safe transformer
+;; uses it (a macro definition, so it must expand in the boot unit). The
+;; standard with-syntax reduction over syntax-case: bind pattern vars from a
+;; list of expression values.
+(define-syntax with-syntax
+  (syntax-rules ()
+    ((_ ((p e) ...) body ...)
+     (syntax-case (list e ...) ()
+       ((p ...) body ...)))))
 
 (define (condition? x) (error-object? x))
 (define (message-condition? x) (error-object? x))
@@ -423,6 +454,21 @@
 ;; CONTRACT misc: system is the shell-out; Gambit spells it shell-command.
 (define (system cmd) (shell-command cmd))
 
+;; CONTRACT: getenv — Chez's (getenv "NAME") returns #f when the variable is
+;; unset; Gambit's raises ("Unbound OS environment variable"). Preserve the
+;; zero-arg alist form and the optional-default form; make the bare string form
+;; Chez-shaped.
+(define %gambit-getenv getenv)
+(define (getenv key . rest)
+  (if (null? rest)
+      (guard (e (#t #f)) (%gambit-getenv key))
+      (apply %gambit-getenv key rest)))
+
+;; CONTRACT: fork-thread — Chez's spawn; Gambit composes make-thread +
+;; thread-start!. lazy-bridge.ss shadows it to flip jolt-mt? and track live
+;; threads, so it must exist before that file loads.
+(define (fork-thread thunk) (thread-start! (make-thread thunk)))
+
 (define (scheme-version)
   (guard (e (#t "Gambit Scheme"))
     (##version-string)))
@@ -449,15 +495,58 @@
                   (else (display c port) (loop (+ i 1) args))))
               (begin (display c port) (loop (+ i 1) args))))))))
 
+;; R6RS fold-left / fold-right — Gambit binds neither (its SRFI-1 fold has a
+;; DIFFERENT proc arg order: (kons x acc) vs R6RS's (f acc x)). Direct ports.
+(define (fold-left f init . lists)
+  (if (null? (cdr lists))
+      (let loop ((acc init) (l (car lists)))
+        (if (null? l) acc (loop (f acc (car l)) (cdr l))))
+      (let loop ((acc init) (ls lists))
+        (if (null? (car ls)) acc
+            (loop (apply f acc (map car ls)) (map cdr ls))))))
+(define (fold-right f init . lists)
+  (if (null? (cdr lists))
+      (let loop ((l (car lists)))
+        (if (null? l) init (f (car l) (loop (cdr l)))))
+      (let loop ((ls lists))
+        (if (null? (car ls)) init
+            (apply f (append (map car ls) (list (loop (map cdr ls)))))))))
+
 ;; R6RS get-line over Gambit's read-line.
 (define (get-line port) (read-line port))
 
+;; Chez's format accepts a #f port meaning "to a string" — records.ss calls
+;; (format #f "f~a" i). The plain SRFI-28 spelling (format "~a" x) is the
+;; default; a leading #f shifts to the next arg as the format string.
 (define (format fmt . args)
-  (call-with-output-string
-    (lambda (p) (%format-to p fmt args))))
+  (if (eq? fmt #f)
+      (call-with-output-string (lambda (p) (%format-to p (car args) (cdr args))))
+      (call-with-output-string (lambda (p) (%format-to p fmt args)))))
 
 (define (printf fmt . args)
   (%format-to (current-output-port) fmt args))
 
 (define (fprintf port fmt . args)
   (%format-to port fmt args))
+
+;; make-thread-parameter — Chez spelling; Gambit has no such name (probed
+;; 4.9.7). Plain make-parameter IS thread-aware here (G0 pin: parameters
+;; fork-inherit into SRFI-18 threads), which is the whole point of Chez's
+;; thread parameters, so the alias is faithful. rt-core's throw-site params
+;; (jolt-throw-cont/sitep) and print depth use it.
+(define (make-thread-parameter v) (make-parameter v))
+
+;; virtual-register / set-virtual-register!: Chez's fixed per-thread slot
+;; array (rt-core claims slots 2/3/4). Gambit has no equivalent; one parameter
+;; per claimed slot, created lazily, reproduces the per-thread semantics and
+;; the "fresh thread starts every slot at fixnum 0" contract. converters.ss's
+;; jolt-print-one stashes a print-readably override in slot jolt-vreg-print-
+;; readably through these.
+(define %vreg-table (make-table test: eqv?))  ;; slot fixnum -> parameter
+(define (virtual-register n)
+  (let ((p (table-ref %vreg-table n #f)))
+    (if p (p) 0)))
+(define (set-virtual-register! n v)
+  (let ((p (or (table-ref %vreg-table n #f)
+               (let ((q (make-parameter 0))) (table-set! %vreg-table n q) q))))
+    (p v)))

--- a/host/gambit/records-gambit.ss
+++ b/host/gambit/records-gambit.ss
@@ -1,0 +1,2216 @@
+;; records-gambit.ss — GENERATED from host/chez/records.ss by
+;; host/gambit/gen-records.ss (make gambitgen). Do not edit; regenerate
+;; when records.ss changes. The define-jrec-family transformer is
+;; expansion-phase-hostile on Gambit; its uses are pre-expanded here.
+
+(define-record-type (jrdesc make-jrdesc-rec jrdesc?)
+  (fields tag fkeys index (mutable ptable))
+  (nongenerative chez-jrdesc-v3))
+
+(define (make-jrdesc tag fkey-list)
+  (let ((index (make-eq-hashtable)))
+    (let loop ((ks fkey-list) (i 0))
+      (unless (null? ks)
+        (hashtable-set! index (car ks) i)
+        (loop (cdr ks) (+ i 1))))
+    (make-jrdesc-rec tag (list->vector fkey-list) index #f)))
+
+(define (jrdesc-nfields d) (vector-length (jrdesc-fkeys d)))
+
+;; (define-syntax define-jrec-family ...) — pre-expanded below
+
+;; expansion of (define-jrec-family 8)
+(define-record-type (jrec make-jrec0 jrec?)
+  (fields (immutable desc) (immutable ext))
+  (nongenerative chez-jrec-v4))
+
+(define-record-type (jrec1 make-jrec1 jrec1?)
+  (parent jrec)
+  (fields (mutable f0))
+  (nongenerative chez-jrec1v1))
+
+(define-record-type (jrec2 make-jrec2 jrec2?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1))
+  (nongenerative chez-jrec2v1))
+
+(define-record-type (jrec3 make-jrec3 jrec3?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1) (mutable f2))
+  (nongenerative chez-jrec3v1))
+
+(define-record-type (jrec4 make-jrec4 jrec4?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1) (mutable f2) (mutable f3))
+  (nongenerative chez-jrec4v1))
+
+(define-record-type (jrec5 make-jrec5 jrec5?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1) (mutable f2) (mutable f3)
+    (mutable f4))
+  (nongenerative chez-jrec5v1))
+
+(define-record-type (jrec6 make-jrec6 jrec6?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1) (mutable f2) (mutable f3)
+    (mutable f4) (mutable f5))
+  (nongenerative chez-jrec6v1))
+
+(define-record-type (jrec7 make-jrec7 jrec7?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1) (mutable f2) (mutable f3)
+    (mutable f4) (mutable f5) (mutable f6))
+  (nongenerative chez-jrec7v1))
+
+(define-record-type (jrec8 make-jrec8 jrec8?)
+  (parent jrec)
+  (fields (mutable f0) (mutable f1) (mutable f2) (mutable f3)
+    (mutable f4) (mutable f5) (mutable f6) (mutable f7))
+  (nongenerative chez-jrec8v1))
+
+(define-record-type (jrec* make-jrec* jrec*?)
+  (parent jrec)
+  (fields (mutable vals))
+  (nongenerative chez-jrecsp-v1))
+
+(define (jrec-nfields r)
+  (cond
+    ((jrec1? r) 1)
+    ((jrec2? r) 2)
+    ((jrec3? r) 3)
+    ((jrec4? r) 4)
+    ((jrec5? r) 5)
+    ((jrec6? r) 6)
+    ((jrec7? r) 7)
+    ((jrec8? r) 8)
+    ((jrec*? r) (vector-length (jrec*-vals r)))
+    (else 0)))
+
+(define (jrec-field-ref r i)
+  (let ((n (jrdesc-nfields (jrec-desc r))))
+    (case n
+      ((1)
+       (case i
+         ((0) (jrec1-f0 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((2)
+       (case i
+         ((0) (jrec2-f0 r))
+         ((1) (jrec2-f1 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((3)
+       (case i
+         ((0) (jrec3-f0 r))
+         ((1) (jrec3-f1 r))
+         ((2) (jrec3-f2 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((4)
+       (case i
+         ((0) (jrec4-f0 r))
+         ((1) (jrec4-f1 r))
+         ((2) (jrec4-f2 r))
+         ((3) (jrec4-f3 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((5)
+       (case i
+         ((0) (jrec5-f0 r))
+         ((1) (jrec5-f1 r))
+         ((2) (jrec5-f2 r))
+         ((3) (jrec5-f3 r))
+         ((4) (jrec5-f4 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((6)
+       (case i
+         ((0) (jrec6-f0 r))
+         ((1) (jrec6-f1 r))
+         ((2) (jrec6-f2 r))
+         ((3) (jrec6-f3 r))
+         ((4) (jrec6-f4 r))
+         ((5) (jrec6-f5 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((7)
+       (case i
+         ((0) (jrec7-f0 r))
+         ((1) (jrec7-f1 r))
+         ((2) (jrec7-f2 r))
+         ((3) (jrec7-f3 r))
+         ((4) (jrec7-f4 r))
+         ((5) (jrec7-f5 r))
+         ((6) (jrec7-f6 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      ((8)
+       (case i
+         ((0) (jrec8-f0 r))
+         ((1) (jrec8-f1 r))
+         ((2) (jrec8-f2 r))
+         ((3) (jrec8-f3 r))
+         ((4) (jrec8-f4 r))
+         ((5) (jrec8-f5 r))
+         ((6) (jrec8-f6 r))
+         ((7) (jrec8-f7 r))
+         (else (error 'jrec-field-ref "index out of range" i))))
+      (else
+       (if (jrec*? r)
+           (vector-ref (jrec*-vals r) i)
+           (error 'jrec-field-ref "not a fielded record" r))))))
+
+(define (jrec-field-set! r i v)
+  (cond
+    ((jrec1? r)
+     (case i
+       ((0) (jrec1-f0-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec2? r)
+     (case i
+       ((0) (jrec2-f0-set! r v))
+       ((1) (jrec2-f1-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec3? r)
+     (case i
+       ((0) (jrec3-f0-set! r v))
+       ((1) (jrec3-f1-set! r v))
+       ((2) (jrec3-f2-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec4? r)
+     (case i
+       ((0) (jrec4-f0-set! r v))
+       ((1) (jrec4-f1-set! r v))
+       ((2) (jrec4-f2-set! r v))
+       ((3) (jrec4-f3-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec5? r)
+     (case i
+       ((0) (jrec5-f0-set! r v))
+       ((1) (jrec5-f1-set! r v))
+       ((2) (jrec5-f2-set! r v))
+       ((3) (jrec5-f3-set! r v))
+       ((4) (jrec5-f4-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec6? r)
+     (case i
+       ((0) (jrec6-f0-set! r v))
+       ((1) (jrec6-f1-set! r v))
+       ((2) (jrec6-f2-set! r v))
+       ((3) (jrec6-f3-set! r v))
+       ((4) (jrec6-f4-set! r v))
+       ((5) (jrec6-f5-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec7? r)
+     (case i
+       ((0) (jrec7-f0-set! r v))
+       ((1) (jrec7-f1-set! r v))
+       ((2) (jrec7-f2-set! r v))
+       ((3) (jrec7-f3-set! r v))
+       ((4) (jrec7-f4-set! r v))
+       ((5) (jrec7-f5-set! r v))
+       ((6) (jrec7-f6-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec8? r)
+     (case i
+       ((0) (jrec8-f0-set! r v))
+       ((1) (jrec8-f1-set! r v))
+       ((2) (jrec8-f2-set! r v))
+       ((3) (jrec8-f3-set! r v))
+       ((4) (jrec8-f4-set! r v))
+       ((5) (jrec8-f5-set! r v))
+       ((6) (jrec8-f6-set! r v))
+       ((7) (jrec8-f7-set! r v))
+       (else (error 'jrec-field-set! "index out of range" i))))
+    ((jrec*? r) (vector-set! (jrec*-vals r) i v))
+    (else (error 'jrec-field-set! "not a fielded record" r))))
+
+(define (jrec-field-at r i k)
+  (cond
+    ((jrec1? r)
+     (case i ((0) (jrec1-f0 r)) (else (jolt-get r k))))
+    ((jrec2? r)
+     (case i
+       ((0) (jrec2-f0 r))
+       ((1) (jrec2-f1 r))
+       (else (jolt-get r k))))
+    ((jrec3? r)
+     (case i
+       ((0) (jrec3-f0 r))
+       ((1) (jrec3-f1 r))
+       ((2) (jrec3-f2 r))
+       (else (jolt-get r k))))
+    ((jrec4? r)
+     (case i
+       ((0) (jrec4-f0 r))
+       ((1) (jrec4-f1 r))
+       ((2) (jrec4-f2 r))
+       ((3) (jrec4-f3 r))
+       (else (jolt-get r k))))
+    ((jrec5? r)
+     (case i
+       ((0) (jrec5-f0 r))
+       ((1) (jrec5-f1 r))
+       ((2) (jrec5-f2 r))
+       ((3) (jrec5-f3 r))
+       ((4) (jrec5-f4 r))
+       (else (jolt-get r k))))
+    ((jrec6? r)
+     (case i
+       ((0) (jrec6-f0 r))
+       ((1) (jrec6-f1 r))
+       ((2) (jrec6-f2 r))
+       ((3) (jrec6-f3 r))
+       ((4) (jrec6-f4 r))
+       ((5) (jrec6-f5 r))
+       (else (jolt-get r k))))
+    ((jrec7? r)
+     (case i
+       ((0) (jrec7-f0 r))
+       ((1) (jrec7-f1 r))
+       ((2) (jrec7-f2 r))
+       ((3) (jrec7-f3 r))
+       ((4) (jrec7-f4 r))
+       ((5) (jrec7-f5 r))
+       ((6) (jrec7-f6 r))
+       (else (jolt-get r k))))
+    ((jrec8? r)
+     (case i
+       ((0) (jrec8-f0 r))
+       ((1) (jrec8-f1 r))
+       ((2) (jrec8-f2 r))
+       ((3) (jrec8-f3 r))
+       ((4) (jrec8-f4 r))
+       ((5) (jrec8-f5 r))
+       ((6) (jrec8-f6 r))
+       ((7) (jrec8-f7 r))
+       (else (jolt-get r k))))
+    ((jrec*? r)
+     (if (fx< i (vector-length (jrec*-vals r)))
+         (vector-ref (jrec*-vals r) i)
+         (jolt-get r k)))
+    (else (jolt-get r k))))
+
+(define jrec-ctor-vec
+  (vector make-jrec0 make-jrec1 make-jrec2 make-jrec3
+    make-jrec4 make-jrec5 make-jrec6 make-jrec7 make-jrec8))
+
+(define (make-jrec-from-existing src ov ov-val ext)
+  (let ((desc (jrec-desc src)))
+    (case (jrec-nfields src)
+      ((0) (make-jrec0 desc ext))
+      ((1)
+       (make-jrec1 desc ext (if (eq? ov 0) ov-val (jrec1-f0 src))))
+      ((2)
+       (make-jrec2
+         desc
+         ext
+         (if (eq? ov 0) ov-val (jrec2-f0 src))
+         (if (eq? ov 1) ov-val (jrec2-f1 src))))
+      ((3)
+       (make-jrec3 desc ext (if (eq? ov 0) ov-val (jrec3-f0 src))
+         (if (eq? ov 1) ov-val (jrec3-f1 src))
+         (if (eq? ov 2) ov-val (jrec3-f2 src))))
+      ((4)
+       (make-jrec4 desc ext (if (eq? ov 0) ov-val (jrec4-f0 src))
+         (if (eq? ov 1) ov-val (jrec4-f1 src))
+         (if (eq? ov 2) ov-val (jrec4-f2 src))
+         (if (eq? ov 3) ov-val (jrec4-f3 src))))
+      ((5)
+       (make-jrec5 desc ext (if (eq? ov 0) ov-val (jrec5-f0 src))
+         (if (eq? ov 1) ov-val (jrec5-f1 src))
+         (if (eq? ov 2) ov-val (jrec5-f2 src))
+         (if (eq? ov 3) ov-val (jrec5-f3 src))
+         (if (eq? ov 4) ov-val (jrec5-f4 src))))
+      ((6)
+       (make-jrec6 desc ext (if (eq? ov 0) ov-val (jrec6-f0 src))
+         (if (eq? ov 1) ov-val (jrec6-f1 src))
+         (if (eq? ov 2) ov-val (jrec6-f2 src))
+         (if (eq? ov 3) ov-val (jrec6-f3 src))
+         (if (eq? ov 4) ov-val (jrec6-f4 src))
+         (if (eq? ov 5) ov-val (jrec6-f5 src))))
+      ((7)
+       (make-jrec7 desc ext (if (eq? ov 0) ov-val (jrec7-f0 src))
+         (if (eq? ov 1) ov-val (jrec7-f1 src))
+         (if (eq? ov 2) ov-val (jrec7-f2 src))
+         (if (eq? ov 3) ov-val (jrec7-f3 src))
+         (if (eq? ov 4) ov-val (jrec7-f4 src))
+         (if (eq? ov 5) ov-val (jrec7-f5 src))
+         (if (eq? ov 6) ov-val (jrec7-f6 src))))
+      ((8)
+       (make-jrec8 desc ext (if (eq? ov 0) ov-val (jrec8-f0 src))
+         (if (eq? ov 1) ov-val (jrec8-f1 src))
+         (if (eq? ov 2) ov-val (jrec8-f2 src))
+         (if (eq? ov 3) ov-val (jrec8-f3 src))
+         (if (eq? ov 4) ov-val (jrec8-f4 src))
+         (if (eq? ov 5) ov-val (jrec8-f5 src))
+         (if (eq? ov 6) ov-val (jrec8-f6 src))
+         (if (eq? ov 7) ov-val (jrec8-f7 src))))
+      (else
+       (let ((nv (jrec-vec-copy (jrec*-vals src))))
+         (when ov (vector-set! nv ov ov-val))
+         (make-jrec* desc ext nv))))))
+
+(define (make-jrec desc vals ext)
+  (let ((n (vector-length vals)))
+    (if (fx<= n 8)
+        (apply
+          (vector-ref jrec-ctor-vec n)
+          desc
+          ext
+          (vector->list vals))
+        (make-jrec* desc ext vals))))
+
+(define jrec-fast-type-probe
+  (make-jrec 'fast-type-probe (vector) jolt-nil))
+
+(define (jrec-vals r)
+  (let* ((n (jrec-nfields r)) (v (make-vector n)))
+    (do ((i 0 (fx+ i 1)))
+        ((fx= i n) v)
+      (vector-set! v i (jrec-field-ref r i)))))
+
+(define (jrec-tag r) (jrdesc-tag (jrec-desc r)))
+
+(define (jrec-pic-desc x) (and (jrec? x) (jrec-desc x)))
+
+(define chez-record-type-tbl
+  (make-hashtable string-hash string=?))
+
+(define (jrec-record? x)
+  (and (jrec? x)
+       (hashtable-ref chez-record-type-tbl (jrec-tag x) #f)
+       #t))
+
+(define chez-deftype-tag-set
+  (make-hashtable string-hash string=?))
+
+(define chez-deftype-ctor-tag (make-weak-eq-hashtable))
+
+(define (mm-dispatch-val-canon dval)
+  (or (and (procedure? dval)
+           (hashtable-ref chez-deftype-ctor-tag dval #f))
+      dval))
+
+(define chez-simple-name-tag
+  (make-hashtable string-hash string=?))
+
+(define (chez-deftype-simple->tag nm)
+  (hashtable-ref chez-simple-name-tag nm #f))
+
+(define chez-tag-desc (make-hashtable string-hash string=?))
+
+(define (jrec-collection? x)
+  (and (jrec? x)
+       (or (jrec-record? x)
+           (let ((tag (jrec-tag x)))
+             (or (find-method-any-protocol tag "cons")
+                 (find-method-any-protocol tag "first"))))
+       #t))
+
+(define (jrec-maplike? x)
+  (and (jrec? x)
+       (or (jrec-record? x)
+           (find-method-any-protocol (jrec-tag x) "without"))
+       #t))
+
+(define jolt-deftype-kw (keyword "jolt" "deftype"))
+
+(define jrec-absent (list 'jrec-absent))
+
+(define chez-record-shapes-tbl
+  (make-hashtable string-hash string=?))
+
+(define chez-protocol-methods-tbl
+  (make-hashtable string-hash string=?))
+
+(define chez-record-dbl-tbl
+  (make-hashtable string-hash string=?))
+
+(define (chez-double-tag? t)
+  (and (string? t) (string=? t "double")))
+
+(define (register-record-shape! ctor-key field-kws
+         field-tags type-tag)
+  (hashtable-set!
+    chez-record-shapes-tbl
+    ctor-key
+    (vector field-kws field-tags type-tag))
+  (hashtable-set!
+    chez-record-dbl-tbl
+    type-tag
+    (list->vector (map chez-double-tag? field-tags))))
+
+(define (chez-shape-simple-name s)
+  (let loop ((i (- (string-length s) 1)))
+    (cond
+      ((< i 0) s)
+      ((or (char=? (string-ref s i) #\.)
+           (char=? (string-ref s i) #\/))
+       (substring s (+ i 1) (string-length s)))
+      (else (loop (- i 1))))))
+
+(define (chez-resolve-field-tag tag by-name owner-ns)
+  (cond
+    ((or (not tag) (jolt-nil-t? tag)) jolt-nil)
+    ((string=? tag "num") "num")
+    ((string=? tag "double") "double")
+    (else
+     (let* ((simple (chez-shape-simple-name tag))
+            (qualified? (not (string=? simple tag)))
+            (ck (or (and qualified? (hashtable-ref by-name tag #f))
+                    (hashtable-ref
+                      by-name
+                      (string-append owner-ns "." simple)
+                      #f)
+                    (hashtable-ref by-name simple #f))))
+       (if ck ck jolt-nil)))))
+
+(define (chez-ctor-key-ns k)
+  (let loop ((i 0))
+    (cond
+      ((>= i (string-length k)) k)
+      ((char=? (string-ref k i) #\/) (substring k 0 i))
+      (else (loop (+ i 1))))))
+
+(define (chez-record-shapes-map)
+  (let ((by-name (make-hashtable string-hash string=?))
+        (kw-fields (keyword #f "fields"))
+        (kw-tags (keyword #f "tags"))
+        (kw-type (keyword #f "type"))
+        (out (jolt-hash-map)))
+    (let-values (((ks vs)
+                  (hashtable-entries chez-record-shapes-tbl)))
+      (vector-for-each
+        (lambda (k v)
+          (let ((type-tag (vector-ref v 2)))
+            (hashtable-set! by-name type-tag k)
+            (hashtable-set!
+              by-name
+              (chez-shape-simple-name type-tag)
+              k)))
+        ks
+        vs)
+      (vector-for-each
+        (lambda (k v)
+          (let* ((fields (vector-ref v 0))
+                 (tags (vector-ref v 1))
+                 (type-tag (vector-ref v 2))
+                 (owner-ns (chez-ctor-key-ns k))
+                 (rtags (map (lambda (t)
+                               (chez-resolve-field-tag t by-name owner-ns))
+                             tags)))
+            (set! out
+              (jolt-assoc
+                out
+                k
+                (jolt-hash-map kw-fields (apply jolt-vector fields) kw-tags
+                  (apply jolt-vector rtags) kw-type type-tag)))))
+        ks
+        vs))
+    out))
+
+(define (chez-find-ctor-key name ns)
+  (let* ((simple (chez-shape-simple-name name))
+         (target (string-append "->" simple))
+         (preferred (string-append ns "/->" simple)))
+    (if (hashtable-ref chez-record-shapes-tbl preferred #f)
+        preferred
+        (let loop ((ks (vector->list
+                         (hashtable-keys chez-record-shapes-tbl))))
+          (cond
+            ((null? ks) #f)
+            ((string=? (chez-shape-simple-name (car ks)) target)
+             (car ks))
+            (else (loop (cdr ks))))))))
+
+(define (chez-protocol-methods-map)
+  (let ((out (jolt-hash-map)))
+    (let-values (((ks vs)
+                  (hashtable-entries chez-protocol-methods-tbl)))
+      (vector-for-each
+        (lambda (k v)
+          (set! out (jolt-assoc out k (jolt-vector (car v) (cdr v)))))
+        ks
+        vs))
+    out))
+
+(define (jrec-field-index r k)
+  (hashtable-ref (jrdesc-index (jrec-desc r)) k #f))
+
+(define (jrec-vec-copy v)
+  (let* ((n (vector-length v)) (out (make-vector n)))
+    (let loop ((i 0))
+      (when (< i n)
+        (vector-set! out i (vector-ref v i))
+        (loop (+ i 1))))
+    out))
+
+(define (jrec-ext-pairs ext)
+  (let loop ((s (jolt-seq ext)) (acc '()))
+    (if (jolt-nil? s)
+        (reverse acc)
+        (let ((e (seq-first s)))
+          (loop
+            (jolt-seq (seq-more s))
+            (cons (cons (jolt-nth e 0) (jolt-nth e 1)) acc))))))
+
+(define (jrec-lookup r k d)
+  (if (eq? k jolt-deftype-kw)
+      (jrec-tag r)
+      (let ((i (jrec-field-index r k)))
+        (if i
+            (jrec-field-ref r i)
+            (let ((ext (jrec-ext r)))
+              (if (jolt-nil? ext)
+                  d
+                  (let ((v (jolt-get ext k jrec-absent)))
+                    (if (eq? v jrec-absent) d v))))))))
+
+(define (jrec-has? r k)
+  (and (not (eq? k jolt-deftype-kw))
+       (or (and (jrec-field-index r k) #t)
+           (let ((ext (jrec-ext r)))
+             (and (not (jolt-nil? ext))
+                  (not (eq? jrec-absent (jolt-get ext k jrec-absent))))))))
+
+(define (jrec-ref coll k d)
+  (if (eq? k jolt-deftype-kw)
+      (jrec-tag coll)
+      (let ((i (jrec-field-index coll k)))
+        (if i
+            (jrec-field-ref coll i)
+            (let* ((ext (jrec-ext coll))
+                   (v (if (jolt-nil? ext)
+                          jrec-absent
+                          (jolt-get ext k jrec-absent))))
+              (if (eq? v jrec-absent)
+                  (cond
+                    ((find-method-any-protocol (jrec-tag coll) "valAt") =>
+                     (lambda (m) (jolt-invoke m coll k d)))
+                    ((find-method-any-protocol (jrec-tag coll) "get") =>
+                     (lambda (m)
+                       (let ((r (jolt-invoke m coll k)))
+                         (if (jolt-nil? r) d r))))
+                    (else d))
+                  v))))))
+
+(define (jolt-set-field! inst k v)
+  (if (jrec? inst)
+      (let ((i (jrec-field-index inst k)))
+        (if i
+            (let* ((flags (hashtable-ref
+                            chez-record-dbl-tbl
+                            (jrec-tag inst)
+                            #f))
+                   (v2 (if (and flags
+                                (fx< i (vector-length flags))
+                                (vector-ref flags i)
+                                (number? v)
+                                (not (flonum? v)))
+                           (exact->inexact v)
+                           v)))
+              (jrec-field-set! inst i v2)
+              v2)
+            (throw-jvm
+              'IllegalArgumentException
+              (string-append
+                "set! of an unknown field: "
+                (jolt-final-str k)))))
+      (if (let ((kn (cond
+                      ((string? k) k)
+                      ((keyword-t? k) (keyword-t-name k))
+                      (else #f))))
+            (and kn (string=? kn "__methodImplCache")))
+          v
+          (throw-jvm
+            'IllegalArgumentException
+            "set! of a field on a non-record"))))
+
+(define (jrec-ext=? ea eb)
+  (cond
+    ((and (jolt-nil? ea) (jolt-nil? eb)) #t)
+    ((or (jolt-nil? ea) (jolt-nil? eb)) #f)
+    (else (jolt=2 ea eb))))
+
+(define (jrec=? a b)
+  (and (string=? (jrec-tag a) (jrec-tag b))
+       (let ((n (jrec-nfields a)))
+         (and (= n (jrec-nfields b))
+              (let loop ((i 0))
+                (or (= i n)
+                    (and (jolt=2 (jrec-field-ref a i) (jrec-field-ref b i))
+                         (loop (+ i 1)))))))
+       (jrec-ext=? (jrec-ext a) (jrec-ext b))))
+
+(define (jrec-hash r)
+  (let* ((class-hash (compute-symbol-hasheq #f (jrec-tag r)))
+         (fkeys (jrdesc-fkeys (jrec-desc r)))
+         (n (jrec-nfields r))
+         (result (let loop ((i 0) (acc 0) (cnt 0))
+                   (if (= i n)
+                       (cons acc cnt)
+                       (loop
+                         (+ i 1)
+                         (add32
+                           acc
+                           (entry-hasheq
+                             (vector-ref fkeys i)
+                             (jrec-field-ref r i)))
+                         (+ cnt 1)))))
+         (ext (jrec-ext r))
+         (total (if (jolt-nil? ext)
+                    result
+                    (pmap-fold
+                      ext
+                      (lambda (k v a)
+                        (cons
+                          (add32 (car a) (entry-hasheq k v))
+                          (+ (cdr a) 1)))
+                      result)))
+         (map-hash (mix-coll-hash (car total) (cdr total))))
+    (i32 (bitwise-xor class-hash map-hash))))
+
+(define (jrec-pr r)
+  (let ((fkeys (jrdesc-fkeys (jrec-desc r))))
+    (string-append "#" (jrec-tag r) "{"
+      (let ((n (vector-length fkeys)))
+        (let loop ((i 0) (first #t) (acc ""))
+          (if (= i n)
+              (let ((ext (jrec-ext r)))
+                (if (jolt-nil? ext)
+                    acc
+                    (let eloop ((es (jrec-ext-pairs ext))
+                                (first first)
+                                (acc acc))
+                      (if (null? es)
+                          acc
+                          (eloop
+                            (cdr es)
+                            #f
+                            (string-append acc (if first "" ", ")
+                              (jolt-pr-readable (caar es)) " "
+                              (jolt-pr-readable (cdar es))))))))
+              (loop
+                (+ i 1)
+                #f
+                (string-append acc (if first "" ", ")
+                  (jolt-pr-readable (vector-ref fkeys i)) " "
+                  (jolt-pr-readable (jrec-field-ref r i)))))))
+      "}")))
+
+(register-eq-arm!
+  (lambda (a b) (or (jrec? a) (jrec? b)))
+  (lambda (a b)
+    (cond
+      ((and (jrec? a) (jrec-cl a "equiv")) =>
+       (lambda (m) (if (jolt-truthy? (jolt-invoke m a b)) #t #f)))
+      ((and (jrec? b) (jrec-cl b "equiv")) =>
+       (lambda (m) (if (jolt-truthy? (jolt-invoke m b a)) #t #f)))
+      ((and (jrec? a) (jrec-cl a "equals")) =>
+       (lambda (m) (if (jolt-truthy? (jolt-invoke m a b)) #t #f)))
+      ((and (jrec? b) (jrec-cl b "equals")) =>
+       (lambda (m) (if (jolt-truthy? (jolt-invoke m b a)) #t #f)))
+      ((or (jrec-sequential-decl? a) (jrec-sequential-decl? b))
+       (and (seq-eq-candidate? a)
+            (seq-eq-candidate? b)
+            (seq=? a b)))
+      ((and (jrec? a) (jrec? b)) (jrec=? a b))
+      (else #f))))
+
+(register-hash-arm!
+  jrec?
+  (lambda (x)
+    (cond
+      ((jrec-cl x "hasheq") => (lambda (m) (jolt-invoke m x)))
+      ((jrec-cl x "hashCode") => (lambda (m) (jolt-invoke m x)))
+      (else (jrec-hash x)))))
+
+(define jrec-cl rec-coll-method)
+
+(define jrec-coll-iface-names
+  '("IPersistentCollection" "IPersistentMap" "IPersistentVector" "IPersistentSet"
+     "IPersistentStack" "IPersistentList" "ISeq" "Seqable"
+     "Indexed" "Counted" "Associative" "ILookup" "Reversible"
+     "Sorted"))
+
+(define (jrec-declares-coll-iface? x)
+  (and (jrec? x)
+       (not (jrec-record? x))
+       (let ((ti (hashtable-ref type-registry (jrec-tag x) #f)))
+         (and ti
+              (let loop ((ps (vector->list (hashtable-keys ti))))
+                (cond
+                  ((null? ps) #f)
+                  ((member
+                     (jch-last-segment (car ps))
+                     jrec-coll-iface-names)
+                   #t)
+                  (else (loop (cdr ps)))))))))
+
+(define (jrec-sequential-decl? x)
+  (and (jrec? x)
+       (not (jrec-record? x))
+       (let ((ti (hashtable-ref type-registry (jrec-tag x) #f)))
+         (and ti
+              (let loop ((ps (vector->list (hashtable-keys ti))))
+                (cond
+                  ((null? ps) #f)
+                  ((string=? (jch-last-segment (car ps)) "Sequential") #t)
+                  (else (loop (cdr ps)))))))))
+
+(define (seq-eq-candidate? x)
+  (or (jolt-sequential? x)
+      (jolt-lazyseq? x)
+      (jrec-sequential-decl? x)))
+
+(define (jrec-abstract-method-error x method)
+  (jolt-throw
+    (jolt-host-throwable
+      "java.lang.AbstractMethodError"
+      (string-append "Method " (jrec-tag x) "/" method
+        "() is abstract"))))
+
+(define (iface-method v method nargs)
+  (cond
+    ((jrec? v)
+     (if nargs
+         (find-method-any-protocol-arity (jrec-tag v) method nargs)
+         (find-method-any-protocol (jrec-tag v) method)))
+    ((jreify? v)
+     (let ((rm (reified-methods v)))
+       (and rm (hashtable-ref rm method #f))))
+    (else #f)))
+
+(register-count-arm!
+  (lambda (coll) (or (jrec? coll) (jolt-transient? coll)))
+  (lambda (coll)
+    (cond
+      ((jrec-cl coll "count") =>
+       (lambda (m) (jolt-invoke m coll)))
+      ((jrec-declares-coll-iface? coll)
+       (jrec-abstract-method-error coll "count"))
+      ((jrec? coll)
+       (+ (jrec-nfields coll)
+          (let ((ext (jrec-ext coll)))
+            (if (jolt-nil? ext) 0 (jolt-count ext)))))
+      ((jolt-transient? coll) (t-count coll))
+      (else (error 'count "uncountable record")))))
+
+(register-contains-arm!
+  (lambda (coll) (jrec-cl coll "containsKey"))
+  (lambda (coll k)
+    (if (jolt-truthy?
+          (jolt-invoke (jrec-cl coll "containsKey") coll k))
+        #t
+        #f)))
+
+(register-contains-arm!
+  (lambda (coll) (and (jrec? coll) (jrec-cl coll "contains")))
+  (lambda (coll k)
+    (if (jolt-truthy?
+          (jolt-invoke (jrec-cl coll "contains") coll k))
+        #t
+        #f)))
+
+(register-contains-arm!
+  (lambda (coll)
+    (and (jrec? coll)
+         (not (jrec-cl coll "containsKey"))
+         (not (jrec-cl coll "contains"))))
+  (lambda (coll k) (jrec-has? coll k)))
+
+(register-contains-arm! jolt-transient? t-contains?)
+
+(register-empty-arm!
+  jolt-transient?
+  (lambda (t) (zero? (t-count t))))
+
+(define %r-jolt-nth jolt-nth)
+
+(set! jolt-nth
+  (case-lambda
+    ((coll i)
+     (if (jolt-transient? coll)
+         (begin
+           (jolt-trans-check coll "nth")
+           (if (eq? (jolt-transient-kind coll) 'vec)
+               (let ((idx (->idx i)))
+                 (if (tvec-in-bounds? coll idx)
+                     (vector-ref (jolt-transient-buf coll) idx)
+                     (error 'nth "index out of bounds")))
+               (%r-jolt-nth (jolt-transient-buf coll) i)))
+         (%r-jolt-nth coll i)))
+    ((coll i d)
+     (if (jolt-transient? coll)
+         (if (eq? (jolt-transient-kind coll) 'vec)
+             (let ((idx (->idx i)))
+               (if (tvec-in-bounds? coll idx)
+                   (vector-ref (jolt-transient-buf coll) idx)
+                   d))
+             (%r-jolt-nth (jolt-transient-buf coll) i d))
+         (%r-jolt-nth coll i d)))))
+
+(define %r-jolt-assoc1 jolt-assoc1)
+
+(set! jolt-assoc1
+  (lambda (coll k v)
+    (cond
+      ((jrec-cl coll "assoc") =>
+       (lambda (m) (jolt-invoke m coll k v)))
+      ((jrec? coll)
+       (let ((i (and (keyword? k) (jrec-field-index coll k))))
+         (if i
+             (let ((v2 (let ((flags (hashtable-ref
+                                      chez-record-dbl-tbl
+                                      (jrec-tag coll)
+                                      #f)))
+                         (if (and flags
+                                  (fx< i (vector-length flags))
+                                  (vector-ref flags i)
+                                  (number? v)
+                                  (not (flonum? v)))
+                             (exact->inexact v)
+                             v))))
+               (make-jrec-from-existing coll i v2 (jrec-ext coll)))
+             (let ((ext (jrec-ext coll)))
+               (make-jrec-from-existing
+                 coll
+                 #f
+                 #f
+                 (%r-jolt-assoc1
+                   (if (jolt-nil? ext) empty-pmap ext)
+                   k
+                   v))))))
+      (else (%r-jolt-assoc1 coll k v)))))
+
+(define (jrec->map-without r drop-k)
+  (let* ((fkeys (jrdesc-fkeys (jrec-desc r)))
+         (n (vector-length fkeys)))
+    (let loop ((i 0) (m empty-pmap))
+      (if (= i n)
+          (let ((ext (jrec-ext r)))
+            (if (jolt-nil? ext)
+                m
+                (fold-left
+                  (lambda (mm p) (%r-jolt-assoc1 mm (car p) (cdr p)))
+                  m
+                  (jrec-ext-pairs ext))))
+          (let ((fk (vector-ref fkeys i)))
+            (loop
+              (+ i 1)
+              (if (eq? fk drop-k)
+                  m
+                  (%r-jolt-assoc1 m fk (jrec-field-ref r i)))))))))
+
+(define %r-jolt-dissoc jolt-dissoc)
+
+(define %r-jolt-dissoc2 jolt-dissoc2)
+
+(define (jrec-dissoc1 coll k)
+  (if (not (jrec? coll))
+      (%r-jolt-dissoc coll k)
+      (let ((i (and (keyword? k) (jrec-field-index coll k))))
+        (if i
+            (jrec->map-without coll k)
+            (let ((ext (jrec-ext coll)))
+              (if (jolt-nil? ext)
+                  coll
+                  (let ((ne (%r-jolt-dissoc ext k)))
+                    (make-jrec-from-existing
+                      coll
+                      #f
+                      #f
+                      (if (= 0 (jolt-count ne)) jolt-nil ne)))))))))
+
+(set! jolt-dissoc
+  (lambda (coll . ks)
+    (cond
+      ((jrec-cl coll "without") =>
+       (lambda (m)
+         (fold-left (lambda (c k) (jolt-invoke m c k)) coll ks)))
+      ((jrec? coll) (fold-left jrec-dissoc1 coll ks))
+      (else (apply %r-jolt-dissoc coll ks)))))
+
+(set! jolt-dissoc2
+  (lambda (coll k)
+    (cond
+      ((jrec-cl coll "without") =>
+       (lambda (m) (jolt-invoke m coll k)))
+      ((jrec? coll) (jrec-dissoc1 coll k))
+      (else (%r-jolt-dissoc2 coll k)))))
+
+(define (jrec-seq-col m which)
+  (let loop ((s (jolt-seq m)) (acc '()))
+    (if (jolt-nil? s)
+        (list->cseq (reverse acc))
+        (loop
+          (jolt-seq (seq-more s))
+          (cons (jolt-nth (seq-first s) which) acc)))))
+
+(define %r-jolt-keys jolt-keys)
+
+(set! jolt-keys
+  (lambda (m)
+    (if (jrec? m) (jrec-seq-col m 0) (%r-jolt-keys m))))
+
+(define %r-jolt-vals jolt-vals)
+
+(set! jolt-vals
+  (lambda (m)
+    (if (jrec? m) (jrec-seq-col m 1) (%r-jolt-vals m))))
+
+(define (jrec-entry-list r)
+  (let* ((fkeys (jrdesc-fkeys (jrec-desc r)))
+         (n (vector-length fkeys)))
+    (let loop ((i 0) (acc '()))
+      (if (= i n)
+          (let ((ext (jrec-ext r)))
+            (append
+              (reverse acc)
+              (if (jolt-nil? ext)
+                  '()
+                  (map (lambda (p) (make-map-entry (car p) (cdr p)))
+                       (jrec-ext-pairs ext)))))
+          (loop
+            (+ i 1)
+            (cons
+              (make-map-entry (vector-ref fkeys i) (jrec-field-ref r i))
+              acc))))))
+
+(register-seq-arm!
+  (lambda (x) (and (jrec? x) (jrec-declares-coll-iface? x)))
+  (lambda (x) (jrec-abstract-method-error x "seq")))
+
+(register-seq-arm!
+  jrec-record?
+  (lambda (x) (list->cseq (jrec-entry-list x))))
+
+(register-seq-arm!
+  (lambda (x) (jrec-cl x "seq"))
+  (lambda (x) (jolt-seq (jolt-invoke (jrec-cl x "seq") x))))
+
+(register-conj-arm!
+  (lambda (coll) (jrec-cl coll "cons"))
+  (lambda (coll x)
+    (jolt-invoke (jrec-cl coll "cons") coll x)))
+
+(register-conj-arm!
+  (lambda (coll)
+    (and (jrec? coll) (not (jrec-cl coll "cons"))))
+  (lambda (coll x)
+    (if (pmap? x)
+        (pmap-fold-fwd x (lambda (k v c) (jolt-assoc1 c k v)) coll)
+        (jolt-assoc1 coll (jolt-nth x 0) (jolt-nth x 1)))))
+
+(register-empty-arm!
+  jrec-collection?
+  (lambda (coll) (jolt-nil? (jolt-seq coll))))
+
+(define %r-jolt-peek jolt-peek)
+
+(set! jolt-peek
+  (lambda (coll)
+    (cond
+      ((jrec-cl coll "peek") => (lambda (m) (jolt-invoke m coll)))
+      (else (%r-jolt-peek coll)))))
+
+(define %r-jolt-pop jolt-pop)
+
+(set! jolt-pop
+  (lambda (coll)
+    (cond
+      ((jrec-cl coll "pop") => (lambda (m) (jolt-invoke m coll)))
+      (else (%r-jolt-pop coll)))))
+
+(register-pr-arm! jrec? jrec-pr)
+
+(register-map-pred-arm! jrec-maplike?)
+
+(def-var! "clojure.core" "map?" jolt-map?)
+
+(def-var!
+  "clojure.core"
+  "coll?"
+  (lambda (x) (or (jrec-collection? x) (jolt-coll-pred? x))))
+
+(define proto-kw-jtype (keyword #f "jolt/type"))
+
+(define proto-kw-protocol (keyword #f "jolt/protocol"))
+
+(define proto-kw-name (keyword #f "name"))
+
+(define (jolt-protocol-value? v)
+  (and (pmap? v)
+       (eq? (jolt-get v proto-kw-jtype jolt-nil)
+            proto-kw-protocol)))
+
+(define (protocol-value-key v)
+  (and (jolt-protocol-value? v)
+       (let ((n (jolt-get v proto-kw-name jolt-nil)))
+         (cond
+           ((symbol-t? n) (symbol-t-name n))
+           ((string? n) n)
+           (else #f)))))
+
+(define (proto-str-index s ch)
+  (let ((n (string-length s)))
+    (let loop ((i 0))
+      (cond
+        ((fx=? i n) #f)
+        ((char=? (string-ref s i) ch) i)
+        (else (loop (fx+ i 1)))))))
+
+(define (proto-iface-name key)
+  (let ((i (proto-str-index key #\/)))
+    (jch-munge-segments
+      (if i
+          (string-append
+            (substring key 0 i)
+            "."
+            (substring key (fx+ i 1) (string-length key)))
+          key))))
+
+(define (proto-key-qualified? key)
+  (and (proto-str-index key #\/) #t))
+
+(define (dotted-name? s) (and (proto-str-index s #\.) #t))
+
+(define (proto-class-match? key qname)
+  (let ((ki (proto-iface-name key))
+        (qi (proto-iface-name qname)))
+    (or (string=? ki qi)
+        (and (or (not (dotted-name? ki)) (not (dotted-name? qi)))
+             (string=? (jch-last-segment ki) (jch-last-segment qi))))))
+
+(define type-registry (make-hashtable string-hash string=?))
+
+(define jolt-proto-epoch 0)
+
+(define proto-method-keys
+  (make-hashtable string-hash string=?))
+
+(define (intern-pm-key proto method)
+  (let* ((s (string-append
+              proto
+              (string (integer->char 0))
+              method))
+         (k (hashtable-ref proto-method-keys s #f)))
+    (or k
+        (let ((nk (gensym (string-append proto "." method))))
+          (hashtable-set! proto-method-keys s nk)
+          nk))))
+
+(define (find-protocol-method-desc desc proto method)
+  (let ((pt (jrdesc-ptable desc)))
+    (and pt
+         (hashtable-ref pt (intern-pm-key proto method) #f))))
+
+(define (register-protocol-method type-tag proto method fn)
+  (set! jolt-proto-epoch (fx+ jolt-proto-epoch 1))
+  (let* ((ti (or (hashtable-ref type-registry type-tag #f)
+                 (let ((h (make-hashtable string-hash string=?)))
+                   (hashtable-set! type-registry type-tag h)
+                   h)))
+         (pi (or (hashtable-ref ti proto #f)
+                 (let ((h (make-hashtable string-hash string=?)))
+                   (hashtable-set! ti proto h)
+                   h))))
+    (hashtable-set! pi method fn))
+  (let ((desc (hashtable-ref chez-tag-desc type-tag #f)))
+    (when desc
+      (let ((pt (or (jrdesc-ptable desc)
+                    (let ((h (make-eq-hashtable)))
+                      (jrdesc-ptable-set! desc h)
+                      h))))
+        (hashtable-set! pt (intern-pm-key proto method) fn))))
+  (remove-clone! type-tag proto method)
+  (if #f #f))
+
+(define (find-protocol-method type-tag proto method)
+  (let ((ti (hashtable-ref type-registry type-tag #f)))
+    (and ti
+         (let ((pi (hashtable-ref ti proto #f)))
+           (and pi (hashtable-ref pi method #f))))))
+
+(define (find-method-any-protocol type-tag method)
+  (let ((ti (hashtable-ref type-registry type-tag #f)))
+    (and ti
+         (let* ((ks (hashtable-keys ti)) (n (vector-length ks)))
+           (let loop ((i 0))
+             (and (fx< i n)
+                  (let ((f (hashtable-ref
+                             (hashtable-ref ti (vector-ref ks i) #f)
+                             method
+                             #f)))
+                    (or f (loop (fx+ i 1))))))))))
+
+(define (proc-accepts? f n)
+  (and (procedure? f)
+       (bitwise-bit-set? (procedure-arity-mask f) n)))
+
+(define (find-method-any-protocol-arity type-tag method
+         nargs)
+  (let ((ti (hashtable-ref type-registry type-tag #f)))
+    (and ti
+         (let* ((ks (hashtable-keys ti)) (n (vector-length ks)))
+           (let loop ((i 0) (fallback #f))
+             (if (fx>= i n)
+                 fallback
+                 (let ((f (hashtable-ref
+                            (hashtable-ref ti (vector-ref ks i) #f)
+                            method
+                            #f)))
+                   (cond
+                     ((and f (proc-accepts? f nargs)) f)
+                     (else (loop (fx+ i 1) (or fallback f)))))))))))
+
+(define (type-satisfies? type-tag proto)
+  (let ((ti (hashtable-ref type-registry type-tag #f)))
+    (and ti (hashtable-ref ti proto #f) #t)))
+
+(define (type-implements-class? type-tag qname)
+  (let ((ti (hashtable-ref type-registry type-tag #f)))
+    (and ti
+         (or (and (hashtable-ref ti qname #f) #t)
+             (let* ((ks (hashtable-keys ti)) (n (vector-length ks)))
+               (let loop ((i 0))
+                 (and (fx< i n)
+                      (or (proto-class-match? (vector-ref ks i) qname)
+                          (loop (fx+ i 1))))))))))
+
+(def-var!
+  "jolt.host"
+  "jrec-method?"
+  (lambda (v name)
+    (cond
+      ((jrec? v)
+       (if (find-method-any-protocol (jrec-tag v) name) #t #f))
+      ((reified-methods v) =>
+       (lambda (m) (if (hashtable-ref m name #f) #t #f)))
+      (else #f))))
+
+(set-str-tostring-hook!
+  (lambda (v)
+    (and (jrec? v)
+         (find-method-any-protocol (jrec-tag v) "toString")
+         (record-method-dispatch v "toString" jolt-nil))))
+
+(define (value-host-tags obj)
+  (cond
+    ((flonum? obj) '("Double" "Float" "Number" "Object"))
+    ((and (number? obj) (exact? obj) (not (integer? obj)))
+     '("Ratio" "Number" "Object"))
+    ((number? obj)
+     '("Long" "Integer" "BigInteger" "BigInt" "Number" "Object"))
+    ((string? obj) '("String" "CharSequence" "Object"))
+    ((boolean? obj) '("Boolean" "Object"))
+    ((char? obj) (jch-tags "java.lang.Character"))
+    ((keyword? obj) (jch-tags "clojure.lang.Keyword"))
+    ((jolt-symbol? obj) (jch-tags "clojure.lang.Symbol"))
+    ((jolt-map-entry? obj) (jch-tags "clojure.lang.MapEntry"))
+    ((pvec? obj) (jch-tags "clojure.lang.PersistentVector"))
+    ((pmap? obj)
+     (if (pmap-order obj)
+         (jch-tags "clojure.lang.PersistentArrayMap")
+         (jch-tags "clojure.lang.PersistentHashMap")))
+    ((pset? obj) (jch-tags "clojure.lang.PersistentHashSet"))
+    ((or (cseq? obj) (empty-list-t? obj))
+     (jch-tags "clojure.lang.PersistentList"))
+    ((jolt-lazyseq? obj) (jch-tags "clojure.lang.LazySeq"))
+    ((var-cell? obj) (jch-tags "clojure.lang.Var"))
+    ((jclass? obj) '("Class" "java.lang.Class" "Object"))
+    ((and (procedure? obj)
+          (hashtable-ref chez-deftype-ctor-tag obj #f))
+     '("Class" "java.lang.Class" "Object"))
+    ((and (procedure? obj) (hashtable-ref proc-name-tbl obj #f)) =>
+     (lambda (p)
+       (list
+         (string-append
+           (class-munge-name (car p))
+           "$"
+           (class-munge-name (cdr p)))
+         "AFunction" "clojure.lang.AFunction" "AFn"
+         "clojure.lang.AFn" "IFn" "clojure.lang.IFn" "Fn"
+         "clojure.lang.Fn" "Object")))
+    ((and (jhost? obj) (jhost-value-tags (jhost-tag obj))) =>
+     (lambda (tags) tags))
+    ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'byte))
+     '("[B" "Object"))
+    ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'char))
+     '("[C" "Object"))
+    ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'int))
+     '("[I" "Object"))
+    ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'long))
+     '("[J" "Object"))
+    ((and (jolt-array? obj) (eq? (jolt-array-kind obj) 'double))
+     '("[D" "Object"))
+    ((jolt-array? obj) '("[Ljava.lang.Object;" "Object"))
+    ((regex-t? obj) (jch-tags "java.util.regex.Pattern"))
+    ((juuid? obj) (jch-tags "java.util.UUID"))
+    ((jinst? obj) (jch-tags "java.util.Date"))
+    ((jbigdec? obj) (jch-tags "java.math.BigDecimal"))
+    ((procedure? obj) (jch-tags "clojure.lang.AFunction"))
+    ((jolt-nil? obj) '("nil"))
+    ((jrec-record? obj)
+     (cons
+       (jrec-tag obj)
+       '("IRecord" "clojure.lang.IRecord" "IPersistentMap"
+          "clojure.lang.IPersistentMap" "APersistentMap" "Associative"
+          "ILookup" "Seqable" "Counted" "IPersistentCollection" "IObj"
+          "IMeta" "Map" "java.util.Map" "Iterable"
+          "java.lang.Iterable" "Object")))
+    ((jrec? obj) (list (jrec-tag obj) "Object"))
+    ((jolt-ex-info-record? obj)
+     (jch-tags (jolt-ex-info-record-class-name obj)))
+    ((jolt-atom? obj) (jch-tags "clojure.lang.Atom"))
+    ((jns? obj) (jch-tags "clojure.lang.Namespace"))
+    (else '("Object"))))
+
+(define (make-deftype-ctor name-sym field-kws . rest-args)
+  (let* ((tag (string-append
+                (chez-current-ns)
+                "."
+                (symbol-t-name name-sym)))
+         (kws (seq->list field-kws))
+         (field-tags (if (pair? rest-args)
+                         (seq->list (car rest-args))
+                         '()))
+         (dbl-flags (list->vector (map chez-double-tag? field-tags)))
+         (ndbl (vector-length dbl-flags))
+         (desc (make-jrdesc tag kws))
+         (old-desc (hashtable-ref chez-tag-desc tag #f))
+         (_ (when old-desc (jrdesc-ptable-set! old-desc #f)))
+         (_ (hashtable-set! chez-tag-desc tag desc))
+         (nf (length kws))
+         (ctor (lambda args
+                 (when (not (= (length args) nf))
+                   (jolt-throw
+                     (str "Wrong number of args ("
+                          (length args)
+                          ") passed to: "
+                          (jrec-tag
+                            (make-jrec
+                              desc
+                              (make-vector 0 jolt-nil)
+                              jolt-nil)))))
+                 (let ((v (make-vector nf jolt-nil)))
+                   (let loop ((as args) (i 0))
+                     (if (null? as)
+                         (make-jrec desc v jolt-nil)
+                         (let ((a (car as)))
+                           (vector-set!
+                             v
+                             i
+                             (if (and (fx< i ndbl)
+                                      (vector-ref dbl-flags i)
+                                      (number? a)
+                                      (not (flonum? a)))
+                                 (exact->inexact a)
+                                 a))
+                           (loop (cdr as) (+ i 1)))))))))
+    (register-class-ctor! tag ctor)
+    (when (or (not (hashtable-ref
+                     class-ctors-tbl
+                     (symbol-t-name name-sym)
+                     #f))
+              (hashtable-ref
+                chez-simple-name-tag
+                (symbol-t-name name-sym)
+                #f))
+      (register-class-ctor! (symbol-t-name name-sym) ctor))
+    (hashtable-set! chez-deftype-tag-set tag #t)
+    (hashtable-set!
+      chez-simple-name-tag
+      (symbol-t-name name-sym)
+      tag)
+    (jch-set-supers! tag '("clojure.lang.IType"))
+    (hashtable-set! chez-deftype-ctor-tag ctor tag)
+    (register-record-shape!
+      (string-append
+        (chez-current-ns)
+        "/->"
+        (symbol-t-name name-sym))
+      kws
+      field-tags
+      tag)
+    ctor))
+
+(define (make-protocol name-str methods)
+  (jolt-hash-map (keyword #f "jolt/type") (keyword #f "jolt/protocol")
+    (keyword #f "name") (jolt-symbol jolt-nil name-str)
+    (keyword #f "methods") methods))
+
+(define (register-protocol-methods! proto-name method-names)
+  (let ((ns (chez-current-ns)))
+    (for-each
+      (lambda (mn)
+        (let ((m (if (symbol-t? mn) (symbol-t-name mn) mn)))
+          (hashtable-set!
+            chez-protocol-methods-tbl
+            (string-append ns "/" m)
+            (cons proto-name m))))
+      (seq->list method-names)))
+  jolt-nil)
+
+(define host-type-set
+  (let ((h (make-hashtable string-hash string=?)))
+    (for-each
+      (lambda (n) (hashtable-set! h n #t))
+      '("Long" "Integer" "Number" "Double" "Ratio" "BigInt"
+        "BigInteger" "String" "CharSequence" "Boolean" "Character"
+        "Keyword" "Symbol" "Named" "Object" "nil" "Fn" "IFn" "AFn"
+        "URI" "Var" "IDeref" "PersistentVector" "APersistentVector"
+        "IPersistentVector" "PersistentArrayMap" "APersistentMap"
+        "IPersistentMap" "PersistentHashSet" "APersistentSet"
+        "IPersistentSet" "ASeq" "ISeq" "IPersistentCollection"
+        "Associative" "Sequential" "PersistentList"
+        "IPersistentList" "IPersistentStack" "Map" "java.util.Map"
+        "List" "java.util.List" "Set" "java.util.Set" "Collection"
+        "java.util.Collection" "Iterable" "java.lang.Iterable"
+        "UUID" "BigDecimal" "Date" "Timestamp" "Instant"
+        "java.sql.Date" "Pattern" "java.util.regex.Pattern"
+        "Duration" "Period" "LocalDate" "LocalTime" "LocalDateTime"
+        "ZonedDateTime" "OffsetDateTime" "OffsetTime" "ZoneId"
+        "ZoneOffset" "Clock" "Year" "YearMonth" "Month" "DayOfWeek"
+        "ChronoUnit" "ChronoField" "TemporalAmount" "TemporalUnit"
+        "TemporalField" "ByteBuffer" "java.nio.ByteBuffer" "[B" "[C"
+        "[I" "[J" "[D" "[Ljava.lang.Object;" "Reader"
+        "java.io.Reader" "Writer" "java.io.Writer" "StringReader"
+        "java.io.StringReader" "PushbackReader"
+        "java.io.PushbackReader" "BufferedReader"
+        "java.io.BufferedReader" "FilterReader"
+        "java.io.FilterReader" "InputStream" "java.io.InputStream"
+        "OutputStream" "java.io.OutputStream"))
+    h))
+
+(define (strip-prefix s p)
+  (let ((pl (string-length p)))
+    (and (> (string-length s) pl)
+         (string=? (substring s 0 pl) p)
+         (substring s pl (string-length s)))))
+
+(define (canonical-host-tag type-name)
+  (let ((base (or (strip-prefix type-name "java.lang.")
+                  (strip-prefix type-name "java.util.regex.")
+                  (strip-prefix type-name "java.util.")
+                  (strip-prefix type-name "java.net.")
+                  (strip-prefix type-name "java.math.")
+                  (strip-prefix type-name "java.time.")
+                  (strip-prefix type-name "clojure.lang.")
+                  type-name)))
+    (cond
+      ((let loop ((i 0))
+         (cond
+           ((fx>=? i (string-length type-name)) #f)
+           ((char=? (string-ref type-name i) #\$) #t)
+           (else (loop (fx+ i 1)))))
+       type-name)
+      ((hashtable-ref host-type-set base #f) base)
+      ((and (not (hashtable-ref
+                   chez-simple-name-tag
+                   type-name
+                   #f))
+            (not (hashtable-ref chez-deftype-tag-set type-name #f))
+            (or (jch-known? base) (jch-known? type-name)))
+       (jch-last-segment type-name))
+      (else #f))))
+
+(define extend-mark "__jolt_extend__")
+
+(define (mark-extend! tag proto-name)
+  (let ((ti (hashtable-ref type-registry tag #f)))
+    (when ti
+      (let ((pi (hashtable-ref ti proto-name #f)))
+        (when pi (hashtable-set! pi extend-mark #t))))))
+
+(define (register-method type-name proto-name method-name
+         fn)
+  (let* ((host (canonical-host-tag type-name))
+         (local (string-append (chez-current-ns) "." type-name))
+         (tag (cond
+                (host host)
+                ((hashtable-ref chez-deftype-tag-set local #f) local)
+                ((hashtable-ref chez-deftype-tag-set type-name #f)
+                 type-name)
+                ((hashtable-ref chez-simple-name-tag type-name #f))
+                (else local))))
+    (register-protocol-method tag proto-name method-name fn)
+    (mark-extend! tag proto-name)
+    jolt-nil))
+
+(define (register-inline-method type-name proto-name
+         method-name fn)
+  (register-protocol-method
+    (string-append (chez-current-ns) "." type-name)
+    proto-name
+    method-name
+    fn)
+  jolt-nil)
+
+(define (register-inline-protocol! type-name proto-name)
+  (let* ((tag (string-append (chez-current-ns) "." type-name))
+         (ti (or (hashtable-ref type-registry tag #f)
+                 (let ((h (make-hashtable string-hash string=?)))
+                   (hashtable-set! type-registry tag h)
+                   h))))
+    (unless (hashtable-ref ti proto-name #f)
+      (hashtable-set!
+        ti
+        proto-name
+        (make-hashtable string-hash string=?))))
+  (let ((iface (cond
+                 ((proto-key-qualified? proto-name)
+                  (proto-iface-name proto-name))
+                 ((dotted-name? proto-name) proto-name)
+                 (else
+                  (let ((fqn (jch-fqn-of-simple proto-name)))
+                    (if (string=? fqn proto-name)
+                        (string-append
+                          (jch-munge-segments (chez-current-ns))
+                          "."
+                          proto-name)
+                        fqn))))))
+    (jch-mark-interface! iface)
+    (jch-register-supers!
+      (string-append (chez-current-ns) "." type-name)
+      (list iface)))
+  jolt-nil)
+
+(define (protocol-resolve proto-name method-name obj)
+  (cond
+    ((and (jrec? obj)
+          (let* ((desc (jrec-desc obj))
+                 (f (find-protocol-method-desc
+                      desc
+                      proto-name
+                      method-name)))
+            (or f
+                (find-protocol-method
+                  (jrdesc-tag desc)
+                  proto-name
+                  method-name)))))
+    ((reified-methods obj) =>
+     (lambda (rm)
+       (or (hashtable-ref rm method-name #f)
+           (let loop ((tags (value-host-tags obj)))
+             (cond
+               ((null? tags)
+                (throw-jvm
+                  'IllegalArgumentException
+                  (string-append "No reified method " method-name)))
+               ((find-protocol-method (car tags) proto-name method-name))
+               (else (loop (cdr tags))))))))
+    (else
+     (let loop ((tags (value-host-tags obj)))
+       (cond
+         ((null? tags)
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " in " proto-name)))
+         ((find-protocol-method (car tags) proto-name method-name))
+         (else (loop (cdr tags))))))))
+
+(define (protocol-dispatch1 proto-name method-name obj)
+  ((protocol-resolve proto-name method-name obj) obj))
+
+(define (protocol-dispatch2 proto-name method-name obj a)
+  ((protocol-resolve proto-name method-name obj) obj a))
+
+(define (protocol-dispatch3 proto-name method-name obj a b)
+  ((protocol-resolve proto-name method-name obj) obj a b))
+
+(define (protocol-dispatch proto-name method-name obj
+         rest-args)
+  (let ((rest (if (jolt-nil? rest-args)
+                  '()
+                  (seq->list rest-args))))
+    (apply
+      (protocol-resolve proto-name method-name obj)
+      obj
+      rest)))
+
+(define jolt-pic-n 4)
+
+(define (jolt-pic-make)
+  (let ((v (make-vector (+ (* jolt-pic-n 2) 2) #f)))
+    (vector-set! v (* jolt-pic-n 2) 0)
+    (vector-set! v (+ (* jolt-pic-n 2) 1) -1)
+    v))
+
+(define (jolt-pic-install v d proto method obj)
+  (let ((f (protocol-resolve proto method obj)))
+    (when d
+      (let ((slot (* (vector-ref v (* jolt-pic-n 2)) 2)))
+        (vector-set! v slot d)
+        (vector-set! v (fx+ slot 1) f)
+        (vector-set!
+          v
+          (* jolt-pic-n 2)
+          (if (fx= (vector-ref v (* jolt-pic-n 2)) (fx- jolt-pic-n 1))
+              0
+              (fx+ (vector-ref v (* jolt-pic-n 2)) 1)))))
+    f))
+
+(define (jolt-pic-rebuild v d proto method obj)
+  (let ((f (protocol-resolve proto method obj)))
+    (when d
+      (let loop ((i 0))
+        (when (fx< i (* jolt-pic-n 2))
+          (vector-set! v i #f)
+          (loop (fx+ i 1))))
+      (vector-set! v 0 d)
+      (vector-set! v 1 f)
+      (vector-set! v (* jolt-pic-n 2) 1)
+      (vector-set! v (+ (* jolt-pic-n 2) 1) jolt-proto-epoch))
+    f))
+
+(define (devirt-resolve type-tag proto-name method-name obj)
+  (or (find-protocol-method type-tag proto-name method-name)
+      (protocol-resolve proto-name method-name obj)))
+
+(define clone-registry
+  (make-hashtable string-hash string=?))
+
+(define (register-clone type-tag proto method fn)
+  (let* ((ti (or (hashtable-ref clone-registry type-tag #f)
+                 (let ((h (make-hashtable string-hash string=?)))
+                   (hashtable-set! clone-registry type-tag h)
+                   h)))
+         (pi (or (hashtable-ref ti proto #f)
+                 (let ((h (make-hashtable string-hash string=?)))
+                   (hashtable-set! ti proto h)
+                   h))))
+    (hashtable-set! pi method fn)
+    jolt-nil))
+
+(define (register-clone* type-name proto method fn)
+  (register-clone
+    (string-append (chez-current-ns) "." type-name)
+    proto
+    method
+    fn))
+
+(define (find-clone type-tag proto method)
+  (let ((ti (hashtable-ref clone-registry type-tag #f)))
+    (and ti
+         (let ((pi (hashtable-ref ti proto #f)))
+           (and pi (hashtable-ref pi method #f))))))
+
+(define (remove-clone! type-tag proto method)
+  (let ((ti (hashtable-ref clone-registry type-tag #f)))
+    (when ti
+      (let ((pi (hashtable-ref ti proto #f)))
+        (when pi (hashtable-delete! pi method))))))
+
+(define (devirt-resolve-fl type-tag proto-name method-name
+         obj)
+  (or (find-clone type-tag proto-name method-name)
+      (devirt-resolve type-tag proto-name method-name obj)))
+
+(define-record-type jiterator
+  (fields (mutable cur))
+  (nongenerative jolt-iterator-v1))
+
+(register-seq-arm! jiterator? jiterator-cur)
+
+(define (condition->message-string c)
+  (if (message-condition? c)
+      (let* ((m (condition-message c))
+             (irr (if (irritants-condition? c)
+                      (condition-irritants c)
+                      '()))
+             (append-irr (lambda ()
+                           (let loop ((xs irr) (acc m))
+                             (if (null? xs)
+                                 acc
+                                 (loop
+                                   (cdr xs)
+                                   (string-append
+                                     acc
+                                     " "
+                                     (jolt-pr-str (car xs)))))))))
+        (if (and (string? m)
+                 (let scan ((i 0))
+                   (cond
+                     ((>= i (string-length m)) #f)
+                     ((char=? (string-ref m i) #\~) #t)
+                     (else (scan (+ i 1))))))
+            (guard (e (#t (append-irr))) (apply format m irr))
+            (append-irr)))
+      (with-output-to-string (lambda () (display-condition c)))))
+
+(def-var!
+  "jolt.host"
+  "condition-message"
+  (lambda (c)
+    (if (condition? c) (condition->message-string c) jolt-nil)))
+
+(define (record-method-dispatch-base obj method-name
+         rest-args)
+  (let ((rest (if (jolt-nil? rest-args)
+                  '()
+                  (seq->list rest-args))))
+    (cond
+      ((and (procedure? obj)
+            (hashtable-ref chez-deftype-ctor-tag obj #f)) =>
+       (lambda (tag)
+         (cond
+           ((or (string=? method-name "getName")
+                (string=? method-name "getCanonicalName")
+                (string=? method-name "getTypeName"))
+            tag)
+           ((string=? method-name "getSimpleName") (last-dot tag))
+           ((string=? method-name "toString")
+            (string-append "class " tag))
+           (else
+            (throw-jvm
+              'IllegalArgumentException
+              (string-append
+                "No method "
+                method-name
+                " on class "
+                tag))))))
+      ((jolt-multifn? obj)
+       (cond
+         ((string=? method-name "addMethod")
+          (hashtable-set!
+            (jolt-multifn-methods obj)
+            (car rest)
+            (cadr rest))
+          obj)
+         ((string=? method-name "removeMethod")
+          (hashtable-delete! (jolt-multifn-methods obj) (car rest))
+          obj)
+         ((string=? method-name "getMethod")
+          (or (hashtable-ref (jolt-multifn-methods obj) (car rest) #f)
+              jolt-nil))
+         ((string=? method-name "getMethodTable")
+          (let ((tbl (jolt-multifn-methods obj)) (m (jolt-hash-map)))
+            (vector-for-each
+              (lambda (k)
+                (set! m (jolt-assoc1 m k (hashtable-ref tbl k #f))))
+              (hashtable-keys tbl))
+            m))
+         ((string=? method-name "toString")
+          (jolt-str-render-one obj))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on MultiFn")))))
+      ((and (jrec? obj)
+            (find-method-any-protocol-arity
+              (jrec-tag obj)
+              method-name
+              (+ 1 (length rest)))) =>
+       (lambda (f) (apply jolt-invoke f obj rest)))
+      ((and (jrec? obj)
+            (null? rest)
+            (jrec-has? obj (keyword #f method-name)))
+       (jrec-lookup obj (keyword #f method-name) jolt-nil))
+      ((and (jrec-record? obj)
+            (member
+              method-name
+              '("valAt" "assoc" "without" "containsKey" "cons" "count"
+                 "seq" "equiv" "entryAt" "empty")))
+       (cond
+         ((string=? method-name "valAt")
+          (if (null? (cdr rest))
+              (jolt-get obj (car rest) jolt-nil)
+              (jolt-get obj (car rest) (cadr rest))))
+         ((string=? method-name "assoc")
+          (jolt-assoc1 obj (car rest) (cadr rest)))
+         ((string=? method-name "without")
+          (jolt-dissoc obj (car rest)))
+         ((string=? method-name "containsKey")
+          (if (jolt-truthy? (jolt-contains? obj (car rest))) #t #f))
+         ((string=? method-name "cons") (jolt-conj1 obj (car rest)))
+         ((string=? method-name "count") (jolt-count obj))
+         ((string=? method-name "seq") (jolt-seq obj))
+         ((string=? method-name "equiv")
+          (if (jolt= obj (car rest)) #t #f))
+         ((string=? method-name "entryAt")
+          (if (jolt-truthy? (jolt-contains? obj (car rest)))
+              (make-map-entry
+                (car rest)
+                (jolt-get obj (car rest) jolt-nil))
+              jolt-nil))
+         (else jolt-nil)))
+      ((reified-methods obj) =>
+       (lambda (rm)
+         (let ((f (hashtable-ref rm method-name #f))
+               (d (jreify-delegate obj)))
+           (cond
+             (f (apply jolt-invoke f obj rest))
+             (d (record-method-dispatch d method-name rest-args))
+             (else
+              (throw-jvm
+                'IllegalArgumentException
+                (string-append "No method " method-name)))))))
+      ((string? obj) (jolt-string-method method-name obj rest))
+      ((jiterator? obj)
+       (cond
+         ((string=? method-name "hasNext")
+          (not (jolt-nil? (jolt-seq (jiterator-cur obj)))))
+         ((string=? method-name "next")
+          (let ((s (jolt-seq (jiterator-cur obj))))
+            (if (jolt-nil? s)
+                (throw-jvm 'NoSuchElementException "iterator exhausted")
+                (let ((v (jolt-first s)))
+                  (jiterator-cur-set! obj (jolt-rest s))
+                  v))))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on Iterator")))))
+      ((string=? method-name "iterator")
+       (make-jiterator (jolt-seq obj)))
+      ((keyword-t? obj)
+       (cond
+         ((string=? method-name "sym")
+          (jolt-symbol (keyword-t-ns obj) (keyword-t-name obj)))
+         ((string=? method-name "getName") (keyword-t-name obj))
+         ((string=? method-name "getNamespace")
+          (or (keyword-t-ns obj) jolt-nil))
+         ((string=? method-name "toString")
+          (string-append
+            ":"
+            (if (keyword-t-ns obj)
+                (string-append (keyword-t-ns obj) "/")
+                "")
+            (keyword-t-name obj)))
+         ((string=? method-name "hashCode")
+          (jolt-s32
+            (+ (java-symbol-hash
+                 (keyword-t-name obj)
+                 (keyword-t-ns obj))
+               2654435769)))
+         ((string=? method-name "equals")
+          (and (pair? rest) (eq? obj (car rest))))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on Keyword")))))
+      ((symbol-t? obj)
+       (cond
+         ((string=? method-name "getName") (symbol-t-name obj))
+         ((string=? method-name "getNamespace")
+          (or (symbol-t-ns obj) jolt-nil))
+         ((string=? method-name "toString")
+          (string-append
+            (if (symbol-t-ns obj)
+                (string-append (symbol-t-ns obj) "/")
+                "")
+            (symbol-t-name obj)))
+         ((string=? method-name "equals")
+          (and (pair? rest) (jolt=2 obj (car rest))))
+         ((string=? method-name "hashCode")
+          (java-symbol-hash (symbol-t-name obj) (symbol-t-ns obj)))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on Symbol")))))
+      ((jns? obj)
+       (cond
+         ((or (string=? method-name "name")
+              (string=? method-name "getName"))
+          (jolt-symbol #f (jns-name obj)))
+         ((string=? method-name "toString") (jns-name obj))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on Namespace")))))
+      ((var-cell? obj)
+       (cond
+         ((string=? method-name "ns") (intern-ns! (var-cell-ns obj)))
+         ((or (string=? method-name "sym")
+              (string=? method-name "name"))
+          (jolt-symbol #f (var-cell-name obj)))
+         ((string=? method-name "getName")
+          (jolt-symbol (var-cell-ns obj) (var-cell-name obj)))
+         ((string=? method-name "toString")
+          (string-append
+            "#'"
+            (var-cell-ns obj)
+            "/"
+            (var-cell-name obj)))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on Var")))))
+      ((condition? obj)
+       (cond
+         ((throwable-method obj method-name rest) => car)
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on Throwable")))))
+      ((char? obj)
+       (cond
+         ((string=? method-name "toString") (string obj))
+         ((string=? method-name "charValue") obj)
+         ((string=? method-name "hashCode") (char->integer obj))
+         ((string=? method-name "equals")
+          (and (pair? rest)
+               (char? (car rest))
+               (char=? obj (car rest))))
+         ((string=? method-name "compareTo")
+          (let ((o (car rest)))
+            (cond ((char<? obj o) -1) ((char>? obj o) 1) (else 0))))
+         (else
+          (throw-jvm
+            'IllegalArgumentException
+            (string-append "No method " method-name " on char")))))
+      ((or (string=? method-name "indexOf")
+           (string=? method-name "lastIndexOf"))
+       (let ((target (car rest))
+             (last? (string=? method-name "lastIndexOf")))
+         (let loop ((s (jolt-seq obj)) (i 0) (found -1))
+           (cond
+             ((jolt-nil? s) found)
+             ((jolt=2 (seq-first s) target)
+              (if last? (loop (jolt-seq (seq-more s)) (fx+ i 1) i) i))
+             (else (loop (jolt-seq (seq-more s)) (fx+ i 1) found))))))
+      ((string=? method-name "contains")
+       (let ((target (car rest)))
+         (let loop ((s (jolt-seq obj)))
+           (cond
+             ((jolt-nil? s) #f)
+             ((jolt=2 (seq-first s) target) #t)
+             (else (loop (jolt-seq (seq-more s))))))))
+      ((string=? method-name "toString")
+       (jolt-str-render-one obj))
+      ((string=? method-name "hashCode") (jolt-hash obj))
+      ((string=? method-name "equals")
+       (and (pair? rest) (if (jolt= obj (car rest)) #t #f)))
+      ((string=? method-name "__methodImplCache") jolt-nil)
+      ((jrec? obj)
+       (let ((boxed (dot-coll-method obj method-name rest)))
+         (if boxed (car boxed) (no-method-throw method-name obj))))
+      (else (no-method-throw method-name obj)))))
+
+(define (no-method-throw method-name obj)
+  (if (jolt-nil? obj)
+      (throw-jvm
+        'NullPointerException
+        (string-append
+          "Cannot invoke \""
+          method-name
+          "\" because the target is null"))
+      (throw-jvm
+        'IllegalArgumentException
+        (string-append
+          "No matching method "
+          method-name
+          " found for "
+          (guard (e (#t "?")) (jolt-class-name obj))))))
+
+(define method-dispatch-arms '())
+
+(define (register-method-arm! priority arm)
+  (set! method-dispatch-arms
+    (let ins ((as method-dispatch-arms))
+      (cond
+        ((null? as) (list (cons priority arm)))
+        ((< priority (caar as)) (cons (cons priority arm) as))
+        (else (cons (car as) (ins (cdr as))))))))
+
+(define arm-priority-getclass 5)
+
+(define arm-priority-dotform 30)
+
+(define arm-priority-date 40)
+
+(define arm-priority-file 41)
+
+(define arm-priority-regex 42)
+
+(define arm-priority-nio-path 42)
+
+(define arm-priority-htable 43)
+
+(define arm-priority-host-type 44)
+
+(define (record-method-dispatch obj method-name rest-args)
+  (let loop ((as method-dispatch-arms))
+    (if (null? as)
+        (record-method-dispatch-base obj method-name rest-args)
+        (let ((r ((cdar as) obj method-name rest-args)))
+          (if (eq? r 'pass) (loop (cdr as)) r)))))
+
+(register-method-arm!
+  arm-priority-getclass
+  (lambda (obj method-name rest-args)
+    (if (string=? method-name "getClass")
+        (jolt-class obj)
+        'pass)))
+
+(define-record-type jreify
+  (fields methods protos delegate)
+  (nongenerative chez-jreify-v2))
+
+(define (reified-methods obj)
+  (and (jreify? obj) (jreify-methods obj)))
+
+(define (reify-delegate obj)
+  (and (jreify? obj) (jreify-delegate obj)))
+
+(register-get-arm!
+  jreify?
+  (lambda (coll k d)
+    (let ((m (and (reified-methods coll)
+                  (hashtable-ref (reified-methods coll) "valAt" #f))))
+      (if m (jolt-invoke m coll k d) d))))
+
+(define (make-reified-delegating methods-map delegate
+         proto-names)
+  (let ((ht (make-hashtable string-hash string=?))
+        (protos (if (and (pair? proto-names)
+                         (null? (cdr proto-names))
+                         (jolt-coll-pred? (car proto-names)))
+                    (seq->list (car proto-names))
+                    proto-names)))
+    (for-each
+      (lambda (p)
+        (hashtable-set!
+          ht
+          (if (keyword? p) (keyword-t-name p) p)
+          (jolt-get methods-map p jolt-nil)))
+      (seq->list (jolt-keys methods-map)))
+    (make-jreify
+      ht
+      (map (lambda (p) (if (symbol-t? p) (symbol-t-name p) p))
+           protos)
+      delegate)))
+
+(define (make-reified methods-map . proto-names)
+  (make-reified-delegating methods-map #f proto-names))
+
+(define (iface-prefers-seq? v)
+  (or (jrec-declares-coll-iface? v)
+      (and (iface-method v "seq" #f) #t)))
+
+(define (iface-iterator-obj v)
+  (and (or (jrec? v) (jreify? v))
+       (not (iface-prefers-seq? v))
+       (iface-method v "iterator" #f)))
+
+(define (iface-iterator-cursor v)
+  (and (or (jrec? v) (jreify? v))
+       (not (iface-prefers-seq? v))
+       (iface-method v "hasNext" #f)))
+
+(define (iterator-cursor->seq it)
+  (jolt-make-lazy-seq
+    (lambda ()
+      (if (jolt-truthy?
+            (record-method-dispatch it "hasNext" jolt-nil))
+          (let ((v (record-method-dispatch it "next" jolt-nil)))
+            (jolt-cons v (iterator-cursor->seq it)))
+          jolt-nil))))
+
+(register-seq-arm!
+  iface-iterator-cursor
+  (lambda (x) (jolt-seq (iterator-cursor->seq x))))
+
+(register-seq-arm!
+  (lambda (x)
+    (and (iface-iterator-obj x)
+         (not (iface-iterator-cursor x))))
+  (lambda (x)
+    (jolt-seq (record-method-dispatch x "iterator" jolt-nil))))
+
+(define (jolt-satisfies? proto obj)
+  (let* ((pn (jolt-get proto (keyword #f "name") jolt-nil))
+         (pn-str (if (symbol-t? pn) (symbol-t-name pn) pn)))
+    (unless (string? pn-str)
+      (throw-jvm
+        'IllegalArgumentException
+        (string-append
+          "satisfies? expects a protocol, got: "
+          (cond
+            ((jclass? proto) (jclass-name proto))
+            ((jolt-nil? proto) "nil")
+            (else (jolt-final-str proto))))))
+    (cond
+      ((jrec? obj) (type-satisfies? (jrec-tag obj) pn-str))
+      ((jreify? obj)
+       (and (memp
+              (lambda (p)
+                (or (string=? p pn-str) (proto-class-match? p pn-str)))
+              (jreify-protos obj))
+            #t))
+      (else
+       (let loop ((tags (value-host-tags obj)))
+         (cond
+           ((null? tags) #f)
+           ((type-satisfies? (car tags) pn-str) #t)
+           (else (loop (cdr tags)))))))))
+
+(define (last-dot s)
+  (let loop ((i (- (string-length s) 1)))
+    (cond
+      ((< i 0) s)
+      ((char=? (string-ref s i) #\.)
+       (substring s (+ i 1) (string-length s)))
+      (else (loop (- i 1))))))
+
+(define (memp pred lst)
+  (cond
+    ((null? lst) #f)
+    ((pred (car lst)) lst)
+    (else (memp pred (cdr lst)))))
+
+(define (extenders proto)
+  (let* ((pn (jolt-get proto (keyword #f "name") jolt-nil))
+         (pn-str (if (symbol-t? pn) (symbol-t-name pn) pn))
+         (out '()))
+    (vector-for-each
+      (lambda (tag)
+        (let ((ti (hashtable-ref type-registry tag #f)))
+          (when ti
+            (let ((pi (hashtable-ref ti pn-str #f)))
+              (when (and pi (hashtable-ref pi extend-mark #f))
+                (set! out (cons (jolt-symbol jolt-nil tag) out)))))))
+      (hashtable-keys type-registry))
+    (if (null? out) jolt-nil (list->cseq out))))
+
+(register-str-render!
+  jrec?
+  (lambda (v)
+    (let ((f (find-protocol-method
+               (jrec-tag v)
+               "Object"
+               "toString")))
+      (if f
+          (jolt-invoke f v)
+          (let ((s (jrec-pr v)))
+            (substring s 1 (string-length s)))))))
+
+(register-str-render!
+  (lambda (v)
+    (and (jreify? v)
+         (reified-methods v)
+         (hashtable-ref (reified-methods v) "toString" #f)
+         #t))
+  (lambda (v)
+    (jolt-invoke
+      (hashtable-ref (reified-methods v) "toString" #f)
+      v)))
+
+(def-var!
+  "clojure.core"
+  "make-deftype-ctor"
+  make-deftype-ctor)
+
+(define (register-record-type! name-sym)
+  (let ((tag (string-append
+               (chez-current-ns)
+               "."
+               (symbol-t-name name-sym))))
+    (hashtable-set! chez-record-type-tbl tag #t)
+    (let ((protos (filter
+                    (lambda (s) (not (string=? s "clojure.lang.IType")))
+                    (jch-direct-supers tag))))
+      (jch-set-supers!
+        tag
+        (append
+          protos
+          '("clojure.lang.IRecord" "clojure.lang.IObj" "clojure.lang.IPersistentMap"
+             "java.util.Map" "clojure.lang.IHashEq"
+             "java.io.Serializable"))))
+    (let ((ctor (hashtable-ref class-ctors-tbl tag #f))
+          (shape (hashtable-ref
+                   chez-record-shapes-tbl
+                   (string-append
+                     (chez-current-ns)
+                     "/->"
+                     (symbol-t-name name-sym))
+                   #f)))
+      (when (and ctor shape)
+        (register-class-statics!
+          tag
+          (list
+            (cons
+              "create"
+              (lambda (m)
+                (let ((kws (vector-ref shape 0)))
+                  (let loop ((rec (apply
+                                    ctor
+                                    (map (lambda (k) (jolt-get m k)) kws)))
+                             (ks (seq->list (jolt-seq (jolt-keys m)))))
+                    (cond
+                      ((null? ks) rec)
+                      ((member (car ks) kws) (loop rec (cdr ks)))
+                      (else
+                       (loop
+                         (jolt-assoc rec (car ks) (jolt-get m (car ks)))
+                         (cdr ks)))))))))))))
+  jolt-nil)
+
+(def-var!
+  "clojure.core"
+  "register-record-type!"
+  register-record-type!)
+
+(def-var! "clojure.core" "make-protocol" make-protocol)
+
+(def-var!
+  "clojure.core"
+  "register-protocol-methods!"
+  register-protocol-methods!)
+
+(def-var! "clojure.core" "register-method" register-method)
+
+(def-var!
+  "clojure.core"
+  "register-inline-method"
+  register-inline-method)
+
+(def-var!
+  "clojure.core"
+  "register-inline-protocol!"
+  register-inline-protocol!)
+
+(def-var! "jolt.host" "set-field!" jolt-set-field!)
+
+(def-var!
+  "clojure.core"
+  "protocol-dispatch"
+  (lambda (pn mn obj rest)
+    (protocol-dispatch pn mn obj rest)))
+
+(def-var!
+  "clojure.core"
+  "protocol-dispatch1"
+  (lambda (pn mn obj) (protocol-dispatch1 pn mn obj)))
+
+(def-var!
+  "clojure.core"
+  "protocol-dispatch2"
+  (lambda (pn mn obj a) (protocol-dispatch2 pn mn obj a)))
+
+(def-var!
+  "clojure.core"
+  "protocol-dispatch3"
+  (lambda (pn mn obj a b) (protocol-dispatch3 pn mn obj a b)))
+
+(def-var! "clojure.core" "satisfies?" jolt-satisfies?)
+
+(def-var! "clojure.core" "extenders" extenders)
+
+(def-var! "jolt.host" "type-satisfies?" type-satisfies?)
+
+(def-var!
+  "jolt.host"
+  "protocol-key-of"
+  (lambda (sym)
+    (or (and (symbol-t? sym)
+             (let ((v (jolt-resolve sym)))
+               (and (var-cell? v) (protocol-value-key (var-cell-root v)))))
+        jolt-nil)))
+
+(def-var!
+  "clojure.core"
+  "make-reified"
+  (lambda (mm . rest) (apply make-reified mm rest)))
+
+(def-var!
+  "clojure.core"
+  "record-method-dispatch"
+  (lambda (obj m rest) (record-method-dispatch obj m rest)))
+

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -1,0 +1,1041 @@
+;; rt-core.ss — the Gambit target's kernel: the port of host/chez/rt.ss's
+;; kernel surface to native gsi (Gambit 4.9.7). G2 (jolt-mj95.3).
+;;
+;; PORT-LOG (every rt.ss region: ported / skipped):
+;;   ported  rt arithmetic/logic shims (jolt-inc/dec/->fx/->fl/not) [151-175]
+;;   ported  ex-info record type [177-187]
+;;   ported  exceptions: jolt-throw-cont/sitep, jolt-catch-complete!,
+;;           jolt-throw/jolt-throw-message/jolt-unwrap-throw, jolt-ex-info,
+;;           jolt-host-throwable, throw-jvm, jolt-capture-fault! [189-211, 366-447]
+;;           -- ADAPTED: Chez's compound-condition raise (make-message-condition +
+;;           define-condition-type &jolt-throw) becomes a tagged (cons 'jolt-throw v);
+;;           guard still catches it and jolt-unwrap-throw recovers v. No manifest
+;;           file reads the condition surface, only raises and catches.
+;;   ported  tail-frame recovery vregs [213-306] -- via the virtual-register/
+;;           set-virtual-register! shims in prelude-shims.ss (one parameter per
+;;           claimed slot; Gambit has no vregs). jolt-vreg-site/catch-line/
+;;           print-readably keep their numbers.
+;;   skipped compile-time callsite tables (jolt-callsite-*, jolt-register-callsite!)
+;;           [308-364] -- consumed only by source-registry.ss (excluded from G2).
+;;   ported  host interop jolt-host-call [449-461] -- record-method-dispatch
+;;           resolves at call time (records.ss); directory-list is Gambit-native.
+;;   ported  var cells: jolt-var, var-cell-lookup, var-deref, def-var!,
+;;           def-var-with-meta!, def-dynvar!, set-var-meta!, mark-macro!,
+;;           macro-var?, declare-var!, the var-meta/macro tables, proc-name-tbl,
+;;           ns-has-vars-set [463-524, 582-630]
+;;   skipped telemetry clocks/memory (jolt-wall-nanos/jolt-mono-nanos, the
+;;           sa-stats def-vars, machine-type/scheme-version) [526-580] -- Chez
+;;           time objects; no manifest consumer. The jolt.host/throwable and
+;;           available-processors def-vars ARE kept.
+;;   ported  jolt number printing [652-759] -- verbatim (Chez's number->string
+;;           layout is what jolt re-arranges; Gambit's number->string for a
+;;           flonum prints the same shortest-round-trip digits).
+;;   ported  *print-level*/*print-length* + with-deeper-print [760-812]
+;;   ported  pr-str fast path + arms + #object fallback [813-924]
+;;   ported  randomness [947-986] -- ADAPTED: no lazy clock-seed; Gambit's
+;;           default random source is process-seeded, so jolt-random is
+;;           (random-integer n) directly.
+;;   skipped OS entropy (jolt-entropy-source + the /dev/urandom / Windows
+;;           paths) [987-1065] -- ADAPTED: jolt-random-bytes fills a bytevector
+;;           with (random-integer 256) per byte. Divergence, documented: not a
+;;           CSPRNG; uniqueness holds, unpredictability does not.
+;;   skipped jolt-foreign-proc-safe macro [52-69] -- a procedural transformer
+;;           needing with-syntax in its body (Gambit cannot see top-level macros
+;;           there); its only users were the cpu-count region, which is skipped.
+;;   skipped cpu-count region [71-133] -- jolt-available-processors returns 1.
+;;   skipped the (load "host/chez/...") orchestration -- boot.ss splices this
+;;           file; the manifest is boot.ss's job.
+;;
+;; Sits above the value model (values.ss) and below an emitted program. Adds the
+;; two things the back end's output references that aren't in the value layer:
+;;   1. the var-cell late-binding registry (Clojure vars — a global root that a
+;;      reference reads at call time, so redefinition / mutual recursion work);
+;;   2. the rt primitive shims the emitter names (jolt-inc/dec/not) and jolt's
+;;      number printing (all jolt numbers model Clojure doubles; integer-valued
+;;      print without a trailing ".0").
+;; Emitted programs do `(load "host/chez/rt.ss")`; this loads values.ss in turn.
+
+;; Chez-compat preamble — must precede EVERYTHING else in the runtime bring-up
+;; (every load path enters through this file). Two adaptations for vendored
+;; portable R[457]RS code (vendor/irregex) and for host code generally:
+;; a cond-expand at expression position (Chez's is library-only), and `error`
+;; called with a lone string (Chez's error wants who+msg). Both are normalized
+;; without changing behavior for standard-shape calls.
+(define-syntax cond-expand
+  (syntax-rules (else)
+    ((_ (else e ...)) (begin e ...))
+    ((_ (else e ...) c ...) (begin e ...))
+    ((_ (req e ...) c ...) (cond-expand c ...))
+    ((_) (if #f #f))))
+(define %chez-error error)
+(define (error . args)
+  (if (and (pair? args) (string? (car args)))
+      (apply %chez-error #f args)
+      (apply %chez-error args)))
+
+;; The scheme-adapter runtime loads FIRST: top-levels below (and in the
+;; java/*.ss loads) call sa-* entry points. rt.ss owning this load makes every
+;; loader of rt.ss — boot scripts, gate harnesses, emitted programs — correct
+;; by construction; a boot file loading it earlier is a harmless re-define.
+;; SKIPPED on the gambit target: jolt-foreign-proc-safe (a procedural
+;; transformer whose body needs with-syntax — Gambit cannot see top-level
+;; macros there) and the whole cpu-count region, which was its only user.
+;; jolt-available-processors: this target reports 1 usable processor (G2
+;; divergence; pmap look-ahead windows read it).
+(define (jolt-available-processors) 1)
+
+;; --- version ------------------------------------------------------------------
+;; One source of truth for the jolt version string, read by jolt.host/jolt-version
+;; (loader.ss), (System/getProperty "jolt.version"), and clojure.core/*jolt-version*
+;; (dynamic-var-defaults.ss). A self-contained binary bakes the release tag by
+;; emitting (define jolt-baked-version-early "…") at the TOP of flat.ss
+;; (build-jolt.ss) — early so every consumer that loads later sees it. A dev run
+;; has no baked define and falls back to $JOLT_VERSION (bin/jolt sets it from
+;; `git describe`), then "dev".
+(define (jolt-version-string)
+  (or (sa-baked-global 'jolt-baked-version-early)
+      (let ((v (getenv "JOLT_VERSION"))) (and v (> (string-length v) 0) v))
+      "dev"))
+
+;; --- rt arithmetic / logic shims (named in the emitter's native-ops) ----------
+(define (jolt-inc x) (+ (jolt-need-num x) 1))
+(define (jolt-dec x) (- (jolt-need-num x) 1))
+;; longCast/doubleCast coerce a primitive-hinted parameter or return: ^long
+;; truncates a flonum toward zero and passes an exact integer through, ^double
+;; widens any number. The hint is a promise the body's fx*/fl* ops rely on, so a
+;; value outside the tower is the JVM's cast failure (ClassCastException, or NPE
+;; for nil) — a raw host error would escape with no class for a catch to select.
+;; A ^long is a 64-bit value; a Chez fixnum is only 61-bit, so a value that
+;; overflows the fixnum range (a full-width long, e.g. from unchecked / wrapping
+;; arithmetic) passes through as an exact integer rather than erroring. fx ops in
+;; the body still require fixnums (they raise on a bignum), but generic /
+;; unchecked-* ops handle it.
+(define (jolt->fx x)
+  (cond ((fixnum? x) x)
+        ((and (number? x) (exact? x) (integer? x)) x)
+        ((flonum? x) (exact (truncate x)))
+        ((rational? x) (exact (truncate x)))
+        (else (jolt-num-cast-throw x))))
+(define (jolt->fl x)
+  (cond ((flonum? x) x)
+        ((number? x) (exact->inexact x))
+        (else (jolt-num-cast-throw x))))
+;; jolt `not`: only nil and false are falsey.
+(define (jolt-not x) (if (jolt-truthy? x) #f #t))
+
+;; --- ex-info record type -----------------------------------------------------
+;; A throwable (ex-info or host-constructed typed throwable) is a distinct
+;; record type — NOT a pmap — so pmap?/coll?/seqable?/ifn?/associative?/
+;; counted? are naturally false without per-kind exclusion arms.
+;; Equality: identity (records default to identity equality — (= e e2) false,
+;; (= e e) true, matching the JVM where ExceptionInfo does NOT implement
+;; equals). get / keyword lookup: MISS (record is NOT ILookup).
+;; error-offset stores ParseException.getErrorOffset (0 when not set).
+(define-record-type jolt-ex-info-record
+  (fields class-name message cause data (mutable error-offset))
+  (nongenerative jolt-ex-info-record-v1))
+
+;; --- exceptions --------------------------------------------------------------
+;; throw raises a Chez condition WRAPPING the jolt value; catch (emitted as
+;; `guard`) and jolt-report-uncaught unwrap it back via jolt-unwrap-throw.
+;; Raising the value RAW broke when a throw crossed the host/`eval` boundary:
+;; Chez re-wrapped the non-condition into a compound condition whose
+;; message-extraction APPLIES the value (crashing on an empty-map :data ->
+;; "attempt to apply non-procedure"), and the real message was lost. A real
+;; condition propagates intact through any number of eval boundaries.
+;; Capture the live continuation at the throw site (identity-tagged with the
+;; thrown value) so an uncaught error can walk the native frames back to a Clojure
+;; stack trace (source-registry.ss). call/cc is paid only on a throw, never per
+;; call; the captured k is walked, never invoked.
+(define jolt-throw-cont (make-thread-parameter #f))
+;; The site vreg's ('ns/fn' . line) pair as it stood AT the raise (R2, bead
+;; jolt-knn8). Only tail sites write the vreg, so its live value can be a
+;; returned call's residue — the reporter must see the throw-time snapshot,
+;; validated against the callsite tables, never the live slot.
+(define jolt-throw-sitep (make-thread-parameter #f))
+
+;; Cleared after a catch handler completes normally so the parked continuation
+;; (and its captured frames) does not root live data until the next throw.
+(define (jolt-catch-complete!)
+  (jolt-throw-cont #f) (jolt-throw-sitep #f))
+
+;; --- tail-frame recovery: compile-time tables + one vreg store (R4) ----------
+;; TCO erases tail-called frames from the native continuation, so an uncaught
+;; error's backtrace shows only the surviving non-tail spine — the immediate
+;; error site is often a tail call and is missing. When tracing is enabled
+;; (JOLT_TRACE, wired in compile-eval.ss), the emitter instruments TAIL CALL
+;; SITES ONLY, and the instrumentation is ONE virtual-register store of a
+;; static ('ns/fn' . line) pair — no allocation, no marks, no per-entry work.
+;; Erased chains are reconstructed at REPORT time from the callsite tables
+;; (above): backward from the throw-time pair through unambiguous tail-entry
+;; edges, forward from each live frame's registered callee through unambiguous
+;; tail exits. Two earlier designs died here: the R0 ring push cost ~10x on
+;; call-heavy code, and the R1-R3 continuation-marks ribs ballooned the heap
+;; to tens of GB on delegation-heavy code (rewrite-clj's zipper suite: 40s ->
+;; 300s timeout; every hop's mark op allocated). What ships is the JVM model:
+;; all metadata compile-time, the stack itself the only runtime record.
+(define jolt-trace-on? #f)
+;; Per-thread trace state lives in Chez VIRTUAL REGISTERS, not thread parameters:
+;; a thread-parameter WRITE costs ~32ns against ~1ns for a virtual-register write
+;; (measured, Chez 10.4 arm64), and jolt-site! sits on the hot path. Reads are
+;; ~2.4ns vs ~3.3ns, a smaller but free win.
+;;
+;; Virtual registers are a fixed global resource: (virtual-register-count) slots for
+;; the whole process (16 on every platform jolt targets). jolt claims three, allocated
+;; here so the assignment is in one place; nothing else in the runtime uses them.
+;; A freshly forked thread starts every slot at fixnum 0, NOT #f, so "unset" means
+;; fixnum 0 (the site slots hold a site pair or 0). Slots 0 and 1 are FREE since
+;; R3 (jolt-230w) removed the R1 ring/mark vregs — the tail marks live on the
+;; continuation, not in a vreg — so new virtual-register users should claim them
+;; before renumbering anything. The surviving slots keep their R2 numbers.
+(define jolt-vreg-site 2)        ; ('ns/fn' . line) of the innermost live call site
+(define jolt-vreg-catch-line 3)  ; the site at the throw a catch clause is handling
+(define jolt-vreg-print-readably 4)  ; the print family's *print-readably* override; 0 = unset
+;; Effective *print-readably* for the readable renderer's string/char cases. The
+;; print family stashes its override in the slot above — a virtual-register write
+;; is ~1ns vs a pmap alloc + fold + two thread-parameter writes per dynamic
+;; binding — and only consults the var when the slot is unset. A fresh thread
+;; starts the slot at fixnum 0, so a stored #f (readably off) stays distinct from
+;; "unset"; jolt-var/-get resolve at call time (vars.ss / rt.ss load later).
+;; Resolved once and reused: jolt-var rebuilds "clojure.core/*print-readably*"
+;; with string-append and hashes it on every call, which on a per-item path is
+;; the whole cost of the lookup. The cell is stable under redefinition —
+;; def-var! mutates the root in place — and jolt-var-get still consults the
+;; binding stack, so a (binding [*print-readably* …]) is honoured. Lazily, since
+;; vars.ss/rt.ss finish loading after this point. Same shape as pm-cell
+;; (io-streams.ss) and the cells the backend emits for compiled code.
+(define pr-readably-cell #f)
+(define (jolt-pr-readable?)
+  (let ((o (virtual-register jolt-vreg-print-readably)))
+    (if (eq? o 0)
+        (begin
+          (unless pr-readably-cell
+            (set! pr-readably-cell (jolt-var "clojure.core" "*print-readably*")))
+          (jolt-truthy? (jolt-var-get pr-readably-cell)))
+        (jolt-truthy? o))))
+(define (jolt-trace-enable!) (set! jolt-trace-on? #t))
+
+;; TAIL call emissions store their static ('ns/fn' . line) pair here right
+;; before the call (sited-tail-call / the :throw case). Since R2 (bead
+;; jolt-knn8) NOTHING else writes it — non-tail code carries no per-call
+;; instrumentation — so the live slot can hold a returned chain's residue.
+;; Consumers therefore read the THROW-TIME snapshot (jolt-throw-sitep), and the
+;; reporter validates it against the callsite table before splicing.
+(define (jolt-site! p) (set-virtual-register! jolt-vreg-site p))
+;; The line to report for the INNERMOST frame. Inside a catch clause that is the
+;; line the throw came from, snapshotted on the way in; else the pair stashed at
+;; the raise. Never the live vreg — it can be stale between throws.
+(define (jolt-throw-line)
+  (let ((c (virtual-register jolt-vreg-catch-line)))
+    (if (pair? c)
+        (let ((l (cdr c))) (and (fixnum? l) (fx>? l 0) l))
+        (let ((s (jolt-throw-sitep)))
+          (if (pair? s)
+              (let ((l (cdr s))) (and (fixnum? l) (fx>? l 0) l))
+              #f)))))
+;; The site pair ('ns/fn' . line) of the innermost call at the throw — the
+;; catch-line snapshot when a handler is running, else the raise-time stash.
+;; #f when unset. The reporter must validate this against the callsite table
+;; (jolt-callsite-callee) before trusting the name.
+(define (jolt-throw-site)
+  (let ((c (virtual-register jolt-vreg-catch-line)))
+    (if (pair? c)
+        c
+        (let ((s (jolt-throw-sitep)))
+          (and (pair? s) s)))))
+;; Emitted around a catch clause's body: snapshot the throwing site and return the
+;; previous snapshot, which the paired leave restores. Save/restore rather than a
+;; bare set so a nested catch cannot leave an inner throw's site behind for an
+;; outer handler that runs afterwards. Reads the raise-time stash, not the live
+;; vreg — by handler time the handler's context is what the vreg describes.
+(define (jolt-catch-enter!)
+  (let ((prev (virtual-register jolt-vreg-catch-line))
+        (cur (jolt-throw-sitep)))
+    (set-virtual-register! jolt-vreg-catch-line (if (pair? cur) cur 0))
+    prev))
+
+;; --- compile-time callsite tables (R2 + R4, beads jolt-knn8 / jolt-hm1p) -----
+;; (jolt-register-callsite! "ns/f" line "ns/callee" tail?): the emitter
+;; registers, at def load time, the STATIC callee of each call site in a traced
+;; fn. Costs nothing per call — this is the metadata the reporter reconstructs
+;; TCO-erased chains from (R4: there is NO runtime chain recording at all; Chez
+;; continuation marks at production volume ballooned the heap to tens of GB on
+;; delegation-heavy code, so the whole marks layer was replaced by these tables
+;; plus the two vreg site stores).
+;; Three views, all load-time-built, report-time-read:
+;;   all sites:  (fqn:line) -> callees     — the staleness validator's evidence
+;;   tail exits: fqn -> ((line . callee)…) — forward walk: how a fn left its
+;;                                           frame (the TCO hop it made)
+;;   tail entries: callee -> ((fqn . line)…) — backward walk: who could have
+;;                                             tail-called the erased fn
+;; A line can carry several calls (an operand and its outer call share it), so
+;; every view holds LISTS of distinct entries; walks follow only UNAMBIGUOUS
+;; edges and stop at the first fork, so a reconstruction can be incomplete but
+;; never invented.
+(define jolt-callsite-table (make-hashtable string-hash string=?))
+(define jolt-tail-exits (make-hashtable string-hash string=?))
+(define jolt-tail-entries (make-hashtable string-hash string=?))
+;; fn -> every callee it registers anywhere: the validator's second evidence
+;; tier, because a CATCH context's frame can resolve to an imprecise line (the
+;; guard's establishment point, not the failing try's) and a line-keyed lookup
+;; then reads the wrong site's callees.
+(define jolt-fn-callees-table (make-hashtable string-hash string=?))
+(define (jolt-callsite-key fqn line)
+  (string-append fqn ":" (number->string line)))
+(define (jolt-table-add! tbl key entry)
+  (let ((cur (hashtable-ref tbl key '())))
+    (unless (member entry cur)
+      (hashtable-set! tbl key (cons entry cur)))))
+(define (jolt-register-callsite! fqn line callee tail?)
+  (jolt-table-add! jolt-callsite-table (jolt-callsite-key fqn line) callee)
+  (jolt-table-add! jolt-fn-callees-table fqn callee)
+  (when tail?
+    (jolt-table-add! jolt-tail-exits fqn (cons line callee))
+    (jolt-table-add! jolt-tail-entries callee (cons fqn line)))
+  jolt-nil)
+;; The registered static callees at (fqn, line) as a non-empty list, or #f
+;; (unknown / dynamic site — nothing was registered).
+(define (jolt-callsite-callees fqn line)
+  (and (string? fqn) (fixnum? line)
+       (let ((v (hashtable-ref jolt-callsite-table (jolt-callsite-key fqn line) '())))
+         (and (pair? v) v))))
+;; A fn's registered tail exits ((line . callee)…) / tail entries ((fqn . line)…).
+(define (jolt-callsite-tail-exits fqn)
+  (and (string? fqn) (hashtable-ref jolt-tail-exits fqn '())))
+(define (jolt-callsite-tail-entries fqn)
+  (and (string? fqn) (hashtable-ref jolt-tail-entries fqn '())))
+;; Every callee a fn registers, at any line, or #f when the fn is unregistered.
+(define (jolt-callsite-fn-callees fqn)
+  (and (string? fqn)
+       (let ((v (hashtable-ref jolt-fn-callees-table fqn '())))
+         (and (pair? v) v))))
+(define (jolt-catch-leave! prev)
+  (set-virtual-register! jolt-vreg-catch-line (if (pair? prev) prev 0)))
+
+
+
+;; GAMBIT ADAPTATION (see port-log): Chez's compound-condition raise becomes a
+;; tagged pair (cons 'jolt-throw v). guard still catches it, and
+;; jolt-unwrap-throw recovers v. jolt-throw-condition?/jolt-throw-condition-value
+;; keep their names and meaning.
+(define (jolt-throw-condition? x) (and (pair? x) (eq? (car x) 'jolt-throw)))
+(define (jolt-throw-condition-value x) (cdr x))
+;; Fallback &message for a leaked condition; the real message always comes from
+;; the unwrapped value via ex-message.
+(define (jolt-throw-message v)
+  (if (jolt-ex-info-record? v)
+      (let ((m (jolt-ex-info-record-message v)))
+        (if (string? m) m "jolt error"))
+      "jolt error"))
+(define (jolt-throw v)
+  (call/cc (lambda (k)
+             (jolt-throw-cont (cons v k))
+             (jolt-throw-sitep (let ((s (virtual-register jolt-vreg-site)))
+                                 (and (pair? s) s)))
+             (raise (cons 'jolt-throw v)))))
+;; The same capture for a HOST condition (a fault raised outside jolt-throw:
+;; car of a non-pair, a bad flvector index). Installed by the cli's run wrapper
+;; via with-exception-handler, which runs BEFORE the stack unwinds — a guard's
+;; handler runs after, when the frames are already gone. Identity-tagged with
+;; the condition itself, which is what jolt-unwrap-throw hands the reporter for
+;; a non-&jolt-throw raise. jolt throws skip this (they captured already, with
+;; the RIGHT identity — overwriting would orphan their k).
+(define (jolt-capture-fault! c)
+  (unless (jolt-throw-condition? c)
+    ;; NO call/cc here: Chez already attaches &continuation to a serious
+    ;; condition, and jolt-error-continuation reads it — a per-raise capture
+    ;; would heap-freeze a whole stack for every INTERNALLY-CAUGHT host
+    ;; condition, which a hot raise path cannot afford. Only the site pair is
+    ;; stashed; an O(1) read.
+    (jolt-throw-sitep (let ((s (virtual-register jolt-vreg-site)))
+                        (and (pair? s) s)))))
+(define (jolt-unwrap-throw x)
+  (if (jolt-throw-condition? x) (jolt-throw-condition-value x) x))
+;; ex-info builds a jolt-ex-info-record (NOT a pmap — pmap?/coll?/seqable?/ifn?
+;; /associative?/counted? are naturally false). Arity 2 (msg data) or 3 (msg data cause).
+;; No :jolt/class field on plain ex-info — class defaults to clojure.lang.ExceptionInfo
+;; via ex-info-class in records-interop.ss.
+(define (jolt-ex-info msg data . more)
+  (make-jolt-ex-info-record "clojure.lang.ExceptionInfo" msg
+                             (if (null? more) jolt-nil (car more))
+                             data 0))
+;; A host-constructed throwable (RuntimeException. etc.): a jolt-ex-info-record
+;; carrying its canonical JVM class-name, so (class …) / instance? / .getMessage /
+;; ex-message all reflect the real type.
+;; java.text.ParseException carries an int error offset (getErrorOffset). Stored
+;; in the record's error-offset field.
+(define (jolt-host-throwable class-name msg . more)
+  (make-jolt-ex-info-record class-name msg
+                             (if (null? more) jolt-nil (car more))
+                             jolt-nil 0))
+
+;; throw-jvm: raise a typed JVM throwable by simple class name.
+;; (throw-jvm 'NoSuchElementException msg) -> (jolt-throw (jolt-host-throwable
+;;   "java.util.NoSuchElementException" msg)). The symbol->FQN table covers the
+;; common exception types so call sites read as a bare symbol; an explicit FQN
+;; string is also accepted for anything not in the table.
+;; An unlisted simple name resolves through the modeled class hierarchy once
+;; class-hierarchy.ss loads (it patches this to jch-fqn-of-simple). Until then —
+;; during early boot before that file loads — a bare name is the only answer.
+(define jvm-throwable-fqn-fallback (lambda (sym) (symbol->string sym)))
+(define jvm-throwable-fqn
+  (lambda (sym)
+    (case sym
+      ((IllegalArgumentException) "java.lang.IllegalArgumentException")
+      ((IllegalStateException) "java.lang.IllegalStateException")
+      ((ArithmeticException) "java.lang.ArithmeticException")
+      ((NumberFormatException) "java.lang.NumberFormatException")
+      ((UnsupportedOperationException) "java.lang.UnsupportedOperationException")
+      ((NoSuchElementException) "java.util.NoSuchElementException")
+      ((NoSuchFieldException) "java.lang.NoSuchFieldException")
+      ((IndexOutOfBoundsException) "java.lang.IndexOutOfBoundsException")
+      ((ClassCastException) "java.lang.ClassCastException")
+      ((NullPointerException) "java.lang.NullPointerException")
+      ((ArityException) "clojure.lang.ArityException")
+      ((IllegalAccessError) "java.lang.IllegalAccessError")
+      (else (jvm-throwable-fqn-fallback sym)))))
+(define (throw-jvm type msg)
+  (jolt-throw (jolt-host-throwable (jvm-throwable-fqn type) msg)))
+
+;; --- host interop ------------------------------------------------------------
+;; (.method target arg*) with method in backend supported-host-methods
+;; (isDirectory/listFiles) lowers to (jolt-host-call "method" target arg*). Those
+;; map onto Chez path operations when the receiver is a path STRING; a File value
+;; is intercepted by io.ss's wrapper before reaching here. Any other receiver (a
+;; deftype/record with its own .isDirectory) routes to the normal method dispatch
+;; instead of misapplying file ops to it. record-method-dispatch is loaded later
+;; (records.ss) and resolved at call time.
+(define (jolt-host-call method target . args)
+  (cond
+    ((and (string=? method "isDirectory") (string? target)) (if (file-directory? target) #t #f))
+    ((and (string=? method "listFiles") (string? target)) (list->cseq (directory-list target)))
+    (else (record-method-dispatch target method (apply jolt-vector args)))))
+
+;; --- var cells: late-bound global roots (Clojure vars) -----------------------
+;; A var is a mutable cell keyed by "ns/name". A `:def` sets the root; a `:var`
+;; reference reads it at use time (late binding), so a forward/mutually-recursive
+;; reference resolves to whatever the cell holds when the call actually runs.
+;; declare / (def name) with no init, and a forward var-deref on a not-yet-defined
+;; name, reserve a cell whose root is a per-cell unbound sentinel. Per-cell (not a
+;; single global) so it names its var like the JVM's Var$Unbound, and every read
+;; surface (a plain read, var-get, deref/@) returns the SAME object.
+(define-record-type jolt-var-unbound (fields ns name) (nongenerative jolt-var-unbound-v1))
+;; `defined?` distinguishes a genuinely interned var (def / declare / a native-op
+;; cell) from a cell lazily materialised by a forward `var-deref` / `(var x)` on a
+;; not-yet-defined name — `resolve` returns the cell iff defined?.
+;; ns-unmap clears it. Avoids the (def x nil) edge of probing the root.
+(define-record-type var-cell (fields ns name (mutable root) (mutable defined?)) (nongenerative var-cell-v2))
+(define var-table (make-hashtable string-hash string=?))
+(define (jolt-var ns name)
+  (let ((k (string-append ns "/" name)))
+    (or (hashtable-ref var-table k #f)
+        (let ((c (make-var-cell ns name (make-jolt-var-unbound ns name) #f)))
+          (hashtable-set! var-table k c)
+          c))))
+;; non-creating lookup (resolve / find-var / ns-unmap): #f when absent, so a
+;; probe never interns an empty cell.
+(define (var-cell-lookup ns name) (hashtable-ref var-table (string-append ns "/" name) #f))
+(define (var-deref ns name) (var-cell-root (jolt-var ns name)))
+;; def-var! / declare-var! return the VAR CELL, not the value — Clojure's `def`
+;; evaluates to #'ns/name (a first-class var), so (var? (def x 1)) is true and
+;; (pr-str (def x 1)) is "#'ns/x". The prelude's def-var! forms discard the
+;; return, so this is transparent there.
+;; proc -> (ns . name) for the var it was def'd into, so (class a-fn) can report a
+;; JVM-style class name and clojure.spec.alpha's fn-sym can recover the symbol of a
+;; bare-fn predicate. Weak so GC'd fns drop out. Last def of a given proc wins.
+(define proc-name-tbl (make-weak-eq-hashtable))
+(define (def-var! ns name v)
+  ;; first def of a given proc wins, so an alias like (def inc' inc) — which binds
+  ;; the SAME proc to a second var — doesn't rename inc.
+  (when (and (procedure? v) (not (hashtable-contains? proc-name-tbl v)))
+    (hashtable-set! proc-name-tbl v (cons ns name)))
+  (hashtable-set! ns-has-vars-set ns #t)
+  (let ((c (jolt-var ns name))) (var-cell-root-set! c v) (var-cell-defined?-set! c #t) c))
+;; Value-position comparison references compile to the seq.ss chain singletons
+;; (jolt-lt/gt/le/ge), not to the clojure.core var roots — the roots were later
+;; re-bound by the checked numeric layer, so def-var! never saw these procs.
+;; Register them so a stored comparator like (sorted-map-by >) travels as a
+;; fn-ref (by name) like any other named core fn.
+(hashtable-set! proc-name-tbl jolt-lt (cons "clojure.core" "<"))
+(hashtable-set! proc-name-tbl jolt-gt (cons "clojure.core" ">"))
+(hashtable-set! proc-name-tbl jolt-le (cons "clojure.core" "<="))
+(hashtable-set! proc-name-tbl jolt-ge (cons "clojure.core" ">="))
+;; Set of ns-name strings that have at least one var — makes ns-has-vars? O(1)
+;; instead of scanning the entire var-table per require-miss. Updated in def-var!
+;; (and wherever vars are removed, though removal is rare).
+(define ns-has-vars-set (make-hashtable string-hash string=?))
+;; jolt.host/throwable — build a typed throwable a library can throw so (class …),
+;; instance?, .getMessage and ex-message all reflect the named JVM class (e.g. an
+;; http client throwing java.net.ConnectException). Strictly better than a
+;; hand-rolled :jolt/ex-info table, which carries only the class.
+(def-var! "jolt.host" "throwable" jolt-host-throwable)
+;; jolt.host/available-processors — the host's usable CPU count (see above). The
+;; JVM spelling of the same question, Runtime.availableProcessors, is mapped in
+;; the java layer (java/process.ss); clojure.core reaches it through here.
+(def-var! "jolt.host" "available-processors" (lambda () (jolt-available-processors)))
+
+;; SKIPPED on the gambit target: the telemetry primitives region (wall/mono
+;; clocks, sa-stats counters, thread-id, machine-type/scheme-version) — Chez
+;; time objects and Chez-shipped statistics; no manifest consumer needs them
+;; (see port-log). jolt.host/throwable + available-processors above are kept.
+
+;; var def-time metadata: the :def emit passes the def's reader meta
+;; (^:private / ^Type tag / docstring -> {:doc}) here, stored in an eq side-table
+;; keyed by the cell. jolt-meta (natives-meta.ss) merges it onto {:ns :name},
+;; which it derives from the cell — so EVERY var (plain def, native-op, declare)
+;; reports {:ns :name} like Clojure, with the user meta layered on when present.
+(define var-meta-table (make-eq-hashtable))
+(define jolt-kw-var-ns (keyword #f "ns"))
+(define jolt-kw-var-name (keyword #f "name"))
+(define jolt-kw-var-macro (keyword #f "macro"))
+(define (def-var-with-meta! ns name v m)
+  (let ((c (def-var! ns name v))) (hashtable-set! var-meta-table c m) c))
+;; A runtime-defined DYNAMIC var (the *earmuffed* core vars): tagged :dynamic so
+;; push-thread-bindings accepts it — with no meta entry a var is non-dynamic and
+;; binding throws, like the JVM.
+(define (def-dynvar! ns name v)
+  (def-var-with-meta! ns name v
+    (jolt-hash-map (keyword #f "dynamic") #t)))
+;; Attach meta to an already-interned var (the declare/no-init emission path:
+;; (def ^:dynamic *x*) must be bindable before its root is set).
+(define (set-var-meta! ns name m)
+  (hashtable-set! var-meta-table (jolt-var ns name) m))
+;; runtime-macro registry: a var whose root holds a macro
+;; expander fn is flagged here, so the ON-CHEZ analyzer's form-macro?/form-expand-1
+;; (host-contract.ss) expand it. The prelude emits each core/stdlib defmacro as a
+;; def-var! of its (cross-compiled) expander followed by (mark-macro! ns name).
+;; Keyed by cell (eq), like var-meta-table — survives a later (def name ...) that
+;; replaces the expander but keeps the same cell, matching Clojure (a defmacro IS a
+;; def whose var carries :macro).
+(define var-macro-table (make-eq-hashtable))
+(define (mark-macro! ns name)
+  (let ((c (jolt-var ns name))) (hashtable-set! var-macro-table c #t) c))
+(define (macro-var? cell) (and cell (hashtable-ref var-macro-table cell #f) #t))
+;; declare / (def name) with no init: reserve the cell ONLY if absent. An
+;; existing root is left intact — Clojure's (def x) with no init does not clobber
+;; a prior binding (do (def x 7) (def x) x) => 7. Returns the cell either way.
+(define (declare-var! ns name)
+  (let* ((k (string-append ns "/" name))
+         (c (hashtable-ref var-table k #f)))
+    (if c
+        ;; a declare marks an ALREADY-interned cell resolvable — set-var-meta!
+        ;; (jolt-var) may have interned it undefined? first (the no-init def with
+        ;; metadata emits set-var-meta! then declare-var!), so without this a
+        ;; declaration-only var stays defined?=#f and resolve/find-var/ns-interns
+        ;; miss it in an AOT build. The existing root is left intact.
+        (begin (var-cell-defined?-set! c #t) c)
+        (let ((c (make-var-cell ns name (make-jolt-var-unbound ns name) #t)))  ; declared => interned/resolvable
+          (hashtable-set! var-table k c)
+          c))))
+
+;; regex: defines regex-t + the re-* fns (def-var!'d into
+;; clojure.core), so it loads after def-var! and before the printer below (which
+;; renders a regex-t as #"source").
+
+;; atoms: host-coupled mutable cells; def-var!'d into clojure.core
+;; (atom/deref/swap!/reset! + the compare/vals kernel). Loads after def-var! and
+;; jolt-invoke (seq.ss) / jolt= (values.ss) / jolt-vector (collections.ss).
+
+;; refs: Clojure refs and serialized transactions (STM).  Loaded after atoms
+;; (shares the IRef seam and jolt-deref); must load before loader.ss (wires
+;; *loaded-libs*) and before concurrency.ss (which chains jolt-deref further).
+
+;; type predicates + simple accessors: seed natives the overlay
+;; assumes (map?/vector?/nil?/number?/.../name/namespace), def-var!'d into
+;; clojure.core. Loads after the value-model record predicates they wrap.
+
+;; --- jolt number printing ----------------------------------------------------
+;; jolt has a numeric tower (exact integer / ratio / double, distinguished by
+;; class). Exact integer-valued values print without a ".0" ((+ 1 2) -> "3");
+;; a double prints with one ((* 1.0 5) -> "5.0", as the JVM does).
+
+;; Double.toString layout: plain decimal when 1e-3 <= |x| < 1e7, otherwise
+;; scientific d.dddE±x with one digit before the point; the mantissa always
+;; carries a decimal point ("1.0E100", "2.3E-4", "1.2345678E7"). Chez's
+;; shortest-round-trip digits are kept; only the layout is rearranged.
+(define (jolt-flonum->string x)
+  (let* ((s (number->string x))
+         (neg? (char=? (string-ref s 0) #\-))
+         (body0 (if neg? (substring s 1 (string-length s)) s))
+         ;; Chez appends a "|prec" suffix to subnormal strings (e.g. "5e-324|1").
+         ;; Strip it before the exponent substring is parsed, else string->number
+         ;; misreads "-324|1" as a precision-qualified flonum (-256.0) and corrupts
+         ;; the value.
+         (bar (let loop ((i 0))
+                (cond ((fx>=? i (string-length body0)) #f)
+                      ((char=? (string-ref body0 i) #\|) i)
+                      (else (loop (fx+ i 1))))))
+         (body (if bar (substring body0 0 bar) body0))
+         (blen (string-length body))
+         (epos (let loop ((i 0))
+                 (cond ((fx>=? i blen) #f)
+                       ((memv (string-ref body i) '(#\e #\E)) i)
+                       (else (loop (fx+ i 1))))))
+         (mant (if epos (substring body 0 epos) body))
+         (eexp (if epos (string->number (substring body (fx+ epos 1) blen)) 0))
+         (mlen (string-length mant))
+         (dot (let loop ((i 0))
+                (cond ((fx>=? i mlen) #f)
+                      ((char=? (string-ref mant i) #\.) i)
+                      (else (loop (fx+ i 1))))))
+         (digits (if dot
+                     (string-append (substring mant 0 dot) (substring mant (fx+ dot 1) mlen))
+                     mant))
+         (point (+ (if dot dot mlen) eexp)))
+    ;; normalize: drop leading zeros (adjusting the point), then trailing zeros
+    (let* ((dlen0 (string-length digits))
+           (lead (let loop ((i 0))
+                   (if (and (fx<? i (fx- dlen0 1)) (char=? (string-ref digits i) #\0))
+                       (loop (fx+ i 1)) i)))
+           (digits (substring digits lead dlen0))
+           (point (- point lead))
+           (dlen (let loop ((i (string-length digits)))
+                   (if (and (fx>? i 1) (char=? (string-ref digits (fx- i 1)) #\0))
+                       (loop (fx- i 1)) i)))
+           (digits (substring digits 0 dlen))
+           (res (cond
+                  ((string=? digits "0") "0.0")
+                  ((and (>= point -2) (<= point 7))   ; 1e-3 <= |x| < 1e7
+                   (cond
+                     ((<= point 0)
+                      (string-append "0." (make-string (- point) #\0) digits))
+                     ((>= point dlen)
+                      (string-append digits (make-string (- point dlen) #\0) ".0"))
+                     (else (string-append (substring digits 0 point) "."
+                                          (substring digits point dlen)))))
+                  (else
+                   (string-append (substring digits 0 1) "."
+                                  (if (fx>? dlen 1) (substring digits 1 dlen) "0")
+                                  "E" (number->string (- point 1)))))))
+      (if neg? (string-append "-" res) res))))
+
+(define (jolt-num->string x)
+  (cond
+    ;; the -e / element printer renders the infinities and NaN in READABLE form
+    ;; (##Inf reads back, like Clojure's REPL/pr); str/print uses "Infinity"/"NaN"
+    ;; (see jolt-str-render-one in converters.ss).
+    ((and (flonum? x) (fl= x +inf.0)) "##Inf")
+    ((and (flonum? x) (fl= x -inf.0)) "##-Inf")
+    ((and (flonum? x) (not (fl= x x))) "##NaN")
+    ;; str of a bigint has NO N suffix (BigInt.toString); only the readable
+    ;; printer adds it (see jolt-pr-readable-base).
+    ((and (exact? x) (integer? x)) (number->string x))
+    ((flonum? x) (jolt-flonum->string x))
+    (else (number->string x))))
+;; true when an exact integer prints with the BigInt N suffix under pr.
+;; number? first — Chez's exact? raises on a non-number, and the readable
+;; printer probes every value through this.
+(define (jolt-bigint-print? x)
+  (and (number? x) (exact? x) (integer? x)
+       (or (> x 9223372036854775807) (< x -9223372036854775808))))
+
+;; Program-final-value printer. jolt's `-e` prints in str-style: strings raw (no
+;; quotes), chars as `\c`/`\newline`, collections recursively. NOTE: maps/sets
+;; render in HAMT-iteration order, which is not a stable insertion order —
+;; so unordered values are compared via `=` (true/false), not printed form.
+(define (jolt-str-join strs)
+  (cond ((null? strs) "") ((null? (cdr strs)) (car strs))
+        (else (string-append (car strs) " " (jolt-str-join (cdr strs))))))
+;; map ENTRIES join with ", " like the reference printer: {:a 1, :b 2}
+(define (jolt-str-join-comma strs)
+  (cond ((null? strs) "") ((null? (cdr strs)) (car strs))
+        (else (string-append (car strs) ", " (jolt-str-join-comma (cdr strs))))))
+(define (jolt-char->string c)
+  (if (jolt-pr-readable?)
+      (string-append "\\" (case c ((#\newline) "newline") ((#\space) "space") ((#\tab) "tab")
+                                  ((#\return) "return") ((#\backspace) "backspace") ((#\page) "formfeed")
+                                  (else (string c))))
+      (string c)))
+;; Render a value for a MESSAGE — a host exception's text ("<x> cannot be cast
+;; to …"), a gate's divergence report. str-style at the top level, where a bare
+;; nil renders as the empty string (a nil ELEMENT inside a collection still prints
+;; "nil", which jolt-pr-str handles). The `-e` / REPL result printer is
+;; jolt-repl-str (printing.ss), which is readable instead.
+(define (jolt-final-str x) (if (jolt-nil? x) "" (jolt-pr-str x)))
+;; --- *print-level* / *print-length* -----------------------------------------
+;; Both vars default to nil (= unlimited). A non-nil number limits collection
+;; nesting depth / element count in BOTH printers (jolt-pr-str here and
+;; jolt-pr-readable in printing.ss). Cells captured lazily — the vars are def'd
+;; after rt.ss. The nil default takes a fast path: jolt-print-hash? is #f and the
+;; limited-string walkers never truncate.
+(define plevel-cell #f)
+(define plength-cell #f)
+(define (jolt-print-level)
+  (unless plevel-cell (set! plevel-cell (jolt-var "clojure.core" "*print-level*")))
+  (let ((v (jolt-var-get plevel-cell))) (and (number? v) v)))
+(define (jolt-print-length)
+  (unless plength-cell (set! plength-cell (jolt-var "clojure.core" "*print-length*")))
+  (let ((v (jolt-var-get plength-cell))) (and (number? v) v)))
+(define jolt-print-depth (make-thread-parameter 0))
+;; A collection at depth >= *print-level* renders as "#". The top-level collection
+;; is depth 0, so *print-level* 0 collapses any collection, 1 keeps the outermost.
+(define (jolt-print-hash?)
+  (let ((lvl (jolt-print-level))) (and lvl (fx>=? (jolt-print-depth) lvl))))
+;; Rendered element strings of a vector (by index), honoring *print-length*: at
+;; most N, then "...". render-one runs at the current (already bumped) depth.
+(define (jolt-limited-vec-strs x render-one)
+  (let ((len (pvec-count x)) (lim (jolt-print-length)))
+    (let loop ((i 0) (acc '()))
+      (cond ((fx>=? i len) (reverse acc))
+            ((and lim (fx>=? i lim)) (reverse (cons "..." acc)))
+            (else (loop (fx+ i 1) (cons (render-one (pvec-nth-d x i jolt-nil)) acc)))))))
+;; Rendered element strings of a seq, walked lazily so an infinite seq is realized
+;; only up to *print-length*.
+(define (jolt-limited-seq-strs s render-one)
+  (let ((lim (jolt-print-length)))
+    (let loop ((s s) (i 0) (acc '()))
+      (cond ((jolt-nil? s) (reverse acc))
+            ((and lim (fx>=? i lim)) (reverse (cons "..." acc)))
+            (else (loop (jolt-seq (seq-more s)) (fx+ i 1) (cons (render-one (seq-first s)) acc)))))))
+;; Truncate an already-collected element-string list (set / map, finite) to
+;; *print-length*, appending "..." when more remain.
+(define (jolt-limited-list-strs strs)
+  (let ((lim (jolt-print-length)))
+    (if (not lim) strs
+        (let loop ((s strs) (i 0) (acc '()))
+          (cond ((null? s) (reverse acc))
+                ((fx>=? i lim) (reverse (cons "..." acc)))
+                (else (loop (cdr s) (fx+ i 1) (cons (car s) acc))))))))
+;; bump the print depth around a collection's element rendering — but only when
+;; *print-level* is set, since depth is consulted only to enforce it. With the
+;; common nil default this is a plain begin, so printing pays no parameterize.
+(define-syntax with-deeper-print
+  (syntax-rules ()
+    ((_ body ...) (if (jolt-print-level)
+                      (parameterize ((jolt-print-depth (fx+ (jolt-print-depth) 1))) body ...)
+                      (begin body ...)))))
+
+;; The value types the runtime itself owns: Chez immediates plus the two value
+;; records (keyword, symbol) no host shim can model. Every printer base case
+;; renders these directly, so walking the arm registries for one is dead work —
+;; and in print-heavy code they are nearly every value. Both printers and the str
+;; renderer skip straight to their base case for a value that answers true here.
+;;
+;; The correctness condition is that NO registered arm may match one of these, or
+;; the fast path would silently bypass it. That is enforced at registration
+;; (pr-arm-reject-fast-type!) rather than left to a comment, so a library shim
+;; registering through __register-pr! / __register-str! cannot introduce an arm
+;; the fast path would skip: it fails loudly at the point of registration instead
+;; of rendering wrongly at some later print.
+(define (pr-fast-type? x)
+  (or (number? x)
+      (string? x)
+      (jolt-nil? x)
+      (eq? x #t)
+      (eq? x #f)
+      (char? x)
+      (keyword? x)
+      (jolt-symbol? x)))
+
+;; One representative per fast-path type, covering the numeric tower (fixnum,
+;; bignum, ratio, flonum) since an arm could plausibly claim only one of those.
+(define pr-fast-probes
+  (list 0 (expt 2 70) 1/2 1.5 "s" jolt-nil #t #f #\a
+        (keyword #f "k") (jolt-symbol #f "s")))
+;; Shares reject-fast-type-claim! (values.ss) with the eq and hash registries,
+;; which enforce the same invariant over their own — narrower — fast paths.
+(define (pr-arm-reject-fast-type! who pred)
+  (reject-fast-type-claim! who pred pr-fast-probes
+                           "the printer fast path (see pr-fast-type? in rt.ss)"))
+
+;; A host shim registers a type's str-style rendering via register-pr-str-arm! (or
+;; register-pr-arm! in printing.ss for both printers at once) instead of
+;; set!-wrapping jolt-pr-str. Disjoint types, checked before the base cases.
+(define jolt-pr-str-arms '())
+(define (register-pr-str-arm! pred render)
+  (pr-arm-reject-fast-type! 'register-pr-str-arm! pred)
+  (set! jolt-pr-str-arms (cons (cons pred render) jolt-pr-str-arms)))
+;; Fallback rendering for a value no printer branch claims. The JVM prints an
+;; unknown object as #object[<class> <hash> <toString>]; jolt used to hand the
+;; value to Chez's writer, which leaked the internal record layout into
+;; user-visible output — (pr-str (atom 1)) read #[jolt-atom-v3 1 () …] and
+;; (pr-str (io/file "/tmp/x")) read #[jolt-jfile-v1 /tmp/x]. Rendering the
+;; #object[…] shape here fixes every host type at once, so a per-type print arm
+;; becomes a refinement rather than the only thing standing between a value and
+;; Chez syntax.
+;;
+;; Content is the value's str rendering, taken STRAIGHT from the str registry
+;; rather than through jolt-str-render-one, whose own fallback is this function —
+;; going through it would recurse. Types with no str arm print bare, like the
+;; JVM's default Object.toString. readable? quotes the content, which is the
+;; (pr x) vs (print x) difference on the JVM. The identity hash is omitted, as
+;; jolt omits it in the print arms it already has.
+(define (jolt-object-content x)
+  (let loop ((rs str-render-registry))
+    (cond ((null? rs) #f)
+          (((caar rs) x) ((cdar rs) x))
+          (else (loop (cdr rs))))))
+(define (jolt-object-repr x readable?)
+  (let ((cls (guard (e (#t #f)) (jolt-class-name x)))
+        (content (guard (e (#t #f)) (jolt-object-content x))))
+    (cond ((not (string? cls)) (format "~a" x))
+          ((not (string? content)) (string-append "#object[" cls "]"))
+          (readable? (string-append "#object[" cls " \"" (jolt-str-escape content) "\"]"))
+          (else (string-append "#object[" cls " " content "]")))))
+
+;; readable? reaches only the #object[…] fallback: every other branch renders the
+;; same either way, and the readable printer handles the types that differ (string
+;; quoting, ##Inf) before it delegates here.
+(define (jolt-pr-str-base x) (jolt-pr-str-base/readable x #f))
+(define (jolt-pr-str-base/readable x readable?)
+  (cond
+    ((jolt-nil? x) "nil")
+    ((eq? x #t) "true")
+    ((eq? x #f) "false")
+    ((number? x) (jolt-num->string x))
+    ((string? x) x)
+    ((char? x) (jolt-char->string x))
+    ((keyword? x) (let ((ns (keyword-t-ns x)))
+                    (if ns (string-append ":" ns "/" (keyword-t-name x)) (string-append ":" (keyword-t-name x)))))
+    ((jolt-symbol? x) (let ((ns (symbol-t-ns x)))
+                        (if (or (jolt-nil? ns) (not ns) (eq? ns '())) (symbol-t-name x)
+                            (string-append ns "/" (symbol-t-name x)))))
+    ((regex-t? x) (string-append "#\"" (regex-t-source x) "\""))
+    ((pvec? x) (if (jolt-print-hash?) "#"
+                   (with-deeper-print
+                     (string-append "[" (jolt-str-join (jolt-limited-vec-strs x jolt-pr-str)) "]"))))
+    ((pset? x) (if (jolt-print-hash?) "#"
+                   (with-deeper-print
+                     (string-append "#{" (jolt-str-join (jolt-limited-list-strs
+                       (pset-fold x (lambda (e a) (cons (jolt-pr-str e) a)) '()))) "}"))))
+    ((pmap? x) (if (jolt-print-hash?) "#"
+                   (with-deeper-print
+                     (string-append "{" (jolt-str-join-comma (jolt-limited-list-strs
+                       (pmap-fold x (lambda (k v a) (cons (string-append (jolt-pr-str k) " " (jolt-pr-str v)) a)) '()))) "}"))))
+    ;; lists / cons / lazy seqs all print as (...) — forces a finite seq (or up to
+    ;; *print-length* of an infinite one).
+    ((empty-list-t? x) (if (jolt-print-hash?) "#" "()"))
+    ((cseq? x) (if (jolt-print-hash?) "#"
+                   (with-deeper-print
+                     (string-append "(" (jolt-str-join (jolt-limited-seq-strs x jolt-pr-str)) ")"))))
+    (else (jolt-object-repr x readable?))))
+(define (jolt-pr-str x) (jolt-pr-str/readable x #f))
+(define (jolt-pr-str/readable x readable?)
+  (if (pr-fast-type? x)
+      (jolt-pr-str-base/readable x readable?)
+      (let loop ((as jolt-pr-str-arms))
+        (cond ((null? as) (jolt-pr-str-base/readable x readable?))
+              (((caar as) x) ((cdar as) x))
+              (else (loop (cdr as)))))))
+
+;; converters + string ops: str/subs/vec/keyword/symbol/compare/int/
+;; double/gensym — host-coupled seed natives def-var!'d into clojure.core. Loaded
+;; LAST because `str` reuses jolt-pr-str (defined just above).
+
+;; transients: copy-on-write transient collections + persistent disj;
+;; extends get/count/contains? to see through a transient. After collections.ss
+;; (the persistent ops it delegates to).
+
+;; seq-native shims: mapcat/take-while/drop-while/partition/sort +
+;; reduced/reduced?/identical? — seed-native fns the overlay assumes are core
+;; natives. Over the seq layer + jolt-compare, so loaded after converters.ss.
+
+;; readable printer + output seams: __pr-str1/__write/
+;; __with-out-str/__eprint/__eprintf — the host seams the overlay print family
+;; (pr-str/pr/prn/print/println/*-str) is built on. After converters.ss (uses
+;; jolt-pr-str/jolt-str-join) + seq.ss (jolt-invoke).
+
+;; --- randomness -------------------------------------------------------------
+;; Chez's PRNG starts every thread from the SAME fixed seed, and the state is
+;; per-thread rather than shared. Both halves of that diverge from Clojure, where
+;; rand/rand-int/Math.random run off one process-global java.util.Random seeded
+;; from the clock:
+;;
+;;   - across processes, every jolt run replayed one identical stream, so two
+;;     unrelated processes agreed on every "random" value — including every
+;;     random-uuid, so a fleet minted colliding UUIDs;
+;;   - across threads, each forked thread restarted that same stream from the
+;;     top, so N request threads drew N identical values in ONE process.
+;;
+;; Seeding lazily on first use covers both: a thread that never draws pays
+;; nothing, and one that does is seeded before its first value. Seed from the
+;; clock (as the JVM does) mixed with pid and thread id so two threads starting
+;; inside the same nanosecond still diverge, and a counter so that even a
+;; coarse clock cannot hand out one seed twice.
+;; GAMBIT ADAPTATION (see port-log): no lazy clock-seed. Gambit's default
+;; random source is already seeded from time+pid at process start, so the
+;; Chez seeding machinery (random-seeded?/random-seed-counter/seed-random!)
+;; is deleted; every jolt-level draw is (random-integer n), same [0, n) contract
+;; as Chez's (random n).
+(define (jolt-random n) (random-integer n))
+
+;; GAMBIT ADAPTATION (see port-log): no OS CSPRNG on this target — the whole
+;; entropy-source region (/dev/urandom, BCryptGenRandom, the warn-once
+;; fallback) is deleted. jolt-random-bytes fills a bytevector with
+;; (random-integer 256) per byte. Divergence, documented: uniqueness holds,
+;; unpredictability does not (random-uuid values stay unique per process, but
+;; are guessable — acceptable for G2, wrong for anything security-sensitive).
+(define (jolt-random-bytes n)
+  (let ((bv (make-bytevector n 0)))
+    (let loop ((i 0))
+      (if (fx=? i n)
+          bv
+          (begin (bytevector-u8-set! bv i (random-integer 256))
+                 (loop (fx+ i 1)))))))
+
+;; collection constructors + rand: bind the public
+;; clojure.core names hash-map/hash-set/array-map/set/rand to the existing
+;; pmap/pset ctors. After collections.ss (the ctors) + seq.ss (seq->list).
+
+;; bit ops + parse-long/parse-double: host-coupled scalar
+;; seed natives over the all-flonum number model.
+
+;; multimethods: defmulti/defmethod dispatch runtime. Needs jolt-invoke
+;; (seq.ss), jolt=/key-hash/jolt-hash-map (collections.ss), jolt-atom? (atoms.ss),
+;; jolt-pr-str (above), and the var-cell machinery — so loaded last.
+
+;; the single JVM class/interface graph — value-host-tags, instance?, isa?/supers,
+;; and the exception hierarchy all derive from it. Before records.ss so
+;; value-host-tags can build on jch-tags.
+
+;; records + protocols: defrecord/deftype/defprotocol/
+;; extend-type/reify. A jrec record type set!-extended into the collection
+;; dispatchers + a protocol registry. After multimethods.ss (chez-current-ns) and
+;; the dispatchers/printers it wraps (collections/seq/values/converters/printing/
+;; transients).
+
+;; metadata: meta / with-meta over an identity-keyed
+;; side-table. After records.ss (jrec) + the collection ctors it copies.
+
+;; host class tokens: bare class names (String/Keyword/File...) ->
+;; canonical JVM class-name strings + (class x). After natives-meta.ss (jolt-type)
+;; and the printer (jolt-str-render-one).
+
+;; dynamic vars: *clojure-version* / *unchecked-math* constants the host
+;; binds natively. After collections.ss (jolt-hash-map) + def-var!.
+
+;; host tables + sorted collections: jolt.host/tagged-table/
+;; ref-put!/ref-get + the 25-sorted tier's runtime (sorted-map/sorted-set routed
+;; through their :ops table). Loaded LAST — wraps the jrec-extended dispatchers
+;; (records.ss), jolt-disj (transients.ss), and value-host-tags (records.ss).
+
+;; lazy-seq bridge: make-lazy-seq / coll->cells over the
+;; cseq model — unblocks every overlay fn built on the lazy-seq macro (repeat/
+;; iterate/cycle/dedupe/take-nth/keep/interpose/reductions/tree-seq/lazy-cat).
+;; Loaded LAST so %ls-seq captures the fully-extended (sorted-aware) jolt-seq.
+
+;; transducer surface: native volatile boxes, cat, +
+;; the transduce/sequence entry points over into-xform/reduce-seq. After
+;; natives-seq.ss (into-xform), seq.ss (reduce-seq) + atoms.ss (deref).
+
+;; vars as first-class objects: var?/var-get/deref/invoke/=/
+;; pr-str over the rt.ss var-cell. After natives-transduce.ss (chains deref) + the
+;; printers. emit lowers :the-var to (jolt-var ns name).
+
+;; misc scalar natives: UUID (random-uuid/parse-uuid/uuid?), format/
+;; printf, tagged-literal, bigint. After the printers + converters (str/pr-str of
+;; a uuid). Overlay names (uuid?/random-uuid/parse-uuid/tagged-literal?) re-asserted
+;; in post-prelude.ss.
+
+;; format / printf: the %-directive engine. After natives-misc.ss + converters.ss
+;; (jolt-str-render-one).
+
+;; extension points: the keyed provider registry core declares a
+;; contract on and a library fills in (jolt.host/register-extension-point! /
+;; register-extension! / refine-extension! / extension-value). Host-neutral — the
+;; java layer and libraries are clients. After collections.ss (jolt maps),
+;; converters.ss + the printers (error messages render values), and rt.ss's
+;; throw-jvm.
+
+;; namespaces: the namespace value model — find-ns/ns-name/
+;; all-ns/the-ns/create-ns/in-ns/ns-publics/ns-map/ns-interns/ns-aliases/resolve/
+;; find-var/ns-unmap/*ns*, over the var-table + chez-current-ns. Loaded LAST: needs
+;; var-cell + var-cell-defined?, jolt-symbol/jolt-hash-map/jolt-assoc, chez-current-ns
+;; (multimethods.ss), list->cseq (seq.ss), and the fully-patched printers (vars.ss).
+
+;; dynamic var binding: the per-thread binding stack +
+;; push/pop/get-thread-bindings/__thread-bound?/var-set/alter-var-root/__local-var.
+;; Chains var-deref (rt.ss) and jolt-var-get (vars.ss) onto the stack, so a `binding`
+;; frame is seen by every var read. Loaded LAST: needs the fully-extended var-read
+;; paths + jolt-hash-map/pmap-fold/pmap-assoc (collections.ss).
+
+;; java.lang.String method interop: jolt-string-method, the
+;; portable String/CharSequence surface record-method-dispatch falls through to on
+;; a string target. After regex.ss (jolt-re-pattern/regex-t-irx) + records.ss
+;; (which references jolt-string-method).
+
+;; host class statics + constructors: host-static-ref/
+;; host-static-call/host-new + the jhost method registry. Loads LAST — it extends
+;; record-method-dispatch (records.ss) and reuses natives-str helpers (str-trim,
+;; ascii-string-down, re-split, str-split-drop-trailing) + the regex-t accessors.
+
+;; generic dot-form dispatch: field access + map/vector member access
+;; for the `.` / `.-field` desugar. Loads after host-static.ss so it wraps every
+;; record-method-dispatch arm (jhost/number/regex/jrec/string) and falls through.
+
+;; java.io.File + host file I/O: path-backed jfile record, slurp/spit/
+;; flush, file-seq dir primitives, clojure.java.io/file. Loads LAST so its jfile
+;; arm wraps the fully-built record-method-dispatch and the str/type/instance-check
+;; extensions sit over every prior shim.
+
+;; #inst values + the java.util/java.text date layer: jinst (RFC3339 ms), Date,
+;; sql.Date/Timestamp, Calendar, TimeZone, SimpleDateFormat. Loads LAST — it
+;; extends record-method-dispatch / jolt-get / jolt= / jolt-hash / jolt-pr-str /
+;; jolt-type / instance-check and uses host-static.ss's registries. libc time
+;; primitives (zone offset, locale names) exposed as jolt.host vars, used by the
+;; library's zone/localized layer.
+
+;; java.time is split (RFC 0008): the base VALUE types (Instant, LocalDate/Time/
+;; DateTime, Duration, Period, Year/YearMonth, enums) are portable Clojure under
+;; stdlib/jolt/time/, autoloaded on first use by host-static.ss with no dependency.
+;; Everything that formats or names a zone (DateTimeFormatter, ZoneOffset/ZoneId,
+;; ZonedDateTime/OffsetDateTime, localized formatting, java.util.Locale) is the
+;; jolt-lang/time library — one implementation of each, not carried in core.
+
+;; Chez-side data reader: read-string / __parse-next /
+;; __read-tagged. Loads after inst-time.ss — __read-tagged reuses its #uuid/#inst
+;; constructors, and the reader needs the full value/collection layer above.
+
+;; clojure.math: native flonum-math shims def-var!'d into the
+;; clojure.math ns. Self-contained (only def-var! + Chez math), order-independent.
+
+;; reader/macro runtime support: #?() feature set, reader-conditional + re-matcher
+;; tagged-map ctors, macroexpand. After ns.ss; macroexpand call-time-refs the macro
+;; table (host-contract) + analyzer ctx.
+
+;; Java-style arrays: object/typed array constructors + a jolt-array
+;; backing; extends count/nth/seq/get/ref-put! so the overlay aget/aset/alength see
+;; it. After the dispatchers it chains.
+
+;; java.io byte/char streams (FileInputStream/…/ByteArrayOutputStream/Buffered*)
+;; over Chez ports. After io.ss (extends its slurp/__close/reader-jhost?) and
+;; natives-array.ss (the byte-array <-> bytevector bridge).
+
+;; java.lang.ProcessBuilder / Process. After io-streams (make-in-stream /
+;; make-out-stream) and host-static-methods (all-env-pairs).
+;; proxy: extends-by-delegation over a concrete host class. After host-static.ss
+;; (host-new + the ctor table it probes), records-interop.ss (instance-check) and
+;; io-streams.ss, so a proxy over a stream class finds its constructor.
+
+;; clojure.lang.PersistentQueue: a functional queue + EMPTY static.
+;; Chains seq/count/empty?/peek/pop/conj/sequential?/class/instance?/printer, so
+;; load after natives-array (the dispatchers it extends).
+
+;; syntax-quote form builders: __sqcat/__sqvec/__sqmap/__sqset/
+;; __sq1, def-var!'d into clojure.core. A cross-compiled macro expander (analyzer
+;; on Chez) calls these to build its expansion as reader forms. Needs the
+;; collection/seq layer + def-var!; order-independent past those.
+
+;; concurrency: real OS-thread futures + blocking promises, shared-heap
+;; (JVM) semantics. Loaded LAST — chains the fully-built jolt-deref and conveys the
+;; thread-local binding stack (dyn-binding.ss) into workers. pmap/pcalls/pvalues
+;; (overlay, over `future`) light up once future-call exists here.
+
+;; clojure.core.async: real-thread blocking channels + go/go-loop/
+;; thread macros, def-var!'d into clojure.core.async. After concurrency.ss (reuses
+;; ms->duration) and the collection/seq layer.
+
+;; BigDecimal: the jbigdec value type + bigdec/decimal?/class/equality/
+;; printing. Loads LAST so its set!-wraps of jolt-class/jolt=2/the printers sit
+;; outermost over every earlier extension.
+
+;; Native stack traces: jv$ns$name -> source registry + continuation frame walk +
+;; uncaught-throwable renderer. After the printers/equality it relies on.
+
+;; Unique anon-fn names -> {source form, ns, free locals} for the image write
+;; side. Plain defines (no def-var! / manifest lines): only emitted code and the
+;; image writer call them, never Clojure.
+
+;; State images: dump the value graph to a file and read it back. Loads LAST —
+;; walks jolt collections, var cells and atoms, prints paths through the printers,
+;; and reads proc-name-tbl to write a fn as its var's name.


### PR DESCRIPTION
Round G2 of the Gambit JS backend epic (jolt-mj95): the full curated kernel manifest — 39 files through host-contract — boots on native Gambit, with the jolt reader and readable printer at byte-parity with the Chez build. `(jolt-pr-readable (jolt-read-string "[1 :kw {\"s\" 2/3} #{sym}]"))` renders identical to Chez `pr-str`, quoting, ratios and sets included.

## The phase wall and its solution

Gambit expands an entire `##include` unit before evaluating any of it, so a procedural macro transformer that calls runtime helpers — records.ss's `define-jrec-family` — is unexpandable there (the same wall as `with-syntax`). `gen-records.ss` solves it the seed-mint way: run ON CHEZ, it reads records.ss as data, evals the transformer, applies it to each use, and `syntax->datum` yields the exact expansion with no lowering, written to a generated `records-gambit.ss` (parens only — Gambit rejects Chez brackets). The pattern is reusable for any expansion-hostile macro.

## The target-owned kernel

rt.ss is Chez's kernel; `host/gambit/rt-core.ss` is Gambit's — the def-var!/var-cell table, throw machinery, `__register-*` seams, printer core and vreg surface ported from rt.ss's spec, with the Chez FFI/entropy/process regions skipped (those capabilities raise via the adapter).

## Gates

`make gambitkernel` (113 checks, detection-gated): collection ops through the real natives, seq walking with lazy producers forced through the printer, renders pinned to Chez-captured strings (escapes, chars, ##Inf/##NaN, bigint N, ratios, namespaced keywords), reader round-trips compared by jolt= and re-render, collection hasheq vs Chez values, meta round-trip, def-var!/var-deref. gambitcheck stays green; full gate green — 56 ci targets (MAKE_EXIT=0). New shims this round: fold-left/fold-right (Gambit's fold flips the proc arg order), hashtable-clear!, format's #f/port first-arg shapes.

Next: G3 cross-mints the :gambit seed on Chez and lights up compile-eval — jolt evaluating on Gambit; G4 compiles the stack to the JS bundle for the browser demo.