### PR TITLE
make gambitweb; bind the clojure.core names the java/ tree owns; readable host errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ JOLT-TARGETS-NEEDING-DEPS := \
   values wp ci
 
 # Only mark PHONY targets for names that have file system conflicts:
-.PHONY: build install test ci gate-run-test gate-run-ci gate-status
+.PHONY: build install test ci gate-run-test gate-run-ci gate-status \
+        gambitcheck gambitkernel gambiteval gambitseed gambitweb
 
 default:: build
 
@@ -568,6 +569,7 @@ certify:
 # cleanly when gambit-scheme is absent. NEVER bare gsc/gsi (gsc on PATH is
 # Ghostscript): always the brew-prefix binary.
 GAMBIT_GSI := $(shell brew --prefix gambit-scheme 2>/dev/null)/bin/gsi
+GAMBIT_GSC := $(shell brew --prefix gambit-scheme 2>/dev/null)/bin/gsc
 gambitcheck:
 	@if [ -x "$(GAMBIT_GSI)" ]; then \
 		"$(GAMBIT_GSI)" host/gambit/gambitcheck.ss; \
@@ -587,12 +589,31 @@ gambitkernel:
 
 # G3 eval gate: real jolt source through jolt-compile-eval on the booted
 # manifest + cross-minted seed, renders pinned to Chez captures. Detection-
-# gated like gambitcheck; boots the full seed so it takes ~1 min on gsi.
+# gated like gambitcheck and NOT in the ci list — it boots the full seed, so
+# it takes about a minute on gsi. Run from the repo root.
 gambiteval:
 	@if [ -x "$(GAMBIT_GSI)" ]; then \
 		"$(GAMBIT_GSI)" host/gambit/eval-test.ss; \
 	else \
 		echo "gambiteval: gambit-scheme not installed (brew) — skipped"; \
+	fi
+
+# The browser bundle: the whole stack (kernel + seed + compiler + a queue-polling
+# REPL loop) compiled to one JavaScript file by the Gambit backend. ~30s, ~32MB
+# raw / ~4MB gzipped, which is what a web server ships. Point GAMBIT_WEB_OUT at
+# a site checkout to refresh the live demo:
+#   make gambitweb GAMBIT_WEB_OUT=../jolt-lang.github.io/resources/static/js/jolt-web.js
+# NEVER bare gsc — that is Ghostscript on a brew machine.
+GAMBIT_WEB_OUT ?= target/gambit/jolt-web.js
+gambitweb:
+	@if [ -x "$(GAMBIT_GSC)" ]; then \
+		mkdir -p "$$(dirname "$(GAMBIT_WEB_OUT)")"; \
+		out="$$(cd "$$(dirname "$(GAMBIT_WEB_OUT)")" && pwd)/$$(basename "$(GAMBIT_WEB_OUT)")"; \
+		(cd host/gambit && "$(GAMBIT_GSC)" -target js -exe -o "$$out" repl-main.ss); \
+		echo "gambitweb: $(GAMBIT_WEB_OUT) ($$(wc -c < "$$out" | tr -d ' ') bytes,\
+ $$(gzip -c "$$out" | wc -c | tr -d ' ') gzipped)"; \
+	else \
+		echo "gambitweb: gambit-scheme not installed (brew) — skipped"; \
 	fi
 
 # G3 compiler-on-gsi (jolt-mj95.4): cross-mint the Gambit seed from the Chez
@@ -601,16 +622,6 @@ gambiteval:
 # Runs on CHEZ (gambitseed), not gsi.
 gambitseed:
 	$(CHEZ) --script host/gambit/gen-seed.ss
