### PR TITLE
System/exit ends the process, not just the thread that called it

### DIFF
--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -288,7 +288,9 @@
         ;; millisecond-granular, so any interval under a millisecond timed as 0.
         ;; jolt-mono-nanos (rt.ss) is Chez's 'time-monotonic clock, which is both.
         (cons "nanoTime" (lambda () (->num (jolt-mono-nanos))))
-        (cons "exit" (lambda args (exit (if (null? args) 0 (jnum->exact (car args))))))
+        ;; jolt-exit-process (rt.ss), not Chez's exit: this has to end the PROCESS
+        ;; from whichever thread called it, the way System.exit does.
+        (cons "exit" (lambda args (jolt-exit-process (if (null? args) 0 (jnum->exact (car args))))))
         ;; System/gc -> a full Chez collection (so weak references clear and their
         ;; guardians fire); Runtime.gc() routes here too.
         (cons "gc" (lambda _

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -94,6 +94,35 @@
                         (sa-foreign-procedure-blocking name args res)))))
          #'(if (eq? (sa-os-family) 'windows) win unx))))))
 
+;; --- process-wide exit --------------------------------------------------------
+;; System.exit halts the VM from ANY thread on the JVM. Chez's exit unwinds only
+;; the CALLING thread, so off the main thread it was a silent no-op as far as the
+;; process was concerned: a worker that decided the program should stop could not
+;; stop it, and nothing said it had tried (jolt-7xls). A watchdog thread is the
+;; shape that wants this — it can describe the hang it found and not end it.
+;;
+;; The boot thread keeps the normal path, exit handlers and all, including the
+;; stdout/stderr flush cli-core installs as one. Any other thread flushes those
+;; same two ports by hand and calls libc _exit. _exit rather than exit: the C exit
+;; runs atexit handlers and flushes C stdio from a thread the C runtime is not
+;; expecting it from, and jolt's buffered output is Chez's, not stdio's, so the
+;; handlers buy nothing here and can deadlock. Skipping the unwind is right on its
+;; own terms too — the JVM does not run finally blocks on System.exit either.
+;;
+;; jolt-foreign-proc-safe answers #f where the entry does not resolve, and then
+;; this is exactly what it was before: an exit that only the boot thread can act
+;; on. Nothing depends on the hard path existing, so a host without _exit degrades
+;; rather than failing to boot.
+(define jolt-boot-thread-id (get-thread-id))
+(define jolt-c-exit (jolt-foreign-proc-safe "_exit" '(int) 'void))
+(define (jolt-exit-process code)
+  (if (or (eqv? (get-thread-id) jolt-boot-thread-id) (not jolt-c-exit))
+      (exit code)
+      (begin
+        (guard (_ (#t #f)) (flush-output-port (current-output-port)))
+        (guard (_ (#t #f)) (flush-output-port (current-error-port)))
+        (jolt-c-exit code))))
+
 ;; --- how many processors can this process use ---------------------------------
 ;; Backs jolt.host/available-processors, which Runtime.availableProcessors and
 ;; pmap's look-ahead window read. Each host is asked the question the JVM asks

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -476,6 +476,37 @@ else
   fails=$((fails + 1))
 fi
 
+# System/exit ends the PROCESS from whichever thread calls it, with that thread's
+# status, the way System.exit does on the JVM (checked against Clojure 1.12.3).
+# Chez's exit unwinds only the calling thread, so this used to be a silent no-op
+# off the main thread: the program carried on and nothing said a thread had asked
+# it to stop. A watchdog is the shape that wants it — it could name the hang it
+# found and not end it (jolt-7xls).
+ex_dir="$(mktemp -d)"
+{ echo '(.start (Thread. (fn [] (Thread/sleep 100) (println "child exiting") (System/exit 3))))'
+  echo '(Thread/sleep 5000)'
+  echo '(println "MAIN STILL ALIVE")'
+} > "$ex_dir/x.clj"
+ex_out="$($jolt run "$ex_dir/x.clj" 2>&1)"; ex_st=$?
+if [ "$ex_st" = "3" ] && ! printf '%s' "$ex_out" | grep -q 'MAIN STILL ALIVE'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: System/exit on a spawned thread should end the process with its status"
+  echo "    exit $ex_st: $(printf '%s' "$ex_out" | tail -1)"
+  fails=$((fails + 1))
+fi
+# Its own buffered output survives: the hard exit does not run Chez's exit
+# handlers, so it owes the flush they would have done.
+printf '(.start (Thread. (fn [] (print "partial-line") (System/exit 4))))\n(Thread/sleep 5000)\n' > "$ex_dir/y.clj"
+exf_out="$($jolt run "$ex_dir/y.clj" 2>&1)"; exf_st=$?
+if [ "$exf_st" = "4" ] && [ "$exf_out" = "partial-line" ]; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: unflushed output from an exiting thread was lost (exit $exf_st, got \`$exf_out\`)"
+  fails=$((fails + 1))
+fi
+rm -rf "$ex_dir"
+
 # A readiness registration must never be lost. jolt.io-poller drained its pending
 # registrations in two critical sections, so one landing in between was erased
 # before reaching the kqueue/epoll set and the fiber waiting on that fd never

--- a/test/chez/poller-registration.clj
+++ b/test/chez/poller-registration.clj
@@ -25,11 +25,13 @@
 ;; main thread parked in a condition wait, poller thread in kevent — and reported
 ;; nothing (jolt-8tma). Hence the watchdog: the MAIN thread does nothing but
 ;; watch a deadline, and the workload runs on a spawned thread, so a wedge fails
-;; the case and names the round and phase it stopped in. That way round, not the
-;; other, because System/exit on a spawned thread only unwinds that thread on
-;; this host (jolt-7xls) — a watchdog anywhere but the main thread can describe a
-;; hang and not end it. What made that one run wedge is still unknown; this is
-;; what will say where it was the next time.
+;; the case and names the round and phase it stopped in. That way round because
+;; the watcher must be the one thread that cannot be what wedges — every socket,
+;; fiber and channel in this case belongs to the workload. (It was also the only
+;; way round that worked when this was written: System/exit on a spawned thread
+;; unwound that thread and left the process running, which is jolt-7xls, fixed
+;; since.) What made that one run wedge is still unknown; this is what will say
+;; where it was the next time.
 (require '[jolt.socket])
 (require '[clojure.core.async :as a])
 


### PR DESCRIPTION
jolt-7xls, left open by #581.

On the JVM `System.exit` halts the VM from any thread. Here it was Chez's `exit`, which unwinds only the calling thread when that thread is not the main one, so off the main thread the call did nothing the process could notice. A worker that decided the program should stop could not stop it, and nothing reported that it had tried. That is how it turned up: the poller-registration watchdog could name the hang it had found and not fail the run.

The boot thread keeps the normal path, exit handlers and all, including the stdout/stderr flush cli-core installs as one. Any other thread flushes those two ports by hand and calls libc `_exit`. `_exit` rather than `exit` because the C `exit` runs atexit handlers and flushes C stdio from a thread the C runtime is not expecting it from, and jolt's buffered output is Chez's rather than stdio's, so those handlers buy nothing here and can deadlock. Not unwinding is right on its own terms as well, since the JVM does not run finally blocks on `System.exit` either.

The entry resolves through `jolt-foreign-proc-safe`, which answers `#f` where `_exit` does not resolve, leaving the old behaviour rather than failing to boot, and which already carries the policy of keeping a foreign reference out of compiled fasl on Windows.

Checked against Clojure 1.12.3 for both the exit status and main never running past the exit. Two smoke cases cover it: a spawned thread's exit ends the process with that thread's status, and output the thread had buffered still arrives, since the hard path owes the flush the exit handler would otherwise have done. I also verified a future, a fiber, script mode and the ordinary main-thread exit by hand.

The poller-registration comment that pointed at this is updated. Its structure stays as it is, since the watcher should be the one thread that cannot be what wedges.