### PR TITLE
Regenerate records-gambit.ss, and gate it against drifting again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ JOLT-TARGETS-NEEDING-DEPS := \
 # Only mark PHONY targets for names that have file system conflicts:
 .PHONY: build install test ci gate-run-test gate-run-ci gate-status \
         gambitcheck gambitkernel gambiteval gambitseed gambitweb gambitprofile \
+        gambitgen gambitgencheck \
         fibersbench \
         fibersresidue
 
@@ -121,7 +122,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp depssmoke depsunit \
   fnform traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
-  certify gambitcheck fibers
+  certify gambitcheck gambitgencheck fibers
 TEST-GATES := submodules selfhost ci
 
 GATE-RECEIPT := target/gate-receipt
@@ -606,6 +607,29 @@ certify:
 # Ghostscript): always the brew-prefix binary.
 GAMBIT_GSI := $(shell brew --prefix gambit-scheme 2>/dev/null)/bin/gsi
 GAMBIT_GSC := $(shell brew --prefix gambit-scheme 2>/dev/null)/bin/gsc
+
+# host/gambit/records-gambit.ss is GENERATED from host/chez/records.ss (the
+# define-jrec-family phase wall — see gen-records.ss). Regenerate after every
+# records.ss change.
+gambitgen:
+	$(CHEZ) --script host/gambit/gen-records.ss
+
+# ...and this is what makes that an invariant rather than a note: regenerate into
+# a temp file and diff. A records.ss change that never reached the generated file
+# fails here instead of silently leaving the Gambit host a release behind. Runs
+# on Chez alone, so it gates in CI whether or not gambit is installed.
+gambitgencheck:
+	@out=$$(mktemp -d)/records-gambit.ss; \
+	  GEN_RECORDS_OUT="$$out" $(CHEZ) --script host/gambit/gen-records.ss >/dev/null; \
+	  if diff -q "$$out" host/gambit/records-gambit.ss >/dev/null; then \
+	    echo "gambitgencheck: records-gambit.ss is current with records.ss"; \
+	  else \
+	    echo "gambitgencheck: host/gambit/records-gambit.ss is STALE — run 'make gambitgen'" >&2; \
+	    diff -u host/gambit/records-gambit.ss "$$out" | head -40 >&2; \
+	    rm -f "$$out"; exit 1; \
+	  fi; \
+	  rm -f "$$out"
+
 gambitcheck:
 	@if [ -x "$(GAMBIT_GSI)" ]; then \
 		"$(GAMBIT_GSI)" host/gambit/gambitcheck.ss; \

--- a/host/gambit/eval-test.ss
+++ b/host/gambit/eval-test.ss
@@ -63,6 +63,26 @@
 (check "(area {:shape :circle :r 21})" "42")
 ;; anonymous fns + map results
 (check "((fn [a b] {:sum (+ a b) :prod (* a b)}) 3 4)" "{:sum 7, :prod 12}")
+;; deftype interface surface: a CharSequence window answers count/seq/nth and the
+;; regex entry points, and a collection deftype prints in its collection's shape.
+;; These live in records.ss, so they reach here only through the GENERATED
+;; records-gambit.ss — a stale generation shows up as a failure on these rows.
+(check (string-append "(do (deftype Sg [s cnt] CharSequence (length [_] cnt)"
+                      " (charAt [_ i] (.charAt s i)) (subSequence [_ a b] (subs s a b))"
+                      " (toString [_] (subs s 0 cnt)))"
+                      " [(count (->Sg \"abcd\" 3)) (vec (seq (->Sg \"abcd\" 3))) (nth (->Sg \"abcd\" 3) 1)])")
+       "[3 [\\a \\b \\c] \\b]")
+(check (string-append "(do (deftype Sgr [s cnt] CharSequence (length [_] cnt)"
+                      " (charAt [_ i] (.charAt s i)) (subSequence [_ a b] (subs s a b))"
+                      " (toString [_] (subs s 0 cnt)))"
+                      " (re-matches #\"a+\" (->Sgr \"aaa\" 3)))")
+       "\"aaa\"")
+(check (string-append "(do (deftype Psq [v] clojure.lang.ISeq (seq [_] (seq v))"
+                      " (first [_] (first v)) (next [_] (next (seq v))) (more [_] (rest (seq v)))"
+                      " (count [_] (count v)) (equiv [_ o] (= (seq v) o)) (empty [_] nil)"
+                      " (cons [_ o] (cons o (seq v))))"
+                      " [(pr-str (->Psq [1 2 3])) (str (->Psq [1 2 3]))])")
+       "[\"(1 2 3)\" \"(1 2 3)\"]")
 ;; the runtime target must never emit chez unsafe spellings
 (check "(count \"gambit\")" "6")
 

