### PR TITLE
Fibers R2: per-fiber dynamic state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fibers R2 (jolt-nvpr.3): per-fiber dynamic state.** A fiber's `binding`
+  frames, current namespace, and STM `*txn*` now travel with the fiber instead
+  of the carrier. R0 pinned the bug: dyn-binding.ss pushes a binding frame by
+  calling a thread parameter as a setter, and a setter write survives a
+  continuation escape — a fiber parked inside a `binding` leaked its frames
+  onto the carrier, visible to the scheduler and every other fiber, and a
+  second fiber's pop could pop the parked fiber's. The fix lives in the
+  scheduler: each fiber carries a dynamic slice (`host/chez/fibers.ss`,
+  `jolt-dslice`), saved on switch-out and restored on switch-in, with the
+  carrier reverting to the caller's state between fibers. Writes are diffed
+  with eq? (a thread-parameter write is 33ns vs 2ns to read), so identical
+  slices cost reads only; the switch ratio in `make fibers` moved from ~22x to
+  ~27x a bare procedure call (ceiling 60x). `sa-fiber-spawn` conveys the
+  parent's bindings and namespace but never its `*txn*` (async-go-spawn
+  parity), so a child spawned inside a dosync cannot join the parent's
+  transaction. `dyn-binding.ss` is untouched. The new `make fibers` gate
+  (`fibers-state-test.ss`) asserts the six R2 scenarios: binding invisibility
+  between siblings, the parked-frame leak regression, bindings intact on
+  resume, transaction isolation across two fibers on one carrier, spawn
+  conveyance, and namespace-follows-fiber.
+
 - **Fibers R1 (jolt-nvpr.2): the fiber primitive and a single-carrier
   scheduler** behind the new `coroutines` CONTRACT.txt tier (`sa-fiber-spawn`,
   `sa-fiber-yield`, `sa-fiber-resume`, `sa-fiber-run-all`), in

--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,11 @@ values:
 # per-fiber raise isolation, round-robin order, deep-stack yield) plus the
 # pinned numbers (spawn < 5us, switch < 100ns, per-fiber live < 8KB by R0's
 # corrected absolute-live-bytes measurement). Detection-free, no jolt boot.
+# fibers-state-test.ss is the R2 dynamic-slice gate (per-fiber bindings/ns/txn;
+# loads rt.ss for the real thread parameters).
 fibers:
 	@$(CHEZ) --script test/chez/fibers-test.ss
+	@$(CHEZ) --script test/chez/fibers-state-test.ss
 
 # Corpus conformance vs JVM-sourced expecteds (allowlist + floor).
 corpus:

--- a/host/chez/fibers.ss
+++ b/host/chez/fibers.ss
@@ -25,9 +25,11 @@
 ;;     and invoked exactly once per resume, so the multi-shot re-entry trap
 ;;     cannot happen).
 ;;
-;; The slice: the record carries a `slice` field that R1 leaves #f — R2 owns
-;; the dynamic-binding work (per the round split, dyn-binding.ss is NOT
-;; touched here; the field is the place R2 fills).
+;; The slice: the record carries a `slice` field holding the fiber's per-fiber
+;; dynamic state (a jolt-dslice record — the dyn-binding-stack value, the
+;; current namespace, and the STM *txn*). R2 owns the dynamic-binding work
+;; (per the round split, dyn-binding.ss is NOT touched here; the swap lives in
+;; the switch below).
 ;;
 ;; Loaded from rt.ss in the usual place AND from scheme-adapter-runtime.ss
 ;; (which loads first, so the gate-time adaptercheck, which loads only that
@@ -39,7 +41,8 @@
 ;; sa-fiber-resume) | 'done | 'dead (raised; error field holds the condition).
 ;; thunk: the fiber body (immutable). k: the one-shot continuation captured at
 ;; the last park (unconsumed while 'parked). result/error: completion payload.
-;; next: intrusive run-queue link. slice: R2's per-fiber dynamic slice (#f).
+;; next: intrusive run-queue link. slice: R2's per-fiber dynamic slice (a
+;; jolt-dslice: dyn-binding-stack value, current ns, *txn* — see below).
 (define-record-type jolt-fiber
   (fields (mutable state)
           thunk
@@ -49,6 +52,30 @@
           (mutable next)
           (mutable slice))
   (nongenerative jolt-fiber-v1))
