### PR TITLE
Fibers R6: measure it, and keep :thread the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ JOLT-TARGETS-NEEDING-DEPS := \
 
 # Only mark PHONY targets for names that have file system conflicts:
 .PHONY: build install test ci gate-run-test gate-run-ci gate-status \
-        gambitcheck gambitkernel gambiteval gambitseed gambitweb gambitprofile
+        gambitcheck gambitkernel gambiteval gambitseed gambitweb gambitprofile \
+        fibersbench
 
 default:: build
 
@@ -233,6 +234,13 @@ fibers:
 	@$(CHEZ) --script test/chez/fibers-chan-test.ss
 	@$(CHEZ) --script test/chez/fibers-go-test.ss
 	@$(CHEZ) --script test/chez/fibers-pool-test.ss
+
+# Fibers R6 (jolt-nvpr.7): the :thread vs :fiber benchmark harness. Opt-in and
+# NOT part of the gate — benchmarks do not belong in CI. Runs each measurement
+# phase as a subprocess and prints the comparison table; like aba.sh it is
+# blind to dev mode (every phase runs the runtime from source).
+fibersbench:
+	@sh bench/fibers/run.sh
 
 # Corpus conformance vs JVM-sourced expecteds (allowlist + floor).
 corpus:

--- a/bench/fibers/bench-fibers.ss
+++ b/bench/fibers/bench-fibers.ss
@@ -1,0 +1,464 @@
+;; bench/fibers/bench-fibers.ss — Fibers R6 measurement harness (jolt-nvpr.7).
+;;
+;; One phase per invocation:  chez --script bench/fibers/bench-fibers.ss <phase> [arg]
+;; Run the full set (and get the comparison table) via bench/fibers/run.sh,
+;; wired in as `make fibersbench`. Opt-in; NOT part of make test / make ci.
+;;
+;; Every memory and per-switch figure is produced the R0-corrected way: objects
+;; RETAINED in a global, a forced (collect (collect-maximum-generation)),
+;; ABSOLUTE live bytes, cross-checked against peak RSS from /usr/bin/time -l
+;; (the run.sh wrapper). Per-phase bytes-allocated deltas on unretained objects
+;; are never used — that method produced two wrong findings earlier in this
+;; epic (fibers-r0-findings.md, CORRECTIONS).
+;;
+;; The :thread backend here is today's go = one OS thread per go block
+;; (async-go-spawn-thread); :fiber is the fiber backend (jolt-fiber-go-spawn /
+;; sa-fiber-spawn). Both are exactly what the `go` macro dispatches to at
+;; runtime, called at the host level so the timed region measures the runtime,
+;; not compile-eval.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(printf "bench: chez ~a threaded ~a cpus ~a\n"
+        (scheme-version) (threaded?) (guard (e (#t 1)) (jolt-available-processors)))
+(flush-output-port (current-output-port))
+
+(define argv (command-line))
+(define (a i) (and (fx<? i (length argv)) (list-ref argv i)))
+
+(define (mono-nanos)
+  (let ((t (current-time 'time-monotonic)))
+    (+ (* 1000000000 (time-second t)) (time-nanosecond t))))
+(define (now-secs) (/ (exact->inexact (mono-nanos)) 1000000000.0))
+
+;; Bounded wait: a bug must print a TIMEOUT, never hang the phase.
+(define (wait-until pred secs what)
+  (let ((deadline (+ (now-secs) secs)))
+    (let loop ()
+      (cond ((pred) #t)
+            ((> (now-secs) deadline)
+             (printf "  TIMEOUT waiting for ~a (~a s)\n" what secs) #f)
+            (else (sleep (make-time 'time-duration 1000000 0)) (loop))))))
+
+(define (spawn-n n mk)
+  (let loop ((i 0) (acc '()))
+    (if (fx<? i n) (loop (fx+ i 1) (cons (mk i) acc)) (reverse acc))))
+
+(define (all-done? fs)
+  (or (null? fs) (and (eq? (jolt-fiber-state (car fs)) 'done) (all-done? (cdr fs)))))
+
+(define (flush!) (flush-output-port (current-output-port)))
+
+;; --- 1. spawn cost -----------------------------------------------------------
+;; K processes that immediately park, one K per process (so a failed run cannot
+;; contaminate the next K with its leftover blocked threads). The thread body
+;; blocks on a shared empty channel take — the go/thread park. The fiber body
+;; parks at the primitive (the R1 shape the plan's 0.84us spawn number came
+;; from); the go-fiber body parks on a fresh channel (the go path, minus the
+;; O(K^2) shared-channel waiter registration that would pollute a spawn number
+;; with channel cost — that cost is a property of the channel, not the spawn).
+;; Pool (fiber backends): started before the timed region — a real process pays
+;; the one-time carrier start once.
+(define (spawn-phase backend k)
+  (define parked-mu (make-mutex))
+  (define parked 0)
+  (define park-ch (jolt-async-chan 0))
+  (define t0 0) (define t1 0) (define t2 0)
+  (define created 0)
+  (define fail-msg #f)
+  (define got-all #f)
+  (define (bump-parked!)
+    (mutex-acquire parked-mu)
+    (set! parked (+ parked 1))
+    (mutex-release parked-mu))
+  (define (spawn-one)
+    (case backend
+      ((thread)
+       (async-go-spawn-thread
+        (lambda () (bump-parked!) (jolt-async-take park-ch))))
+      ((fiber)
+       (sa-fiber-spawn (lambda () (bump-parked!) (jolt-fiber-park!) 'x)))
+      ((fiber-go)
+       (jolt-fiber-go-spawn
+        (lambda () (bump-parked!) (jolt-fiber-<! (jolt-async-chan 0)))))
+      (else (error 'spawn-phase "bad backend" backend))))
+  ;; Pool (fiber backends): start BEFORE the timed region, then let the fresh
+  ;; carrier threads reach their first safepoint (condition-wait) before the
+  ;; baseline collect — a collect in the fork window races "cannot collect when
+  ;; multiple threads are active" (probe: .dirge/probes/fibers-r6/gc-with-carriers.ss).
+  (when (memq backend '(fiber fiber-go))
+    (jolt-fiber-ensure-carrier!)
+    (sleep (make-time 'time-duration 200000000 0)))
+  (set! parked 0)
+  (collect (collect-maximum-generation))
+  (set! t0 (mono-nanos))
+  (let loop ((i 0))
+    (cond
+      (fail-msg #f)
+      ((fx=? i k) #f)
+      ((> (- (now-secs) (/ (exact->inexact t0) 1000000000.0)) 20.0)
+       (set! fail-msg
+             (string-append "budget: only " (number->string i)
+                            " created in 20 s (machine swapping?)")))
+      (else
+       (guard (e (#t (set! fail-msg
+                           (if (condition? e) (condition-message e)
+                               (format "~a" e)))))
+         (spawn-one))
+       (unless fail-msg (set! created (fx+ i 1)))
+       (loop (fx+ i 1)))))
+  (set! t1 (mono-nanos))
+  (set! got-all
+        (wait-until (lambda () (fx=? parked k)) 30.0
+                    (string-append (symbol->string backend) " spawns to park")))
+  (set! t2 (mono-nanos))
+  (when (and (fx=? created k) (not got-all))
+    (set! fail-msg (string-append "hang: " (number->string created)
+                                  " created but not all parked in 30 s")))
+  (printf "backend: ~a\n" backend)
+  (printf "k: ~a\n" k)
+  (printf "created: ~a/~a\n" created k)
+  (printf "create-ms: ~a\n" (exact->inexact (/ (- t1 t0) 1000000.0)))
+  (printf "per-create-us: ~a\n"
+          (if (fx>? created 0) (exact->inexact (/ (- t1 t0) 1000.0 created)) 0.0))
+  (printf "all-parked: ~a\n" (if got-all #t #f))
+  (printf "park-ms: ~a\n" (exact->inexact (/ (- t2 t1) 1000000.0)))
+  (printf "fail: ~a\n" (or fail-msg "none"))
+  (flush!))
+
+;; --- 2. memory per parked process --------------------------------------------
+;; The R0 way: retain in a global, force (collect (collect-maximum-generation)),
+;; read ABSOLUTE live bytes. run.sh wraps each phase in /usr/bin/time -l and
+;; diffs peak RSS against the mem-baseline phase for the cross-check.
+(define (mem-baseline)
+  (collect (collect-maximum-generation))
+  (printf "count: 0\n")
+  (printf "live-delta: 0\n")
+  (flush!))
+
+(define (mem-fiber-raw)
+  ;; R0's exact shape: 200k sa-fiber-spawn'd fibers run once and park, retained.
+  (define k 200000)
+  (define mem-held '())
+  (define baseline 0)
+  (define live-delta 0)
+  (define parked-n 0)
+  (jolt-fiber-carrier-count-set! 1)          ; run-all drains carrier 0 only
+  (collect (collect-maximum-generation))
+  (set! baseline (bytes-allocated))
+  (set! mem-held
+        (spawn-n k (lambda (i) (sa-fiber-spawn (lambda () (jolt-fiber-park!) 'x)))))
+  (sa-fiber-run-all)
+  (set! parked-n
+        (let loop ((fs mem-held) (n 0))
+          (if (null? fs) n
+              (loop (cdr fs)
+                    (if (eq? (jolt-fiber-state (car fs)) 'parked) (+ n 1) n)))))
+  (collect (collect-maximum-generation))
+  (set! live-delta (- (bytes-allocated) baseline))
+  (printf "backend: fiber-raw\n")
+  (printf "count: ~a\n" k)
+  (printf "live-delta: ~a\n" live-delta)
+  (printf "per-live-bytes: ~a\n" (/ (exact->inexact (max 0 live-delta)) k))
+  (printf "parked: ~a/~a\n" parked-n k)
+  (flush!))
+
+(define (mem-fiber-go)
+  ;; A fiber parked on a CHANNEL TAKE (what a go body actually does), measured by
+  ;; retaining the FIBER RECORDS.
+  ;;
+  ;; Two earlier shapes of this phase both under-reported by ~20x, and both were
+  ;; retention bugs rather than anything about fibers:
+  ;;   - spawning through jolt-fiber-go-spawn retains only the RESULT channel it
+  ;;     returns, not the fiber; with each body parking on a channel of its own,
+  ;;     fiber and channel form a cycle nothing else points at, so the collector
+  ;;     took all of them and the figure described the retained channels.
+  ;;   - the `parked` counter was bumped on ENTRY to the body, before the take, so
+  ;;     it read 100000/100000 while fibers were still queued; pool-reset then
+  ;;     dropped the queues holding them.
+  ;; The RSS cross-check disagreed by 22x both times and was the honest number.
+  ;; Retaining what you are weighing is the whole method.
+  ;;
+  ;; This drains on the CALLING thread with sa-fiber-run-all and never starts the
+  ;; pool, because a forced full collect cannot run while carrier threads are
+  ;; alive (Chez: "cannot collect when multiple threads are active").
+  (define k 10000)
+  (define mem-held '())
+  (define park-ch #f)
+  (define baseline 0)
+  (define live-delta 0)
+  ;; Pin the pool to ONE carrier before spawning. R5 round-robins placement across
+  ;; N carriers, and sa-fiber-run-all on the calling thread drains only carrier 0's
+  ;; queue — so on this 10-core machine exactly a tenth of the fibers ever parked
+  ;; (1000 of 10000, 10000 of 100000: the ratio was the giveaway) and the figure
+  ;; described a tenth of the population.
+  (jolt-fiber-carrier-count-set! 1)
+  (jolt-fiber-pool-reset!)
+  (collect (collect-maximum-generation))
+  (set! baseline (bytes-allocated))
+  (set! park-ch (jolt-async-chan 1))
+  (set! mem-held (cons park-ch mem-held))
+  (do ((i 0 (fx+ i 1))) ((fx=? i k))
+    (set! mem-held (cons (sa-fiber-spawn (lambda () (jolt-fiber-<! park-ch))) mem-held)))
+  (sa-fiber-run-all)                       ; each fiber runs until it parks on the take
+  (let ((n-parked (let loop ((l mem-held) (n 0))
+                    (cond ((null? l) n)
+                          ((and (jolt-fiber? (car l))
+                                (eq? (jolt-fiber-state (car l)) (quote parked)))
+                           (loop (cdr l) (fx+ n 1)))
+                          (else (loop (cdr l) n))))))
+    (collect (collect-maximum-generation))
+    (set! live-delta (- (bytes-allocated) baseline))
+    (printf "backend: fiber-chan-park\n")
+    (printf "count: ~a\n" k)
+    (printf "live-delta: ~a\n" live-delta)
+    (printf "per-live-bytes: ~a\n" (/ (exact->inexact (max 0 live-delta)) k))
+    (printf "parked: ~a/~a\n" n-parked k)
+    (flush!)))
+
+(define (mem-thread)
+  ;; go threads: one OS thread per go, body blocked on a shared empty channel
+  ;; take. Thread stacks are NATIVE memory — bytes-allocated captures only the
+  ;; Scheme-side (thread records, result channels); the stack commit shows up in
+  ;; the RSS cross-check (per-thread RSS = (rss - baseline) / K).
+  (define k 2000)
+  (define parked-mu (make-mutex))
+  (define parked 0)
+  (define park-ch (jolt-async-chan 0))
+  (define mem-held '())
+  (define baseline 0)
+  (define live-delta 0)
+  (collect (collect-maximum-generation))
+  (set! baseline (bytes-allocated))
+  (do ((i 0 (fx+ i 1))) ((fx=? i k))
+    (set! mem-held
+          (cons (async-go-spawn-thread
+                 (lambda ()
+                   (mutex-acquire parked-mu)
+                   (set! parked (+ parked 1))
+                   (mutex-release parked-mu)
+                   (jolt-async-take park-ch)))
+                mem-held)))
+  (wait-until (lambda () (fx=? parked k)) 60.0 "threads to park")
+  (collect (collect-maximum-generation))
+  (set! live-delta (- (bytes-allocated) baseline))
+  (printf "backend: thread\n")
+  (printf "count: ~a\n" k)
+  (printf "live-delta: ~a\n" live-delta)
+  (printf "per-live-bytes: ~a\n" (/ (exact->inexact (max 0 live-delta)) k))
+  (printf "parked: ~a/~a\n" parked k)
+  (flush!))
+
+;; --- 3. channel throughput ---------------------------------------------------
+(define (backend-ops backend)
+  (if (eq? backend 'thread)
+      (list jolt-async-take jolt-async-give async-go-spawn-thread)
+      (list jolt-fiber-<! jolt-fiber->! jolt-fiber-go-spawn)))
+
+(define ping-last-ms 0.0)
+
+;; One ping-pong run, N round trips (each = A gives, B returns). Result in
+;; ping-last-ms so a caller can average runs without re-spawning the boot.
+(define (ping-pong-timed backend n)
+  (let ((ops (backend-ops backend)))
+    (define take (car ops)) (define give (cadr ops)) (define spawn (caddr ops))
+    (let ((ping (jolt-async-chan 0)) (pong (jolt-async-chan 0)))
+      (define t0 0) (define t1 0)
+      (define ra #f) (define rb #f)
+      (set! t0 (mono-nanos))
+      (set! ra (spawn (lambda () (let loop ((i 0))
+                                   (when (fx<? i n)
+                                     (give ping i) (take pong) (loop (fx+ i 1)))))))
+      (set! rb (spawn (lambda () (let loop ((i 0))
+                                   (when (fx<? i n)
+                                     (take ping) (give pong i) (loop (fx+ i 1)))))))
+      (jolt-async-take ra)                   ; blocks until A's go closes
+      (set! t1 (mono-nanos))
+      (set! ping-last-ms (exact->inexact (/ (- t1 t0) 1000000.0))))))
+
+(define (ping-phase backend pin-one?)
+  (define n 10000)
+  (define per-run '())
+  (define mean 0.0)
+  (define best 0.0)
+  (printf "backend: ~a\n" backend)
+  (printf "pool-carriers: ~a\n"
+          (if (eq? backend 'thread) 'n/a
+              (begin (if pin-one? (jolt-fiber-carrier-count-set! 1)
+                         (jolt-fiber-carrier-count-set! (jolt-available-processors)))
+                     (jolt-fiber-ensure-carrier!)
+                     (jolt-fiber-carrier-count))))
+  (set! per-run
+        (let loop ((i 0) (acc '()))
+          (if (fx=? i 3)
+              (reverse acc)
+              (begin (ping-pong-timed backend n) (loop (fx+ i 1) (cons ping-last-ms acc))))))
+  (set! mean (/ (apply + per-run) (length per-run)))
+  (set! best (apply min per-run))
+  (printf "runs-ms: ~a\n"
+          (apply string-append
+                 (map (lambda (x) (string-append (number->string x) " ")) per-run)))
+  (printf "mean-ms: ~a\n" mean)
+  (printf "per-roundtrip-us: ~a\n" (/ (* mean 1000.0) n))
+  (printf "per-handoff-us: ~a\n" (/ (* mean 1000.0) (* 2.0 n)))
+  (printf "handoffs-per-sec: ~a\n" (/ (* 2.0 n) (/ mean 1000.0)))
+  (flush!))
+
+(define fanin-last-ms 0.0)
+
+(define (fanin-phase backend)
+  (define p 8) (define m 2500)
+  (define per-run '())
+  (define mean 0.0)
+  (printf "backend: ~a\n" backend)
+  (set! per-run
+        (let loop ((i 0) (acc '()))
+          (if (fx=? i 3)
+              (reverse acc)
+              (begin
+                (let ((ops (backend-ops backend)))
+                  (define take (car ops)) (define give (cadr ops)) (define spawn (caddr ops))
+                  (let ((c (jolt-async-chan 0)))
+                    (define t0 0) (define rc #f)
+                    (set! t0 (mono-nanos))
+                    (set! rc (spawn (lambda () (let loop ((k 0))
+                                                 (when (fx<? k (* p m))
+                                                   (take c) (loop (fx+ k 1)))))))
+                    (do ((j 0 (fx+ j 1))) ((fx=? j p))
+                      (spawn (lambda () (let loop ((j 0))
+                                          (when (fx<? j m)
+                                            (give c j) (loop (fx+ j 1)))))))
+                    (jolt-async-take rc)
+                    (set! fanin-last-ms (exact->inexact (/ (- (mono-nanos) t0) 1000000.0)))))
+                (loop (fx+ i 1) (cons fanin-last-ms acc))))))
+  (set! mean (/ (apply + per-run) (length per-run)))
+  (printf "runs-ms: ~a\n"
+          (apply string-append
+                 (map (lambda (x) (string-append (number->string x) " ")) per-run)))
+  (printf "mean-ms: ~a\n" mean)
+  (printf "values-per-sec: ~a\n" (/ (* p m) (/ mean 1000.0)))
+  (flush!))
+
+;; --- 4. context-switch cost --------------------------------------------------
+(define (switch-phase)
+  ;; (a) bare continuation switch — R0's self-roundtrip, 12.5 ns.
+  (define N 1000000)
+  (define t0 0) (define t1 0)
+  (define bare-ns 0.0)
+  (define SW-N 64) (define SW-M 10000)
+  (define sched-ns 0.0)
+  (define old-trip 0)
+  (define (self-roundtrip n)
+    (if (= n 0) #f
+        (let ((v (call/cc (lambda (k) (k n)))))
+          (self-roundtrip (- v 1)))))
+  (define (sw-fiber)
+    (sa-fiber-spawn
+      (lambda () (let loop ((m SW-M)) (when (fx>? m 0) (sa-fiber-yield) (loop (fx- m 1)))))))
+  (define (run-sw)
+    (define fs (spawn-n SW-N (lambda (i) (sw-fiber))))
+    (sa-fiber-run-all)
+    fs)
+  (self-roundtrip 1000)
+  (collect (collect-maximum-generation))
+  (set! t0 (mono-nanos))
+  (self-roundtrip N)
+  (set! t1 (mono-nanos))
+  (set! bare-ns (/ (exact->inexact (- t1 t0)) N))
+  (printf "bare-switch-ns: ~a\n" bare-ns)
+  ;; (b) the current scheduler yield round trip WITH the slice swap — the R2
+  ;;     "64 ns" shape, on today's (R1+R2+R5) scheduler. 2 switches per yield.
+  (jolt-fiber-carrier-count-set! 1)
+  (run-sw)                                 ; warmup
+  (set! old-trip (collect-trip-bytes))
+  (collect-trip-bytes 100000000000)        ; no gen-0 in the timed region
+  (collect (collect-maximum-generation))
+  (set! t0 (mono-nanos))
+  (run-sw)
+  (set! t1 (mono-nanos))
+  (collect-trip-bytes old-trip)
+  (set! sched-ns (/ (exact->inexact (- t1 t0)) (* 2.0 SW-N SW-M)))
+  (printf "scheduler-switch-ns: ~a\n" sched-ns)
+  (printf "scheduler-switches: ~a\n" (* 2 SW-N SW-M))
+  (flush!))
+
+;; --- 5. scaling with carriers -------------------------------------------------
+(define (scaling-phase)
+  (define n-cpu (jolt-fiber-carrier-count))
+  (define M 40)
+  (define iters 10000000)
+  (define (work i)
+    (let loop ((j 0) (acc 0)) (if (fx<? j i) (loop (fx+ j 1) (fx+ acc j)) acc)))
+  (define (run-batch c)
+    (define t0 0) (define t1 0)
+    (define fs #f)
+    (define got #f)
+    (define secs 0.0)
+    (jolt-fiber-carrier-count-set! c)
+    (jolt-fiber-pool-reset!)
+    (jolt-fiber-ensure-carrier!)
+    (set! t0 (mono-nanos))
+    (set! fs (spawn-n M (lambda (i) (sa-fiber-spawn (lambda () (work iters))))))
+    (set! got (wait-until (lambda () (all-done? fs)) 60.0
+                          (string-append (number->string c) "-carrier batch")))
+    (set! t1 (mono-nanos))
+    (set! secs (/ (exact->inexact (- t1 t0)) 1000000000.0))
+    (printf "carriers: ~a\n" c)
+    (printf "ms: ~a\n" (* secs 1000.0))
+    (printf "mops-per-sec: ~a\n" (/ (* M iters) secs 1000000.0))
+    (printf "completed: ~a\n" (if got #t #f))
+    (flush!))
+  (printf "cpu-count: ~a\n" n-cpu)
+  (for-each run-batch '(1 2 4))
+  (run-batch n-cpu)
+  ;; uneven lifetimes: at n-cpu carriers, fiber 0 does 10x the work. Fibers do
+  ;; not migrate (R0(d)), so the long fiber pins its carrier and the total time
+  ;; is bounded by it — a property of the design, not a defect.
+  (let ((c n-cpu))
+    (define t0 0) (define t1 0)
+    (define fs #f)
+    (define got #f)
+    (define secs 0.0)
+    (jolt-fiber-carrier-count-set! c)
+    (jolt-fiber-pool-reset!)
+    (jolt-fiber-ensure-carrier!)
+    (set! t0 (mono-nanos))
+    (set! fs (spawn-n c
+                      (lambda (i)
+                        (sa-fiber-spawn
+                          (lambda () (work (* iters (if (fx=? i 0) 10 1))))))))
+    (set! got (wait-until (lambda () (all-done? fs)) 120.0 "uneven batch"))
+    (set! t1 (mono-nanos))
+    (set! secs (/ (exact->inexact (- t1 t0)) 1000000000.0))
+    (printf "uneven-carriers: ~a\n" c)
+    (printf "uneven-ms: ~a\n" (* secs 1000.0))
+    (printf "uneven-mops-per-sec: ~a\n" (/ (* iters (+ 10 (- c 1))) secs 1000000.0))
+    (printf "uneven-completed: ~a\n" (if got #t #f))
+    (flush!)))
+
+;; --- dispatch ----------------------------------------------------------------
+(let ((phase (and (a 1) (string->symbol (a 1)))))
+  (case phase
+    ((spawn-thread)  (spawn-phase 'thread (or (and (a 2) (string->number (a 2))) 1000)))
+    ((spawn-fiber)   (spawn-phase 'fiber (or (and (a 2) (string->number (a 2))) 1000)))
+    ((spawn-fiber-go) (spawn-phase 'fiber-go (or (and (a 2) (string->number (a 2))) 1000)))
+    ((mem-baseline)  (mem-baseline))
+    ((mem-fiber-raw) (mem-fiber-raw))
+    ((mem-fiber-go)  (mem-fiber-go))
+    ((mem-thread)    (mem-thread))
+    ((ping-thread)   (ping-phase 'thread #f))
+    ((ping-fiber)    (ping-phase 'fiber #f))
+    ((ping-fiber-1)  (ping-phase 'fiber #t))
+    ((fanin-thread)  (fanin-phase 'thread))
+    ((fanin-fiber)   (fanin-phase 'fiber))
+    ((switch)        (switch-phase))
+    ((scaling)       (scaling-phase))
+    (else
+     (printf "usage: bench-fibers.ss <phase> [arg]\n")
+     (printf "  spawn-thread K | spawn-fiber K | spawn-fiber-go K\n")
+     (printf "  mem-baseline | mem-fiber-raw | mem-fiber-go | mem-thread\n")
+     (printf "  ping-thread | ping-fiber | fanin-thread | fanin-fiber\n")
+     (printf "  switch | scaling\n")
+     (exit 1))))
+(exit 0)

--- a/bench/fibers/run.sh
+++ b/bench/fibers/run.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# bench/fibers/run.sh — Fibers R6 benchmark driver (jolt-nvpr.7).
+#
+# Runs the whole measurement set as :thread vs :fiber pairs, wraps the memory
+# phases in /usr/bin/time -l for the peak-RSS cross-check (the R0 method:
+# retained objects, forced full collect, absolute live bytes, RSS from the OS),
+# and prints the comparison table. Run via `make fibersbench`.
+#
+# Like aba.sh, this is blind to dev mode: every phase runs the runtime from
+# source with chez --script (the gate boot may use the precompiled
+# target/dev/gate.so when fresh, which is behavior-identical to the literal
+# loads). Benchmarks are opt-in and NOT part of make test / make ci.
+set -e
+cd "$(dirname "$0")/../.."
+root="$PWD"
+
+CHEZ_BIN="${CHEZ:-$(command -v chez || command -v scheme || true)}"
+[ -n "$CHEZ_BIN" ] || { echo "chez not found on PATH (set CHEZ)" >&2; exit 1; }
+HARNESS="$root/bench/fibers/bench-fibers.ss"
+
+phase() { # phase <args...> — run one harness phase, echo its lines
+  "$CHEZ_BIN" --script "$HARNESS" "$@"
+}
+
+phase_rss() { # like phase but under /usr/bin/time -l; appends peak-rss-bytes
+  out=$(/usr/bin/time -l "$CHEZ_BIN" --script "$HARNESS" "$@" 2>&1) || true
+  # macOS /usr/bin/time -l prints the NUMBER FIRST, then the label, so the value
+  # is $1 and not $5 — $5 is the literal word "size", which is what this printed
+  # before and why the whole memory table came out as "size -". GNU time (Linux)
+  # puts the label first, so accept either by taking whichever field is numeric.
+  rss=$(printf '%s\n' "$out" | awk '/maximum resident set size/{
+          for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) { print $i; exit }
+        }')
+  printf '%s\n' "$out" | grep -v 'maximum resident set size' || true
+  echo "peak-rss-bytes: ${rss:-NA}"
+}
+
+get() { # get <key> — extract "key: value" from stdin
+  sed -n "s/^$1: //p"
+}
+
+echo "machine: $(sysctl -n machdep.cpu.brand_string 2>/dev/null) / $(sysctl -n hw.ncpu 2>/dev/null) cores / $(( $(sysctl -n hw.memsize 2>/dev/null) / 1073741824 )) GiB"
+first=$(phase switch | head -1)
+echo "$first"
+echo
+
+# --- 1. spawn cost -----------------------------------------------------------
+echo "== 1. spawn cost (K processes that immediately park) =="
+printf '%-11s %-9s %-9s %-10s %-13s %-10s %s\n' \
+  backend K created create-ms per-create-us all-parked fail
+SPAWN_KS="1000 10000 100000"
+for backend in fiber thread; do
+  for k in $SPAWN_KS; do
+    out=$(phase "spawn-$backend" "$k")
+    created=$(printf '%s\n' "$out" | get created)
+    cms=$(printf '%s\n' "$out" | get create-ms)
+    perus=$(printf '%s\n' "$out" | get per-create-us)
+    parked=$(printf '%s\n' "$out" | get all-parked)
+    fail=$(printf '%s\n' "$out" | get fail)
+    printf '%-11s %-9s %-9s %-10s %-13s %-10s %s\n' \
+      "$backend" "$k" "$created" "$cms" "$perus" "$parked" "$fail"
+  done
+done
+echo
+
+# --- 2. memory per parked process -------------------------------------------
+echo "== 2. memory per parked process (retained, forced full collect, absolute live; RSS cross-check) =="
+base_out=$(phase_rss mem-baseline)
+base_rss=$(printf '%s\n' "$base_out" | get peak-rss-bytes)
+echo "boot baseline peak RSS: ${base_rss:-NA} bytes"
+printf '%-13s %-9s %-13s %-13s %-11s\n' backend K live-B/unit peak-RSS RSS/unit
+for memphase in mem-fiber-raw mem-fiber-go mem-thread; do
+  out=$(phase_rss "$memphase")
+  cnt=$(printf '%s\n' "$out" | get count)
+  lv=$(printf '%s\n' "$out" | get live-delta)
+  pk=$(printf '%s\n' "$out" | get peak-rss-bytes)
+  perlive=$(printf '%s\n' "$out" | get per-live-bytes)
+  perrss=$(awk -v r="$pk" -v b="$base_rss" -v k="$cnt" \
+    'BEGIN{ if (r+0>0 && b+0>0 && k+0>0) printf "%.0f", (r-b)/k; else printf "-" }')
+  printf '%-13s %-9s %-13s %-13s %-11s\n' "$memphase" "$cnt" "$perlive" "$pk" "$perrss"
+done
+echo
+
+# --- 3. channel throughput ---------------------------------------------------
+echo "== 3. channel throughput =="
+for backend in thread fiber; do
+  out=$(phase "ping-$backend")
+  rt=$(printf '%s\n' "$out" | get per-roundtrip-us)
+  hps=$(printf '%s\n' "$out" | get handoffs-per-sec)
+  echo "ping-pong ($(printf '%s\n' "$out" | get runs-ms)) $backend: $rt us/roundtrip  $hps handoffs/sec"
+  [ "$backend" = thread ] && rt_thread=$rt
+done
+p1=$(phase ping-fiber-1)
+echo "ping-pong, pool pinned to 1 carrier (runs $(printf '%s\n' "$p1" | get runs-ms)): $(printf '%s\n' "$p1" | get per-roundtrip-us) us/roundtrip  $(printf '%s\n' "$p1" | get handoffs-per-sec) handoffs/sec  — floor when both fibers share one carrier"
+for backend in thread fiber; do
+  out=$(phase "fanin-$backend")
+  echo "fan-in 8x2500 (runs $(printf '%s\n' "$out" | get runs-ms)) $backend: $(printf '%s\n' "$out" | get values-per-sec) values/sec"
+done
+echo
+
+# --- 4. context-switch cost --------------------------------------------------
+echo "== 4. context-switch cost =="
+sw=$(phase switch)
+bare=$(printf '%s\n' "$sw" | get bare-switch-ns)
+sched=$(printf '%s\n' "$sw" | get scheduler-switch-ns)
+echo "bare continuation switch:   $bare ns  (R0 measured 12.5 ns)"
+echo "scheduler yield + slice:    $sched ns  (R2 measured 64 ns)"
+echo "OS-thread channel handoff:  $(awk -v r="$rt_thread" 'BEGIN{printf "%.1f", r*1000/2}') ns  (from ping-pong: per-roundtrip/2)"
+echo
+
+# --- 5. scaling with carriers ------------------------------------------------
+echo "== 5. scaling with carriers (CPU-bound, 40 fibers x 1e7) =="
+sc=$(phase scaling)
+printf '%-10s %-10s %s\n' carriers ms mops/sec
+printf '%s\n' "$sc" | awk '/^carriers: /{c=$2} /^ms: /{m=$2} /^mops-per-sec: /{printf "  %-8d %-10s %s\n", c, m, $2}'
+un=$(printf '%s\n' "$sc" | get uneven-ms)
+echo "uneven lifetimes ($(printf '%s\n' "$sc" | get uneven-carriers) carriers, one fiber does 10x): ${un} ms — fibers do not migrate, so the long fiber pins its carrier (property, not defect)"
+echo
+echo "done."


### PR DESCRIPTION
`make fibersbench` (opt-in, **not** in `make ci`) runs `:thread` against `:fiber` as pairs. All figures below are from that harness on an Apple M1 Max / 10 cores / 64 GiB, Chez 10.4.1.

## The decision: `:thread` stays the default

Fibers win overwhelmingly at the two things they exist for. They lose the thing that matters most for a *default*: a `go` body on a thread can block freely and runs in parallel, while a fiber that blocks **pins its carrier** and strands everything queued behind it — and we cannot compensate by adding carriers the way the JVM can, because our continuations do not migrate. Until R8 converts IO, threads are the safer default. Fibers are documented as the right choice for many mostly-channel-bound processes.

## Spawn — processes that immediately park

| processes | fiber | OS thread |
| --- | --- | --- |
| 1,000 | 2.8 ms | 74 ms |
| 10,000 | 7.2 ms | 7.2 s |
| 100,000 | 69 ms | **cannot get there** — 15,519 in a 20 s budget, machine swapping |

## Memory per parked process

Retained in a global, forced full collect, absolute live bytes, peak RSS cross-check.

| | live | peak RSS |
| --- | --- | --- |
| fiber | 3,995 B | 5,961 B |
| fiber parked on a channel | 4,129 B | 6,403 B |
| OS thread | 68,720 B | 290,365 B |

~17x smaller in live bytes, ~45x by RSS. The bare-park figure **confirms R0's 3485 B family** rather than replacing it.

## The result worth not burying

| workload | fiber | OS thread |
| --- | --- | --- |
| ping-pong across two carriers | 7.8 µs/rt | **6.3 µs/rt** |
| ping-pong on one carrier | **1.8 µs/rt** | — |
| fan-in, 8 producers → 1 | **102,777/s** | 60,487/s |

Two fibers on *different* carriers are **slower than two OS threads**, because each handoff wakes the other carrier — the same cost as waking a thread, plus scheduling. On the same carrier nothing leaves the thread and it is 3.5x faster. So "fibers are faster" is not a claim these numbers support; "fibers are cheaper, and faster when the work spreads" is.

Switch cost: bare continuation switch **9.33 ns** (R0: 12.5); full scheduler round trip **107.6 ns** — which does *not* contradict R2's 64 ns, since R2 measured the switch and this measures a whole yield through the scheduler. OS-thread handoff 3,163 ns.

Scaling (40 CPU-bound fibers): 465 → 233 → 116 → 92 ms at 1/2/4/10 carriers. With one fiber doing 10x the work: 116 ms instead of 92 — fibers do not migrate, so the long one holds its carrier.

## Four harness bugs, all under-reporting

Worth listing because three are the same trap R0 fell into:

1. RSS parsed the wrong `awk` field — macOS `/usr/bin/time -l` prints the number *before* the label, so `$5` was the literal word `size` and the entire memory table printed as `size -`.
2. A shell typo (`$mephase` for `$memphase`) ran every memory row with an empty argument.
3. The go-fiber phase retained the **result channel**, not the fiber, and each body parked on its own channel — fiber and channel form a cycle nothing else points at, so the collector took all of them. It reported **159.9 B/unit against an RSS cross-check of 3,569** — a 22x disagreement, and RSS was again the honest number.
4. That phase then parked exactly a **tenth** of its fibers (1000 of 10000): R5 round-robins placement and `sa-fiber-run-all` drains only carrier 0's queue. The ratio was the giveaway.

Also recorded: **a forced full collect cannot run while carrier threads are alive** (`cannot collect when multiple threads are active`), so a memory probe must stop the pool first. The R0 method and a running pool are incompatible — worth knowing before the next probe.

## Verification

`make test` green at 57 ci targets; `portcheck`, `adaptercheck`, `gambitcheck` green; `make libconformance LIBS="core.async"` `ok`. Numbers appended to `fibers-r0-findings.md` rather than edited over R0's.

Site docs are committed in the `jolt-lang.github.io` checkout but **not pushed** — publishing docs for an opt-in, unreleased feature is a call for the maintainer.