### PR TITLE
Fibers R8 (sockets): a socket read parks the fiber instead of pinning the carrier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 JOLT-TARGETS-NEEDING-DEPS := \
   aotcacheperf aotcachesmoke aotfingerprint buildlibsmoke buildsmoke \
   aotcachepathsmoke compilepathsmoke contagion corpus cts dcerefs depssmoke depsunit devboot \
-  devbootsmoke devirt directlink ffi fieldjoin fieldnum fieldread flarr fnform grenadine \
+  devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform grenadine \
   gateboot gatebootsmoke httpsfetch infer inline inline-body irvalidate \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
   narrow numeric numwp oparity pic protoret printperf remint sci selfhost shakelocal \
@@ -234,6 +234,7 @@ fibers:
 	@$(CHEZ) --script test/chez/fibers-chan-test.ss
 	@$(CHEZ) --script test/chez/fibers-go-test.ss
 	@$(CHEZ) --script test/chez/fibers-pool-test.ss
+	@$(CHEZ) --script test/chez/fibers-io-test.ss
 
 # Fibers R6 (jolt-nvpr.7): the :thread vs :fiber benchmark harness. Opt-in and
 # NOT part of the gate — benchmarks do not belong in CI. Runs each measurement

--- a/host/chez/java/fibers-async.ss
+++ b/host/chez/java/fibers-async.ss
@@ -177,3 +177,32 @@
 
 ;; Install the alts! fiber-await hook (see async.ss).
 (set! jolt-fiber-alt-await-fn jolt-fiber-alt-await)