+
+;; --- the per-fiber dynamic slice ---------------------------------------------
+;; R2 (jolt-nvpr.3). jolt's `binding` macro pushes by calling the
+;; dyn-binding-stack thread parameter as a SETTER, and a setter write is not
+;; undone by a continuation escape (R0(a)): a fiber that parks inside a binding
+;; leaves its frames on the carrier, visible to the scheduler and to every
+;; other fiber, and a second fiber popping its own frame can pop the parked
+;; fiber's. `set-chez-ns!` leaks the same way. The swap below saves the fiber's
+;; slice on switch-out and restores the incoming party's on switch-in.
+;;
+;; The scheduler's own slice is captured per sa-fiber-run-all entry, so the
+;; carrier reverts to the CALLER's state between fibers (the parked-fiber leak
+;; regression). *txn* is parameterize-managed inside dosync, so it unwinds on
+;; park on its own (R0(a)) — its two jobs in the slice are: a fiber parked
+;; inside a dosync resumes INSIDE its txn, and sa-fiber-spawn does NOT convey
+;; it (async-go-spawn parity: a child whose first dosync joined the parent's
+;; txn would write into the parent's log).
+;;
+;; Writes are diffed with eq?: a thread-parameter WRITE is ~33 ns vs ~2 ns to
+;; read (R0(c)), so a swap between two parties with identical slices — the
+;; common case — costs a few reads and zero writes.
+(define-record-type jolt-dslice
+  (fields (mutable stack) (mutable ns) (mutable txn))
+  (nongenerative jolt-dslice-v1))
 
 ;; The virtual-register slot holding the current fiber record (0 = not on a
 ;; fiber — a fresh thread starts every slot at fixnum 0, NOT #f). Allocated
@@ -68,6 +95,59 @@
 ;; can only park while ITS carrier's scheduler is running it, so there is
 ;; never a second writer.
 (define jolt-sched-k #f)
+
+;; The three thread parameters that make up a fiber's dynamic slice live in
+;; other host files (dyn-binding.ss's dyn-binding-stack, multimethods.ss's
+;; chez-current-ns-param, refs.ss's *txn*). The full boot defines all three
+;; BEFORE this file's last load (rt.ss loads fibers.ss last), so these
+;; references capture the real parameters there; a standalone load (the R1
+;; gate, or scheme-adapter-runtime.ss before the rest of rt.ss) sees them
+;; unbound and gets a private fallback parameter instead — behaviorally
+;; identical for the R1 semantics, and rt.ss's later re-load of this file
+;; re-captures the real ones (the harmless re-define pattern this file already
+;; uses for jolt-vreg-current-fiber). The probe is a guard on the reference,
+;; not top-level-bound? (blocklisted: fibers.ss is not a target-owned file).
+(define jolt-slice-stack-param
+  (guard (e (#t (make-thread-parameter '())))
+    dyn-binding-stack))
+(define jolt-slice-ns-param
+  (guard (e (#t (make-thread-parameter "user")))
+    chez-current-ns-param))
+(define jolt-slice-txn-param
+  (guard (e (#t (make-thread-parameter #f)))
+    *txn*))
+
+;; The scheduler's own slice — the caller's dynamic state at sa-fiber-run-all
+;; entry — kept in one mutable record so the per-run capture allocates nothing.
+(define jolt-sched-slice (make-jolt-dslice #f #f #f))
+(define (jolt-sched-slice-capture!)
+  (jolt-dslice-stack-set! jolt-sched-slice (jolt-slice-stack-param))
+  (jolt-dslice-ns-set! jolt-sched-slice (jolt-slice-ns-param))
+  (jolt-dslice-txn-set! jolt-sched-slice (jolt-slice-txn-param)))
+
+;; Save the CURRENT carrier values into fiber f's slice record. Runs in f's own
+;; dynamic context, BEFORE the switch invokes the scheduler continuation — the
+;; parameterize unwind fires as part of that invocation, so reading earlier is
+;; the only way to capture a txn a fiber is parked inside.
+(define (jolt-fiber-slice-save! f)
+  (let ((s (jolt-fiber-slice f)))
+    (jolt-dslice-stack-set! s (jolt-slice-stack-param))
+    (jolt-dslice-ns-set! s (jolt-slice-ns-param))
+    (jolt-dslice-txn-set! s (jolt-slice-txn-param))))
+
+;; Restore the carrier to slice s's values. Writes are diffed with eq?: a
+;; thread-parameter WRITE is ~33 ns vs ~2 ns to read (R0(c)), so a swap between
+;; two fibers with identical slices (the common case — empty stacks, same ns,
+;; no txn) costs the reads and zero writes. eq? can only skip a write when the
+;; carrier already holds the exact object, so it can never miss a change.
+(define (jolt-fiber-slice-restore! s)
+  (when s
+    (let ((v (jolt-dslice-stack s)))
+      (unless (eq? v (jolt-slice-stack-param)) (jolt-slice-stack-param v)))
+    (let ((v (jolt-dslice-ns s)))
+      (unless (eq? v (jolt-slice-ns-param)) (jolt-slice-ns-param v)))
+    (let ((v (jolt-dslice-txn s)))
+      (unless (eq? v (jolt-slice-txn-param)) (jolt-slice-txn-param v)))))
 
 (define (jolt-current-fiber)
   (let ((r (virtual-register jolt-vreg-current-fiber)))
@@ -108,6 +188,7 @@
   (call/1cc
     (lambda (k)
       (jolt-fiber-k-set! f k)
+      (jolt-fiber-slice-save! f)
       (jolt-sched-k))))
 
 ;; (sa-fiber-yield) -> void. Park the current fiber and move it to the back of
@@ -142,10 +223,19 @@
     (jolt-fiber-enqueue! f)))
 
 ;; (sa-fiber-spawn thunk) -> fiber. Create a fiber running THUNK and make it
-;; runnable; return the record. Spawning inside a fiber is legal. The slice
-;; field starts #f (R2 conveys the parent's bindings).
+;; runnable; return the record. Spawning inside a fiber is legal. The child's
+;; slice CONVEYS the parent's current dynamic state (the carrier's live values
+;; at spawn — reading the params in the parent's context), exactly as
+;; async-go-spawn snapshots (dyn-binding-stack) for a thread today; *txn* is
+;; always #f so a child spawned inside a dosync cannot join the parent's
+;; transaction (ref-sets into the parent's log would be committed by the
+;; parent, not the child).
 (define (sa-fiber-spawn thunk)
-  (let ((f (make-jolt-fiber 'ready thunk #f #f #f #f #f)))
+  (let ((f (make-jolt-fiber
+            'ready thunk #f #f #f #f
+            (make-jolt-dslice (jolt-slice-stack-param)
+                              (jolt-slice-ns-param)
+                              #f))))
     (jolt-fiber-enqueue! f)
     f))
 
@@ -157,7 +247,16 @@
   (call/1cc
     (lambda (k)
       (set! jolt-sched-k k)
-      (jolt-fiber-resume* f))))
+      ;; scheduler -> fiber: restore the incoming fiber's slice BEFORE running
+      ;; it (for a resume, before its continuation re-enters — the dynamic-wind
+      ;; before-thunks then re-fire over the restored values)
+      (jolt-fiber-slice-restore! (jolt-fiber-slice f))
+      (jolt-fiber-resume* f)))
+  ;; The fiber parked, finished, or died: its setter-written dynamic state
+  ;; (binding frames, current ns) is still live on the carrier — a continuation
+  ;; escape does not undo a setter write (R0(a)). fiber -> scheduler: revert to
+  ;; the scheduler's slice so the carrier between fibers is the CALLER's state.
+  (jolt-fiber-slice-restore! jolt-sched-slice))
 
 ;; Per-fiber exception isolation: the guard frame sits BELOW the fiber's own
 ;; frames and is part of the fiber's captured continuation, so it catches a
@@ -190,6 +289,7 @@
   (jolt-fiber-state-set! f 'done)
   (jolt-fiber-result-set! f r)
   (jolt-fiber-k-set! f #f)
+  (jolt-fiber-slice-set! f #f)
   (set-virtual-register! jolt-vreg-current-fiber 0)
   (jolt-sched-k))
 
@@ -197,14 +297,18 @@
   (jolt-fiber-state-set! f 'dead)
   (jolt-fiber-error-set! f e)
   (jolt-fiber-k-set! f #f)
+  (jolt-fiber-slice-set! f #f)
   (set-virtual-register! jolt-vreg-current-fiber 0)
   (jolt-sched-k))
 
 ;; (sa-fiber-run-all) -> void. Run the carrier's run queue until it drains —
 ;; the scheduler shape the plan names ("run ready fibers until the queue
 ;; drains, then block in the poller"); the poll step is R8's. A fiber that
-;; parks (jolt-fiber-park!) stops the drain until resumed.
+;; parks (jolt-fiber-park!) stops the drain until resumed. The scheduler's
+;; slice is captured at entry — the caller's dynamic state, which every park
+;; restores onto the carrier.
 (define (sa-fiber-run-all)
+  (jolt-sched-slice-capture!)
   (let loop ()
     (let ((f (jolt-fiber-dequeue!)))
       (when f

--- a/test/chez/fibers-state-test.ss
+++ b/test/chez/fibers-state-test.ss
@@ -1,0 +1,195 @@
+;; test/chez/fibers-state-test.ss — R2 gate for per-fiber dynamic state
+;; (epic jolt-nvpr.3). Run: chez --script test/chez/fibers-state-test.ss
+;; (wired in as part of `make fibers`).
+;;
+;; R0 settled the scope: `guard` and `parameterize` need nothing (a resumed
+;; fiber's own handler catches; parameterize unwinds on park and reinstates on
+;; resume). The one real bug: dyn-binding.ss pushes a binding frame by calling
+;; the dyn-binding-stack thread parameter as a SETTER, and a setter write is
+;; not undone by a continuation escape — a fiber that parks inside a binding
+;; leaves its frames on the carrier, visible to the scheduler and to every
+;; other fiber, and a second fiber popping its own frame can pop the parked
+;; fiber's. set-chez-ns! leaks the same way. R2 fixes it by saving and
+;; restoring the fiber's dynamic slice (dyn-binding-stack, current ns, *txn*)
+;; in the switch.
+;;
+;; This file loads the FULL host runtime (rt.ss), because the slice tests need
+;; the real dyn-binding-stack / chez-current-ns-param / *txn* parameters plus
+;; the push/bind and STM seams. It drives them at host level
+;; (jolt-push-thread-bindings / jolt-sync / jolt-ref-* / set-chez-ns!) rather
+;; than through the overlay macros, so it stays a chez --script gate like
+;; fibers-test.ss. The assert conventions match fibers-test.ss.
+;;
+;; Gate scenarios (spec, in order):
+;;   1. `binding` in one fiber is invisible to another fiber on the same carrier.
+;;   2. A parked fiber's binding frame is invisible to the scheduler — the exact
+;;      R0 leak, as a regression test.
+;;   3. A fiber's bindings are intact on resume after other fibers have pushed
+;;      and popped their own.
+;;   4. Two fibers on one carrier cannot join each other's transaction: a fiber
+;;      inside a dosync parks, another fiber runs and sees no transaction.
+;;   5. Spawn conveys the parent's bindings (and does NOT convey its *txn*).
+;;   6. The current namespace follows the fiber, not the carrier.
+
+(import (chezscheme))
+(load "host/chez/rt.ss")
+
+(define total 0)
+(define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred
+    (set! fails (+ fails 1))
+    (printf "  FAIL: ~a\n" name)))
+
+(printf "== per-fiber dynamic state ==\n")
+
+;; --- 1. binding in one fiber invisible to another on the same carrier -------
+(define *x* (def-dynvar! "app" "*x*" 0))
+(define vis-log '())
+(define vis-f1
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-push-thread-bindings (jolt-hash-map *x* 42))
+      (set! vis-log (cons (jolt-var-get *x*) vis-log))     ; 42, its own binding
+      (sa-fiber-yield)
+      (set! vis-log (cons (jolt-var-get *x*) vis-log))     ; still 42 after f2 ran
+      (jolt-pop-thread-bindings))))
+(define vis-f2
+  (sa-fiber-spawn
+    (lambda ()
+      (set! vis-log (cons (jolt-var-get *x*) vis-log)))))  ; must be the root 0
+(sa-fiber-run-all)
+(ok "1. binding invisible to a sibling fiber" (equal? vis-log '(42 0 42)))
+(ok "1. no frame left on the carrier after both done" (eq? (dyn-binding-stack) '()))
+
+;; --- 2. a parked fiber's frame is invisible to the scheduler (R0 leak) ------
+;; Without the slice swap, (dyn-binding-stack) after the drain would be
+;; ((FIBER-FRAME)) — the fiber parks INSIDE the binding, the setter write
+;; survives the continuation escape, and the leak is visible to the caller.
+(define *y* (def-dynvar! "app" "*y*" 0))
+(define leak-f
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-push-thread-bindings (jolt-hash-map *y* 7))
+      (jolt-fiber-park!)            ; park inside the binding
+      (jolt-pop-thread-bindings))))
+(sa-fiber-run-all)
+(ok "2. parked fiber's frame invisible to the scheduler" (eq? (dyn-binding-stack) '()))
+(ok "2. parked fiber's value not visible to the caller" (= (jolt-var-get *y*) 0))
+(sa-fiber-resume leak-f)
+(sa-fiber-run-all)
+(ok "2. fiber that parked inside a binding completes"
+    (eq? (jolt-fiber-state leak-f) 'done))
+
+;; --- 3. bindings intact on resume after other fibers pushed and popped ------
+(define *z* (def-dynvar! "app" "*z*" 0))
+(define intact-log '())
+(define z-f1
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-push-thread-bindings (jolt-hash-map *z* 100))
+      (set! intact-log (cons (jolt-var-get *z*) intact-log))   ; 100
+      (sa-fiber-yield)
+      ;; z-f2 has pushed and popped its own 200-frame meanwhile
+      (set! intact-log (cons (jolt-var-get *z*) intact-log))   ; still 100
+      (jolt-pop-thread-bindings))))
+(define z-f2
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-push-thread-bindings (jolt-hash-map *z* 200))
+      (set! intact-log (cons (jolt-var-get *z*) intact-log))   ; 200
+      (jolt-pop-thread-bindings))))
+(sa-fiber-run-all)
+(ok "3. bindings intact on resume after sibling push/pop"
+    (equal? intact-log '(100 200 100)))
+(ok "3. top-level stack clean after the round" (eq? (dyn-binding-stack) '()))
+
+;; --- 4. two fibers on one carrier cannot join each other's transaction ------
+;; t1 parks INSIDE a dosync (ref-set r 1, park, ref-set r 2). On park the
+;; parameterize unwinds *txn* and with-mutex releases stm-lock, and the slice
+;; swap keeps the carrier's *txn* #f — t2 runs and sees NO transaction; if it
+;; had inherited t1's *txn*, t2's jolt-sync would have joined it (ref-set into
+;; t1's log) instead of starting its own.
+(define r (jolt-ref-new 0))
+(define t1
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-sync
+        (lambda ()
+          (jolt-ref-set r 1)
+          (jolt-fiber-park!)
+          (jolt-ref-set r 2)))
+      't1-committed)))
+(sa-fiber-run-all)
+(ok "4. t1 parked inside its txn" (eq? (jolt-fiber-state t1) 'parked))
+(ok "4. no txn on the carrier while t1 is parked" (eq? (*txn*) #f))
+(ok "4. t1's write not committed while parked" (= (jolt-ref-val r) 0))
+(define txn-log '())
+(define t2
+  (sa-fiber-spawn
+    (lambda ()
+      (set! txn-log (cons (jolt-txn-running?) txn-log))        ; #f — cannot join
+      (jolt-sync (lambda () (jolt-ref-set r 9)))               ; its OWN txn
+      (set! txn-log (cons (jolt-txn-running?) txn-log)))))     ; #f — over, not joined
+(sa-fiber-run-all)
+(ok "4. t2 sees no transaction while t1 is parked" (equal? txn-log '(#f #f)))
+(ok "4. t2's own txn committed" (= (jolt-ref-val r) 9))
+(sa-fiber-resume t1)
+(sa-fiber-run-all)
+(ok "4. t1 resumed inside ITS txn and committed last" (= (jolt-ref-val r) 2))
+(ok "4. t1 completed" (eq? (jolt-fiber-state t1) 'done))
+
+;; --- 5. spawn conveys the parent's bindings (and NOT its *txn*) ------------
+(define *w* (def-dynvar! "app" "*w*" 0))
+(define conv-log '())
+(define conv-f
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-push-thread-bindings (jolt-hash-map *w* 5))
+      (let ((child
+             (sa-fiber-spawn
+               (lambda () (set! conv-log (cons (jolt-var-get *w*) conv-log))))))
+        (sa-fiber-yield)                                    ; let the child run
+        (set! conv-log (cons 'parent-ok conv-log)))
+      (jolt-pop-thread-bindings))))
+(sa-fiber-run-all)
+(ok "5. spawn conveys the parent's bindings" (equal? conv-log '(parent-ok 5)))
+(ok "5. parent's frame popped at the end" (= (jolt-var-get *w*) 0))
+(define conv-txn #t)
+(define txn-parent
+  (sa-fiber-spawn
+    (lambda ()
+      (jolt-sync
+        (lambda ()
+          (let ((child
+                 (sa-fiber-spawn
+                   (lambda () (set! conv-txn (jolt-txn-running?))))))
+            (sa-fiber-yield)))))))
+(sa-fiber-run-all)
+(ok "5. spawn does NOT convey the parent's txn" (eq? conv-txn #f))
+
+;; --- 6. the current namespace follows the fiber, not the carrier ------------
+(define ns-log '())
+(define ns-f1
+  (sa-fiber-spawn
+    (lambda ()
+      (set-chez-ns! "app.a")
+      (set! ns-log (cons (chez-current-ns) ns-log))
+      (sa-fiber-yield)
+      (set! ns-log (cons (chez-current-ns) ns-log)))))
+(define ns-f2
+  (sa-fiber-spawn
+    (lambda ()
+      (set! ns-log (cons (chez-current-ns) ns-log))      ; must be the carrier's "user"
+      (set-chez-ns! "app.b"))))
+(sa-fiber-run-all)
+(ok "6. namespace follows the fiber, not the carrier"
+    (equal? ns-log '("app.a" "user" "app.a")))
+(ok "6. carrier ns restored to the scheduler's after the round"
+    (string=? (chez-current-ns) "user"))
+
+(printf "\nfibers-state-test: ~a checks, ~a failure(s)\n" total fails)
+(if (= fails 0)
+    (begin (printf "fibers-state-test: PASS — per-fiber dynamic state\n") (exit 0))
+    (exit 1))

--- a/test/chez/fibers-test.ss
+++ b/test/chez/fibers-test.ss
@@ -213,6 +213,14 @@
 ;; catches a real regression (a switch that starts copying stacks, or a slice
 ;; swap that regresses to thread parameters at 33 ns per write) without
 ;; measuring the runner's mood.
+;;
+;; The ratio is not machine-INVARIANT, only machine-tolerant: continuation
+;; capture is more memory-bound than a bare call, so it degrades faster on a
+;; slower box. Measured pair — dev machine 53ns switch / 2.40ns call = 22x;
+;; shared CI runner 134ns / 3.92ns = 34x (the switch slowed 2.5x, the call
+;; 1.6x). 60x was chosen to sit ~1.75x above the CI figure; a much slower or
+;; noisier runner could climb toward it, and the fix then is to raise the
+;; ceiling with the new measured pair recorded here, not to delete the check.
 (define CAL-N 2000000)
 (define (cal-op x) x)                       ; a bare procedure call
 (define cal-t0 (mono-nanos))


### PR DESCRIPTION
R0 narrowed this round to a single proven bug, so it is much smaller than planned.

## The bug

`dyn-binding.ss` pushes a binding frame by calling the thread parameter as a **setter**:

```scheme
(dyn-binding-stack (cons pairs (dyn-binding-stack)))
```

A setter write is not undone by a continuation escape. So a fiber parked inside a `binding` left its frame **on the carrier** — visible to the scheduler and to every other fiber on it — and a sibling popping its own frame could pop the parked fiber's.

R0 cleared the two things that looked scarier: `guard` handler chains ride the continuation correctly (the Guile Fibers exception bug does not reproduce on Chez) and `parameterize` unwinds on park and reinstates on resume. So the fix is contained to the scheduler and **`dyn-binding.ss` is untouched** — rewriting `binding` onto `parameterize` would also work, but that file is hot and shared by every thread.

## The fix, and why it is nearly free

The fiber's slice — binding stack, current ns, `*txn*` — is saved into the `slice` field R1 reserved and restored on switch. Restores are **diffed with `eq?`**, because R0 measured a thread-parameter write at **33 ns** against **2 ns** to read: a switch between fibers with identical slices (the common case — empty stacks, same ns, no txn) costs three reads and *zero* writes. `eq?` can only skip a redundant write, never miss a change.

One ordering subtlety: `*txn*` must be read **before** the switch invokes the scheduler continuation, because the `parameterize` unwind fires as part of that invocation.

Measured cost: the switch goes **53 ns → 64 ns**, against the **107 ns** the naive three-writes-per-switch version measured in R0.

Spawn conveys the parent's bindings, as `async-go-spawn` already does for a thread, but deliberately does **not** convey its transaction.

## Gate — `test/chez/fibers-state-test.ss`, 19 checks, run from `make fibers`

- `binding` in one fiber invisible to a sibling on the same carrier, and no frame left on the carrier afterwards
- **the leak itself as a regression**: a parked fiber's frame invisible to the scheduler, its value invisible to the caller
- bindings intact on resume after siblings push and pop their own
- **STM isolation**: a fiber parks mid-transaction, a sibling runs seeing no txn and commits its own, then the first resumes *inside its own* txn and commits last
- spawn conveys the parent's bindings but not its transaction
- the current namespace follows the fiber, not the carrier

## Verification

`make fibers` 29 + 19 checks; `portcheck` (102 files), `adaptercheck`, `gambitcheck` green; full gate green at 57 ci targets. The switch assertion stays a ratio against a bare-call calibration (26.9x local, ceiling 60x) rather than an absolute ceiling — R1's absolute 100 ns passed locally at 53 ns and failed CI at 124 ns.