### PR TITLE
Make a hung gate and an unspecified oracle answer report themselves

### DIFF
--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -612,6 +612,29 @@ if printf '%s' "$pos_err" | grep -q '^  trace:'; then
   echo "--- got ---"; echo "$pos_err"; exit 1
 fi
 
+# The build reads a namespace's forms through its own read-all, which had the same
+# stray-close-delimiter blindness the loader did: the position parks on the paren,
+# the loop reads that as end of input, and the image is emitted from the forms
+# BEFORE it — a successful build of a program missing everything after the typo.
+echo "build smoke: a stray close paren fails the build"
+stray="$(dirname "$out")/stray"; mkdir -p "$stray/src/app"
+printf '{}\n' > "$stray/deps.edn"
+{ echo '(ns app.core)'
+  echo ''
+  echo '(defn -main [& _]'
+  echo '  (println :a)))'
+  echo ''
+  echo '(defn unreachable [] :nope)'
+} > "$stray/src/app/core.clj"
+stray_err="$(JOLT_PWD="$stray" "$joltabs" build -m app.core -o "$(dirname "$out")/stray-bin" 2>&1 || true)"
+if ! printf '%s' "$stray_err" | grep -q 'Unmatched delimiter'; then
+  echo "  FAIL: build did not report the stray close paren"
+  echo "--- got ---"; echo "$stray_err"; exit 1
+fi
+if [ -x "$(dirname "$out")/stray-bin" ]; then
+  echo "  FAIL: build produced a binary from a file it could not read"; exit 1
+fi
+
 # A set literal mixing an auto keyword with a plain one of the same alias text
 # must BUILD. ::o/x and :o/x are distinct, but the require scan reads in scan mode,
 # where an unresolved alias keeps its text, so both read as :o/x — and the

--- a/host/chez/cap.sh
+++ b/host/chez/cap.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# cap.sh SECONDS CMD [ARG...] — run CMD under a wall-clock cap, POSIX sh only.
+#
+# A stand-in for `timeout --foreground` on a host without GNU coreutils (a stock
+# macOS has neither timeout nor gtimeout). smoke.sh ran every case UNCAPPED
+# there, having printed one note about it, so a case that hung wedged the whole
+# gate: `make test` sat on the poller-registration case for over ninety minutes
+# with no output, because make prints nothing for a target until it finishes
+# (jolt-8tma).
+#
+# Like --foreground and unlike a plain `timeout`, this leaves the process group
+# alone: the command runs as an ordinary child, so a case that spawns children
+# and asserts on their process group (jolt.process, the SIGTERM exit 143 case)
+# sees the same group it would with no cap at all.
+#
+# Exits with the command's own status, or 124 on expiry — the status timeout(1)
+# reports, so a caller can tell "this case failed" from "this case hung".
+secs="$1"
+shift
+
+# 0<&0 is not redundant: a shell with job control off points a BACKGROUND
+# command's stdin at /dev/null unless the command redirects it itself, and the
+# cases that pipe a program in (`jolt - < prog.clj`, every REPL case) then read
+# nothing at all. An explicit redirection opts back into the caller's stdin.
+"$@" 0<&0 &
+cmd_pid=$!
+
+# A marker file rather than "is the watchdog still alive": the watchdog outlives
+# its own expiry by the grace period below, so its being alive says nothing about
+# whether it fired.
+marker="${TMPDIR:-/tmp}/jolt-cap.$$"
+rm -f "$marker"
+
+# The watchdog polls in one-second steps and ENDS ITSELF once the command is
+# gone. Signalling it instead does not work: a POSIX shell waiting on a
+# foreground `sleep` defers the signal until that sleep returns, so a `kill` here
+# followed by a `wait` there charged every single capped invocation the full cap
+# — the smoke suite went from three minutes to two minutes PER CASE.
+#
+# Both streams go to /dev/null because this outlives cap.sh itself: a caller
+# reading the case's output through $(...) waits for EOF on the pipe, and a
+# background writer still holding it would hang the caller for exactly as long as
+# the deferred-signal version did.
+(
+  waited=0
+  while [ "$waited" -lt "$secs" ]; do
+    sleep 1
+    kill -0 "$cmd_pid" 2>/dev/null || exit 0
+    waited=$((waited + 1))
+  done
+  : > "$marker"
+  kill -TERM "$cmd_pid" 2>/dev/null
+  # A jolt wedged on a lock does not always act on SIGTERM, and the whole point
+  # of a cap is that it always ends.
+  sleep 2
+  kill -KILL "$cmd_pid" 2>/dev/null
+) >/dev/null 2>&1 &
+
+# The shell announces a killed background job on ITS stderr ("Terminated: 15"),
+# which would land in the middle of the case output that smoke.sh reads. Only the
+# reaping is silenced here; the command's own stderr is its own and untouched.
+{ wait "$cmd_pid"; status=$?; } 2>/dev/null
+
+if [ -f "$marker" ]; then
+  rm -f "$marker"
+  exit 124
+fi
+exit "$status"

