### PR TITLE
Gambit build profiles: choose how much of the language a bundle carries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ test/_*.janet
 
 # Beads issue tracker (local dev tooling)
 .beads/
+
+# generated gambit profile boots (host/gambit/boot.ss is the source of order)
+host/gambit/boot-*.ss

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ JOLT-TARGETS-NEEDING-DEPS := \
 
 # Only mark PHONY targets for names that have file system conflicts:
 .PHONY: build install test ci gate-run-test gate-run-ci gate-status \
-        gambitcheck gambitkernel gambiteval gambitseed gambitweb
+        gambitcheck gambitkernel gambiteval gambitseed gambitweb gambitprofile
 
 default:: build
 
@@ -598,15 +598,33 @@ gambiteval:
 		echo "gambiteval: gambit-scheme not installed (brew) — skipped"; \
 	fi
 
+# Build profiles: generate the reduced repl profile and check that the language
+# still works while an excluded feature reports itself instead of failing as an
+# unbound name. Cheap (a gsi load, no js compile), so it can gate the mechanism.
+gambitprofile:
+	@if [ -x "$(GAMBIT_GSI)" ]; then \
+		$(CHEZ) --script host/gambit/gen-boot.ss repl; \
+		"$(GAMBIT_GSI)" host/gambit/profile-test.ss; \
+	else \
+		echo "gambitprofile: gambit-scheme not installed (brew) — skipped"; \
+	fi
+
 # The browser bundle: the whole stack (kernel + seed + compiler + a queue-polling
 # REPL loop) compiled to one JavaScript file by the Gambit backend. ~30s, ~32MB
 # raw / ~4MB gzipped, which is what a web server ships. Point GAMBIT_WEB_OUT at
 # a site checkout to refresh the live demo:
 #   make gambitweb GAMBIT_WEB_OUT=../jolt-lang.github.io/resources/static/js/jolt-web.js
 # NEVER bare gsc — that is Ghostscript on a brew machine.
+# PROFILE selects how much of the language the bundle carries (host/gambit/
+# profiles.ss lists them: full, repl, kernel). gen-boot.ss writes the boot for it
+# on Chez — Gambit resolves ##include at expansion time, so this cannot be a
+# runtime switch — and binds every name an excluded group owned to a raise that
+# names the group.
+PROFILE ?= full
 GAMBIT_WEB_OUT ?= target/gambit/jolt-web.js
 gambitweb:
 	@if [ -x "$(GAMBIT_GSC)" ]; then \
+		$(CHEZ) --script host/gambit/gen-boot.ss $(PROFILE); \
 		mkdir -p "$$(dirname "$(GAMBIT_WEB_OUT)")"; \
 		out="$$(cd "$$(dirname "$(GAMBIT_WEB_OUT)")" && pwd)/$$(basename "$(GAMBIT_WEB_OUT)")"; \
 		(cd host/gambit && "$(GAMBIT_GSC)" -target js -exe -o "$$out" repl-main.ss); \

--- a/README.md
+++ b/README.md
@@ -391,18 +391,64 @@ make gambitkernel             # the booted kernel and natives (113 checks)
 make gambiteval               # jolt source through the compiler, renders pinned to Chez
 make gambitseed               # re-mint host/gambit/seed/ (runs on Chez, after a seed change)
 make gambitweb                # => target/gambit/jolt-web.js, the browser bundle
