### PR TITLE
R0 residue: the size of a fiber with real frames, and memory under churn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ JOLT-TARGETS-NEEDING-DEPS := \
 # Only mark PHONY targets for names that have file system conflicts:
 .PHONY: build install test ci gate-run-test gate-run-ci gate-status \
         gambitcheck gambitkernel gambiteval gambitseed gambitweb gambitprofile \
-        fibersbench
+        fibersbench \
+        fibersresidue
 
 default:: build
 
@@ -242,6 +243,12 @@ fibers:
 # blind to dev mode (every phase runs the runtime from source).
 fibersbench:
 	@sh bench/fibers/run.sh
+
+# R0-residue probes (jolt-nvpr.10): the size of a fiber with REAL frames, and
+# memory under fiber churn. Opt-in like fibersbench, NOT part of make ci.
+fibersresidue:
+	@$(CHEZ) --script bench/fibers/residue.ss
+	@$(CHEZ) --script bench/fibers/churn.ss
 
 # Corpus conformance vs JVM-sourced expecteds (allowlist + floor).
 corpus:

--- a/bench/fibers/churn.ss
+++ b/bench/fibers/churn.ss
@@ -1,0 +1,32 @@
+;; jolt-nvpr.10 probe A — memory under fiber CHURN. R0 measured a steady-state
+;; population; this creates fibers, runs them to completion, discards them, and
+;; asks whether live bytes return to baseline wave over wave. A creep with a flat
+;; population is the finding; a clean result is also a result.
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+(jolt-fiber-carrier-count-set! 1)
+(jolt-fiber-pool-reset!)
+(define ch (jolt-async-chan 1))
+(define (wave! n)
+  ;; each fiber parks on a take, is fed, and finishes — a full lifecycle
+  (let loop ((i 0) (fs '()))
+    (if (< i n)
+        (loop (+ i 1) (cons (sa-fiber-spawn (lambda () (jolt-fiber-<! ch))) fs))
+        (begin
+          (sa-fiber-run-all)                       ; all park
+          (do ((j 0 (+ j 1))) ((= j n))
+            (jolt-async-give ch j)
+            (sa-fiber-run-all))                    ; each wakes and finishes
+          (length fs)))))
+(collect (collect-maximum-generation))
+(define base (bytes-allocated))
+(printf "baseline live: ~a bytes\n" base)
+(let loop ((w 0))
+  (when (< w 8)
+    (wave! 2000)
+    (collect (collect-maximum-generation))
+    (printf "  wave ~a: ~a fibers created so far, live delta ~a B\n"
+            w (* 2000 (+ w 1)) (- (bytes-allocated) base))
+    (flush-output-port (current-output-port))
+    (loop (+ w 1))))
+(printf "done.\n")

--- a/bench/fibers/residue.ss
+++ b/bench/fibers/residue.ss
@@ -1,0 +1,41 @@
+;; jolt-nvpr.10 probe B — the size of a fiber with REAL frames.
+;; Method: retain in a global, force a full collect, absolute live bytes.
+;; Per-phase bytes-allocated deltas are not evidence (they produced both of R0's
+;; wrong findings). The pool is never started, because a forced full collect
+;; cannot run while carrier threads are alive.
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+(define held '())
+(define (measure label k mk)
+  (set! held '())
+  (jolt-fiber-carrier-count-set! 1)
+  (jolt-fiber-pool-reset!)
+  (collect (collect-maximum-generation))
+  (let ((base (bytes-allocated)))
+    (do ((i 0 (+ i 1))) ((= i k))
+      (set! held (cons (sa-fiber-spawn (mk i)) held)))
+    (sa-fiber-run-all)
+    (let ((parked (let loop ((l held) (n 0))
+                    (cond ((null? l) n)
+                          ((eq? (jolt-fiber-state (car l)) 'parked) (loop (cdr l) (+ n 1)))
+                          (else (loop (cdr l) n))))))
+      (collect (collect-maximum-generation))
+      (let ((live (- (bytes-allocated) base)))
+        (printf "  ~a: ~a B/fiber   (~a/~a parked)\n"
+                label (/ (exact->inexact live) k) parked k)))))
+
+(define ch (jolt-async-chan 1))
+;; 0. a fiber that RAN TO COMPLETION: the continuation is dropped, so this is the
+;;    record alone and shows what the stack segment costs by its absence.
+(measure "completed (no continuation) " 10000 (lambda (i) (lambda () (sa-fiber-yield) 'done)))
+;; 1. parked ONE frame deep on a channel take — the R0 baseline shape
+(measure "1 frame, parked on channel " 10000 (lambda (i) (lambda () (jolt-fiber-<! ch))))
+;; 2. realistic body: nested calls with live locals, parked on a channel take
+(define (lvl3 a b) (jolt-fiber-<! ch))
+(define (lvl2 a b) (let ((x (+ a 1)) (y (* b 2))) (lvl3 x y)))
+(define (lvl1 a)   (let ((z (list a a))) (lvl2 a (length z))))
+(measure "3 nested calls + channel   " 10000 (lambda (i) (lambda () (lvl1 i))))
+;; 3. the same inside a try/finally (dynamic-wind stays on the stack)
+(measure "same, inside dynamic-wind  " 10000
+         (lambda (i) (lambda () (dynamic-wind (lambda () #f) (lambda () (lvl1 i) 'done) (lambda () #f)))))
+(printf "done.\n")


### PR DESCRIPTION
The two probes R0 left open, as `make fibersresidue` (opt-in, not in `make ci`). Bead jolt-nvpr.10.

## A fiber with real frames costs what a synthetic one does

| shape | live B/fiber | parked |
| --- | --- | --- |
| completed (continuation dropped) | **88** | 0/10000 |
| parked 1 frame deep on a channel take | **4,143** | 10000/10000 |
| parked 3 nested calls deep, live locals | **4,153** | 10000/10000 |
| the same inside a `dynamic-wind` | **4,254** | 10000/10000 |

**Ten bytes for two extra frames.** That confirms R0's "fixed stack segment, not frames" with a realistic body rather than a synthetic loop, and it means the figure a user's program pays is the same ~4.15 KB. R0's 3,485 B was a bare-yield park; a channel park adds the handler and its mailbox — matching R6's independently measured 4,128 B.

A `dynamic-wind` on the stack costs ~100 B, worth knowing because R4 made a park *not* run the `finally`, so the wind stays live across it.

A **completed** fiber costs 88 B: the segment is released when the continuation is dropped. So 4 KB is the price of being *parked*, not of existing — the right model for capacity planning, and why churn is cheap.

## No creep under churn

Eight waves of 2,000 fibers, each spawned, parked on a take, fed, and run to completion; absolute live bytes after a forced full collect at the end of every wave:

```
196,240 / 196,640 / 196,528 / 196,640 / 196,528 / 196,640 / 196,352 / 196,640 B
```

**Flat across 16,000 fibers.** The ~196 KB is a one-time first-wave cost, not per fiber. Nothing retains dead fibers — not the run queue, not the carrier slice, not the channel waiter lists. A clean result, reported as one.

## Why these numbers are trustworthy where two R0 figures were not

Retain in a global, force `(collect (collect-maximum-generation))`, read **absolute** live bytes, and **assert the parked count alongside every figure**. That last check is what caught two bad readings while writing this: a row that was measuring *completed* rather than parked fibers, and R6's finding that the pool must be pinned to one carrier because `sa-fiber-run-all` drains only carrier 0's queue — otherwise exactly a tenth of the fibers park and the figure describes a tenth of the population.

`make test` green.