-
-# G3 gate (jolt-mj95.4): 40+ jolt source rows through jolt-compile-eval on
-# native gsi via the gambit boot + seed. Detection-gated like gambitkernel;
-# NOT in the ci list. Run from the repo root.
-gambiteval:
-	@if [ -x "$(GAMBIT_GSI)" ]; then \
-		"$(GAMBIT_GSI)" host/gambit/eval-test.ss; \
-	else \
-		echo "gambiteval: gambit-scheme not installed (brew) — skipped"; \
-	fi
 
 # Re-mint the seed after changing a seed source (reader/analyzer/backend/core).
 remint:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![tests](https://github.com/jolt-lang/jolt/actions/workflows/tests.yml/badge.svg)](https://github.com/jolt-lang/jolt/actions/workflows/tests.yml)
 
-A Clojure implementation on [Chez Scheme](https://cisco.github.io/ChezScheme/).
-Jolt reads Clojure source, analyzes it to a host-neutral IR, emits Scheme, and
-runs it on Chez. The compiler is self-hosted: it is written in Clojure
-(`jolt-core/`) and compiles itself. It ships a Clojure-compatible standard library.
+A Clojure implementation on Scheme. Jolt reads Clojure source, analyzes it to a
+host-neutral IR, emits Scheme, and runs it — on [Chez](https://cisco.github.io/ChezScheme/)
+by default, or on [Gambit](https://gambitscheme.org/) compiled to JavaScript for
+the browser. The compiler is self-hosted: it is written in Clojure (`jolt-core/`)
+and compiles itself. It ships a Clojure-compatible standard library.
 
 ## Requirements
 
@@ -364,6 +365,48 @@ source roots by *when* they load:
 Chez (read → analyze → IR → emit → eval). `host/chez/bootstrap.ss` rebuilds that
 seed from source on pure Chez; the build is a self-hosting fixpoint (a rebuild
 reproduces the checked-in seed byte-for-byte).
+
+`host/gambit/` is the same overlay on a second Scheme — its own adapter, kernel,
+and cross-minted seed. See [Scheme backends](#scheme-backends).
+
+## Scheme backends
+
+Chez is the default target: every gate, library, and release runs there, and it
+is the only target with FFI, native compilation, program images, and standalone
+binaries. Gambit is a second, demo-grade target that also compiles to a single
+JavaScript file — the live REPL on the [website](https://jolt-lang.github.io) is
+jolt evaluating in the browser.
+
+Host-specific runtime code sits behind an adapter contract
+(`host/scheme-adapter/CONTRACT.txt` lists the names and capability tiers;
+`TARGET-CONTRACT.md` next to it is the porting document). A target implements a
+capability or degrades it honestly — an absent one raises rather than faking a
+result.
+
+The Gambit targets need `gambit-scheme` (brew) and skip cleanly without it:
+
+```bash
+make gambitcheck              # adapter + shims on native gsi
+make gambitkernel             # the booted kernel and natives (113 checks)
+make gambiteval               # jolt source through the compiler, renders pinned to Chez
+make gambitseed               # re-mint host/gambit/seed/ (runs on Chez, after a seed change)
+make gambitweb                # => target/gambit/jolt-web.js, the browser bundle
+```
+
+`make gambitweb` compiles the whole stack — kernel, seed, compiler, and a
+queue-polling REPL loop (`host/gambit/repl-main.ss`) — into one self-contained
+JavaScript file in about 30 seconds. The output is roughly 32 MB raw and 4 MB
+gzipped, which is what a web server actually ships. The build is reproducible:
+the same sources produce a byte-identical bundle. Point it at a site checkout to
+refresh the live demo:
+
+```bash
+make gambitweb GAMBIT_WEB_OUT=../jolt-lang.github.io/resources/static/js/jolt-web.js
+```
+
+The page defines `joltQueue` and `joltOut` before loading the bundle; a Scheme
+thread inside it polls the queue and hands results back, so page JavaScript never
+calls into Scheme.
 
 ## Differences from Clojure
 

--- a/host/gambit/boot.ss
+++ b/host/gambit/boot.ss
@@ -100,6 +100,9 @@
 ;; post-prelude re-asserts the native overrides the overlay stubs out (ns-name,
 ;; char?, atom?, realized?, ...) — cli.ss order: prelude, post-prelude, image.
 (##include "../chez/post-prelude.ss")
+;; the clojure.core names the excluded java/ tree owns on Chez — after
+;; post-prelude so these bindings are the last word
+(##include "host-vars.ss")
 (##include "seed/image.ss")
 (##include "../chez/compile-eval.ss")
 

--- a/host/gambit/eval-test.ss
+++ b/host/gambit/eval-test.ss
@@ -66,6 +66,31 @@
 ;; the runtime target must never emit chez unsafe spellings
 (check "(count \"gambit\")" "6")
 
+;; ---- host tier: the names the excluded java/ tree owns on Chez ---------------
+;; `time` reaches current-time-ms and the printer's host-writer probe; both were
+;; unbound names before host-vars.ss, so the macro died with a bare Gambit error.
+(check "(time 1)" "1")
+(check "(time (reduce + (range 100)))" "4950")
+(check "(> (current-time-ms) 1700000000000)" "true")
+(check "(do (flush) :ok)" ":ok")
+
+;; A type this target cannot construct answers the question instead of raising.
+(check "(delay? 1)" "false")
+(check "(queue? 1)" "false")
+(check "(tap> 1)" "false")
+
+;; An absent capability raises a catchable, named error rather than crashing on
+;; an unbound global.
+(check "(try (future 1) (catch Exception e (str (class e))))"
+       "\"class java.lang.UnsupportedOperationException\"")
+
+;; Gambit has no arity introspection, so its own runtime raises on a mismatch;
+;; those exceptions must still carry a class and a message (they rendered as
+;; "#object[:object]" before).
+(check "(try ((fn [x] x)) (catch Exception e (str (class e))))"
+       "\"class clojure.lang.ArityException\"")
+(check "(str (class 1))" "\"class java.lang.Long\"")
+
 ;; a ^double-hinted fn compiles WITHOUT #3% in the emitted text (the R9
 ;; target-prims table at :gambit maps the unsafe prefix to "")
 (let ((scm (jolt-analyze-emit-form

--- a/host/gambit/host-vars.ss
+++ b/host/gambit/host-vars.ss
@@ -1,0 +1,249 @@
+;; host-vars.ss — the clojure.core names host/chez/java/* binds on Chez.
+;;
+;; On Chez the java/ tree owns the JVM-shaped half of clojure.core: clocks, file
+;; IO, the interop entry points, agents and futures, taps, the library shim
+;; hooks. This target boots none of those files, so without this one every such
+;; name is an UNBOUND GLOBAL: calling it raises a bare Gambit exception with no
+;; jolt context and no position. `(time 1)` was exactly that — the macro expands
+;; to a current-time-ms call, which crashed with an unreadable error rather than
+;; reporting a missing capability.
+;;
+;; Every name here is either implemented on Gambit or bound to a raise that says
+;; which capability is absent. Nothing stays unbound, and nothing pretends to
+;; work — the same rule the sa-* capability tiers follow.
+;;
+;; Loaded after the prelude and post-prelude so these bindings are the last word.
+
+;; ---- degradation -----------------------------------------------------------
+;; A catchable UnsupportedOperationException naming the operation and the reason,
+;; so the failure reads the same whether it reaches a REPL, a catch clause, or a
+;; log line.
+(define (gambit-unsupported-fn name reason)
+  (lambda args
+    (jolt-throw
+      (jolt-host-throwable
+        "java.lang.UnsupportedOperationException"
+        (string-append "clojure.core/" name " is unsupported on the gambit target: "
+                       reason)))))
+
+(define (degrade-core-var! name reason)
+  (def-var! "clojure.core" name (gambit-unsupported-fn name reason)))
+
+(define (degrade-core-vars! names reason)
+  (for-each (lambda (n) (degrade-core-var! n reason)) names))
+
+;; ---- system tier: real -----------------------------------------------------
+
+;; Epoch milliseconds, like System/currentTimeMillis — this backs `time`, and
+;; user code reads it as a wall clock, so it must be epoch-based rather than the
+;; process-relative (real-time) the adapter's sa-real-time-ms reports.
+(define (gambit-epoch-ms)
+  (inexact->exact (floor (* 1000 (time->seconds (current-time))))))
+(def-var! "clojure.core" "current-time-ms" gambit-epoch-ms)
+
+(def-var! "clojure.core" "flush"
+  (lambda args (force-output) jolt-nil))
+
+(def-var! "clojure.core" "__stdin-read-line"
+  (lambda args
+    (let ((l (read-line)))
+      (if (eof-object? l) jolt-nil l))))
+
+;; ---- file IO: real on gsi ---------------------------------------------------
+;; These work wherever the host has a filesystem. Under the js target the open
+;; fails and Gambit's own error surfaces with its message intact (the condition
+;; shims in prelude-shims.ss make it readable), which is the honest outcome for
+;; a target that has no files.
+
+(define (gambit-read-all port)
+  (call-with-output-string
+    (lambda (out)
+      (let loop ()
+        (let ((c (read-char port)))
+          (unless (eof-object? c)
+            (write-char c out)
+            (loop)))))))
+
+(def-var! "clojure.core" "slurp"
+  (lambda (src . opts)
+    (if (string? src)
+        (call-with-input-file src gambit-read-all)
+        (jolt-throw
+          (jolt-host-throwable "java.lang.IllegalArgumentException"
+            "slurp on the gambit target takes a path string")))))
+
+(def-var! "clojure.core" "spit"
+  (lambda (dest content . opts)
+    (if (string? dest)
+        (begin
+          (call-with-output-file dest
+            (lambda (p) (display (jolt-str-render-one content) p)))
+          jolt-nil)
+        (jolt-throw
+          (jolt-host-throwable "java.lang.IllegalArgumentException"
+            "spit on the gambit target takes a path string")))))
+
+;; ---- library shim hooks: real ----------------------------------------------
+;; The underlying arm registries are all present in the portable runtime, so a
+;; library that models its own host values works here unchanged.
+
+(def-var! "clojure.core" "__register-eq!"
+  (lambda (pred handler)
+    (register-eq-arm! (lambda (a b) (jolt-truthy? (jolt-invoke pred a b)))
+                      (lambda (a b) (jolt-truthy? (jolt-invoke handler a b))))
+    jolt-nil))
+
+(def-var! "clojure.core" "__register-hash!"
+  (lambda (pred handler)
+    (register-hash-arm! (lambda (x) (jolt-truthy? (jolt-invoke pred x)))
+                        (lambda (x) (jolt-invoke handler x)))
+    jolt-nil))
+
+(def-var! "clojure.core" "__register-str!"
+  (lambda (pred render)
+    (register-str-render! (lambda (x) (jolt-truthy? (jolt-invoke pred x)))
+                          (lambda (x) (jolt-invoke render x)))
+    jolt-nil))
+
+(def-var! "clojure.core" "__register-pr!"
+  (lambda (pred render)
+    (register-pr-arm! (lambda (x) (jolt-truthy? (jolt-invoke pred x)))
+                      (lambda (x) (jolt-invoke render x)))
+    jolt-nil))
+
+(def-var! "clojure.core" "__register-instance-check!"
+  (lambda (f)
+    (register-instance-check-arm!
+      (lambda (cls val) (jolt-truthy? (jolt-invoke f cls val))))
+    jolt-nil))
+
+;; ---- queries answer, they do not raise -------------------------------------
+;; A predicate whose type cannot exist on this target is false, not an error —
+;; a caller asking "is this a delay?" deserves an answer.
+
+(def-var! "clojure.core" "delay?" (lambda (x) #f))
+(def-var! "clojure.core" "queue?" (lambda (x) #f))
+
+;; No tap registry exists, so nothing is listening and tap> reports that.
+;; Registering one, on the other hand, is a request this target cannot honor.
+(def-var! "clojure.core" "tap>" (lambda (x) #f))
+
+;; The reader consults this map; empty is the truth here, not a missing name.
+;; empty-pmap is a VALUE, not a constructor — calling it applies the map
+(def-var! "clojure.core" "default-data-readers" empty-pmap)
+
+;; ---- host errors carry a class and a message --------------------------------
+;; Gambit has no arity introspection (see procedure-arity-mask in
+;; prelude-shims.ss), so seq.ss's structural arity pre-check always passes and
+;; Gambit's own runtime raises instead. Those exception objects have no JVM class,
+;; so (class e), (str e), and a catch clause all fell through to the class-model
+;; default and printed "#object[:object]" — which is what `(time)` reported
+;; instead of an arity error. Map Gambit's wording onto the class the equivalent
+;; Chez failure carries. The wording is Gambit's own (there is no arg count or
+;; callee name to recover), but the class and the message are real.
+
+(define (gambit-msg-has? m sub)
+  (let ((ml (string-length m)) (sl (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> (+ i sl) ml) #f)
+            ((string=? (substring m i (+ i sl)) sub) #t)
+            (else (loop (+ i 1)))))))
+
+(define (gambit-host-error? x)
+  (and (condition? x) (not (jolt-ex-info-record? x))))
+
+(define (gambit-error-class x)
+  (let ((m (or (condition-message x) "")))
+    (cond
+      ((gambit-msg-has? m "Wrong number of arguments") "clojure.lang.ArityException")
+      ((gambit-msg-has? m "Unbound variable")          "java.lang.IllegalStateException")
+      ((gambit-msg-has? m "Division by zero")          "java.lang.ArithmeticException")
+      ((gambit-msg-has? m "expected")                  "java.lang.ClassCastException")
+      ((gambit-msg-has? m "Operator is not a PROCEDURE") "java.lang.ClassCastException")
+      (else "java.lang.RuntimeException"))))
+
+(define (gambit-collapse-lines s)
+  ;; Gambit's description runs onto further lines (the procedure and the args it
+  ;; got); a message is one line everywhere else in jolt, so fold them together.
+  (let ((n (string-length s)))
+    (call-with-output-string
+      (lambda (o)
+        (let loop ((i 0) (gap #f))
+          (if (>= i n)
+              #t
+              (let ((c (string-ref s i)))
+                (cond ((memv c '(#\newline #\return #\tab)) (loop (+ i 1) #t))
+                      (else (when (and gap (> i 0)) (write-char #\space o))
+                            (write-char c o)
+                            (loop (+ i 1) #f))))))))))
+
+(define (gambit-error-tostring x)
+  (string-append (gambit-error-class x) ": "
+                 (gambit-collapse-lines (or (condition-message x) "host error"))))
+
+(register-class-arm! gambit-host-error? gambit-error-class)
+(register-str-render! gambit-host-error? gambit-error-tostring)
+(register-pr-arm! gambit-host-error? gambit-error-tostring)
+
+;; ---- host objects cannot exist here ----------------------------------------
+;; The jhost record (java/host-static.ss) and the reader/stream shims built on
+;; it live in the java/ tree this target does not boot, so no value here can BE
+;; one. Answering #f makes every branch guarded by these predicates dead code —
+;; which is why the accessors behind them need no stand-in, since Scheme resolves
+;; a global only when it is actually reached. printing.ss consults jhost? on the
+;; way to a writer, which is what made `(time 1)` die on an unbound name.
+
+;; The reader/stream shims genuinely do not exist here, so nothing is one.
+(define (reader-jhost? x) #f)
+(define (jhost-seqable-shim? x) #f)
+
+;; jhost itself, on the other hand, is the generic carrier for a host value, and
+;; the class model needs it: (class x) returns a Class OBJECT, which on Chez is a
+;; jhost tagged "class" (java/host-static-classes.ss). Without it (class e) died
+;; on an unbound make-class-obj. Same record shape as Chez's, so the booted
+;; class/printing code reads it unchanged.
+(define-record-type jhost
+  (fields tag (mutable state))
+  (nongenerative gambit-jhost-v1))
+
+(define (make-class-obj name) (make-jhost "class" (vector name)))
+(define (jclass? x) (and (jhost? x) (string=? (jhost-tag x) "class")))
+(define (jclass-name x) (vector-ref (jhost-state x) 0))
+
+;; Class tokens intern per name so identity, = and defmethod keys are stable.
+(define jolt-class-for-tbl (make-hashtable string-hash string=?))
+(define (jolt-class-for name)
+  (or (hashtable-ref jolt-class-for-tbl name #f)
+      (let ((obj (make-class-obj name)))
+        (hashtable-set! jolt-class-for-tbl name obj)
+        obj)))
+(register-str-render! jclass? (lambda (x) (string-append "class " (jclass-name x))))
+(register-pr-arm! jclass? jclass-name)
+(register-eq-arm! (lambda (a b) (and (jclass? a) (jclass? b)))
+                  (lambda (a b) (string=? (jclass-name a) (jclass-name b))))
+
+;; ---- absent capabilities ---------------------------------------------------
+
+(degrade-core-vars! '("host-new" "host-static-call" "host-static-ref" "make-proxy")
+                    "there are no JVM class shims on this target")
+
+(degrade-core-vars! '("future-call" "future-cancel" "send-via" "agent-errors"
+                      "clear-agent-errors" "await-for" "error-handler" "error-mode"
+                      "set-error-handler!" "set-error-mode!" "release-pending-sends"
+                      "set-agent-send-executor!" "set-agent-send-off-executor!"
+                      "shutdown-agents")
+                    "futures and agents are not wired up on this target")
+
+(degrade-core-vars! '("make-delay") "delays are not wired up on this target")
+
+(degrade-core-vars! '("clojure.lang.PersistentQueue")
+                    "persistent queues are not wired up on this target")
+
+(degrade-core-vars! '("require" "use")
+                    "this target loads no source at runtime")
+
+(degrade-core-vars! '("bigdec" "rationalize")
+                    "there is no BigDecimal on this target")
+
+(degrade-core-vars! '("add-tap" "remove-tap")
+                    "there is no tap registry on this target")

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -414,10 +414,41 @@
      (syntax-case (list e ...) ()
        ((p ...) body ...)))))
 
-(define (condition? x) (error-object? x))
-(define (message-condition? x) (error-object? x))
+;; error-object? covers only what `error` raised. Gambit's OWN runtime
+;; exceptions — unbound variable, wrong argument count, wrong type — are
+;; separate object types it answers #f for, and there is no umbrella predicate
+;; (no `exception?`, no `##exception?` in 4.9.7). Treating them as non-conditions
+;; makes every host-level failure opaque to the shared code: records-interop
+;; classifies a raise by `condition?`, so a Gambit error fell through to the
+;; class-model default and rendered as "#object[:object]" with no message.
+;;
+;; display-exception describes any exception Gambit knows ("Unbound variable: x",
+;; "Wrong number of arguments passed to procedure"), and prints the distinctive
+;; "This object was raised: <v>" for a plain value — so the description itself is
+;; the test, and a new exception type in a future Gambit is covered without a
+;; list to maintain.
+(define (%gambit-exception-text x)
+  (guard (e (#t #f))
+    (let ((s (call-with-output-string (lambda (p) (display-exception x p)))))
+      (and (string? s)
+           (> (string-length s) 0)
+           (not (string-prefix? "This object was raised:" s))
+           (%trim-trailing-newline s)))))
+
+(define (%trim-trailing-newline s)
+  (let loop ((n (string-length s)))
+    (cond ((= n 0) "")
+          ((memv (string-ref s (- n 1)) '(#
+ewline #eturn)) (loop (- n 1)))
+          (else (substring s 0 n)))))
+
+(define (condition? x)
+  (or (error-object? x) (and (%gambit-exception-text x) #t)))
+(define (message-condition? x) (condition? x))
 (define (condition-message c)
-  (if (error-object? c) (error-object-message c) #f))
+  (cond ((error-object? c) (error-object-message c))
+        ((%gambit-exception-text c))
+        (else #f)))
 (define (condition-irritants c)
   (if (error-object? c) (error-object-irritants c) '()))
 

--- a/host/gambit/repl-main.ss
+++ b/host/gambit/repl-main.ss
@@ -34,20 +34,33 @@
 
 (define (throw-text e)
   ;; a jolt throw is a condition wrapping the jolt value (rt-core); an ex-info
-  ;; record renders as Class: message. Plain conditions carry a message.
+  ;; record renders as Class: message. A host-level failure goes through the same
+  ;; class mapping and one-line folding the rest of the runtime uses
+  ;; (gambit-error-tostring, host-vars.ss), so the REPL never prints a bare
+  ;; "error" or a multi-line Gambit description.
   (or (guard (ee (#t #f))
         (let ((v (jolt-unwrap-throw e)))
           (and (jolt-ex-info-record? v)
                (string-append (jolt-ex-info-record-class-name v) ": "
                               (let ((m (jolt-ex-info-record-message v)))
                                 (if (string? m) m (jolt-pr-readable m)))))))
-      (guard (ee (#t #f))
-        (let ((m (condition-message e))) (and (string? m) m)))
+      (guard (ee (#t #f)) (and (gambit-host-error? e) (gambit-error-tostring e)))
+      (guard (ee (#t #f)) (let ((v (jolt-unwrap-throw e))) (jolt-pr-readable v)))
       "error"))
 
+;; An expression's printed output belongs in the terminal that ran it, not in the
+;; browser console, so each evaluation runs with stdout captured and the text is
+;; emitted before the value (or before the error, if it printed and then threw).
 (define (repl-step src)
-  (guard (e (#t (js-emit "error" (throw-text e))))
-    (js-emit "result" (jolt-eval-str src))))
+  (let ((printed "") (value #f) (failure #f))
+    (set! printed
+      (call-with-output-string
+        (lambda (port)
+          (parameterize ((current-output-port port))
+            (guard (e (#t (set! failure (throw-text e))))
+              (set! value (jolt-eval-str src)))))))
+    (when (> (string-length printed) 0) (js-emit "out" printed))
+    (if failure (js-emit "error" failure) (js-emit "result" value))))
 
 (js-ready!)
 (let loop ()

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -1200,10 +1200,7 @@
 ;; no-op keeps those calls inert, matching the image-off degradation.
 (define (image-register-fn-form! . _) #f)
 
-;; host-static-classes.ss is excluded (no JVM class mirrors on this target);
-;; instance-check paths probe jclass? — always #f, the cond arms fall through.
-(define (jclass? x) #f)
-(define (jclass-name x) (error (quote jclass-name) "no host classes on the gambit target"))
+;; jclass?/jclass-name and the class objects they read live in host-vars.ss.
 
 ;; ---- concurrency tier stubs (demo boot: single-threaded) ---------------------
 ;; java/concurrency.ss + natives-queue.ss are excluded from this boot. Gambit


### PR DESCRIPTION
Started as `make gambitweb` (so the browser bundle stops being a hand-built artifact) and grew a fix for `(time 1)`, which crashed on the Gambit target.

## make gambitweb

Builds the browser bundle from `host/gambit/repl-main.ss` — ~30s, 32 MB raw / 3.5 MB gzipped, and byte-reproducible (the output matches the bundle already deployed on the site). Defaults to `target/gambit/jolt-web.js`; `GAMBIT_WEB_OUT` points it at a site checkout so the live demo can track main:

```
make gambitweb GAMBIT_WEB_OUT=../jolt-lang.github.io/resources/static/js/jolt-web.js
```

The README documents it with the other four `gambit*` targets, the adapter contract, and what this backend does not support. It also drops a duplicate `gambiteval` target that made `make` warn on every gambit invocation and silently use the second definition.

## (time 1) — one instance of a class of gap

`time` reaches `current-time-ms`, which Chez provides in `host/chez/java/host-static-methods.ss`; this target loads none of the `java/` tree, so the name was an unbound global and the failure arrived as a bare Gambit exception with no message. An audit found **40 clojure.core names in that state**, plus Scheme-level ones (`jhost?`, `make-class-obj`) reachable from booted files.

`host/gambit/host-vars.ss` binds all of them, each implemented or degraded honestly — the rule the `sa-*` tiers already follow:

- **Real:** epoch clock, `flush`, stdin, `slurp`/`spit`, the five `__register-*` library hooks (their registries were already present), and the `jhost` record the class model needs for Class objects.
- **Answered, not raised:** `delay?`/`queue?`/`tap>` are false, `default-data-readers` is empty — a caller asking a question deserves an answer.
- **Raising a catchable UnsupportedOperationException naming the capability:** interop entry points, futures/agents, delays, `require`/`use`, `bigdec`, tap registration.

## The #object[:object] error text

Two causes. `condition?` was R7RS `error-object?`, which is **false for Gambit's own runtime exceptions** (unbound variable, wrong arg count, wrong type) — and Gambit has no umbrella exception predicate, so every host failure was opaque to the shared code that classifies throws. It now tests whether `display-exception` describes the object, which covers current and future exception types without a list to maintain. Second, Gambit has no arity introspection at all, so jolt's structural arity check cannot fire and Gambit's exception escapes; those now map onto the classes their Chez counterparts carry and render one-line as `class: message`.

Before / after:

| expression | before | after |
|---|---|---|
| `(time 1)` | crash, no message | `Elapsed time: 0 msecs` → `1` |
| `(time)` | `#object[:object]` | `clojure.lang.ArityException: Wrong number of arguments passed to procedure` |
| `(future 1)` | unbound global crash | `UnsupportedOperationException: clojure.core/future-call is unsupported on the gambit target: futures and agents are not wired up` |
| `(class e)` | unbound `make-class-obj` | `class clojure.lang.ArityException` |

The REPL entry also captures an expression's printed output into the terminal instead of the browser console.

## Verification

`make gambiteval` covers the new behavior — 42 rows, up from 32. gambitcheck + gambitkernel + gambiteval green on gsi; the rebuilt bundle verified under node (printed output, both error kinds, class objects); full gate green, 56 ci targets. Zero changes to host/chez or jolt-core.