--- a/host/chez/emit-image.ss
+++ b/host/chez/emit-image.ss
@@ -75,12 +75,17 @@
 ;; conditional (e.g. `#?(:cljs …)` with no :clj branch) reads as "no form" — an
 ;; eof marker mid-source — and must be skipped, not treated as end of file, or a
 ;; namespace's forms after it are silently dropped. Mirrors load-jolt-file.
+;; rdr-read-top for the same reason load-jolt-file* uses it: a stray close
+;; delimiter parks the position, which the no-progress arm below reads as end of
+;; input, so a build would emit an image of everything BEFORE the bad paren and
+;; report success. It has to be the same read error the loader raises, or `jolt
+;; build` and `jolt run` disagree about what a file contains (jolt-3amm).
 (define (ei-read-all src)
   (let ((end (string-length src)))
     (let loop ((i 0) (acc '()))
       (if (>= i end)
           (reverse acc)
-          (let-values (((form j) (rdr-read-form src i end)))
+          (let-values (((form j) (rdr-read-top src i end)))
             (if (> j i)
                 (loop j (if (rdr-eof? form) acc (cons form acc)))
                 (reverse acc)))))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -440,9 +440,16 @@
                                           (jolt-aot-capture))))
       (ldr-with-file-vars path
         (lambda ()
+          ;; rdr-read-top, not rdr-read-form: a stray close delimiter is a READ
+          ;; ERROR at a file's top level, and only the top-level entry says so.
+          ;; rdr-read-form leaves the position where it found the `)`, and the
+          ;; (> j i) guard below reads no progress as end of input — so one extra
+          ;; paren silently DROPPED the rest of the file and the run exited 0.
+          ;; A test file that lost its whole body that way still looked like a
+          ;; pass. The JVM raises "Unmatched delimiter: )" here (jolt-3amm).
           (let loop ((i 0))
             (when (< i end)
-              (let-values (((form j) (rdr-read-form src i end)))
+              (let-values (((form j) (rdr-read-top src i end)))
                 (when (> j i)
                   (unless (rdr-eof? form)
                     (when (getenv "JOLT_TRACE_LOAD")

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -1326,9 +1326,11 @@
     (when (and (< k end)
                 (let ((c (string-ref s k)))
                   (or (char=? c #\)) (char=? c #\]) (char=? c #\}))))
-      (jolt-throw (jolt-ex-info (string-append "Unmatched delimiter: "
-                                               (string (string-ref s k)))
-                                empty-pmap)))
+      ;; through rdr-error, so the report names the file and the line:col of the
+      ;; delimiter itself. The loader reads every top-level form through here, and
+      ;; "Unmatched delimiter: )" pointing at 1:1 of a 600-line file says only that
+      ;; the file is unbalanced somewhere.
+      (rdr-error s k (string-append "Unmatched delimiter: " (string (string-ref s k)))))
     (let-values (((form j) (rdr-read-form s k end)))
       (when (rdr-splice-t? form)
         (jolt-throw (jolt-ex-info

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -27,8 +27,11 @@ jolt_bin="${JOLT_BIN:-bin/jolt}"
 # read the process group — under a plain `timeout` that case dies with no output on
 # Linux while still passing on macOS. --foreground leaves the group alone.
 #
-# coreutils' timeout is not on a stock macOS, so fall back to running uncapped rather
-# than skipping the case or hard-failing the gate on a missing tool.
+# coreutils' timeout is not on a stock macOS, and falling back to running UNCAPPED
+# there meant the one host most likely to run this by hand was the one host where a
+# hang could not report itself: a `make test` here sat on the poller-registration
+# case for over ninety minutes behind a one-line note nobody was watching for
+# (jolt-8tma). cap.sh is the same cap in POSIX sh, so every host has one.
 smoke_timeout="${JOLT_SMOKE_TIMEOUT:-120}"
 if [ "$smoke_timeout" = "0" ]; then
   jolt_timeout=""
@@ -40,8 +43,7 @@ else
     fi
   done
   if [ -z "${jolt_timeout:-}" ]; then
-    jolt_timeout=""
-    echo "  note: no timeout(1) with --foreground — a hung case will block instead of failing"
+    jolt_timeout="sh $root/host/chez/cap.sh $smoke_timeout"
   fi
 fi
 jolt="$jolt_timeout $jolt"
@@ -486,6 +488,29 @@ else
   echo "    $(printf '%s' "$pr_out" | tail -1)"
   fails=$((fails + 1))
 fi
+
+# One paren too many must FAIL the file, not truncate it. The loader read forms
+# with the non-top-level reader, which parks on a stray `)` rather than raising,
+# and the loop read a parked position as end of input: everything after the paren
+# was dropped and the run exited 0. A test file that lost its entire body that way
+# still looked like a pass, which is how this was found (jolt-3amm).
+stray_dir="$(mktemp -d)"
+printf '(println "before")\n)\n(println "after")\n' > "$stray_dir/stray.clj"
+stray_out="$($jolt run "$stray_dir/stray.clj" 2>&1)"; stray_st=$?
+if [ "$stray_st" != "0" ] && printf '%s' "$stray_out" | grep -q 'Unmatched delimiter'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a stray close paren should fail the load, not drop the rest of the file"
+  echo "    exit $stray_st: $(printf '%s' "$stray_out" | tail -1)"
+  fails=$((fails + 1))
+fi
+if printf '%s' "$stray_out" | grep -q 'after'; then
+  echo "  FAIL: forms after the stray paren ran anyway"
+  fails=$((fails + 1))
+else
+  pass=$((pass + 1))
+fi
+rm -rf "$stray_dir"
 
 # Two threads requiring one namespace must load it once, and neither may return
 # from require until it is whole. Nothing serialized load-namespace* before, so

--- a/test/chez/poller-registration.clj
+++ b/test/chez/poller-registration.clj
@@ -12,48 +12,96 @@
 ;; The workload keeps registrations landing while the poller is mid-round: rounds
 ;; of fibers that all park on their own socket read, over and over, so some
 ;; registrations are bound to arrive during the drain. Unfixed this loses ~11% of
-;; them (283 of 320); fixed it loses none. Every read is bounded by an alts!!
-;; timeout, so a lost wakeup is a FAILURE and never a hang — and the run STOPS at
-;; the first round that loses one, because otherwise every subsequent loss pays
-;; that timeout again: the unfixed version took over eleven minutes to finish what
-;; the fixed one does in under two seconds, and a gate that slow is its own
-;; problem.
+;; them (283 of 320); fixed it loses none. The run STOPS at the first round that
+;; loses one, because otherwise every subsequent loss pays the alts!! timeout
+;; again: the unfixed version took over eleven minutes to finish what the fixed
+;; one does in under two seconds, and a gate that slow is its own problem.
+;;
+;; This header used to claim that a lost wakeup is a FAILURE and never a hang,
+;; on the grounds that every read is bounded by an alts!! timeout. It is not:
+;; that timeout is itself a core.async channel, so the machinery this case exists
+;; to stress is also the machinery the bound depends on, and .accept and the
+;; socket setup are not bounded at all. A run did wedge — over ninety minutes,
+;; main thread parked in a condition wait, poller thread in kevent — and reported
+;; nothing (jolt-8tma). Hence the watchdog: the MAIN thread does nothing but
+;; watch a deadline, and the workload runs on a spawned thread, so a wedge fails
+;; the case and names the round and phase it stopped in. That way round, not the
+;; other, because System/exit on a spawned thread only unwinds that thread on
+;; this host (jolt-7xls) — a watchdog anywhere but the main thread can describe a
+;; hang and not end it. What made that one run wedge is still unknown; this is
+;; what will say where it was the next time.
 (require '[jolt.socket])
 (require '[clojure.core.async :as a])
 
 (def rounds 40)
 (def per 8)
 
+;; Generous against the real workload (under two seconds) and against the worst
+;; legitimate slow path (one losing round pays a 2s alts!! timeout and then the
+;; run stops), so anything that reaches it is wedged, not slow.
+(def hang-ms 60000)
+
+;; Where the workload is, for the watchdog to quote when it gives up.
+(def progress (atom {:round 0 :phase :starting}))
+(defn- at! [phase] (swap! progress assoc :phase phase))
+
 ;; Both ends of every connection are closed at the end of the round. Holding the
 ;; accepted Socket rather than just its stream is the point: 40 rounds of 8 leaks
 ;; 320 descriptors otherwise, and under a low ulimit -n the gate starts failing on
 ;; accept for a reason that has nothing to do with the bug it exists to catch.
 (defn- one-round [ss port]
-  (let [clients (doall (for [_ (range per)] (java.net.Socket. "127.0.0.1" port)))
-        srvs (doall (for [_ (range per)] (.accept ss)))
+  (let [clients (doall (for [_ (range per)] (do (at! :connect) (java.net.Socket. "127.0.0.1" port))))
+        srvs (doall (for [_ (range per)] (do (at! :accept) (.accept ss))))
         outs (doall (for [c clients]
                       (binding [a/*go-backend* :fiber]
                         (a/go (let [b (byte-array 8)
                                     n (.read (.getInputStream c) b 0 8)]
                                 (String. b 0 n "UTF-8"))))))]
     ;; let them all park before the data arrives, so every read registers
+    (at! :settling)
     (Thread/sleep 15)
+    (at! :writing)
     (doseq [s srvs] (.write (.getOutputStream s) (.getBytes "x" "UTF-8") 0 1))
-    (let [got (doall (for [o outs] (first (a/alts!! [o (a/timeout 2000)]))))]
+    (let [got (doall (for [[i o] (map-indexed vector outs)]
+                       (do (at! (str "collecting " i " of " per))
+                           (first (a/alts!! [o (a/timeout 2000)])))))]
+      (at! :closing)
       (doseq [c clients] (.close c))
       (doseq [s srvs] (.close s))
       (count (filter #(= "x" %) got)))))
 
-(let [ss (java.net.ServerSocket. 0)
-      port (.getLocalPort ss)]
-  (loop [r 0 acc 0]
-    (if (= r rounds)
-      (do (.close ss)
-          (println "POLLER-REGISTRATION OK" acc))
-      (let [n (one-round ss port)]
-        (if (< n per)
-          (do (println (str "POLLER-REGISTRATION LOST " (- per n) " of " per
-                            " readiness registrations in round " r))
-              (.close ss)
-              (System/exit 1))
-          (recur (inc r) (+ acc n)))))))
+(defn- run-rounds []
+  (let [ss (java.net.ServerSocket. 0)
+        port (.getLocalPort ss)]
+    (loop [r 0 acc 0]
+      (swap! progress assoc :round r)
+      (if (= r rounds)
+        (do (.close ss) {:status :ok :total acc})
+        (let [n (one-round ss port)]
+          (if (< n per)
+            (do (.close ss) {:status :lost :missing (- per n) :round r})
+            (recur (inc r) (+ acc n))))))))
+
+(def outcome (atom nil))
+
+(.start (Thread. (fn []
+                   (reset! outcome
+                           (try (run-rounds)
+                                (catch Throwable t {:status :threw :ex (str t)}))))))
+
+;; The main thread from here on is only the deadline. Every exit goes through it.
+(let [deadline (+ (System/currentTimeMillis) hang-ms)]
+  (loop []
+    (Thread/sleep 25)
+    (let [{:keys [status total missing round ex]} @outcome]
+      (cond
+        (= status :ok)    (do (println "POLLER-REGISTRATION OK" total) (System/exit 0))
+        (= status :lost)  (do (println (str "POLLER-REGISTRATION LOST " missing " of " per
+                                            " readiness registrations in round " round))
+                              (System/exit 1))
+        (= status :threw) (do (println (str "POLLER-REGISTRATION THREW " ex)) (System/exit 1))
+        (< (System/currentTimeMillis) deadline) (recur)
+        :else (let [{:keys [round phase]} @progress]
+                (println (str "POLLER-REGISTRATION HUNG after " hang-ms
+                              "ms in round " round " at " phase))
+                (System/exit 1))))))

--- a/test/conformance/certify.clj
+++ b/test/conformance/certify.clj
@@ -345,13 +345,30 @@
         (println (format "  [%s] %s\n      expected: %s\n      %s"
                          (:suite row) (:label row) (:expected row) detail))))
 
+    ;; A row that timed out asserted NOTHING on this run, and the budget is
+    ;; wall-clock on a shared JVM: future-cancel is best-effort, so an earlier
+    ;; runaway keeps its thread (and its allocation) for the rest of the run and
+    ;; can push a later row over the budget on a slower or busier machine. That
+    ;; makes the set environment-dependent, which is why every timed-out row is
+    ;; named here rather than left as a count, and why staleness below ignores
+    ;; them: an allowlist entry for a row the oracle never finished is not
+    ;; evidence the divergence went away.
+    (when (pos? (cnt :timeout))
+      (println (format "\n=== rows the oracle did not finish in %dms (no opinion this run) ===" case-timeout-ms))
+      (doseq [{:keys [row]} (sort-by (comp (juxt :suite :label) :row) (get by :timeout))]
+        (println (format "  [%s] %s\n      actual: %s" (:suite row) (:label row) (:actual row)))))
+
     ;; Partition the rows the JVM has an opinion on into known (allowlisted) vs NEW.
     (let [flagged (concat (get by :divergent []) (get by :throws-mismatch []) (get by :jvm-raises []))
           key-of (fn [{:keys [row]}] [(:suite row) (:label row)])
           new? (fn [r] (let [k (key-of r)] (and (not (known k)) (not (flaky k)))))
           news (filter new? flagged)
           flagged-keys (set (map key-of flagged))
-          stale (clojure.set/difference known flagged-keys)]
+          ;; Rows the oracle had no opinion on: it never ran them to a value, so
+          ;; they are evidence of nothing in either direction.
+          silent-keys (set (map key-of (concat (get by :timeout []) (get by :read-error [])
+                                               (get by :uncertifiable []))))
+          stale (clojure.set/difference known flagged-keys silent-keys)]
       (println (format "\n  allowlist: %d entries (%d flaky); %d of %d divergences known, %d NEW, %d stale"
                        (+ (count known) (count flaky)) (count flaky)
                        (- (count flagged) (count news)) (count flagged) (count news) (count stale)))

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -535,6 +535,18 @@
    {:suite "multimethods / hierarchies", :label "explicit :hierarchy", :category :permissive}
    {:suite "permissive / keys on pair vector", :label "keys works on vector of pairs", :category :permissive}
 
+   ;; (reduce + (eduction …)) with no init. jolt folds it; the JVM's answer is
+   ;; UNSPECIFIED, so this row is :flaky rather than a divergence either way.
+   ;; clojure.core.protocols/CollReduce is extended to both IReduceInit and
+   ;; Iterable, and an Eduction implements both, so find-protocol-impl reduces
+   ;; `pref` over (supers Eduction) — a hash SET — and pref keeps whichever of two
+   ;; unrelated interfaces it sees first. Iterable wins and the row answers 9;
+   ;; IReduceInit wins and the 2-arity casts to IReduce, which an Eduction is not,
+   ;; and it raises ClassCastException. Which one that is falls out of Class
+   ;; identity hash codes: every local run here picks IReduceInit and CI picks
+   ;; Iterable, so allowlisting it as a plain divergence fails one of the two.
+   {:suite "seq / lazy over infinite", :label "eduction reduces", :category :permissive, :flaky true}
+
    ;; with-open closes anything carrying a :close fn; the JVM demands a member
    ;; named close and raises on a map. line-seq and file-seq are the same shape:
    ;; jolt duck-types the reader and takes a path string, where the JVM insists on


### PR DESCRIPTION
The two loose ends from #577, plus one they turned up.

**A hung smoke case wedged the gate instead of failing it (jolt-8tma).** A local `make test` sat on the poller-registration case for over ninety minutes in silence. smoke.sh caps each case with GNU timeout, and where there is none it ran everything uncapped behind a one-line note, which on a stock macOS means no cap at all. `cap.sh` is the same cap in POSIX sh so every host has one. The case also claimed a lost wakeup could never hang it, on the grounds that every read is bounded by an alts!! timeout. That is not a bound, since the timeout is itself a core.async channel and `.accept` is not bounded at all. The workload now runs on a spawned thread with the main thread watching a deadline, so a wedge exits 1 naming the round and phase. That way round rather than a watchdog thread because System/exit on a spawned thread only unwinds that thread on this host, which is filed separately as jolt-7xls. I verified a clean run, an injected hang, an injected throw, and cap.sh's own expiry.

**certify disagreed with itself about the eduction row (jolt-owjl).** The JVM's answer there is genuinely unspecified: `clojure.core.protocols/CollReduce` is extended to both `IReduceInit` and `Iterable`, an `Eduction` implements both, and `find-protocol-impl` reduces `pref` over `(supers Eduction)`, a hash set ordered by Class identity hash codes. Iterable wins and the row answers 9, IReduceInit wins and the two-arity casts to `IReduce` and raises. Twelve consecutive local runs pick one, CI picks the other, which is why allowlisting it as a plain divergence made CI go red the first time. It is `:flaky` now, which is what the allowlist already means by tolerated either way. certify also names the rows it did not finish rather than counting them, and staleness ignores rows the oracle had no opinion on.

**One paren too many silently dropped the rest of a file (jolt-3amm).** This is how the poller test's first version got written: it had an extra paren, so its whole body did not exist, it printed nothing and exited 0, and that is indistinguishable from a pass. `load-jolt-file*` and `ei-read-all` read forms with a reader entry that parks on a stray close delimiter, and both loops read a parked position as end of input. So `jolt run` ran the forms before the paren and exited 0, and a build emitted an image of them and reported success. Both read through `rdr-read-top` now, which raises the JVM's "Unmatched delimiter: )" and, through rdr-error, names the line and column of the delimiter. A run case and a build case cover it.

Full local `make test` is running on the final tree.