### PR TITLE
Shutdown hooks run, and run on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Shutdown hooks run** (#571). `Runtime.addShutdownHook` kept a list nothing
+  ever read, so `jolt.process`'s `:shutdown` option — `destroy-tree` and
+  friends — cleaned up nothing on any exit path, and a `SIGTERM` to a jolt
+  program left its child processes running. Hooks now run once per process from
+  a single registry, on normal return, on `System/exit`, on an uncaught throw,
+  and on `SIGTERM`/`SIGHUP`.
+
+  The signals are taken over only once a hook is actually registered, by a
+  thread parked in `sigwait` — Chez runs a `register-signal-handler` handler on
+  the main thread at its next safe point, and the two ways a program usually
+  waits (a `deref` of a promise, a blocking foreign call) never reach one, so
+  that route would have made the process ignore the signal instead of handling
+  it. A program with no hooks is untouched and dies on `SIGTERM` as before. Exit
+  status is 128+signal, as on the JVM.
+
+- **A blocking stdin read no longer stops the rest of the program.** `read-line`
+  and the REPL waited inside Chez's own blocking read, which holds the whole
+  Scheme world: a `future` stopped ticking and an agent stopped draining the
+  moment the main thread reached a prompt, where a JVM keeps both running. The
+  wait now happens in `sleep` and the port is read once it has something. A
+  buffered line costs one `char-ready?` and no sleep, so a piped `read-line` loop
+  keeps its throughput (1326 -> 1386 ns/line, 1.045x).
+
+- **A subprocess can be interrupted with `^C` again.** Children spawned the
+  default way came up with SIGINT set to `SIG_IGN`, so `^C` in a terminal killed
+  your program and left the subprocess running. That is the `system(3)` leak the
+  convention exists to avoid rather than the convention itself — a child's
+  dispositions should match what a plain shell would give it, as they do on the
+  JVM. `posix_spawn` now drives every spawn rather than only the ones redirecting
+  a stream to `:inherit` (it already piped every other stream); Chez's fork,
+  which is where the ignore was set, stays as the fallback for platforms without
+  the FFI surface.
+
+- **A child process no longer inherits jolt's signal mask.** jolt blocks SIGINT
+  in its own threads so `^C` reaches the one parked for it, and now blocks
+  SIGTERM/SIGHUP for the shutdown watcher; both travelled to every child through
+  `posix_spawn`'s null attributes and through Chez's fork. A child that starts
+  with SIGTERM blocked survives the `destroy` a shutdown hook calls, and one with
+  SIGINT blocked ignores `^C`. The mask is emptied for the length of a spawn and
+  put back, so a child gets the default mask the JVM would give it.
+
 ### Added
 
 - **Fibers R3 (jolt-nvpr.4): one waiter protocol for threads and fibers.** A

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1067,6 +1067,13 @@
               "        (default (* 16 1024 1024)))\n"
               "    (if trip (or (string->number trip) default) default)))\n"))
           (put-string out "(scheme-start\n  (lambda args\n")