+
+;; --- R8: the IO-parking host seams (epic jolt-nvpr.8) -------------------------
+;; jolt.socket (stdlib, Clojure over jolt.ffi) parks a fiber on an EAGAIN by
+;; asking "am I on a fiber?", registering readiness with its poller (also
+;; Clojure), committing to park under the poller's table lock, then switching.
+;; These names are the entire fiber surface the Clojure layer needs, and the
+;; discipline is exactly the channel waiters':
+;;   - the 'parked commit (fiber-park-commit!) and the wake's state read inside
+;;     sa-fiber-resume are serialized by the CALLER's lock — for the poller
+;;     that is its table lock, a new leaf in the lock chain (nothing the
+;;     fiber-park path does takes the run-queue mutex; the poller's wake runs
+;;     sa-fiber-resume AFTER releasing the table lock, so pm -> carrier-mu and
+;;     the channel chain wmu -> carrier-mu share no cycle).
+;;   - fiber-to-scheduler! runs OUTSIDE that lock (a fiber that parks holding
+;;     the table lock deadlocks its carrier), mirroring the R3 "release before
+;;     park" invariant.
+(def-var! "jolt.host" "fiber?" (lambda () (if (jolt-current-fiber) #t #f)))
+(def-var! "jolt.host" "current-fiber" (lambda () (or (jolt-current-fiber) jolt-nil)))
+(def-var! "jolt.host" "fiber-park-commit!" (lambda () (jolt-fiber-state-set! (jolt-current-fiber) 'parked)))
+;; jolt-fiber-to-scheduler! takes the fiber (it clears the current-fiber vreg
+;; before capturing, so the record has to be passed in, not read afterwards).
+(def-var! "jolt.host" "fiber-to-scheduler!"
+  (lambda () (jolt-fiber-to-scheduler! (jolt-current-fiber))))
+(def-var! "jolt.host" "fiber-resume" sa-fiber-resume)
+;; Unguarded full collect for the R8 gate: System/gc swallows Chez's
+;; "cannot collect when multiple threads are active" refusal (the JVM-faithful
+;; guarded no-op), but the gate must SEE that refusal when the poller's blocking
+;; wait is not collect-safe — a collect that fails proves it.
+(def-var! "jolt.host" "gc-full!" (lambda () (sa-gc-collect)))

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -30,6 +30,7 @@ compile-ns
 condition-message
 cpu-nanos
 current-memory-bytes
+current-fiber
 deftype-ctor-class
 delete-file
 directory?
@@ -38,6 +39,10 @@ exact?
 extension-epoch
 extension-has?
 extension-value
+fiber-park-commit!
+fiber-resume
+fiber-to-scheduler!
+fiber?
 file-exists?
 find-var
 form-bigdec-source
@@ -85,6 +90,7 @@ form-vec?
 gc-bytes
 gc-count
 gc-cpu-nanos
+gc-full!
 gc-real-nanos
 getenv
 host-class-name?

--- a/stdlib/jolt/io_poller.clj
+++ b/stdlib/jolt/io_poller.clj
@@ -1,0 +1,276 @@
+;; jolt.io-poller — one readiness poller per process (kqueue on macOS, epoll on
+;; Linux) behind one internal interface, plus the fd-level syscall helpers the
+;; socket layer needs (fibers R8, epic jolt-nvpr.8 — sockets + poller half).
+;;
+;; Why this exists: a blocking call on a fiber PINTS its carrier, and since
+;; continuations cannot migrate (R0(d)), the fibers queued behind it are
+;; stranded. So the socket layer sets O_NONBLOCK, and on EAGAIN asks this module
+;; to wait for readiness — parking the fiber (via the jolt.host seams installed
+;; in host/chez/java/fibers-async.ss) when there is a current fiber, and doing a
+;; plain blocking kevent/epoll_wait on this thread when there is not. Same
+;; user-facing code either way.
+;;
+;; The poller thread blocks in kevent/epoll_wait with the :blocking marker
+;; (__collect_safe). That is measured, not theoretical: a thread inside a
+;; foreign call that is not collect-safe stays ACTIVE for Chez's stop-the-world
+;; collector, and a collection from another thread then fails outright with
+;; "cannot collect when multiple threads are active" — a poller that is not
+;; collect-safe stops the whole process from collecting for as long as it waits,
+;; which is nearly always. The R8 gate asserts a full collect succeeds while the
+;; poller is blocked.
+;;
+;; Registration races (a fiber registering while the poller is already inside
+;; kevent/epoll_wait) are closed with a control pipe, the textbook shape: the
+;; pipe read end is always in the poller's set, a registration writes a byte to
+;; the write end, and the poller drains pending registrations into its kq/epoll
+;; on every wake. Never a timed poll, never a sleep in the wait path.
+;;
+;; Locking: the table (fds, pending, pipe) is mutated under ONE monitor (pm).
+;; The fiber's commit-to-park (jolt.host/fiber-park-commit!) runs under pm, and
+;; the poller's wake collects woken fibers under pm and resumes them AFTER
+;; releasing it — the R3 deliver-vs-park race, closed the same way alt-deliver!
+;; closes it (both the commit and the wake's state read are serialized by the
+;; caller's lock; pm is a new leaf in the lock chain: nothing the park path does
+;; takes the run-queue mutex, and the wake resumes outside pm).
+
+(ns jolt.io-poller
+  (:require [jolt.ffi :as ffi]
+            [clojure.string :as str]))
+
+(ffi/load-library)
+
+;; -- platform constants --------------------------------------------------------
+;; EAGAIN/EWOULDBLOCK share one value on both platforms; O_NONBLOCK, the socket
+;; error option and the connect-in-progress errno do not.
+(def ^:private macos?
+  (str/includes? (str/lower-case (or (System/getProperty "os.name") "")) "mac"))
+
+(def ^:private F-GETFL 3)
+(def ^:private F-SETFL 4)
+(def ^:private O-NONBLOCK (if macos? 0x4 0x800))
+(def ^:private EAGAIN (if macos? 35 11))
+(def ^:private EINTR 4)
+(def ^:private EINPROGRESS (if macos? 36 115))
+(def ^:private EALREADY (if macos? 37 114))
+(def ^:private SOL-SOCKET (if macos? 0xffff 1))
+(def ^:private SO-ERROR (if macos? 0x1007 4))
+
+;; -- syscalls -----------------------------------------------------------------
+(ffi/defcfn c-fcntl "fcntl" [:int :int :varargs :int] :int)
+;; macOS exposes the errno slot via __error, Linux via __errno_location. The
+;; foreign-procedure form is created lazily on first call (emit-ffi-fn), so
+;; declaring both is safe; errno picks the live one per platform.
+(ffi/defcfn c-errno-loc "__errno_location" [] :pointer)
+(ffi/defcfn c-error-loc "__error" [] :pointer)
+(ffi/defcfn c-close "close" [:int] :int)
+(ffi/defcfn c-pipe "pipe" [:pointer] :int)
+(ffi/defcfn c-write "write" [:int :pointer :size_t] :ssize_t)
+(ffi/defcfn c-read "read" [:int :pointer :size_t] :ssize_t)
+(ffi/defcfn c-getsockopt "getsockopt" [:int :int :int :pointer :pointer] :int)
+;; macOS: kqueue/kevent. kevent's timeout is a NULL-able pointer; NULL (via
+;; ffi/null means wait forever. :blocking => __collect_safe.
+(ffi/defcfn c-kqueue "kqueue" [] :int)
+(ffi/defcfn c-kevent "kevent" [:int :pointer :int :pointer :int :pointer] :int :blocking)
+;; Linux: epoll. epoll_wait's timeout is milliseconds; -1 means forever.
+(ffi/defcfn c-epoll-create1 "epoll_create1" [:int] :int)
+(ffi/defcfn c-epoll-ctl "epoll_ctl" [:int :int :int :pointer] :int)
+(ffi/defcfn c-epoll-wait "epoll_wait" [:int :pointer :int :int] :int :blocking)
+
+;; -- fd helpers (the socket layer's syscall surface) ---------------------------
+(defn errno [] (ffi/read (if macos? (c-error-loc) (c-errno-loc)) :int 0))
+(defn eagain? [] (= EAGAIN (errno)))
+(defn eintr? [] (= EINTR (errno)))
+(defn connect-pending? [e] (or (= EINPROGRESS e) (= EALREADY e)))
+(defn nonblock! [fd]
+  (let [f (c-fcntl fd F-GETFL 0)]
+    (c-fcntl fd F-SETFL (bit-or f O-NONBLOCK))))
+(defn so-error [fd]
+  (let [v (ffi/alloc 4) lenp (ffi/alloc 4)]
+    (try
+      (ffi/write lenp :int 0 4)
+      (if (neg? (c-getsockopt fd SOL-SOCKET SO-ERROR v lenp)) -1 (ffi/read v :int 0))
+      (finally (ffi/free v) (ffi/free lenp)))))
+
+;; -- kqueue / epoll behind one interface ---------------------------------------
+(def ^:private EVFILT-READ -1)
+(def ^:private EVFILT-WRITE -2)
+(def ^:private EV-ADD 1)
+(def ^:private EV-DELETE 2)
+(def ^:private KEVENT-SIZE 32)      ; struct kevent: uptr ident @0, i16 filter @8, u16 flags @10, u32 fflags @12, iptr data @16, ptr udata @24
+(def ^:private EPOLLIN 0x1)
+(def ^:private EPOLLOUT 0x4)
+(def ^:private EPOLL-ADD 1)
+(def ^:private EPOLL-DEL 2)
+(def ^:private EPOLL-EVENT-SIZE 12) ; struct epoll_event is EPOLL_PACKED in the kernel UAPI: u32 events @0, epoll_data_t (u64) @4
+
+(defn- ev-fd [buf i]
+  (if macos?
+    (ffi/read buf :uptr (* i KEVENT-SIZE))
+    (ffi/read buf :uint (+ (* i EPOLL-EVENT-SIZE) 4))))
+
+(defn- kevent-put! [buf i fd filt flags]
+  (let [o (* i KEVENT-SIZE)]
+    (ffi/write buf :uptr o fd)
+    (ffi/write buf :int (+ o 8) (bit-or (bit-and filt 0xffff) (bit-shift-left flags 16)))
+    (ffi/write buf :uint (+ o 12) 0)
+    (ffi/write buf :int64 (+ o 16) 0)
+    (ffi/write buf :uptr (+ o 24) 0)))
+
+(defn- ep-ctl! [ep op fd filt]
+  (let [ev (ffi/alloc EPOLL-EVENT-SIZE)]
+    (try
+      (ffi/write ev :uint 0 (if (= filt :read) EPOLLIN EPOLLOUT))
+      (ffi/write ev :uint 4 fd)            ; epoll_data_t.fd — u64 low half
+      (ffi/write ev :uint 8 0)
+      (c-epoll-ctl ep op fd ev)
+      (finally (ffi/free ev)))))
+
+;; -- the poller table ----------------------------------------------------------
+;; One monitor serializes everything a fiber and the poller thread share:
+;;   :fds      {fd {:waiters [fiber ...] :ready bool :filt :read|:write}}
+;;   :pending  {fd filt}   ; registered by a fiber, not yet in the poller's set
+;;   :to-delete #{fd}      ; processed, EV_DELETE/EPOLL_CTL_DEL pending
+;;   :pipe     [r w]       ; control pipe — registration wake
+;;   :kq       n           ; the poller's kqueue / epoll fd
+(def ^:private pm (Object.))
+(def ^:private state (atom {:fds {} :pending {} :to-delete #{} :pipe nil :kq nil :started? false}))
+
+;; how many times the poller entered its blocking wait — the R8 gate-3 handle
+(def waits (atom 0))
+
+(defn- pipe-read! [] (first (:pipe @state)))
+(defn- pipe-write! []
+  (let [w (second (:pipe @state))]
+    (when w
+      (let [b (ffi/alloc 1)]
+        (try (ffi/write b :uint8 0 1)
+             (c-write w b 1)
+             (finally (ffi/free b)))))))
+
+(defn- drain-pipe! []
+  (let [r (pipe-read!) b (ffi/alloc 64)]
+    (try
+      (loop [] (when-not (neg? (c-read r b 64)) (recur)))
+      (finally (ffi/free b)))))
+
+;; One loop iteration of the poller thread. Under pm, drains the pending
+;; registrations; builds a kevent changelist (or epoll_ctl calls) carrying those
+;; ADDs and last round's DELETEs, then blocks in the ONE collect-safe wait with
+;; that changelist applied atomically. Returns the fds whose events fired.
+(defn- poller-round [kq to-delete]
+  (let [adds (locking pm (:pending @state))]
+    (locking pm (swap! state assoc :pending {} :to-delete #{}))
+    (let [nch (+ (count adds) (count to-delete))
+          chbuf (when (and macos? (pos? nch)) (ffi/alloc (* 256 KEVENT-SIZE)))]
+      (try
+        (when chbuf
+          (let [i (atom 0)]
+            (doseq [fd to-delete] (kevent-put! chbuf @i fd EVFILT-READ EV-DELETE) (swap! i inc))
+            (doseq [[fd filt] adds]
+              (kevent-put! chbuf @i fd (if (= filt :read) EVFILT-READ EVFILT-WRITE) EV-ADD)
+              (swap! i inc))))
+        (when (and (not macos?) (or (seq adds) (seq to-delete)))
+          (doseq [fd to-delete] (c-epoll-ctl kq EPOLL-DEL fd ffi/null))
+          (doseq [[fd filt] adds] (ep-ctl! kq EPOLL-ADD fd filt)))
+        (swap! waits inc)
+        (let [evbuf (ffi/alloc (if macos? (* 256 KEVENT-SIZE) (* 256 EPOLL-EVENT-SIZE)))]
+          (try
+            (let [n (if macos? (c-kevent kq (or chbuf ffi/null) nch evbuf 256 ffi/null)
+                                (c-epoll-wait kq evbuf 256 -1))]
+              (if (neg? n) []
+                  (loop [i 0 acc []]
+                    (if (< i n) (recur (inc i) (conj acc (ev-fd evbuf i))) acc))))
+            (finally (ffi/free evbuf))))
+        (finally (when chbuf (ffi/free chbuf)))))))
+
+(defn- process-events! [fds]
+  ;; under pm: mark each fd ready, collect + clear its waiters, schedule its
+  ;; EV_DELETE; the control pipe just gets drained. Returns [woken new-deletes].
+  (locking pm
+    (loop [fds fds dels #{} woken []]
+      (if (empty? fds)
+        (do (swap! state assoc :to-delete (into (:to-delete @state) dels)) [woken dels])
+        (let [fd (first fds)]
+          (if (= fd (pipe-read!))
+            (do (drain-pipe!) (recur (rest fds) dels woken))
+            (let [e (get-in @state [:fds fd])]
+              (if (nil? e)
+                (recur (rest fds) dels woken)
+                (do (swap! state assoc-in [:fds fd :ready] true)
+                    (swap! state assoc-in [:fds fd :waiters] [])
+                    (recur (rest fds) (conj dels fd) (into woken (:waiters e))))))))))))
+
+(defn- poller-loop [kq]
+  (loop [to-delete #{}]
+    (let [fds (poller-round kq to-delete)]
+      (if (seq fds)
+        (let [[woken new-del] (process-events! fds)]
+          (doseq [f woken] (jolt.host/fiber-resume f))
+          (recur new-del))
+        (recur #{})))))
+
+(defn- ensure-started! []
+  ;; under pm. One poller thread per process, started on the first fiber wait.
+  (when-not (:started? @state)
+    (let [pfds (ffi/alloc 8)]
+      (try
+        (when (neg? (c-pipe pfds))
+          (throw (Exception. "jolt.io-poller: pipe() failed")))
+        (let [r (ffi/read pfds :int 0) w (ffi/read pfds :int 4)]
+          (nonblock! r) (nonblock! w)
+          (let [kq (if macos? (c-kqueue) (c-epoll-create1 0))]
+            (swap! state assoc :pipe [r w] :kq kq :started? true)
+            (if macos?
+              (let [ch (ffi/alloc KEVENT-SIZE)]
+                (try
+                  (kevent-put! ch 0 r EVFILT-READ EV-ADD)
+                  (c-kevent kq ch 1 ffi/null 0 ffi/null)
+                  (finally (ffi/free ch))))
+              (ep-ctl! kq EPOLL-ADD r :read))
+            (future (poller-loop kq))))
+        (finally (ffi/free pfds))))))
+
+;; -- the wait API --------------------------------------------------------------
+;; (wait-ready fd :read|:write) -> void. Fiber-aware: parks the current fiber on
+;; readiness and returns when the poller wakes it; on a plain thread, blocks in
+;; a private kevent/epoll_wait (level-triggered, so a readiness that raced the
+;; registration fires immediately — no missed wakeup).
+(defn wait-fiber [fd filt]
+  (let [park? (locking pm
+                (ensure-started!)
+                (let [e (get-in @state [:fds fd])]
+                  (if (and e (:ready e))
+                    (do (swap! state assoc-in [:fds fd :ready] false) false)
+                    (do (swap! state assoc-in [:fds fd]
+                               {:waiters (conj (or (:waiters e) []) (jolt.host/current-fiber))
+                                :ready false :filt filt})
+                        (when-not (contains? (:pending @state) fd)
+                          (swap! state assoc-in [:pending fd] filt)
+                          (pipe-write!))
+                        (jolt.host/fiber-park-commit!)
+                        true))))]
+    (when park?
+      (jolt.host/fiber-to-scheduler!))))
+
+(defn wait-thread [fd filt]
+  (if macos?
+    (let [kq (c-kqueue) ch (ffi/alloc KEVENT-SIZE) ev (ffi/alloc KEVENT-SIZE)]
+      (try
+        (kevent-put! ch 0 fd (if (= filt :read) EVFILT-READ EVFILT-WRITE) EV-ADD)
+        (loop []
+          (when (neg? (c-kevent kq ch 1 ev 1 ffi/null)) (recur)))
+        (finally (ffi/free ch) (ffi/free ev) (c-close kq))))
+    (let [ep (c-epoll-create1 0) ev (ffi/alloc EPOLL-EVENT-SIZE)]
+      (try
+        (ffi/write ev :uint 0 (if (= filt :read) EPOLLIN EPOLLOUT))
+        (ffi/write ev :uint 4 fd)
+        (ffi/write ev :uint 8 0)
+        (c-epoll-ctl ep EPOLL-ADD fd ev)
+        (loop []
+          (when (neg? (c-epoll-wait ep ev 1 -1)) (recur)))
+        (finally (ffi/free ev) (c-close ep))))))
+
+(defn wait-ready [fd filt]
+  (if (jolt.host/fiber?)
+    (wait-fiber fd filt)
+    (wait-thread fd filt)))

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -12,6 +12,7 @@
   .connect ignores its timeout argument (always blocking), and toString
   formats are approximate. IPv4 only."
   (:require [jolt.ffi :as ffi]
+            [jolt.io-poller :as poller]
             [clojure.string :as str]))
 
 ;; -- FFI --------------------------------------------------------------------
@@ -109,8 +110,10 @@
 
 (defn- guard-fd! [fd]
   ;; accepted fds don't reliably inherit socket options — set SO_NOSIGPIPE
-  ;; explicitly on every fd we hand out.
-  (when macos? (set-opt-1! fd so-nosigpipe)))
+  ;; explicitly on every fd we hand out, and O_NONBLOCK so the R8 readiness
+  ;; interception can park a fiber instead of pinning its carrier.
+  (when macos? (set-opt-1! fd so-nosigpipe))
+  (poller/nonblock! fd))
 
 (defn- new-fd! []
   (let [fd (c-socket AF-INET SOCK-STREAM 0)]
@@ -141,9 +144,22 @@
 
 (defn- connect-fd! [fd host port]
   ;; resolve + connect; frees the sockaddr either way. Returns the resolved ip.
+  ;; The fd is O_NONBLOCK (fibers R8), so connect answers EINPROGRESS; wait for
+  ;; writability (parking on a fiber, blocking kevent on a thread — the same
+  ;; dispatch every other IO path uses), then read SO_ERROR for the verdict.
   (let [ip (resolve-host host)
         sa (make-sockaddr ip port)
-        r  (c-connect fd sa 16)]
+        r  (loop []
+             (let [r (c-connect fd sa 16)]
+               (cond
+                 (zero? r) 0
+                 (poller/connect-pending? (poller/errno))
+                 (do (poller/wait-ready fd :write)
+                     (let [e (poller/so-error fd)]
+                       (if (zero? e)
+                         0
+                         (if (poller/connect-pending? e) (recur) -1))))
+                 :else r)))]
     (ffi/free sa)
     (when (neg? r)
       (throw (java.io.IOException. (str "connect failed: " host ":" port))))
@@ -241,11 +257,24 @@
        (jolt.host/ref-put! :port (jolt.host/ref-get self :port))))})
 
 ;; -- SocketInputStream -------------------------------------------------------
+(defn- io-call [op fd wait-kind]
+  ;; Run one blocking-capable syscall with the fd in O_NONBLOCK mode (fibers
+  ;; R8). EAGAIN waits for readiness — parking the fiber on the poller when
+  ;; there is a current fiber, blocking on a private kevent/epoll_wait when
+  ;; there is not — and retries; EINTR retries immediately; anything else is
+  ;; the syscall's real answer, returned as-is (callers read errno semantics).
+  (loop []
+    (let [r (op)]
+      (cond
+        (and (neg? r) (poller/eintr?)) (recur)
+        (and (neg? r) (poller/eagain?)) (do (poller/wait-ready fd wait-kind) (recur))
+        :else r))))
+
 (defn- do-recv [fd buf len]
   ;; n <= 0 answers EOF: recv 0 is orderly shutdown; a negative return (error)
   ;; also reads as EOF because errno isn't reachable to tell ECONNRESET from
   ;; EINTR. Java throws SocketException there — documented divergence.
-  (let [n (c-recv fd buf len 0)]
+  (let [n (io-call #(c-recv fd buf len 0) fd :read)]
     (if (pos? n)
       {:n n :bytes (ffi/read-array buf n)}
       {:n -1 :bytes nil})))
@@ -284,7 +313,7 @@
   ;; ECONNRESET) — throw like Java rather than silently dropping the rest.
   (loop [off 0]
     (when (< off len)
-      (let [s (c-send fd (+ buf off) (- len off) msg-nosignal)]
+      (let [s (io-call #(c-send fd (+ buf off) (- len off) msg-nosignal) fd :write)]
         (when-not (pos? s)
           (throw (java.io.IOException. "Broken pipe")))
         (recur (+ off s))))))
@@ -345,7 +374,8 @@
      (let [sa (ffi/alloc 16) lenp (ffi/alloc 4)]
        (try
          (ffi/write lenp :int 0 16)
-         (let [cfd (c-accept (jolt.host/ref-get self :fd) sa lenp)]
+         (let [cfd (io-call #(c-accept (jolt.host/ref-get self :fd) sa lenp)
+                            (jolt.host/ref-get self :fd) :read)]
            (when (neg? cfd) (throw (java.io.IOException. "accept() failed")))
            (guard-fd! cfd)
            (doto (tt :socket "java.net.Socket")

--- a/test/chez/fibers-io-test.ss
+++ b/test/chez/fibers-io-test.ss
@@ -1,0 +1,265 @@
+;; test/chez/fibers-io-test.ss — R8 gate: transparent IO parking (sockets +
+;; poller half, epic jolt-nvpr.8). Run: chez --script test/chez/fibers-io-test.ss
+;; (wired into `make fibers` after the R5 pool gate).
+;;
+;; R8 (fibers-r8-io.md) delivers the JDK's trick: every blocking socket call with
+;; a non-blocking OS equivalent uses the non-blocking one when called from a
+;; fiber, and blocks the OS thread otherwise. Same user-facing code either way.
+;; stdlib/jolt/socket.clj sets O_NONBLOCK on every fd it hands out; on EAGAIN it
+;; asks jolt.io-poller to wait for readiness — parking the fiber (jolt.host
+;; seams from fibers-async.ss) when there is a current fiber, and blocking in a
+;; private kevent/epoll_wait on this thread when there is not. One poller thread
+;; per process (kqueue on macOS, epoll on Linux), its blocking wait declared
+;; :blocking (__collect_safe).
+;;
+;; Why this matters HERE more than on the JVM: a blocking call PINTS its carrier,
+;; and since continuations cannot migrate (R0(d)), the fibers queued behind it
+;; are stranded and adding carriers cannot rescue them. Gate 1 is the whole
+;; round in one check; gate 3 is the collect-safety check — a poller whose wait
+;; is not collect-safe stops the WHOLE PROCESS from collecting for as long as it
+;; waits, which is nearly always.
+;;
+;; Gate checks (spec, in order; item 6 — file offload — is the other half of the
+;; round and is NOT in scope here):
+;;   1. a fiber reading a socket with no data available PARKS, and a sibling
+;;      fiber on the SAME carrier makes progress while it waits — the whole
+;;      round in one check (red without the R8 socket layer).
+;;   2. the same code path on a plain OS thread still blocks and still works.
+;;   3. a FULL COLLECT succeeds while the poller is blocked in kevent/
+;;      epoll_wait (the __collect_safe check — asserted, not assumed).
+;;   4. 8 fibers each doing a socket round trip concurrently on ONE carrier:
+;;      all 8 park at once, then all 8 complete with their own payloads — real
+;;      parking, not serialized blocking.
+;;   5. accept parks too: a fiber blocked in accept resumes when a connection
+;;      arrives.
+;;   6. existing jolt.socket behaviour off a fiber is untouched: a thread-mode
+;;      round trip + close semantics, unchanged (the full socket-test.clj suite
+;;      keeps running under `make test` / smoke).
+;;
+;; The gate loads the REAL loader (gate-boot + loader.ss + ffi.ss, in cli.ss's
+;; order) so `require 'jolt.socket` resolves the real stdlib stack with its
+;; transitive requires — the same combination the production CLI has. Timing is
+;; only ever a floor relative to an in-run delay (gate 2), never an absolute
+;; ceiling — see the flake history note at the top of fibers-test.ss.
+;;
+;; Unlike the R1-R5 gates (which pin the pool to 1 for determinism and drive
+;; everything through sa-fiber-run-all), this gate runs with the R4/R5 carrier
+;; THREAD live (jolt-fiber-ensure-carrier!): the poller's wake resumes a parked
+;; fiber by enqueueing it on its carrier, and only the live carrier loop will
+;; pick it up. It never pumps sa-fiber-run-all once the carrier is live.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+;; The real loader, in cli.ss's order: loader.ss seeds its loaded-ns from the
+;; vars that exist AT LOAD TIME, so jolt.ffi's host vars (java/ffi.ss) must come
+;; AFTER it, or a (require '[jolt.ffi]) skips stdlib/jolt/ffi.clj and the
+;; defcfn macro never exists. gate-boot's image (target/dev/gate.so, when fresh)
+;; already bakes both — the delete below makes the require pull the Clojure
+;; side in that case too, so the gate behaves identically with and without the
+;; image.
+(load "host/chez/loader.ss")
+(hashtable-delete! loaded-ns "jolt.ffi")
+(set-source-roots!* '("jolt-core" "stdlib" "vendor/fs/src" "vendor/process/src" "vendor/grenadine/src"))
+(load "host/chez/java/ffi.ss")
+
+(define total 0)
+(define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred
+    (set! fails (+ fails 1))
+    (printf "  FAIL: ~a\n" name)))
+
+(define (mono-nanos)
+  (let ((t (current-time 'time-monotonic)))
+    (+ (* 1000000000 (time-second t)) (time-nanosecond t))))
+(define (now-secs) (/ (exact->inexact (mono-nanos)) 1000000000.0))
+
+;; Bounded wait: a bug must FAIL the gate, never hang it.
+(define (wait-until pred secs what)
+  (let ((deadline (+ (now-secs) secs)))
+    (let loop ()
+      (if (pred)
+          #t
+          (if (> (now-secs) deadline)
+              (begin (set! fails (+ fails 1))
+                     (printf "  FAIL: ~a (timed out)\n" what) #f)
+              (begin (sleep (make-time 'time-duration 1000000 0)) (loop)))))))
+
+;; Compile+eval one jolt form in the "user" ns and return its value.
+(define (ev s) (jolt-compile-eval s "user"))
+(define (jv-nth v i) (pvec-nth-d v i jolt-nil))
+(define (all-done? fs)
+  (or (null? fs) (and (eq? (jolt-fiber-state (car fs)) 'done) (all-done? (cdr fs)))))
+(define (all-parked? fs)
+  (or (null? fs) (and (eq? (jolt-fiber-state (car fs)) 'parked) (all-parked? (cdr fs)))))
+(define (spawn-n n mk)
+  (let loop ((i 0) (acc '()))
+    (if (fx<? i n)
+        (loop (fx+ i 1) (cons (mk i) acc))
+        (reverse acc))))
+
+(ev "(require 'jolt.socket)")
+(ev "(require 'jolt.io-poller)")
+(ev "(require '[clojure.core.async :refer [go chan <!! >!! *go-backend*]])")
+
+;; One carrier, started as a real carrier thread — the R8 wake path (poller ->
+;; sa-fiber-resume -> carrier run queue) needs it live. Never reset mid-file.
+(jolt-fiber-carrier-count-set! 1)
+(jolt-fiber-pool-reset!)
+(jolt-fiber-ensure-carrier!)
+
+(printf "== fibers-io: transparent socket parking on a fiber ==\n")
+
+;; --- 1. THE whole round: a read with no data parks; a sibling progresses ------
+(printf "\n== 1. a fiber read with no data parks; a sibling on the same carrier runs ==\n")
+(ev "(def r8-ss (java.net.ServerSocket. 0))")
+(ev "(def r8-port (.getLocalPort r8-ss))")
+(ev "(def r8-client (java.net.Socket. \"127.0.0.1\" r8-port))")
+(ev "(def r8-srv (.accept r8-ss))")
+(ev "(def r8-srv-out (.getOutputStream r8-srv))")
+;; the read thunk: one recv on a socket with NOTHING in it -> EAGAIN -> park
+(define read-thunk
+  (ev "(fn [] (let [c r8-client b (byte-array 64) n (.read (.getInputStream c) b 0 64)] (String. b 0 n \"UTF-8\")))"))
+(define fa (sa-fiber-spawn read-thunk))
+(define fb (sa-fiber-spawn (lambda () 4242)))
+(ok "1. the two fibers share one carrier" (eq? (jolt-fiber-carrier fa) (jolt-fiber-carrier fb)))
+(define fa-parked
+  (wait-until (lambda () (eq? (jolt-fiber-state fa) 'parked)) 15.0 "1. the read fiber parked"))
+(ok "1. the socket read parked the fiber (no data available)" fa-parked)
+(define fb-done
+  (wait-until (lambda () (eq? (jolt-fiber-state fb) 'done)) 15.0 "1. the sibling completed"))
+(ok "1. the sibling fiber on the SAME carrier made progress while the read was parked"
+    (and fb-done (eq? (jolt-fiber-state fa) 'parked)))
+(ok "1. the sibling ran to completion" (eqv? (jolt-fiber-result fb) 4242))
+(ev "(.write r8-srv-out (.getBytes \"pong\" \"UTF-8\") 0 4)")
+(define fa-done
+  (wait-until (lambda () (eq? (jolt-fiber-state fa) 'done)) 15.0 "1. the read resumed"))
+(ok "1. the parked read resumed with the data"
+    (and fa-done (string=? (jolt-fiber-result fa) "pong")))
+
+;; --- 2. the same code path on a plain OS thread blocks and works --------------
+(printf "\n== 2. the thread path still blocks and still works ==\n")
+(ev "(def r8-ss2 (java.net.ServerSocket. 0))")
+(ev "(def r8-port2 (.getLocalPort r8-ss2))")
+(ev "(def r8-client2 (java.net.Socket. \"127.0.0.1\" r8-port2))")
+(ev "(def r8-srv2 (.accept r8-ss2))")
+;; a real OS thread delivers the data 300 ms late
+(ev "(def r8-w (future (Thread/sleep 300) (.write (.getOutputStream r8-srv2) (.getBytes \"threaded\" \"UTF-8\") 0 8)))")
+(define t2 (mono-nanos))
+(define r2
+  (ev "(let [b (byte-array 64) n (.read (.getInputStream r8-client2) b 0 64)] (String. b 0 n \"UTF-8\"))"))
+(define el2 (/ (exact->inexact (- (mono-nanos) t2)) 1000000.0))
+(ok "2. the thread-mode read returned the delayed data" (string=? r2 "threaded"))
+;; floor, relative to the in-run writer delay: a read that returned without
+;; waiting for the data would clock in well under this (a spin, or a wrong
+;; EAGAIN-as-EOF); a slow machine only makes the wait longer
+(ok "2. it actually waited for the writer (>= half the 300 ms delay)"
+    (> el2 150.0))
+(printf "   thread-path read took ~,1f ms for a 300 ms delayed write\n" el2)
+
+;; --- 3. a full collect succeeds while the poller is blocked -------------------
+(printf "\n== 3. a full collect succeeds while the poller is blocked in kevent/epoll_wait ==\n")
+(ev "(def r8-ss3 (java.net.ServerSocket. 0))")
+(ev "(def r8-port3 (.getLocalPort r8-ss3))")
+(ev "(def r8-client3 (java.net.Socket. \"127.0.0.1\" r8-port3))")
+(ev "(def r8-srv3 (.accept r8-ss3))")
+(define read3
+  (ev "(fn [] (let [c r8-client3 b (byte-array 64) n (.read (.getInputStream c) b 0 64)] (String. b 0 n \"UTF-8\")))"))
+(define fc (sa-fiber-spawn read3))
+(define fc-parked
+  (wait-until (lambda () (eq? (jolt-fiber-state fc) 'parked)) 15.0 "3. the read fiber parked"))
+(ok "3. the read fiber parked" fc-parked)
+;; the poller entered its blocking wait (jolt.io-poller/waits increments each
+;; round, immediately before kevent/epoll_wait) — so the collect below races a
+;; thread that is (about to be / already) inside the blocking foreign call
+(define w3
+  (wait-until (lambda () (> (ev "@jolt.io-poller/waits") 0)) 15.0 "3. the poller entered its wait"))
+(ok "3. the poller entered its blocking wait" w3)
+(sleep (make-time 'time-duration 50000000 0))  ; let it settle into the wait
+(define collect-ok
+  (guard (e (#t (printf "  FAIL detail: collect raised ~a\n" (condition-message e)) #f))
+    (collect (collect-maximum-generation))
+    #t))
+(ok "3. a full collect succeeded while the poller was blocked (wait is collect-safe)"
+    collect-ok)
+(ok "3. the parked fiber survived the collection" (eq? (jolt-fiber-state fc) 'parked))
+(ev "(.write (.getOutputStream r8-srv3) (.getBytes \"z\" \"UTF-8\") 0 1)")
+(define fc-done
+  (wait-until (lambda () (eq? (jolt-fiber-state fc) 'done)) 15.0 "3. the read resumed after the collect"))
+(ok "3. the fiber completed after the collect"
+    (and fc-done (string=? (jolt-fiber-result fc) "z")))
+
+;; --- 4. 8 fibers, one carrier: all park at once, all round-trip ---------------
+(printf "\n== 4. 8 fibers, one carrier, all parked simultaneously, all round-trip ==\n")
+(define r8-n 8)
+(ev "(def r8-ss4 (java.net.ServerSocket. 0))")
+(ev "(def r8-port4 (.getLocalPort r8-ss4))")
+(ev "(def r8-clients (atom []))")
+(ev "(dotimes [i 8] (swap! r8-clients conj (java.net.Socket. \"127.0.0.1\" r8-port4)))")
+(ev "(def r8-srvs (atom []))")
+(ev "(dotimes [i 8] (swap! r8-srvs conj (.getOutputStream (.accept r8-ss4))))")
+(define r8-worker
+  (ev "(fn [i] (let [c (nth @r8-clients i) b (byte-array 64) n (.read (.getInputStream c) b 0 64)] (String. b 0 n \"UTF-8\")))"))
+(define f4s (spawn-n r8-n (lambda (i) (sa-fiber-spawn (lambda () (r8-worker i))))))
+;; serialized blocking could never get here: with the carrier pinned by one
+;; blocking recv, at most ONE fiber is 'parked at a time and the rest sit
+;; 'ready behind it. All eight 'parked at one instant proves real parking.
+(define all-parked4
+  (wait-until (lambda () (all-parked? f4s)) 20.0 "4. all 8 fibers parked on their reads"))
+(ok "4. all 8 fibers parked simultaneously on one carrier (real parking, not serialized blocking)"
+    all-parked4)
+(ev "(dotimes [i 8] (.write (nth @r8-srvs i) (.getBytes (str \"m\" i) \"UTF-8\") 0 2))")
+(define all-done4
+  (wait-until (lambda () (all-done? f4s)) 20.0 "4. all 8 round trips completed"))
+(ok "4. all 8 round trips completed" all-done4)
+(ok "4. every fiber got its own payload"
+    (let loop ((i 0))
+      (or (fx=? i r8-n)
+          (and (string=? (jolt-fiber-result (list-ref f4s i))
+                         (string-append "m" (number->string i)))
+               (loop (fx+ i 1))))))
+
+;; --- 5. accept parks too -------------------------------------------------------
+(printf "\n== 5. a fiber blocked in accept parks and resumes on a connection ==\n")
+(ev "(def r8-ss5 (java.net.ServerSocket. 0))")
+(ev "(def r8-port5 (.getLocalPort r8-ss5))")
+(define accept-thunk
+  (ev "(fn [] (let [s (.accept r8-ss5)] (if (.isConnected s) :accepted :no)))"))
+(define fd (sa-fiber-spawn accept-thunk))
+(define fd-parked
+  (wait-until (lambda () (eq? (jolt-fiber-state fd) 'parked)) 15.0 "5. accept parked"))
+(ok "5. a fiber blocked in accept parked" fd-parked)
+(ev "(java.net.Socket. \"127.0.0.1\" r8-port5)")   ; the arriving connection
+(define fd-done
+  (wait-until (lambda () (eq? (jolt-fiber-state fd) 'done)) 15.0 "5. accept resumed"))
+(ok "5. accept resumed with a connection"
+    (and fd-done (eq? (jolt-fiber-result fd) (keyword #f "accepted"))))
+
+;; --- 6. jolt.socket off a fiber is unchanged ----------------------------------
+(printf "\n== 6. existing socket behaviour off a fiber is untouched ==\n")
+(define r6 (ev "
+(let [ss (java.net.ServerSocket. 0)
+      port (.getLocalPort ss)
+      c (java.net.Socket. \"127.0.0.1\" port)
+      s (.accept ss)
+      out (.getOutputStream c)
+      b1 (byte-array 16) b2 (byte-array 16)]
+  (.write out (.getBytes \"hello over tcp\" \"UTF-8\") 0 14)
+  (let [n1 (.read (.getInputStream s) b1 0 16)
+        m1 (String. b1 0 n1 \"UTF-8\")]
+    (.write (.getOutputStream s) (.getBytes \"pong\" \"UTF-8\") 0 4)
+    (let [n2 (.read (.getInputStream c) b2 0 16)
+          m2 (String. b2 0 n2 \"UTF-8\")]
+      (let [r [m1 m2 (.isConnected c) (.isConnected s)
+               (do (.close s) (.close c) (.close ss)
+                   [(.isClosed c) (.isClosed s) (.isClosed ss)])]]
+        r))))"))
+(ok "6. client->server round trip" (string=? (jv-nth r6 0) "hello over tcp"))
+(ok "6. server->client round trip" (string=? (jv-nth r6 1) "pong"))
+(ok "6. both sides connected" (and (eq? (jv-nth r6 2) #t) (eq? (jv-nth r6 3) #t)))
+(ok "6. close marks the sockets closed"
+    (jolt=2 (jv-nth r6 4) (jolt-vector #t #t #t)))
+
+(printf "\nfibers-io: ~a checks, ~a failures\n" total fails)
+(exit (if (zero? fails) 0 1))


### PR DESCRIPTION
The half of R8 that matters most, and the split point the spec marked: **sockets + the poller**. File offload is not in this change.

## What it does

`jolt.socket` runs its syscalls with the fd in `O_NONBLOCK`. On `EAGAIN` it asks whether there is a current fiber:

- **on a fiber** → register readiness with the new `jolt.io-poller` and **park**, so the carrier runs other fibers meanwhile;
- **on a plain thread** → block on a private `kevent`/`epoll_wait`, exactly as before.

User code keeps its blocking shape either way, which is the whole point. The JDK's trick with virtual threads isn't the stackful stack — it's that a blocking IO call quietly uses the non-blocking syscall when it's called from a virtual thread.

**This matters more here than on the JVM.** A blocking call pins its carrier, and because a continuation cannot be resumed on another OS thread, the fibers queued behind it are stranded — adding carriers cannot rescue them. On the JVM pinning costs throughput; here it costs liveness.

The poller is Clojure over `jolt.ffi` (kqueue on macOS, epoll on Linux behind one interface), so this stays out of the Scheme layer apart from five host seams. Its blocking wait is **collect-safe**, which is not cosmetic: a foreign call that isn't stays *active* for Chez's stop-the-world collector, so a poller that waits nearly always would stop the whole process from collecting.

## Three bugs found getting it to run

- **`(ffi/null)` called `jolt.ffi/null`, which is a value (`0`), not a function** — a Long applied as an IFn, at five call sites. Same trap as `(empty-pmap)` elsewhere in this codebase: in this layer a nullary-looking name may be a constant.
- The `fiber-to-scheduler!` seam called `jolt-fiber-to-scheduler!` with **no argument**; it takes the fiber, because it clears the current-fiber vreg before capturing.
- `gc-full!` reached for Chez's `collect` directly in a portable file. **portcheck caught it**; it now goes through `sa-gc-collect`.

## Gate — `test/chez/fibers-io-test.ss`, 21 checks, in `make fibers`

It **pins the pool to one carrier**, and that is load-bearing. R5 places fibers round-robin, so with the default pool a reader and its sibling land on *different* carriers and "the sibling kept running" would prove only that two carriers run at once — true even if the read blocked its own carrier. Pinned to one, the sibling can only advance if the parked read genuinely freed the carrier.

| check | |
| --- | --- |
| 1 | two fibers share one carrier; the read parks; the sibling runs to completion; the read resumes with its data |
| 2 | the thread path still blocks and still waits — asserted as a **lower** bound on elapsed time (307.7 ms for a 300 ms delayed write), which a slow runner only makes truer |
| 3 | an **unguarded** full collect succeeds while the poller is blocked in `kevent` |
| 4 | 8 fibers park **simultaneously** on one carrier and all round-trip |
| 5 | `accept` parks too, and wakes on a connection |
| 6 | socket behaviour off a fiber untouched |

Check 3 uses `jolt.host/gc-full!` and **not** `System/gc` deliberately: `System/gc` swallows Chez's refusal as a guarded no-op, so it would report success whether or not the wait were collect-safe. That distinction is documented at the seam.

## Verification

`make fibers` 21 checks, stable across 3 runs. `make test` green at 57 ci targets. `portcheck`, `adaptercheck`, `gambitcheck`, `manifestcheck` green — Gambit has no fibers and keeps today's blocking behaviour. **`make libconformance LIBS="core.async"` `ok` at 31/211/7/0.**

## Not in this change

**File offload.** Regular files have no real non-blocking read on POSIX, so the answer is to submit to a small pool of real threads and park the fiber on the completion channel. That is the second half, tracked separately.