--- a/host/gambit/gen-records.ss
+++ b/host/gambit/gen-records.ss
@@ -19,7 +19,9 @@
 (print-brackets #f)
 
 (define src "host/chez/records.ss")
-(define out "host/gambit/records-gambit.ss")
+;; GEN_RECORDS_OUT redirects the write, which is what `make gambitgencheck` uses
+;; to generate into a temp file and diff against the committed one.
+(define out (or (getenv "GEN_RECORDS_OUT") "host/gambit/records-gambit.ss"))
 
 (define (read-all f)
   (with-input-from-file f

--- a/host/gambit/records-gambit.ss
+++ b/host/gambit/records-gambit.ss
@@ -371,10 +371,13 @@
 (define chez-record-type-tbl
   (make-hashtable string-hash string=?))
 
-(define (jrec-record? x)
+(define (jrec-record?-uncached x)
   (and (jrec? x)
        (hashtable-ref chez-record-type-tbl (jrec-tag x) #f)
        #t))
+
+(define (jrec-record? x)
+  (and (jrec? x) (vector-ref (jrdesc-ifc-of x) 3)))
 
 (define chez-deftype-tag-set
   (make-hashtable string-hash string=?))
@@ -665,7 +668,41 @@
          (map-hash (mix-coll-hash (car total) (cdr total))))
     (i32 (bitwise-xor class-hash map-hash))))
 
+(define (jrec-coll-print-shape r)
+  (vector-ref (jrdesc-ifc-of r) 1))
+
+(define (jrec-coll-pr r shape)
+  (if (jolt-print-hash?)
+      "#"
+      (with-deeper-print
+        (if (eq? shape 'map)
+            (string-append
+              "{"
+              (jolt-str-join-comma
+                (jolt-limited-list-strs
+                  (map (lambda (e)
+                         (string-append
+                           (jolt-pr-readable (jolt-nth e 0))
+                           " "
+                           (jolt-pr-readable (jolt-nth e 1))))
+                       (seq->list r))))
+              "}")
+            (let ((body (jolt-str-join
+                          (jolt-limited-seq-strs
+                            (jolt-seq r)
+                            jolt-pr-readable))))
+              (case shape
+                ((seq) (string-append "(" body ")"))
+                ((vec) (string-append "[" body "]"))
+                (else (string-append "#{" body "}"))))))))
+
 (define (jrec-pr r)
+  (cond
+    ((jrec-coll-print-shape r) =>
+     (lambda (shape) (jrec-coll-pr r shape)))
+    (else (jrec-field-pr r))))
+
+(define (jrec-field-pr r)
   (let ((fkeys (jrdesc-fkeys (jrec-desc r))))
     (string-append "#" (jrec-tag r) "{"
       (let ((n (vector-length fkeys)))
@@ -722,25 +759,93 @@
 
 (define jrec-cl rec-coll-method)
 
+(define (jrec-declares? x interface)
+  (and (jrec? x) (jch-isa? (jrec-tag x) interface)))
+
+(define jrdesc-ifc-tbl (make-weak-eq-hashtable))
+
+(define jrdesc-ifc-mutex (make-mutex))
+
+(define (jrdesc-ifc d) (hashtable-ref jrdesc-ifc-tbl d #f))
+
+(define (jrdesc-ifc-set! d v)
+  (with-mutex jrdesc-ifc-mutex
+    (hashtable-set! jrdesc-ifc-tbl d v)))
+
+(define (jrdesc-ifc-epoch)
+  (fx+ jch-graph-epoch jolt-proto-epoch))
+
+(define (jrdesc-derive-ifc d record?)
+  (let ((tag (jrdesc-tag d)) (epoch (jrdesc-ifc-epoch)))
+    (vector epoch
+      (and (not record?)
+           (cond
+             ((jch-isa? tag "clojure.lang.ISeq") 'seq)
+             ((jch-isa? tag "clojure.lang.IPersistentVector") 'vec)
+             ((jch-isa? tag "clojure.lang.IPersistentSet") 'set)
+             ((jch-isa? tag "clojure.lang.IPersistentMap") 'map)
+             (else #f)))
+      (jch-isa? tag "java.lang.CharSequence") record?
+      (and (not record?) (tag-declares-coll-iface? tag)))))
+
+(define (jrdesc-ifc-of x)
+  (let* ((d (jrec-desc x)) (c (jrdesc-ifc d)))
+    (if (and c (fx=? (vector-ref c 0) (jrdesc-ifc-epoch)))
+        c
+        (let ((fresh (jrdesc-derive-ifc
+                       d
+                       (jrec-record?-uncached x))))
+          (jrdesc-ifc-set! d fresh)
+          fresh))))
+
+(define (jrec-charseq? x)
+  (and (jrec? x) (vector-ref (jrdesc-ifc-of x) 2)))
+
+(define (jrec-charseq-method x name)
+  (and (jrec-charseq? x) (jrec-cl x name)))
+
+(define (jrec-charseq-length-method x)
+  (or (jrec-cl x "length")
+      (jrec-abstract-method-error x "length")))
+
+(define (jrec-charseq->seq x len charat)
+  (let ((n (->idx (jolt-invoke len x))))
+    (let build ((i 0))
+      (if (fx>=? i n)
+          jolt-nil
+          (cseq-lazy
+            (jolt-invoke charat x i)
+            (lambda () (build (fx+ i 1))))))))
+
+(define (jrec-charseq->string x)
+  (cond
+    ((jrec-charseq-method x "toString") =>
+     (lambda (m) (jolt-need-str (jolt-invoke m x))))
+    ((jrec-charseq-method x "charAt") =>
+     (lambda (m)
+       (list->string
+         (seq->list
+           (jrec-charseq->seq x (jrec-charseq-length-method x) m)))))
+    (else #f)))
+
 (define jrec-coll-iface-names
   '("IPersistentCollection" "IPersistentMap" "IPersistentVector" "IPersistentSet"
      "IPersistentStack" "IPersistentList" "ISeq" "Seqable"
      "Indexed" "Counted" "Associative" "ILookup" "Reversible"
      "Sorted"))
 
+(define (tag-declares-coll-iface? tag)
+  (let ((ti (hashtable-ref type-registry tag #f)))
+    (and ti
+         (let loop ((ps (vector->list (hashtable-keys ti))))
+           (cond
+             ((null? ps) #f)
+             ((member (jch-last-segment (car ps)) jrec-coll-iface-names)
+              #t)
+             (else (loop (cdr ps))))))))
+
 (define (jrec-declares-coll-iface? x)
-  (and (jrec? x)
-       (not (jrec-record? x))
-       (let ((ti (hashtable-ref type-registry (jrec-tag x) #f)))
-         (and ti
-              (let loop ((ps (vector->list (hashtable-keys ti))))
-                (cond
-                  ((null? ps) #f)
-                  ((member
-                     (jch-last-segment (car ps))
-                     jrec-coll-iface-names)
-                   #t)
-                  (else (loop (cdr ps)))))))))
+  (and (jrec? x) (vector-ref (jrdesc-ifc-of x) 4)))
 
 (define (jrec-sequential-decl? x)
   (and (jrec? x)
@@ -776,20 +881,27 @@
        (and rm (hashtable-ref rm method #f))))
     (else #f)))
 
+(define (jrec-field-count coll)
+  (+ (jrec-nfields coll)
+     (let ((ext (jrec-ext coll)))
+       (if (jolt-nil? ext) 0 (jolt-count ext)))))
+
 (register-count-arm!
   (lambda (coll) (or (jrec? coll) (jolt-transient? coll)))
   (lambda (coll)
     (cond
+      ((jolt-transient? coll) (t-count coll))
       ((jrec-cl coll "count") =>
        (lambda (m) (jolt-invoke m coll)))
-      ((jrec-declares-coll-iface? coll)
-       (jrec-abstract-method-error coll "count"))
-      ((jrec? coll)
-       (+ (jrec-nfields coll)
-          (let ((ext (jrec-ext coll)))
-            (if (jolt-nil? ext) 0 (jolt-count ext)))))
-      ((jolt-transient? coll) (t-count coll))
-      (else (error 'count "uncountable record")))))
+      (else
+       (let ((ifc (jrdesc-ifc-of coll)))
+         (cond
+           ((vector-ref ifc 3) (jrec-field-count coll))
+           ((vector-ref ifc 4)
+            (jrec-abstract-method-error coll "count"))
+           ((vector-ref ifc 2)
+            (jolt-invoke (jrec-charseq-length-method coll) coll))
+           (else (jrec-field-count coll))))))))
 
 (register-contains-arm!
   (lambda (coll) (jrec-cl coll "containsKey"))
@@ -975,6 +1087,14 @@
 (register-seq-arm!
   (lambda (x) (and (jrec? x) (jrec-declares-coll-iface? x)))
   (lambda (x) (jrec-abstract-method-error x "seq")))
+
+(register-seq-arm!
+  (lambda (x) (jrec-charseq-method x "charAt"))
+  (lambda (x)
+    (jrec-charseq->seq
+      x
+      (jrec-charseq-length-method x)
+      (jrec-cl x "charAt"))))
 
 (register-seq-arm!
   jrec-record?
@@ -2076,10 +2196,13 @@
                (jrec-tag v)
                "Object"
                "toString")))
-      (if f
-          (jolt-invoke f v)
-          (let ((s (jrec-pr v)))
-            (substring s 1 (string-length s)))))))
+      (cond
+        (f (jolt-invoke f v))
+        ((jrec-coll-print-shape v) =>
+         (lambda (shape) (jrec-coll-pr v shape)))
+        (else
+         (let ((s (jrec-field-pr v)))
+           (substring s 1 (string-length s))))))))
 
 (register-str-render!
   (lambda (v)


### PR DESCRIPTION
`host/gambit/records-gambit.ss` is generated from `host/chez/records.ss` and had
not been regenerated since #567, so the Gambit host was a release behind on the
whole deftype interface surface: no CharSequence entry points, no collection
print shapes, no descriptor cache. Regenerated with `gen-records.ss`; the diff is
exactly #567's content and nothing else.

Most of #567 already reached Gambit for free — its boot `##include`s the Chez
`collections.ss`, `regex.ss` and `java/class-hierarchy.ss` directly, so the nth
arm, the regex CharSequence realization and `jch-graph-epoch` came along. Only
`records-gambit.ss` needed the pass, because `define-jrec-family` is a
procedural transformer Gambit cannot expand in-unit. StringBuilder stays out of
scope: `host-static-classes.ss` is not in the Gambit boot at all.

## Proving it on gsi, not just regenerating

Three `eval-test` rows drive the ported behavior through `jolt-compile-eval` on
native gsi and compare against the Chez build's own rendering: a CharSequence
deftype's `count` / `seq` / `nth`, `re-matches` over one, and a collection
deftype's `pr-str` / `str`. They pass. A stale generation fails them.

## Why the drift was invisible

`gen-records.ss` documented a `make gambitgen` that did not exist, and nothing
compared the generated file to its source. Both targets exist now:

- `gambitgen` writes it (the target its own header has been naming all along).
- `gambitgencheck` regenerates into a temp file and diffs. It runs on Chez
  alone, so it gates in `ci` whether or not gambit-scheme is installed.

The check is verified in both directions rather than assumed: exit 2 against the
pre-#567 generated file, exit 0 against this one.

## Gates

`make ci` green (58 targets, `gambitgencheck` now among them) · `gambitcheck`,
`gambitkernel`, `gambiteval` all PASS on gsi 4.9.7 · `makefilesmoke` green.