+make gambitweb PROFILE=repl   # a smaller bundle (see Build profiles below)
+make gambitprofile            # gate: reduced profile runs, excluded features report
 ```
 
 `make gambitweb` compiles the whole stack — kernel, seed, compiler, and a
 queue-polling REPL loop (`host/gambit/repl-main.ss`) — into one self-contained
-JavaScript file in about 30 seconds. The output is roughly 32 MB raw and 4 MB
-gzipped, which is what a web server actually ships. The build is reproducible:
-the same sources produce a byte-identical bundle. Point it at a site checkout to
-refresh the live demo:
+JavaScript file in about 30 seconds. The build is reproducible: the same sources
+produce a byte-identical bundle. Point it at a site checkout to refresh the live
+demo:
 
 ```bash
 make gambitweb GAMBIT_WEB_OUT=../jolt-lang.github.io/resources/static/js/jolt-web.js
 ```
+
+### Build profiles
+
+`PROFILE` selects how much of the language a build carries.
+`host/gambit/profiles.ss` lists the profiles and the optional feature groups
+they are built from; `boot.ss` remains the source of load order, and a group only
+names which of its files are optional.
+
+```bash
+make gambitweb PROFILE=repl    # clojure.core + compiler, no regex
+make gambitweb PROFILE=full    # everything (the default)
+```
+
+Excluding a group does two things. Its files are left out, and **every name it
+owned is bound to a raise that names the group** — derived by scanning the
+excluded files for their definitions, so the error surface tracks the code
+instead of a hand-kept list. A dropped feature reports itself:
+
+```
+user=> (re-seq #"[a-z]+" "ab cd")
+java.lang.UnsupportedOperationException: jolt-re-pattern is not in this build:
+the regex feature group was excluded
+```
+
+A predicate over a type the build cannot hold answers `false` rather than
+raising — a value simply is not a regex — while anything that would produce or
+consume that type raises. `make gambitprofile` gates both halves: the reduced
+profile still runs the language, and an excluded feature names its group,
+including through indirection like `clojure.string/split`.
+
+Measured cost of each group in the bundle (raw / gzipped, and gzipped is what a
+web server ships):
+
+| group | cost | without it |
+|---|---|---|
+| regex | 2.4 MB / 0.4 MB | no `re-*`, no `#"..."` |
+| compiler | 2.9 MB / 0.5 MB | no `eval`, no REPL, no runtime macros |
+| clojure.core | 8.7 MB / 0.7 MB | the kernel alone — an embedding, not a Clojure |
+| **kernel (floor)** | **19.4 MB / 2.1 MB** | the Gambit runtime plus jolt's kernel |
+| full | 31.0 MB / 3.3 MB | |
+
+The floor dominates, so a profile trades features for the last third of the
+bundle: `repl` ships 27.7 MB / 3.1 MB against `full`'s 32.6 MB / 3.5 MB. Adding
+a group is worth it when it is separable *and* measurable — a group worth
+kilobytes is churn.
 
 The page defines `joltQueue` and `joltOut` before loading the bundle; a Scheme
 thread inside it polls the queue and hands results back, so page JavaScript never

--- a/host/gambit/gen-boot.ss
+++ b/host/gambit/gen-boot.ss
@@ -1,0 +1,335 @@
+;; gen-boot.ss — write host/gambit/boot-<profile>.ss for a build profile.
+;;
+;; Run on CHEZ from the repo root (make gambitweb PROFILE=... does this):
+;;   chez --script host/gambit/gen-boot.ss repl
+;;
+;; Gambit resolves ##include at expansion time, so which files a build carries
+;; cannot be a runtime choice — the boot has to be generated. Same reasoning as
+;; the seed and records-gambit.ss: derive it on Chez, check nothing by hand.
+;;
+;; boot.ss owns the load order; profiles.ss says which of its files are optional
+;; and which profile keeps which groups. Excluded files are dropped from the
+;; include list, and every clojure.core name they define is bound to a raise
+;; naming the group — read out of the files themselves, so the error surface
+;; cannot drift from the code.
+
+(import (chezscheme))
+(print-brackets #f)
+
+(define args (command-line-arguments))
+(define profile-name
+  (if (null? args)
+      (begin (display "usage: gen-boot.ss <profile>\n") (exit 1))
+      (string->symbol (car args))))
+
+(define (read-all f)
+  (with-input-from-file f
+    (lambda ()
+      (let loop ((acc '()))
+        (let ((x (read)))
+          (if (eof-object? x) (reverse acc) (loop (cons x acc))))))))
+
+;; ---- profiles.ss -----------------------------------------------------------
+
+(define spec (read-all "host/gambit/profiles.ss"))
+
+(define (section name)
+  (let loop ((fs spec))
+    (cond ((null? fs) (error 'gen-boot "section missing from profiles.ss" name))
+          ((and (pair? (car fs)) (eq? (caar fs) name)) (cdar fs))
+          (else (loop (cdr fs))))))
+
+(define group-specs (section 'groups))     ; (name label (file ...))
+(define profile-specs (section 'profiles)) ; (name (group ...))
+
+(define (profile-names) (map car profile-specs))
+
+(define kept-groups
+  (let loop ((ps profile-specs))
+    (cond ((null? ps)
+           (display "gen-boot: unknown profile ")
+           (display profile-name)
+           (display "; profiles.ss lists ")
+           (write (profile-names))
+           (newline)
+           (exit 1))
+          ((eq? (caar ps) profile-name) (cadar ps))
+          (else (loop (cdr ps))))))
+
+(define excluded-groups
+  (let loop ((gs group-specs) (acc '()))
+    (cond ((null? gs) (reverse acc))
+          ((memq (caar gs) kept-groups) (loop (cdr gs) acc))
+          (else (loop (cdr gs) (cons (car gs) acc))))))
+
+(define excluded-files
+  (apply append (map caddr excluded-groups)))
+
+;; ---- the names an excluded group takes with it ------------------------------
+;; Scan for (def-var! "clojure.core" "name" — the one way a host file publishes
+;; a core name, and how the emitted prelude publishes every one of them.
+
+(define core-def-prefix
+  (string-append "(def-var! " (string #\") "clojure.core" (string #\")
+                 " " (string #\")))
+
+(define (name-end text start)
+  (let scan ((j start))
+    (cond ((>= j (string-length text)) j)
+          ((char=? (string-ref text j) (string-ref (string #\") 0)) j)
+          (else (scan (+ j 1))))))
+
+(define (file-core-names path)
+  (let ((full (string-append "host/gambit/" path)))
+    (if (not (file-exists? full))
+        (list)
+        (let ((text (call-with-input-file full (lambda (p) (get-string-all p)))))
+          (let loop ((i 0) (acc (list)))
+            (let ((hit (find-substring core-def-prefix text i)))
+              (if (not hit)
+                  (reverse acc)
+                  (let* ((start (+ hit (string-length core-def-prefix)))
+                         (end (name-end text start)))
+                    (loop end (cons (substring text start end) acc))))))))))
+
+(define (find-substring needle hay from)
+  (let ((nl (string-length needle)) (hl (string-length hay)))
+    (let loop ((i from))
+      (cond ((> (+ i nl) hl) #f)
+            ((string=? (substring hay i (+ i nl)) needle) i)
+            (else (loop (+ i 1)))))))
+
+;; A name the KEPT files also define is not missing — the kernel or another
+;; group still provides it.
+(define kept-names
+  (let loop ((gs group-specs) (acc '()))
+    (cond ((null? gs) acc)
+          ((memq (caar gs) kept-groups)
+           (loop (cdr gs) (append (apply append (map file-core-names (caddar gs))) acc)))
+          (else (loop (cdr gs) acc)))))
+
+(define (missing-names-of group)
+  (let ((names (apply append (map file-core-names (caddr group)))))
+    ;; dedupe, and drop anything still provided elsewhere
+    (let loop ((ns names) (seen '()) (acc '()))
+      (cond ((null? ns) (reverse acc))
+            ((member (car ns) seen) (loop (cdr ns) seen acc))
+            ((member (car ns) kept-names) (loop (cdr ns) (cons (car ns) seen) acc))
+            (else (loop (cdr ns) (cons (car ns) seen) (cons (car ns) acc)))))))
+
+;; ---- write the boot --------------------------------------------------------
+
+(define boot-lines
+  (let ((p (open-input-file "host/gambit/boot.ss")))
+    (let loop ((acc '()))
+      (let ((l (get-line p)))
+        (if (eof-object? l)
+            (begin (close-port p) (reverse acc))
+            (loop (cons l acc)))))))
+
+(define (include-line? l)
+  (find-substring "(##include \"" l 0))
+
+(define (included-path l)
+  (let* ((s (find-substring "\"" l 0))
+         (start (+ s 1))
+         (end (let scan ((j start))
+                (if (char=? (string-ref l j) #\") j (scan (+ j 1))))))
+    (substring l start end)))
+
+(define boot-include-paths
+  (let loop ((ls boot-lines) (acc (list)))
+    (cond ((null? ls) (reverse acc))
+          ((find-substring "(##include \"" (car ls) 0)
+           (loop (cdr ls) (cons (included-path (car ls)) acc)))
+          (else (loop (cdr ls) acc)))))
+
+;; ---- the SCHEME-level names an excluded file takes with it -------------------
+;; A booted file may call an excluded file's procedure directly, which no core
+;; var covers: the reader builds a #"..." literal through jolt-re-pattern, and
+;; the class model probes jolt-regex?. Same rule as the hand-written degradations
+;; in host-vars.ss — a PREDICATE answers #f, because a value cannot be of a type
+;; this build does not carry, and anything else raises.
+;;
+;; seed/ files are skipped: their defines are per-var mangled names reached only
+;; through var cells, never called by name from a booted file.
+
+(define (seed-file? path) (find-substring "seed/" path 0))
+
+;; Only names WE define may be degraded. A vendored file defines standard-looking
+;; helpers (irregex has its own vector-copy) that the host itself provides, and
+;; shadowing one of those with a raise would break a build rather than describe
+;; it. Vendored code is reached through our wrappers, which are ours to degrade.
+(define (vendored-file? path) (find-substring "vendor/" path 0))
+(define (degradable-file? path)
+  (and (not (seed-file? path)) (not (vendored-file? path))))
+
+(define (file-text path)
+  (let ((full (string-append "host/gambit/" path)))
+    (if (file-exists? full)
+        (call-with-input-file full (lambda (p) (get-string-all p)))
+        "")))
+
+(define (token-end text start)
+  (let scan ((j start))
+    (cond ((>= j (string-length text)) j)
+          ((memv (string-ref text j) (list #\space #\newline #\tab #\) #\()) j)
+          (else (scan (+ j 1))))))
+
+;; every name a file defines, either shape of define
+;; define-record-type generates NAME?, which a define scan cannot see — the blind
+;; spot that left jhost? unbound when the class model probed it. A record type
+;; from an excluded file has no instances here, so its predicate is #f.
+(define (file-record-predicates path)
+  (let ((text (file-text path)))
+    (let loop ((i 0) (acc (list)))
+      (let ((hit (find-substring "(define-record-type " text i)))
+        (if (not hit)
+            (reverse acc)
+            (let* ((after (+ hit (string-length "(define-record-type ")))
+                   (start (if (and (< after (string-length text))
+                                   (char=? (string-ref text after) #\())
+                              (+ after 1)
+                              after))
+                   (end (token-end text start)))
+              (loop end
+                    (if (> end start)
+                        (cons (string-append (substring text start end) "?") acc)
+                        acc))))))))
+
+(define (file-defines path)
+  (let ((text (file-text path)))
+    (let loop ((i 0) (acc (list)))
+      (let ((hit (find-substring "(define " text i)))
+        (if (not hit)
+            (reverse acc)
+            (let* ((after (+ hit (string-length "(define ")))
+                   (start (if (and (< after (string-length text))
+                                   (char=? (string-ref text after) #\())
+                              (+ after 1)
+                              after))
+                   (end (token-end text start)))
+              (loop end
+                    (if (> end start) (cons (substring text start end) acc) acc))))))))
+
+(define kept-text
+  (let loop ((ls boot-include-paths) (acc (list)))
+    (cond ((null? ls) (apply string-append (reverse acc)))
+          ((or (member (car ls) excluded-files) (seed-file? (car ls))) (loop (cdr ls) acc))
+          (else (loop (cdr ls) (cons (file-text (car ls)) acc))))))
+
+(define kept-defines
+  (let loop ((ls boot-include-paths) (acc (list)))
+    (cond ((null? ls) acc)
+          ((member (car ls) excluded-files) (loop (cdr ls) acc))
+          (else (loop (cdr ls) (append (file-defines (car ls)) acc))))))
+
+(define (predicate-name? n)
+  (let ((len (string-length n)))
+    (and (> len 0) (char=? (string-ref n (- len 1)) #\?))))
+
+(define (scheme-degradations-of group)
+  (let loop ((fs (caddr group)) (acc (list)))
+    (if (null? fs)
+        (reverse acc)
+        (loop (cdr fs)
+              (let inner ((ns (if (degradable-file? (car fs))
+                                  (append (file-defines (car fs))
+                                          (file-record-predicates (car fs)))
+                                  (list)))
+                          (acc acc))
+                (cond ((null? ns) acc)
+                      ((member (car ns) kept-defines) (inner (cdr ns) acc))
+                      ((member (car ns) acc) (inner (cdr ns) acc))
+                      ((find-substring (car ns) kept-text 0)
+                       (inner (cdr ns) (cons (car ns) acc)))
+                      (else (inner (cdr ns) acc))))))))
+
+(define out-path (string-append "host/gambit/boot-" (symbol->string profile-name) ".ss"))
+(define out (open-output-file out-path 'replace))
+
+(put-string out (string-append
+  ";; boot-" (symbol->string profile-name) ".ss — GENERATED by host/gambit/gen-boot.ss\n"
+  ";; from boot.ss + profiles.ss. Do not edit; regenerate.\n;;\n"
+  ";; profile: " (symbol->string profile-name) "\n"))
+(put-string out ";; groups kept:")
+(for-each (lambda (g) (put-string out (string-append " " (symbol->string g)))) kept-groups)
+(put-string out (if (null? kept-groups) " (kernel only)\n" "\n"))
+(put-string out ";; groups excluded:")
+(for-each (lambda (g) (put-string out (string-append " " (symbol->string (car g)))))
+          excluded-groups)
+(put-string out (if (null? excluded-groups) " none\n\n" "\n\n"))
+
+(define dropped 0)
+(for-each
+  (lambda (l)
+    (if (and (include-line? l) (member (included-path l) excluded-files))
+        (begin (set! dropped (+ dropped 1))
+               (put-string out (string-append ";; excluded by profile: " l "\n")))
+        (begin (put-string out l) (put-string out "\n"))))
+  boot-lines)
+
+;; Degradation goes last so it wins over anything an earlier file bound.
+(unless (null? excluded-groups)
+  (put-string out "\n;; ---- excluded features report themselves --------------------------------\n")
+  (put-string out ";; Derived from the def-var! forms in the excluded files, so this list cannot\n")
+  (put-string out ";; drift from the code. A dropped feature raises with its group named rather\n")
+  (put-string out ";; than failing as an unbound global.\n")
+  (put-string out ";; A predicate over a type the build cannot hold answers #f — a value simply\n")
+  (put-string out ";; is not one — while an operation that would have to produce or consume that\n")
+  (put-string out ";; type raises. Same split as the hand-written degradations in host-vars.ss.\n")
+  (put-string out "(define (profile-excluded-pred! nm)\n")
+  (put-string out "  (def-var! \"clojure.core\" nm (lambda args #f)))\n")
+  (put-string out "(define (profile-excluded! nm group)\n")
+  (put-string out "  (def-var! \"clojure.core\" nm\n")
+  (put-string out "    (lambda args\n")
+  (put-string out "      (jolt-throw\n")
+  (put-string out "        (jolt-host-throwable \"java.lang.UnsupportedOperationException\"\n")
+  (put-string out "          (string-append \"clojure.core/\" nm \" is not in this build: the \"\n")
+  (put-string out "                         group \" feature group was excluded\"))))))\n")
+  (for-each
+    (lambda (g)
+      (let ((snames (scheme-degradations-of g)))
+        (unless (null? snames)
+          (put-string out (string-append "\n;; " (symbol->string (car g))
+                                         " — direct callers in booted files\n"))
+          (for-each
+            (lambda (n)
+              (if (predicate-name? n)
+                  (put-string out (string-append "(define (" n " . args) #f)\n"))
+                  (put-string out
+                    (string-append "(define (" n " . args)\n"
+                                   "  (jolt-throw (jolt-host-throwable\n"
+                                   "    \"java.lang.UnsupportedOperationException\"\n"
+                                   "    \"" n " is not in this build: the " (cadr g)
+                                   " feature group was excluded\")))\n"))))
+            snames))))
+    excluded-groups)
+  (for-each
+    (lambda (g)
+      (let ((names (missing-names-of g)))
+        (put-string out (string-append "\n;; " (symbol->string (car g)) " ("
+                                       (number->string (length names)) " names)\n"))
+        (for-each
+          (lambda (n)
+            (if (predicate-name? n)
+                (put-string out (string-append "(profile-excluded-pred! \"" n "\")\n"))
+                (put-string out (string-append "(profile-excluded! \"" n "\" \"" (cadr g) "\")\n"))))
+          names)))
+    excluded-groups))
+
+(close-port out)
+
+;; An entry file (repl-main.ss) includes the ACTIVE profile by a fixed name, so
+;; switching profiles is a regeneration rather than an edit.
+(let ((active (open-output-file "host/gambit/boot-active.ss" 'replace)))
+  (put-string active ";; boot-active.ss — GENERATED. The profile the next bundle build carries.\n")
+  (put-string active (string-append "(##include \"boot-" (symbol->string profile-name) ".ss\")\n"))
+  (close-port active))
+
+(display (string-append "gen-boot: wrote " out-path
+                        " (profile " (symbol->string profile-name)
+                        ", " (number->string dropped) " file(s) excluded, "
+                        (number->string
+                          (apply + (map (lambda (g) (length (missing-names-of g))) excluded-groups)))
+                        " name(s) degraded)\n"))

--- a/host/gambit/profile-test.ss
+++ b/host/gambit/profile-test.ss
@@ -1,0 +1,79 @@
+;; profile-test.ss — the gate for build profiles (make gambitprofile).
+;;
+;; Runs against the generated `repl` profile: clojure.core and the compiler in,
+;; regex out. Two things have to hold for the mechanism to be worth having —
+;; the language still works without the excluded group, and asking for the
+;; excluded feature says so rather than dying on an unbound name.
+;;
+;; gen-boot.ss writes boot-repl.ss; make regenerates it before running this.
+
+(##include "boot-repl.ss")
+
+(define failures 0)
+
+(define (report ok label detail)
+  (if ok
+      (printf "  ok     ~a\n" label)
+      (begin (printf "  FAIL   ~a: ~a\n" label detail)
+             (set! failures (+ failures 1)))))
+
+(define (evals-to label src expected)
+  (let ((actual (guard (e (#t (string-append "THREW " (profile-error-text e))))
+                  (jolt-pr-readable (jolt-compile-eval src "user")))))
+    (report (and (string? actual) (string=? actual expected)) label
+            (string-append "got " actual " expected " expected))))
+
+(define (profile-error-text e)
+  (or (guard (ee (#t #f))
+        (let ((v (jolt-unwrap-throw e)))
+          (and (jolt-ex-info-record? v) (jolt-ex-info-record-message v))))
+      (guard (ee (#t #f)) (condition-message e))
+      "?"))
+
+;; The message must name the group, so a user reads "regex was excluded" rather
+;; than being left to infer it from a missing name.
+(define (excluded-with-group label src group)
+  (let ((msg (guard (e (#t (profile-error-text e)))
+               (jolt-compile-eval src "user")
+               "NO-RAISE")))
+    (report (and (string? msg)
+                 (let loop ((i 0))
+                   (cond ((> (+ i (string-length group)) (string-length msg)) #f)
+                         ((string=? (substring msg i (+ i (string-length group))) group) #t)
+                         (else (loop (+ i 1))))))
+            label
+            (string-append "message did not name the group: " msg))))
+
+(printf "== profile repl: the language without the regex group ==\n")
+
+(evals-to "arithmetic" "(+ 1 2)" "3")
+(evals-to "collections" "(assoc {:a 1} :b 2)" "{:a 1, :b 2}")
+(evals-to "lazy seqs" "(->> (range 100) (filter odd?) (map inc) (reduce +))" "2550")
+(evals-to "defn and recursion"
+          "(do (defn f [n] (if (< n 2) n (+ (f (- n 1)) (f (- n 2))))) (f 15))" "610")
+(evals-to "records" "(do (defrecord Pt [x y]) (pr-str (->Pt 1 2)))"
+          "\"#user.Pt{:x 1, :y 2}\"")
+(evals-to "multimethods"
+          "(do (defmulti area :shape) (defmethod area :circle [c] (* 2 (:r c))) (area {:shape :circle :r 21}))"
+          "42")
+(evals-to "host clock still real" "(> (current-time-ms) 1700000000000)" "true")
+
+(printf "== the excluded group reports itself ==\n")
+
+(excluded-with-group "re-seq" "(re-seq #\"[a-z]+\" \"ab cd\")" "regex")
+(excluded-with-group "re-find" "(re-find #\"x\" \"x\")" "regex")
+(excluded-with-group "re-pattern" "(re-pattern \"x\")" "regex")
+;; clojure.string reaches regex internally, so the report has to survive the
+;; indirection rather than only covering the names a user typed
+(excluded-with-group "clojure.string/split"
+                     "(clojure.string/split \"a,b\" #\",\")" "regex")
+
+;; A predicate over a type this build cannot hold answers instead of raising —
+;; a value simply is not a regex here.
+(evals-to "regex? answers false" "(regex? 1)" "false")
+
+(printf "profile-test: ~a failure(s)\n" failures)
+(if (= failures 0)
+    (begin (display "profile-test: PASS — reduced profile runs, excluded group named\n")
+           (exit 0))
+    (exit 1))

--- a/host/gambit/profiles.ss
+++ b/host/gambit/profiles.ss
@@ -1,0 +1,71 @@
+;; profiles.ss — how much of the language a Gambit build carries.
+;;
+;; DATA, read by gen-boot.ss (on Chez) to write a boot file per profile. Not
+;; loaded at runtime.
+;;
+;; boot.ss stays the single source of load ORDER. This file only says which of
+;; its files belong to an OPTIONAL feature group, and which profile keeps which
+;; groups. Anything boot.ss includes that is not named in a group here is the
+;; kernel: always in, not selectable.
+;;
+;; Excluding a group does two things. Its files are left out of the generated
+;; boot, and every clojure.core name those files define is bound to a raise that
+;; says the group was excluded — DERIVED by scanning the files for def-var!
+;; forms, so the error surface tracks the code instead of a hand-kept list. A
+;; dropped feature reports itself; it never fails as an unbound global.
+;;
+;; Measured cost of each group in the js bundle (raw / gzipped, which is what a
+;; web server ships):
+;;
+;;   regex      2.4 MB / 0.4 MB
+;;   compiler   2.9 MB / 0.5 MB
+;;   core       8.7 MB / 0.7 MB
+;;   ---------------------------
+;;   kernel    19.4 MB / 2.1 MB   floor: the Gambit runtime plus jolt's kernel
+;;   full      31.0 MB / 3.3 MB
+;;
+;; The floor dominates, so profiles trade features for the last third of the
+;; bundle. Adding a group is worth it when it is separable AND measurable; a
+;; group worth kilobytes is churn.
+
+(groups
+
+  ;; Runtime regex: irregex plus the Java-pattern translation in front of it.
+  ;; Without it re-pattern/re-find/re-seq/re-matches and #"..." literals raise.
+  (regex
+   "regex"
+   ("../../vendor/irregex/irregex.scm"
+    "../chez/java/regex-translate.ss"
+    "../chez/regex.ss"))
+
+  ;; clojure.core itself, as emitted by the cross-mint, plus the native
+  ;; re-assertions over it. Excluding this leaves the kernel and no standard
+  ;; library — an embedding, not a Clojure.
+  (core
+   "clojure.core"
+   ("seed/prelude.ss"
+    "../chez/post-prelude.ss"
+    "host-vars.ss"))
+
+  ;; The compiler image and the read-analyze-emit-eval path over it. Excluding
+  ;; it gives a runtime that can hold and print jolt values but cannot compile
+  ;; source, so there is no eval, no REPL, and no runtime macro expansion.
+  (compiler
+   "compiler"
+   ("seed/image.ss"
+    "../chez/compile-eval.ss")))
+
+(profiles
+
+  ;; Everything. What `make gambitcheck`, `gambitkernel` and `gambiteval` run
+  ;; against, and the default for a bundle.
+  (full    (regex core compiler))
+
+  ;; The browser REPL: it must compile what a visitor types, and clojure.core is
+  ;; the language, so both stay. Regex is the one feature a REPL demo can lose
+  ;; and still be a REPL.
+  (repl    (core compiler))
+
+  ;; The floor, for measuring and for embedding: kernel only, no standard
+  ;; library and no compiler.
+  (kernel  ()))

--- a/host/gambit/repl-main.ss
+++ b/host/gambit/repl-main.ss
@@ -13,7 +13,9 @@
 ;;   globalThis.joltQueue = []            // page pushes source strings
 ;;   globalThis.joltOut(kind, text)       // "ready" | "result" | "error"
 
-(##include "boot.ss")
+;; the profile chosen at generation time (make gambitweb PROFILE=...); regenerate
+;; with gen-boot.ss to change what the bundle carries
+(##include "boot-active.ss")
 
 (define (js-ready!)
   (##inline-host-statement


### PR DESCRIPTION
The Gambit target exists to illustrate the porting seam, so a build should carry only what it needs — and say clearly what it left out.

## Measured first

```
regex        2.4 MB /  0.4 MB gz    no re-*, no #"..."
compiler     2.9 MB /  0.5 MB gz    no eval, no REPL, no runtime macros
clojure.core 8.7 MB /  0.7 MB gz    kernel alone — an embedding, not a Clojure
kernel      19.4 MB /  2.1 MB gz    FLOOR: Gambit runtime + jolt kernel
full        31.0 MB /  3.3 MB gz
```

The floor is two thirds of the bundle and cannot be dropped, so profiles trade features for the remaining third: **`repl` ships 27.7 MB / 3.1 MB against `full`'s 32.6 MB / 3.5 MB**. That also settles what *not* to build: a feature group worth kilobytes is churn, so only separable-and-measurable groups exist.

## The mechanism

`host/gambit/profiles.ss` is data — optional feature groups, and profiles built from them (`full`, `repl`, `kernel`). `boot.ss` stays the single source of load order; a group only names which of its files are optional, so there is no second copy of the 45-file manifest to drift out of sync.

```bash
make gambitweb PROFILE=repl
```

`gen-boot.ss` writes the boot for a profile **on Chez** — Gambit resolves `##include` at expansion time, so which files a build carries cannot be a runtime choice; same reasoning as the seed and `records-gambit.ss`.

## Excluded features report themselves

Excluding a group leaves its files out **and binds every name it owned to a raise that names the group** — derived by scanning the excluded files, not from a hand-kept list, so the error surface cannot drift from the code:

```
user=> (re-seq #"[a-z]+" "ab cd")
java.lang.UnsupportedOperationException: jolt-re-pattern is not in this build:
the regex feature group was excluded

user=> (clojure.string/split "a,b" #",")     ; reaches regex internally
java.lang.UnsupportedOperationException: jolt-re-pattern is not in this build: ...
```

A predicate over a type the build cannot hold answers `false` — a value simply is not a regex — while anything that would produce or consume that type raises. Same split as the hand-written degradations in `host-vars.ss`.

Two hazards the derivation has to respect, both found by running it:

- A **vendored** file defines standard-looking names (irregex has its own `vector-copy`); shadowing one with a raise would break a build rather than describe it, so only names we own are degraded.
- A `define` scan cannot see `define-record-type`'s generated `NAME?` — the blind spot that left `jhost?` unbound when the class model probed it — so record predicates are scanned explicitly.

## Verification

`make gambitprofile` (new, ~10s, a gsi load with no js compile) gates both halves: the reduced profile still runs arithmetic, collections, lazy seqs, recursion, records and multimethods, and each excluded route names its group. It caught two real errors while being written, including a wrong sum in one of my own expectations.

Both bundles built and run under node; gambitcheck / gambitkernel / gambiteval unchanged and green on the full profile; full gate green, 56 ci targets. README documents the profiles with the cost table, and the site's Scheme Backends page covers the mechanism.