+          ;; Shutdown hooks (`:shutdown` on a jolt.process, jolt.host/
+          ;; add-shutdown-hook) run from Chez's exit-handler, which is a THREAD
+          ;; parameter — so the wrapper has to be installed on the thread that
+          ;; calls (exit), and for an app that is this one. Installed before the
+          ;; guard so the (exit 1) an uncaught throw takes runs the hooks too.
+          ;; The CLI's own twin of this is at the top of jolt-cli-run.
+          (unless library? (put-string out "    (jolt-install-exit-handler!)\n"))
           ;; The prologue (optional native loads + source-root setup) and the -main
           ;; call (or library export publish) run under one guard so a throw in
           ;; either surfaces as jolt-report-throwable + a non-zero exit/return

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -242,6 +242,12 @@
     (else #f)))
 
 (define (jolt-cli-run cli-args prepare-build!)
+  ;; On the main thread, before anything user code can reach: Chez's exit-handler
+  ;; is a thread parameter, so the shutdown-hook wrapper has to be installed on
+  ;; the thread that will call (exit), and this is that thread for both CLI
+  ;; entries. Without it a hook registered from a worker would be invisible to a
+  ;; System/exit here.
+  (jolt-install-exit-handler!)
   (guard (v (#t (jolt-report-uncaught v)))
     ;; Host faults (a condition raised outside jolt-throw) get their k / marks /
     ;; site captured HERE: a with-exception-handler runs before the stack
@@ -254,7 +260,11 @@
         (when (serious-condition? c) (jolt-capture-fault! c))
         (raise-continuable c))
       (lambda () (jolt-cli-dispatch cli-args prepare-build!)))
-    ;; normal-return twin of the exit-handler flush above
+    ;; normal-return twin of the exit-handler above. A `chez --script` that
+    ;; returns instead of calling (exit) ends the process without ever running
+    ;; the exit handler, so the shutdown hooks have to be run from here as well —
+    ;; the runner is once-per-process, so whichever path gets there first wins.
+    (guard (_ (#t #f)) (jolt-run-shutdown-hooks!))
     (guard (_ (#t #f)) (flush-output-port (current-output-port)))))
 
 (define (jolt-cli-dispatch cli-args prepare-build!)

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1175,11 +1175,9 @@
         (unless enq (jolt-invoke thunk))
         jolt-nil)))
 
-(define jolt-pump-kih
-  (lambda ()
-    (for-each (lambda (th) (guard (e (#t #f)) (th)))
-              (reverse (unbox jolt-shutdown-hooks)))
-    (exit 0)))
+;; (exit 0) rather than calling _exit: the exit handler runs the hooks, so ^C
+;; while parked reaches exactly the same cleanup every other exit path does.
+(define jolt-pump-kih (lambda () (exit 0)))
 
 ;; Park the calling thread until a keyboard interrupt (^C), running the shutdown
 ;; hooks and exiting when it arrives — AND own the main-thread pump while parked.
@@ -1292,44 +1290,235 @@
     (condition-broadcast jolt-main-queue-cv))
   jolt-nil)
 
-;; Shutdown hooks run by jolt-pump-kih (the keyboard-interrupt-handler installed by
-;; park-until-interrupt) before (exit 0), so a foreground server (nREPL) can close
-;; its socket and drop .nrepl-port on ^C instead of Chez's default mutex-corrupting
-;; abort. Newest-first; each hook is isolated so one failing hook can't block the exit.
-(define jolt-shutdown-hooks (box '()))
-(define (jolt-add-shutdown-hook thunk)
-  (set-box! jolt-shutdown-hooks (cons thunk (unbox jolt-shutdown-hooks)))
-  jolt-nil)
+;; --- POSIX signal masks ------------------------------------------------------
+;; pthread_sigmask/sigaddset are libc/libpthread symbols, resolvable once the
+;; process object is loaded (as the socket fns already are). foreign-procedure
+;; resolves its symbol eagerly, and these POSIX signal fns don't exist on
+;; Windows — resolving them unguarded aborted startup ("no entry for
+;; pthread_sigmask"). Guard so a non-POSIX host yields #f; every caller below
+;; then no-ops (Windows delivers ^C through the console, not a per-thread mask).
+;;
+;; The sets live in FOREIGN memory, not bytevectors: the watcher below hands one
+;; to a __collect_safe sigwait and stays parked in it, where the collector is
+;; free to move a bytevector out from under the pointer C is holding.
+(define c-pthread-sigmask
+  (jolt-foreign-proc-safe "pthread_sigmask" '(int void* void*) 'int))
+(define c-sigemptyset (jolt-foreign-proc-safe "sigemptyset" '(void*) 'int))
+(define c-sigaddset (jolt-foreign-proc-safe "sigaddset" '(void* int) 'int))
+;; POSIX SIG_BLOCK/SIG_UNBLOCK numerics differ by platform: Linux/glibc 0/1,
+;; Darwin/macOS 1/2 (SIG_UNBLOCK is SIG_BLOCK+1 on both). Resolve SIG_BLOCK for
+;; this host from the os-family property.
+(define jolt-sig-block-how (if (eq? (sa-os-family) 'macos) 1 0))
+(define jolt-sig-unblock-how (+ jolt-sig-block-how 1))
+(define jolt-sig-setmask-how (+ jolt-sig-block-how 2))
+(define jolt-sigmask-ok? (and c-pthread-sigmask c-sigemptyset c-sigaddset #t))
+;; 128 bytes covers Linux's 1024-bit sigset_t and is larger than macOS's 4-byte
+;; one. The caller owns the block and frees it (or keeps it for the process's
+;; life, as the watcher does).
+(define (jolt-make-sigset sigs)
+  (let ((s (sa-foreign-alloc 128)))
+    (c-sigemptyset s)
+    (for-each (lambda (n) (c-sigaddset s n)) sigs)
+    s))
 
 ;; Per-thread SIGINT mask. A worker thread parked in a foreign call (the nREPL
 ;; accept loop in c-accept, or a conn handler) can't run Chez's keyboard-interrupt
 ;; handler on ^C, so if SIGINT is delivered there the process hangs. Block SIGINT
 ;; in the primordial thread BEFORE forking such workers (they inherit the mask),
 ;; then park-until-interrupt unblocks it in the primordial once its handler is
-;; installed, so ^C is always delivered to the parked thread. pthread_sigmask/
-;; sigaddset are libc/libpthread symbols, resolvable once the process object is
-;; loaded (as the socket fns already are). 128 bytes covers Linux's 1024-bit
-;; sigset_t and is larger than macOS's 4-byte one.
-;; foreign-procedure resolves its symbol eagerly, and these POSIX signal fns don't
-;; exist on Windows — resolving them unguarded aborted startup ("no entry for
-;; pthread_sigmask"). Guard so a non-POSIX host yields #f; jolt-set-sigint-blocked
-;; then no-ops (Windows delivers ^C through the console, not a per-thread mask).
-(define c-pthread-sigmask
-  (jolt-foreign-proc-safe "pthread_sigmask" '(int u8* u8*) 'int))
-(define c-sigemptyset (jolt-foreign-proc-safe "sigemptyset" '(u8*) 'int))
-(define c-sigaddset (jolt-foreign-proc-safe "sigaddset" '(u8* int) 'int))
-;; POSIX SIG_BLOCK/SIG_UNBLOCK numerics differ by platform: Linux/glibc 0/1,
-;; Darwin/macOS 1/2 (SIG_UNBLOCK is SIG_BLOCK+1 on both). Resolve SIG_BLOCK for
-;; this host from the os-family property.
-(define jolt-sig-block-how (if (eq? (sa-os-family) 'macos) 1 0))
+;; installed, so ^C is always delivered to the parked thread.
 (define (jolt-set-sigint-blocked block?)
-  (when (and c-pthread-sigmask c-sigemptyset c-sigaddset)
-    (let ((set (make-bytevector 128 0))
-          (old (make-bytevector 128 0)))
-      (c-sigemptyset set)
-      (c-sigaddset set 2)                          ; SIGINT = 2
-      (c-pthread-sigmask (if block? jolt-sig-block-how (+ jolt-sig-block-how 1)) set old)))
+  (when jolt-sigmask-ok?
+    (let ((set (jolt-make-sigset '(2)))              ; SIGINT = 2
+          (old (sa-foreign-alloc 128)))
+      (c-pthread-sigmask (if block? jolt-sig-block-how jolt-sig-unblock-how) set old)
+      (sa-foreign-free set)
+      (sa-foreign-free old)))
   jolt-nil)
+
+;; --- shutdown hooks ----------------------------------------------------------
+;; ONE registry for every "run this before the process ends" hook, whichever API
+;; asked for it: jolt.host/add-shutdown-hook (nREPL closing its socket and
+;; dropping .nrepl-port on ^C) and java.lang.Runtime's addShutdownHook, which is
+;; what babashka.process's `:shutdown` option registers. Those were two separate
+;; lists with one runner between them, and the Runtime one was written and never
+;; read — so `:shutdown destroy-tree` cleaned up nothing at all, on any exit path
+;; (#571).
+;;
+;; The hooks run:
+;;   - on every (exit n), via the exit handler the arming below installs — a
+;;     -main that returns, an explicit (System/exit n), and an uncaught throw all
+;;     end there;
+;;   - on ^C while parked in park-until-interrupt (jolt-pump-kih exits);
+;;   - on SIGTERM / SIGHUP, through the watcher thread further down.
+;; Once per process, in registration order, each hook isolated so one that
+;; throws cannot keep the rest from running.
+;;
+;; Entries are (key . thunk): the key is what removeShutdownHook matches on (the
+;; JVM hands back the same Thread object), and is the thunk itself for the
+;; anonymous jolt.host form.
+(define jolt-shutdown-hooks (box '()))
+(define jolt-shutdown-mutex (make-mutex))
+(define jolt-shutdown-ran (box #f))
+
+(define (jolt-register-shutdown-hook! key thunk)
+  (with-mutex jolt-shutdown-mutex
+    (set-box! jolt-shutdown-hooks (cons (cons key thunk) (unbox jolt-shutdown-hooks))))
+  ;; outside the mutex: arming takes it to test the watcher's flag
+  (jolt-arm-shutdown!)
+  jolt-nil)
+
+(define (jolt-add-shutdown-hook thunk) (jolt-register-shutdown-hook! thunk thunk))
+
+;; #t when a hook keyed by KEY was registered and is now removed, matching
+;; Runtime.removeShutdownHook's boolean.
+(define (jolt-remove-shutdown-hook! key)
+  (with-mutex jolt-shutdown-mutex
+    (let* ((before (unbox jolt-shutdown-hooks))
+           (after (remp (lambda (e) (eq? (car e) key)) before)))
+      (set-box! jolt-shutdown-hooks after)
+      (not (= (length before) (length after))))))
+
+;; Runs the hooks exactly once per process, whichever exit path gets here first.
+;; The once-flag is flipped under the mutex together with taking the list, so a
+;; SIGTERM landing while the main thread is already exiting cannot run them twice.
+(define (jolt-run-shutdown-hooks!)
+  (let ((hooks (with-mutex jolt-shutdown-mutex
+                 (and (not (unbox jolt-shutdown-ran))
+                      (begin (set-box! jolt-shutdown-ran #t)
+                             (reverse (unbox jolt-shutdown-hooks)))))))
+    (when hooks
+      (for-each (lambda (e) (guard (_ (#t #f)) ((cdr e)))) hooks)))
+  jolt-nil)
+
+;; The Runnable a java.lang.Thread was constructed with, or #f (Thread() with no
+;; target is legal). A shutdown hook is registered AS a Thread — that is the JVM's
+;; API — and the runner invokes its body directly on the thread doing the
+;; shutdown, rather than forking one thread per hook only to wait for it.
+(define (jolt-thread-body th)
+  (and (jhost? th)
+       (string=? (jhost-tag th) "user-thread")
+       (vector-ref (jhost-state th) 0)))
+
+;; Every exit runs the hooks first, then flushes — a hook that prints must reach
+;; the console like any other output. Guarded: a hook that throws, or a broken
+;; pipe on the flush, must not turn exit into a second crash.
+;;
+;; Installed at RUN time, not as a top-level form. A standalone binary boots by
+;; loading a boot file and then calling Sscheme_start, and whatever the boot
+;; file's top-level forms left in exit-handler is not what is in force by the time
+;; the program runs — a wrapper installed at load time is simply never called
+;; there, which is why hooks ran under `chez --script` and not in a built binary.
+;;
+;; PER THREAD, because Chez's exit-handler is a thread parameter: a wrapper
+;; installed on one thread is invisible to (exit) called on another. So every
+;; entry point installs it on the main thread (jolt-cli-run, and the launcher a
+;; `jolt build` emits), and arming installs it on whatever thread registered the
+;; hook — which is the thread most likely to be the one that later exits.
+(define jolt-exit-handler-installed (make-thread-parameter #f))
+(define (jolt-install-exit-handler!)
+  (unless (jolt-exit-handler-installed)
+    (jolt-exit-handler-installed #t)
+    (let ((base (exit-handler)))
+      (exit-handler
+        (lambda args
+          (guard (_ (#t #f)) (jolt-run-shutdown-hooks!))
+          (guard (_ (#t #f)) (flush-output-port (current-output-port)))
+          (guard (_ (#t #f)) (flush-output-port (current-error-port)))
+          (apply base args)))))
+  jolt-nil)
+
+;; --- SIGTERM / SIGHUP --------------------------------------------------------
+;; The signals a JVM runs shutdown hooks for and jolt can take over: SIGTERM (the
+;; default `kill`, what a supervisor sends) and SIGHUP. Same numbers on Linux and
+;; macOS. SIGINT is deliberately NOT here — Chez owns it through
+;; keyboard-interrupt-handler, and ^C reaches a child through the foreground
+;; process group anyway.
+(define jolt-shutdown-signals '(15 1))
+(define jolt-shutdown-sigset #f)
+(define c-sigwait (jolt-foreign-proc-blocking "sigwait" '(void* void*) 'int))
+;; The watcher cannot leave through Chez's (exit): called off the main thread it
+;; never returns. It has already run the hooks and flushed by then, so _exit is
+;; the whole of what is left to do.
+(define c-underscore-exit (jolt-foreign-proc-safe "_exit" '(int) 'void))
+
+;; Arming happens on the FIRST shutdown hook, never before. Taking a signal over means
+;; its default "terminate now" disposition no longer applies, and a program with
+;; nothing to clean up must stay killable even when its main thread is somewhere
+;; Scheme cannot be resumed from — parked in Chez's own blocking stdin read, say,
+;; where no Scheme thread runs at all. A program that registered a hook has asked
+;; for the cleanup and takes that trade; one that never did is left exactly as it
+;; was.
+;;
+;; A DEDICATED THREAD parked in sigwait, not (register-signal-handler): Chez runs
+;; a registered handler on the main thread at its next safe point, and the two
+;; ways a program most often waits — condition-wait (deref of a promise) and a
+;; blocking foreign call — are not safe points. The handler would never run and
+;; the process would then ignore the signal entirely, which is worse than not
+;; handling it. Blocking the signals here also blocks them in every thread forked
+;; afterwards (a new thread inherits its creator's mask), so the kernel has no
+;; thread to deliver to and leaves the signal pending for sigwait to take.
+(define (jolt-arm-shutdown!)
+  (jolt-install-exit-handler!)
+  (when (and jolt-sigmask-ok? c-sigwait c-underscore-exit)
+    (let ((start? (with-mutex jolt-shutdown-mutex
+                    (and (not jolt-shutdown-sigset)
+                         (begin (set! jolt-shutdown-sigset
+                                      (jolt-make-sigset jolt-shutdown-signals))
+                                #t)))))
+      (when start?
+        (let ((old (sa-foreign-alloc 128)))
+          (c-pthread-sigmask jolt-sig-block-how jolt-shutdown-sigset old)
+          (sa-foreign-free old))
+        (fork-thread
+          (lambda ()
+            (let ((sigbuf (sa-foreign-alloc 8)))
+              (let loop ()
+                (if (= 0 (c-sigwait jolt-shutdown-sigset sigbuf))
+                    (let ((sig (sa-foreign-ref 'int sigbuf 0)))
+                      (guard (_ (#t #f)) (jolt-run-shutdown-hooks!))
+                      (guard (_ (#t #f)) (flush-output-port (current-output-port)))
+                      (guard (_ (#t #f)) (flush-output-port (current-error-port)))
+                      ;; 128+signal is the status a shell reports for a process
+                      ;; killed by that signal, and what the JVM exits with here.
+                      (c-underscore-exit (+ 128 sig)))
+                    (loop))))))))) ; EINTR — ask again
+  jolt-nil)
+
+;; --- a child must not inherit jolt's signal mask -----------------------------
+;; Both spawn paths hand the calling thread's mask straight to the child —
+;; posix_spawn with a NULL attrp, and Chez's own fork — and jolt blocks signals
+;; in threads for its own reasons: SIGINT so ^C reaches the thread parked in
+;; park-until-interrupt rather than an nREPL worker sitting in a foreign call,
+;; SIGTERM/SIGHUP so the watcher above can take them. Either one inherited is
+;; wrong in a way that bites at once: a child with SIGTERM blocked survives the
+;; very destroy the shutdown hook exists to call, and a child with SIGINT blocked
+;; ignores ^C (jolt-e5sb). A JVM gives its children a default mask; so does this.
+;;
+;; The mask is emptied on THIS thread for the length of the spawn and put back
+;; exactly as it was, so the whole of jolt's private masking is undone at once
+;; rather than a named subset of it. That leaves one fork+exec in which jolt
+;; itself is unmasked: a SIGTERM landing there kills it without running hooks, as
+;; it did before there were hooks, and a ^C landing there may be taken by this
+;; thread instead of the parked one. Both are pre-existing behavior. The
+;; window-free alternative, posix_spawnattr with POSIX_SPAWN_SETSIGMASK, reaches
+;; only one of the two paths — Chez's fork takes no attributes — and two
+;; mechanisms for one rule is worse than one honest window.
+(define jolt-empty-sigset (and jolt-sigmask-ok? (jolt-make-sigset '())))
+(define (jolt-with-empty-sigmask thunk)
+  (if (not jolt-empty-sigset)
+      (thunk)
+      (let* ((old (sa-foreign-alloc 128))
+             (restore (lambda ()
+                        (c-pthread-sigmask jolt-sig-setmask-how old 0)
+                        (sa-foreign-free old))))
+        (c-pthread-sigmask jolt-sig-setmask-how jolt-empty-sigset old)
+        ;; not dynamic-wind: its after-thunk can run more than once, and this one
+        ;; frees. Normal return and throw both restore exactly once; multiple
+        ;; values survive the round trip.
+        (let ((vals (guard (e (#t (restore) (raise e))) (call-with-values thunk list))))
+          (restore)
+          (apply values vals)))))
 
 (def-var! "jolt.host" "call-on-main-thread" jolt-call-on-main-thread)
 (def-var! "jolt.host" "call-on-main-thread-async" jolt-call-on-main-thread-async)

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -691,8 +691,46 @@
 ;; stdin line seam: the clojure.core *in* reader (50-io.clj) drives read-line /
 ;; read / read+string through __stdin-read-line. Return the next line (newline
 ;; stripped) or nil at EOF. Without this, (read-line) and the REPL call nil.
+;;
+;; Waits in `sleep`, NOT inside the read. Chez's blocking read holds the whole
+;; Scheme world while it waits: no other thread runs at all, so a future stopped
+;; ticking and an agent stopped draining the moment the main thread reached a
+;; prompt, and the SIGTERM watcher (concurrency.ss) could not wake to run the
+;; shutdown hooks either. On the JVM those all keep running while a thread sits in
+;; System.in.read(). sleep is collect-safe, so parking THERE and reading only once
+;; the port has something leaves every other thread alive (jolt-p9ua). Backs off
+;; 0.5ms -> 20ms, the shape proc-wait-blocking uses.
+;;
+;; A line already in the buffer costs one char-ready? and no sleep at all, so a
+;; piped read-line loop keeps its throughput: 1326 -> 1386 ns/line, medians of
+;; four 300k-line runs each with the wait compiled out and back in, 1.045x.
+;; Whether the port can answer char-ready? at all is settled ONCE per port rather
+;; than under a guard per line — the guard was most of the cost and took the same
+;; measurement to 1460 ns/line, 1.10x, which is the ceiling rather than a rounding
+;; error. A port that cannot answer reads the old, blocking way.
+;;
+;; char-ready? promises a CHAR, not a whole line, so a writer that sends half a
+;; line and then stalls still parks the world for the remainder — a far smaller
+;; window than "until any input arrives", and the most this port surface offers.
+(define jolt-stdin-poll-step0 500000)          ; 0.5ms, in nanoseconds
+(define jolt-stdin-poll-step-max (* 20 1000000))   ; 20ms
+(define jolt-stdin-poll-port (box #f))         ; the port the answer below is about
+(define jolt-stdin-poll-ok (box #f))
+(define (jolt-stdin-wait-ready! in)
+  (unless (eq? (unbox jolt-stdin-poll-port) in)
+    (set-box! jolt-stdin-poll-ok (guard (_ (#t #f)) (char-ready? in) #t))
+    (set-box! jolt-stdin-poll-port in))
+  (when (unbox jolt-stdin-poll-ok)
+    (let loop ((step jolt-stdin-poll-step0))
+      (unless (char-ready? in)
+        (sleep (make-time 'time-duration step 0))
+        (loop (min jolt-stdin-poll-step-max (* step 2)))))))
+
 (def-var! "clojure.core" "__stdin-read-line"
-  (lambda () (let ((l (get-line (current-input-port)))) (if (eof-object? l) jolt-nil l))))
+  (lambda ()
+    (let ((in (current-input-port)))
+      (jolt-stdin-wait-ready! in)
+      (let ((l (get-line in))) (if (eof-object? l) jolt-nil l)))))
 
 ;; (type f) -> :jolt/file (the tagged-file :jolt/type). Registered through the
 ;; type-arm registry (natives-meta.ss) so the dispatcher picks it up.

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -1,10 +1,10 @@
-;; java.lang.ProcessBuilder / java.lang.Process over Chez's open-process-ports.
+;; java.lang.ProcessBuilder / java.lang.Process over posix_spawn.
 ;;
 ;; babashka.process (vendored under jolt.process) is built entirely on the JVM
 ;; ProcessBuilder / Process API; this file provides that surface so the library
-;; runs unmodified. A subprocess is spawned by open-process-ports, which forks a
-;; `/bin/sh -c CMD` and hands back binary stdin/stdout/stderr ports plus the pid.
-;; We drive it as ProcessBuilder does:
+;; runs unmodified. A subprocess is a `/bin/sh -c CMD` spawned with posix_spawn,
+;; handing back binary stdin/stdout/stderr ports plus the pid. We drive it as
+;; ProcessBuilder does:
 ;;
 ;;   - the argv list is shell-quoted and `exec`'d, so the shell performs no word
 ;;     splitting or globbing (matching ProcessBuilder, which execs directly) and
@@ -13,12 +13,15 @@
 ;;   - :env  -> `env -i K=V …` prefix (the env map starts as a copy of the parent
 ;;     environment, so `env -i` reproduces exactly the intended set)
 ;;   - file / discard redirects -> shell `1> 'f'` / `2>> 'f'` / `1>/dev/null`
-;;   - INHERIT -> a posix_spawn spawn path that leaves the inherited fds
-;;     untouched in the child (true fd-level inheritance: isatty holds, stdin
-;;     offsets are shared) and builds pipes only for the non-inherited streams.
-;;     Where that FFI surface is unavailable (Windows machine types), a pump
-;;     thread copying between the pipe and jolt's own stdio remains as
-;;     emulation.
+;;   - INHERIT -> no file action, so the child keeps jolt's real descriptor (true
+;;     fd-level inheritance: isatty holds, stdin offsets are shared); every other
+;;     stream gets a pipe.
+;;
+;; Chez's own open-process-ports is the FALLBACK, for machine types where that
+;; FFI surface is missing (Windows), with a pump thread copying between the pipe
+;; and jolt's stdio to emulate INHERIT. It is not the primary path: its fork
+;; leaves SIGINT ignored in the child, so a subprocess spawned through it cannot
+;; be interrupted with ^C (jolt-a4hs).
 ;;
 ;; Exit status, liveness and signalling go through libc waitpid/kill via FFI. A
 ;; per-process mutex serialises reaping so isAlive/waitFor/exitValue never race a
@@ -308,41 +311,18 @@
     (let loop () (unless (unbox (vector-ref latch 2))
                    (condition-wait (vector-ref latch 1) (vector-ref latch 0)) (loop)))))
 
-;; --- fd-level spawn (Redirect.INHERIT) ---------------------------------------
-;; open-process-ports pipes all three streams unconditionally (its child closes
-;; every other descriptor), so INHERIT through it can only ever be pump
-;; emulation: the child sees a pipe, isatty is false, output detours through
-;; jolt's ports, and stdin reads ahead of what the child consumed. A spawn with
-;; any INHERIT stream therefore goes through posix_spawn instead: a child fd
-;; that gets no file action IS the parent's descriptor — tty answers true,
-;; writes land without an intermediary, successive INHERIT-stdin children share
-;; the read offset — and pipes are built only for the streams that ask for one.
-;; Everything downstream (waitpid reaping, kill, the stream wrappers) is shared
-;; with the pipe path. Where this FFI surface is unavailable (Windows machine
-;; types), the pump emulation below remains the fallback.
-
-;; blocking pipe I/O must be __collect_safe: a plain foreign call keeps the
-;; thread "active" for the stop-the-world collector, so a read parked on an
-;; idle pipe would freeze every other thread's GC. Same nt/eval split as
-;; jolt-foreign-proc-safe (a compiled foreign-procedure is a load-time fasl
-;; relocation that aborts boot on Windows machine types).
-(define-syntax proc-foreign-blocking
-  (lambda (x)
-    (syntax-case x (quote)
-      ((_ name (quote args) (quote res))
-       ;; Decide at RUNTIME, not expansion (same compile-file constraint as
-       ;; rt.ss's jolt-foreign-proc-safe): emit both branches under a runtime
-       ;; os-family test.
-       (with-syntax
-           ((win #'(guard (e (#t #f))
-                   (sa-load-shared-object #f)
-                   (and (sa-foreign-entry? name)
-                        (sa-foreign-procedure-runtime name (quote args) (quote res) #t))))
-            (unx #'(guard (e (#t #f))
-                   (sa-load-shared-object #f)
-                   (and (sa-foreign-entry? name)
-                        (sa-foreign-procedure-blocking name args res)))))
-         #'(if (eq? (sa-os-family) 'windows) win unx))))))
+;; --- fd-level spawn (the primary path) ---------------------------------------
+;; A child fd that gets no file action IS the parent's descriptor — tty answers
+;; true, writes land without an intermediary, successive INHERIT-stdin children
+;; share the read offset — and pipes are built for the streams that ask for one.
+;; open-process-ports can do none of that: it pipes all three streams
+;; unconditionally (its child closes every other descriptor), so INHERIT through
+;; it can only ever be pump emulation, where the child sees a pipe, isatty is
+;; false, output detours through jolt's ports, and stdin reads ahead of what the
+;; child consumed. It also leaves SIGINT ignored in its child. So this is the
+;; path every spawn takes where the FFI surface exists, and the pump emulation
+;; below is what remains where it does not (Windows machine types). Everything
+;; downstream — waitpid reaping, kill, the stream wrappers — is shared.
 
 (define proc-c-pipe  (jolt-foreign-proc-safe "pipe"  '(void*) 'int))
 (define proc-c-close (jolt-foreign-proc-safe "close" '(int)   'int))
@@ -351,8 +331,8 @@
 (define proc-fa-close   (jolt-foreign-proc-safe "posix_spawn_file_actions_addclose" '(void* int) 'int))
 (define proc-fa-destroy (jolt-foreign-proc-safe "posix_spawn_file_actions_destroy"  '(void*) 'int))
 (define proc-c-spawn (jolt-foreign-proc-safe "posix_spawn" '(void* string void* void* void* void*) 'int))
-(define proc-c-read  (proc-foreign-blocking "read"  '(int void* size_t) 'ssize_t))
-(define proc-c-write (proc-foreign-blocking "write" '(int void* size_t) 'ssize_t))
+(define proc-c-read  (jolt-foreign-proc-blocking "read"  '(int void* size_t) 'ssize_t))
+(define proc-c-write (jolt-foreign-proc-blocking "write" '(int void* size_t) 'ssize_t))
 
 (define proc-spawn-fd-ok?
   (and proc-c-pipe proc-c-close proc-fa-init proc-fa-dup2 proc-fa-close
@@ -443,7 +423,8 @@
 ;; file action (the child keeps the parent's descriptor); the rest get pipes.
 ;; Returns (values stdin-port stdout-port stderr-port pid), #f for inherited
 ;; ends. attrp is NULL: signal mask and dispositions are inherited, matching
-;; the pipe path.
+;; the pipe path — so the mask is corrected on this side, around the spawn
+;; itself (see the call below).
 (define (proc-spawn-fd-level sh-cmd inherit-in? inherit-out? inherit-err?)
   (define (mk-pipe)
     (let ((fds (sa-foreign-alloc 8)))
@@ -469,7 +450,10 @@
              (envp (proc-marshal-argv
                     (map (lambda (p) (string-append (car p) "=" (cdr p)))
                          (all-env-pairs))))
-             (rc (proc-c-spawn pidbuf "/bin/sh" fa 0 (car argv) (car envp)))
+             ;; attrp is NULL, so the child inherits this thread's signal mask —
+             ;; which must carry none of jolt's own blocking (concurrency.ss).
+             (rc (jolt-with-empty-sigmask
+                   (lambda () (proc-c-spawn pidbuf "/bin/sh" fa 0 (car argv) (car envp)))))
              (pid (sa-foreign-ref 'int pidbuf 0)))
         (proc-fa-destroy fa)
         (sa-foreign-free fa) (sa-foreign-free pidbuf)
@@ -554,13 +538,24 @@
            (rout (proc-pb-redir-out self))
            (rerr (proc-pb-redir-err self))
            (inherit? (lambda (r) (and (proc-redirect? r) (eq? (proc-redirect-kind r) 'inherit)))))
-      (if (and proc-spawn-fd-ok?
-               (or (inherit? rin) (inherit? rout) (inherit? rerr)))
-          ;; fd-level INHERIT: the child writes the real descriptors directly,
+      ;; posix_spawn drives EVERY spawn where the FFI surface exists, not only the
+      ;; ones with an INHERIT stream — it already pipes each stream that is not
+      ;; inherited, so the two differ in how the child is created, not in what it
+      ;; gets. Chez's fork leaves SIGINT set to SIG_IGN in the child, which no
+      ;; amount of care on this side can undo (it happens between its fork and its
+      ;; exec), and a child that cannot be interrupted by ^C is not what
+      ;; ProcessBuilder hands you anywhere else. That is the system(3) leak the
+      ;; convention exists to avoid, not the convention (jolt-a4hs); through
+      ;; posix_spawn a child's dispositions match a plain shell's exactly.
+      ;; The fork path stays as the fallback for machine types without the FFI,
+      ;; INHERIT emulation and all.
+      (if proc-spawn-fd-ok?
+          ;; An INHERITED stream means the child writes jolt's real descriptors,
           ;; so anything jolt has buffered must land first to keep its order.
           (begin
-            (guard (e (#t #f)) (flush-output-port (current-output-port)))
-            (guard (e (#t #f)) (flush-output-port (current-error-port)))
+            (when (or (inherit? rout) (inherit? rerr))
+              (guard (e (#t #f)) (flush-output-port (current-output-port)))
+              (guard (e (#t #f)) (flush-output-port (current-error-port))))
             (call-with-values
               (lambda () (proc-spawn-fd-level (proc-build-shell-command self)
                                               (inherit? rin) (inherit? rout) (inherit? rerr)))
@@ -575,7 +570,11 @@
                                     child-stdout child-stdin (box '()) (box #f))))
                   (make-jhost "process" pst)))))
           (call-with-values
-            (lambda () (sa-run-process (proc-build-shell-command self) #f))
+            ;; Chez forks for this one, so the child inherits this thread's
+            ;; signal mask just as the posix_spawn path does. (It also leaves
+            ;; SIGINT ignored in the child, which is why this is the fallback.)
+            (lambda () (jolt-with-empty-sigmask
+                         (lambda () (sa-run-process (proc-build-shell-command self) #f))))
             (lambda (child-stdin child-stdout child-stderr pid)
               (let* ((latches (box '()))
                      (pst (vector (make-out-stream child-stdin)
@@ -723,10 +722,10 @@
         (cons "thenApply" (lambda (self f) self))))
 
 ;; --- java.lang.Runtime shutdown hooks ----------------------------------------
-;; addShutdownHook stores Thread hooks run at jolt exit; shell's default :shutdown
-;; registers one to kill the child if jolt dies mid-run. shell derefs before
-;; returning, so in practice the hook is removed (JDK9 onExit path) before exit.
-(define proc-shutdown-hooks (box '()))
+;; addShutdownHook registers a Thread hook to run at jolt exit; babashka.process's
+;; `:shutdown` option registers one to kill the child if jolt dies mid-run.
+;; The registry, the runner and the SIGTERM/SIGHUP watcher all live in
+;; concurrency.ss — these are the JVM-shaped door onto them.
 (define the-jolt-runtime (make-jhost "jolt-runtime" #f))
 
 ;; A String[] / collection of strings -> a Scheme list of strings; a lone String
@@ -763,10 +762,12 @@
 
 (register-host-methods! "jolt-runtime"
   (list (cons "addShutdownHook"
-          (lambda (self hook) (set-box! proc-shutdown-hooks (cons hook (unbox proc-shutdown-hooks))) jolt-nil))
-        (cons "removeShutdownHook"
           (lambda (self hook)
-            (set-box! proc-shutdown-hooks (remq hook (unbox proc-shutdown-hooks))) #t))
+            (jolt-register-shutdown-hook! hook
+              (lambda () (let ((body (jolt-thread-body hook))) (when body (jolt-invoke body)))))
+            jolt-nil))
+        (cons "removeShutdownHook"
+          (lambda (self hook) (jolt-remove-shutdown-hook! hook)))
         (cons "availableProcessors" (lambda (self) (->num (jolt-available-processors))))
         ;; The memory trio, over Chez's own heap accounting: current-memory-bytes
         ;; is what the collector has reserved from the OS (the JVM's totalMemory)

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -68,6 +68,29 @@
                         (sa-foreign-procedure name args res)))))
          #'(if (eq? (sa-os-family) 'windows) win unx))))))
 
+;; Same, for an entry point that BLOCKS (a pipe read, sigwait). The call must be
+;; __collect_safe: a plain foreign call keeps the thread "active" for the
+;; stop-the-world collector, so a call parked on an idle pipe would freeze every
+;; other thread's GC. The caller owes it one more thing — anything C keeps a
+;; pointer to across the wait has to live in foreign memory, since the collector
+;; is free to move a bytevector while the thread is deactivated.
+(define-syntax jolt-foreign-proc-blocking
+  (lambda (x)
+    (syntax-case x (quote)
+      ((_ name (quote args) (quote res))
+       ;; Same runtime os-family test as jolt-foreign-proc-safe, for the same
+       ;; compile-file reason.
+       (with-syntax
+           ((win #'(guard (e (#t #f))
+                   (sa-load-shared-object #f)
+                   (and (sa-foreign-entry? name)
+                        (sa-foreign-procedure-runtime name (quote args) (quote res) #t))))
+            (unx #'(guard (e (#t #f))
+                   (sa-load-shared-object #f)
+                   (and (sa-foreign-entry? name)
+                        (sa-foreign-procedure-blocking name args res)))))
+         #'(if (eq? (sa-os-family) 'windows) win unx))))))
+
 ;; --- how many processors can this process use ---------------------------------
 ;; Backs jolt.host/available-processors, which Runtime.availableProcessors and
 ;; pmap's look-ahead window read. Each host is asked the question the JVM asks

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -231,7 +231,7 @@
 ;; (sa-foreign-procedure name args res) -> foreign procedure
 ;; SYNTAX: compile-time-typed foreign-procedure creation. (sa-foreign-procedure
 ;; "f" (int) int) lowers to (foreign-procedure "f" (int) int) — the compiled
-;; (non-Windows) branch of jolt-foreign-proc-safe / proc-foreign-blocking, where
+;; (non-Windows) branch of jolt-foreign-proc-safe / -blocking, where
 ;; the type signature is literal at the call site. Contract: build a foreign
 ;; procedure for a statically-known signature. Degradation: none — a target
 ;; expands this to its native foreign-procedure form.

--- a/test/chez/process-test.clj
+++ b/test/chez/process-test.clj
@@ -171,6 +171,145 @@
   (check-eq "INHERIT stdin shares the fd offset between children"
             (str/includes? out "SECOND=<CD>") true))
 
+;; --- shutdown hooks -----------------------------------------------------------
+;; Runtime.addShutdownHook is what babashka.process's `:shutdown` option registers,
+;; so if the hooks never run, `:shutdown destroy-tree` cleans up nothing (#571).
+;; A nested jolt, because a hook can only be observed by letting a process exit.
+(let [out (:out (sh [jolt-bin "-e" (str "(.addShutdownHook (Runtime/getRuntime)"
+                                        " (Thread. (fn [] (println \"HOOK\"))))"
+                                        " (println \"MAIN\")")]))]
+  (check-eq "shutdown hook runs when the process exits" (str/split-lines out) ["MAIN" "HOOK"]))
+
+(let [out (:out (sh [jolt-bin "-e" (str "(.addShutdownHook (Runtime/getRuntime)"
+                                        " (Thread. (fn [] (println \"HOOK\"))))"
+                                        " (println \"MAIN\") (System/exit 0)")]))]
+  (check-eq "shutdown hook runs on System/exit" (str/split-lines out) ["MAIN" "HOOK"]))
+
+;; Chez's exit-handler is a THREAD parameter, so a hook registered from a worker
+;; installs the wrapper on that worker and nowhere else. The main thread has to
+;; carry one of its own or this hook would be dropped on the way out.
+(let [out (:out (sh [jolt-bin "-e" (str "(let [t (Thread. (fn [] (.addShutdownHook (Runtime/getRuntime)"
+                                        "                          (Thread. (fn [] (println \"HOOK\"))))))]"
+                                        "  (.start t) (.join t) (println \"MAIN\"))")]))]
+  (check-eq "a hook registered off the main thread still runs" (str/split-lines out) ["MAIN" "HOOK"]))
+
+(let [out (:out (sh [jolt-bin "-e" (str "(let [rt (Runtime/getRuntime)"
+                                        "      h (Thread. (fn [] (println \"HOOK\")))]"
+                                        "  (.addShutdownHook rt h) (.removeShutdownHook rt h)"
+                                        "  (println \"MAIN\"))")]))]
+  (check-eq "a removed shutdown hook does not run" (str/split-lines out) ["MAIN"]))
+
+;; Is a pid still alive? `kill -0` is the portable answer (exit 0 = alive). Run
+;; through `sh` so it is the shell BUILTIN: a standalone kill(1) is not on every
+;; Linux image, and ProcessBuilder.start rejects a program it cannot resolve.
+(defn- pid-alive? [pid]
+  (zero? (:exit (sh ["sh" "-c" (str "kill -0 " pid)] {:err :string}))))
+
+;; SIGTERM to a jolt process must run its shutdown hooks BEFORE it exits — the
+;; whole point of `:shutdown destroy-tree` is that a supervisor's `kill` does not
+;; leave the child tree running (#571). Both spawn paths are covered: the default
+;; (piped stdio, Chez's own fork) and fd-level INHERIT (posix_spawn).
+;;
+;; The nested jolt writes its child's pid out through a shell `$$` — the same
+;; probe the bug report used — so this side can ask whether that exact process
+;; outlived the parent.
+(doseq [[label redirs] [["piped stdio" ""]
+                        ["fd-level INHERIT" " :out :inherit :err :inherit"]]]
+  (let [pidf (str (fs/create-temp-file {:prefix "jp-shutdown-" :suffix ".pid"}))
+        nested (str "(require '[jolt.process :as p])"
+                    " @(p/process [\"sh\" \"-c\" \"echo $$ > \\\"$CHILD_PID_FILE\\\"; sleep 30\"]"
+                    " {:extra-env {\"CHILD_PID_FILE\" \"" pidf "\"}" redirs
+                    "  :shutdown p/destroy-tree})")
+        parent (process [jolt-bin "-e" nested])]
+    ;; the grandchild publishes its pid before it sleeps
+    (loop [n 0]
+      (when (and (< n 200) (str/blank? (slurp pidf)))
+        (Thread/sleep 50)
+        (recur (inc n))))
+    (let [gpid (str/trim (slurp pidf))]
+      (p/destroy parent)
+      ;; poll rather than deref: a regression here is "the parent ignores
+      ;; SIGTERM", and @parent would then hang the gate instead of failing it
+      (loop [n 0] (when (and (< n 60) (p/alive? parent)) (Thread/sleep 50) (recur (inc n))))
+      (when (p/alive? parent) (.destroyForcibly (:proc parent)) (Thread/sleep 200))
+      ;; the hook's kill and the child's death are not instantaneous
+      (loop [n 0] (when (and (< n 40) (pid-alive? gpid)) (Thread/sleep 50) (recur (inc n))))
+      (check-eq (str "SIGTERM runs :shutdown hooks (" label ")")
+                (and (seq gpid) (pid-alive? gpid)) false)
+      (when (pid-alive? gpid) (sh ["sh" "-c" (str "kill -9 " gpid)])))
+    (fs/delete-if-exists pidf)))
+
+;; A jolt sitting at a stdin prompt must still take SIGTERM, hooks and all. It
+;; used to wait INSIDE Chez's blocking read, which holds the whole Scheme world:
+;; nothing else runs, so the watcher could not have woken there (jolt-p9ua).
+;; The nested jolt registers a hook, then blocks on read-line with a pipe stdin
+;; nothing ever writes to.
+;;
+;; Nothing here blocks without a bound: a failure has to report itself, not hang
+;; the gate.
+(let [readyf (str (fs/create-temp-file {:prefix "jp-stdin-" :suffix ".txt"}))
+      hookf (str (fs/create-temp-file {:prefix "jp-stdin-hook-" :suffix ".txt"}))
+      nested (str "(.addShutdownHook (Runtime/getRuntime)"
+                  "  (Thread. (fn [] (spit \"" hookf "\" \"RAN\"))))"
+                  " (spit \"" readyf "\" \"ready\") (read-line)")
+      proc (process [jolt-bin "-e" nested])]
+  (loop [n 0]
+    (when (and (< n 200) (str/blank? (slurp readyf)))
+      (Thread/sleep 50)
+      (recur (inc n))))
+  (p/destroy proc)
+  (loop [n 0] (when (and (< n 60) (p/alive? proc)) (Thread/sleep 50) (recur (inc n))))
+  (check-eq "SIGTERM reaches a jolt parked at a stdin prompt" (p/alive? proc) false)
+  ;; SIGKILL, since a process that survived SIGTERM will survive another one
+  (when (p/alive? proc) (.destroyForcibly (:proc proc)) (Thread/sleep 200))
+  (check-eq "and its shutdown hooks run there too" (slurp hookf) "RAN")
+  (fs/delete-if-exists readyf)
+  (fs/delete-if-exists hookf))
+
+;; Same root cause from the other side: while the main thread waits on stdin the
+;; rest of the program has to keep running. A future stopped ticking the moment a
+;; prompt was reached, which is not what a JVM does with a thread in
+;; System.in.read() (jolt-p9ua).
+(let [tickf (str (fs/create-temp-file {:prefix "jp-ticks-" :suffix ".txt"}))
+      nested (str "(future (dotimes [i 100] (Thread/sleep 50) (spit \"" tickf "\" (str i))))"
+                  " (read-line)")
+      proc (process [jolt-bin "-e" nested])
+      tick (fn [] (let [s (str/trim (slurp tickf))] (when-not (str/blank? s) (parse-long s))))]
+  (loop [n 0] (when (and (< n 200) (nil? (tick))) (Thread/sleep 50) (recur (inc n))))
+  (check-eq "a future runs while the main thread waits on stdin" (some? (tick)) true)
+  ;; and keeps running, rather than getting one tick in before the read parks
+  (let [before (or (tick) 0)]
+    (Thread/sleep 400)
+    (check-eq "and keeps running" (> (or (tick) 0) before) true))
+  (.destroyForcibly (:proc proc))
+  (fs/delete-if-exists tickf))
+
+;; A child must be interruptible by ^C, on every spawn path. Chez's fork leaves
+;; SIGINT set to SIG_IGN in the child — the system(3) leak the convention exists
+;; to avoid, not the convention — so a child spawned the default way could not be
+;; interrupted at all where the JVM's dies (jolt-a4hs). posix_spawn drives both
+;; paths now, and `sh` reports 128+SIGINT when the signal lands.
+(check-eq "a child dies on SIGINT (piped stdio)"
+          (:exit (sh ["sh" "-c" "kill -INT $$"])) 130)
+(check-eq "a child dies on SIGINT (fd-level INHERIT)"
+          (:exit @(process ["sh" "-c" "kill -INT $$"] {:out :string :err :inherit})) 130)
+
+;; jolt blocks signals in its own threads — SIGINT so ^C reaches the thread parked
+;; in park-until-interrupt rather than a worker in a foreign call, SIGTERM/SIGHUP
+;; so the shutdown watcher can take them — and a spawn hands the calling thread's
+;; mask straight to the child. Neither may travel: a child with SIGTERM blocked
+;; survives the very destroy the hook exists to call, and one with SIGINT blocked
+;; ignores ^C (jolt-e5sb).
+(.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] nil)))
+(let [proc (process ["sleep" "10"])]
+  (p/destroy proc)
+  (check-eq "a child spawned after a shutdown hook is still killable" (:exit @proc) 143))
+(check-eq "a child does not inherit jolt's blocked SIGTERM"
+          (:exit @(process ["sh" "-c" "kill -TERM $$"] {:out :string :err :inherit})) 143)
+(jolt.host/block-sigint)
+(check-eq "a child does not inherit jolt's blocked SIGINT"
+          (:exit @(process ["sh" "-c" "kill -INT $$"] {:out :string :err :inherit})) 130)
+
 (if (empty? @failures)
   (println "PROCESS-TEST OK")
   (do (doseq [f @failures] (println "FAIL:" f))


### PR DESCRIPTION
Fixes #571.

`Runtime.addShutdownHook` kept a list nothing ever read, so `jolt.process`'s
`:shutdown` option cleaned up nothing on any exit path, and a `SIGTERM` left the
child processes running. One registry now backs that and
`jolt.host/add-shutdown-hook` both, running once per process on a `-main` that
returns, on `System/exit`, on an uncaught throw, and on `SIGTERM`/`SIGHUP`.

The signals are taken over only once a hook is registered, by a thread parked in
`sigwait`. `register-signal-handler` is the obvious route and the wrong one: Chez
runs that handler on the main thread at its next safe point, and neither of the
two ways a program usually waits — a `deref` of a promise, a blocking foreign
call — is one, so the process would have ignored the signal rather than handled
it. A program that registers no hook is untouched.

The exit handler is installed at run time and per thread: whatever a boot file's
top-level forms leave in `exit-handler` is not in force by the time a built
binary runs, and Chez's `exit-handler` is a thread parameter, so a hook
registered from a worker installs a wrapper the main thread's exit never sees.

## Three neighbouring bugs the signal work ran into

**A blocking stdin read held the whole Scheme world.** No other Chez thread ran
at all while the main thread sat at a prompt — a `future` stopped ticking, an
agent stopped draining — and the watcher above could not have woken there
either. `read-line` now waits in `sleep` and reads once the port has something.
A buffered line costs one `char-ready?` and no sleep: 1326 -> 1386 ns/line,
medians of four 300k-line runs each with the wait compiled out and back in,
1.045x. (jolt-p9ua)

**A spawn handed the calling thread's signal mask to the child.** jolt blocks
SIGINT in its own threads so `^C` reaches the one parked for it, and now blocks
SIGTERM/SIGHUP for the watcher. A child inheriting either is wrong immediately:
a blocked SIGTERM survives the `destroy` the hook exists to call, a blocked
SIGINT ignores `^C`. The mask is emptied for the length of a spawn and put back.
(jolt-e5sb)

**A subprocess could not be interrupted with `^C`.** Chez's fork leaves SIGINT
at `SIG_IGN` in the child, between its fork and its exec where nothing on this
side can undo it — the `system(3)` leak the convention exists to avoid rather
than the convention. `posix_spawn` drives every spawn now, not only the ones
with an `:inherit` stream: it already piped every other stream, so the paths
differed in how the child was created and not in what it got. Probed child
dispositions (SIGINT/SIGQUIT/SIGHUP/SIGTERM/SIGPIPE) now match a plain shell's
exactly. Chez's fork stays as the fallback where the FFI surface is missing.
One consequence: every spawn serialises on `proc-spawn-fd-mutex`, held across
`pipe()` and the spawn and nothing else, which posix_spawn's non-close-on-exec
pipe fds needed already. (jolt-a4hs)

## Verification

The bug report's own probe passes on a compiled binary. 15 new checks in
`test/chez/process-test.clj` cover hooks on each exit path, a hook registered
off the main thread, SIGTERM through both spawn paths, a program parked at a
prompt, futures running during a stdin read, mask inheritance, and `^C` killing
a child on both paths.

Each fix was checked against a deliberately reintroduced bug rather than assumed
green: with the mask helper neutered both mask probes report `SURVIVED`/exit 0,
and with the stdin wait compiled out the future never ticks.

`make test` green, `make libconformance` green, the vendored babashka.process
suite clean at its recorded baseline (27 assertions, 0 failures).
