### PR TITLE
io-thread runs its body on a fiber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,10 @@ values:
 # bare monitor-enter/monitor-exit halves across a fiber switch. A monitor is the
 # one lock in the runtime that wraps user code, so neither half of locks.ss's
 # premise — short regions, never spanning a park — holds for it.
+# async-io-thread-test.ss is the io-thread gate (jolt-579): core.async's third
+# carrier. It runs with the pool pinned to ONE carrier, which is what makes "8
+# bodies parked at the same time, all of them resuming" mean that a fiber released
+# its carrier rather than held it.
 fibers:
 	@$(CHEZ) --script test/chez/fibers-test.ss
 	@$(CHEZ) --script test/chez/fibers-state-test.ss
@@ -245,6 +249,7 @@ fibers:
 	@$(CHEZ) --script test/chez/fibers-preempt-test.ss
 	@$(CHEZ) --script test/chez/fibers-lock-test.ss
 	@$(CHEZ) --script test/chez/fibers-monitor-test.ss
+	@$(CHEZ) --script test/chez/async-io-thread-test.ss
 
 # The dynamic-var binding stack (jolt-3bo): lookup cost against binding DEPTH and
 # against the number of vars in one frame, push/pop throughput, and the two

--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -601,15 +601,33 @@
           (if (eq? bv dyn-no-binding) (var-cell-root cell) bv))
         jolt-go-backend-thread)))
 
-;; The R4 dispatcher: go/go-loop/go-spawn go through here and honor the var;
-;; thread/thread-call keep a real OS thread regardless (the documented escape
-;; for blocking work — a fiber would pin its carrier). jolt-fiber-go-spawn is
-;; defined in fibers-async.ss, which loads after this file; the reference
+;; The R4 dispatcher: go/go-loop/go-spawn go through here and honor the var.
+;; Nothing else does — thread is always an OS thread and io-thread is always a
+;; fiber, because both name their carrier at the call site (see async-fiber-spawn
+;; below and the workload table in the overlay's thread-call). jolt-fiber-go-spawn
+;; is defined in fibers-async.ss, which loads after this file; the reference
 ;; resolves at call time, before any :fiber spawn can happen.
 (define (async-go-spawn thunk)
   (if (eq? (go-backend-current) jolt-go-backend-fiber)
       (jolt-fiber-go-spawn thunk)
       (async-go-spawn-thread thunk)))
+
+;; (fiber-spawn thunk) — ALWAYS a fiber, whatever *go-backend* says. This is the
+;; other half of the thread-spawn bargain: thread-spawn asks for an OS thread by
+;; name and gets one, so asking for a fiber by name has to work the same way, and
+;; io-thread (the overlay's thread-call :io) is what asks. A dispatcher would make
+;; io-thread mean "a fiber, unless someone above me bound *go-backend* :thread",
+;; and there is nothing a caller could do with that.
+;;
+;; No CPS pass here — the body parks by capturing a continuation, which is exactly
+;; what a blocking-shaped body wants: a park works anywhere, including inside a
+;; called function, a try or a loop the pass cannot rewrite. That is the
+;; difference from go, not an omission.
+;;
+;; Same forward reference as async-go-spawn: jolt-fiber-go-spawn is defined in
+;; fibers-async.ss, which loads after this file, and resolves at call time.
+(define (async-fiber-spawn thunk)
+  (jolt-fiber-go-spawn thunk))
 
 (define (async-go-spawn-thread thunk)
   (let ((w (ac-make 1 'fixed #f)) (snap (dyn-binding-stack)))
@@ -895,6 +913,9 @@
 ;; thread-spawn: always a real OS thread, whatever *go-backend* says (thread
 ;; is the documented escape; the go macro dispatches, thread must not).
 (cca-def! "thread-spawn" async-go-spawn-thread)
+;; fiber-spawn: always a fiber, whatever *go-backend* says — what the overlay's
+;; io-thread / (thread-call f :io) spawns through.
+(cca-def! "fiber-spawn" async-fiber-spawn)
 ;; non-blocking primitives also used by the Clojure overlay and external callers.
 (cca-def! "__poll!" jolt-async-poll!)
 (cca-def! "__offer!" jolt-async-offer!)

--- a/host/chez/java/fibers-async.ss
+++ b/host/chez/java/fibers-async.ss
@@ -136,7 +136,9 @@
 ;; --- R4: go on fibers, and alts! as a wait set (epic jolt-nvpr.5) -------------
 ;;
 ;; jolt-fiber-go-spawn is the :fiber backend of clojure.core.async/go-spawn
-;; (the dispatcher lives in async.ss; thread stays the :thread backend). It
+;; (the dispatcher lives in async.ss; thread stays the :thread backend), and
+;; since jolt-579 it is also what clojure.core.async/fiber-spawn — io-thread's
+;; carrier — reaches unconditionally, no dispatch involved. It
 ;; spawns the body as a fiber on the R5 carrier pool — N OS threads, each
 ;; looping drain-then-park (fibers.ss). Parking inside the body works ACROSS
 ;; function boundaries, which the JVM's state-machine go structurally cannot

--- a/stdlib/clojure/core/async.clj
+++ b/stdlib/clojure/core/async.clj
@@ -1,8 +1,10 @@
 ;; clojure.core.async — higher-level dataflow API over the channel primitives.
 ;;
 ;; The primitives (chan, <!, >!, <!!, >!!, close!, put!, take!, offer!, timeout,
-;; promise-chan, buffer/dropping-buffer/sliding-buffer, thread, go-spawn) are
-;; provided natively (host/chez/java/async.ss) on real OS threads. go and go-loop
+;; promise-chan, buffer/dropping-buffer/sliding-buffer, thread, go-spawn,
+;; fiber-spawn) are provided natively (host/chez/java/async.ss); everything but
+;; fiber-spawn (which is io-thread's carrier — see thread-call below) runs on real
+;; OS threads. go and go-loop
 ;; are NOT: they are defined below, because the pass that picks a park's
 ;; representation per site needs &env, macroexpand and resolve. This overlay
 ;; adds the portable dataflow operators — alts!, pipe, pipeline, split, reduce,
@@ -484,16 +486,53 @@
 
 ;; --- thread variants --------------------------------------------------------
 
+;; Three carriers, three names, no options — the choice is the call you write:
+;; thread is a real OS thread, io-thread is a fiber, go is the CPS pass on
+;; whatever *go-backend* names. So workload is not a hint here, it selects:
+;;
+;;   :io       a FIBER. Cheap enough to have thousands of, and a park releases
+;;             the carrier — which is what the JVM buys with a virtual thread.
+;;   :mixed    a real OS thread (the default, as on the JVM).
+;;   :compute  a real OS thread.
+;;
+;; :compute is a thread rather than a fiber deliberately, even though preemption
+;; means a compute-bound fiber no longer starves its carrier's queue: fibers are
+;; capped at the carrier count, so N compute bodies on N carriers leave nothing to
+;; run the io-thread bodies that are ready. A thread per compute body is what the
+;; caller asked for by saying :compute.
+;;
+;; What a fiber does NOT get is an OS thread of its own, so a body that blocks
+;; SOMEWHERE THE RUNTIME DOES NOT KNOW ABOUT pins its carrier for the duration.
+;; Channel ops park, and so does jolt.socket (R8: an EAGAIN registers with the
+;; io-poller and parks). Thread/sleep, a blocking read on a raw fd, and an FFI
+;; call that blocks do not — they hold the carrier's OS thread. Use thread for
+;; those; that is what it is for.
 (defn thread-call
-  "Executes f in another thread, returning a channel that receives f's result then
-  closes. Always a real OS thread — thread is the documented escape for blocking
-  work and does NOT honor *go-backend* (unlike go/go-loop)."
-  ([f] (clojure.core.async/thread-spawn f))
-  ([f _workload] (clojure.core.async/thread-spawn f)))
+  "Executes f elsewhere, returning a channel that receives f's result then closes.
+  workload says what f does and picks the carrier: :io runs f on a fiber
+  (blocking-shaped I/O, parks instead of holding a thread), :mixed (the default)
+  and :compute run it on a real OS thread. No workload honors *go-backend* —
+  unlike go/go-loop, thread-call's carrier is fixed by the call site."
+  ([f] (thread-call f :mixed))
+  ([f workload]
+   (case workload
+     :io (clojure.core.async/fiber-spawn f)
+     (:mixed :compute) (clojure.core.async/thread-spawn f)
+     (throw (IllegalArgumentException.
+              (str "Invalid workload " (pr-str workload)
+                   " — expected :io, :compute or :mixed"))))))
 
 (defmacro io-thread
-  "Executes body in another thread, returning a channel that receives the result
-  then closes."
+  "Executes body on a FIBER, returning a channel that receives the result then
+  closes. For blocking-shaped I/O: a channel op or a jolt.socket read that would
+  block parks the fiber and frees its carrier for other work, so thousands of
+  these cost thousands of stacks rather than thousands of OS threads. A park works
+  anywhere in the body — inside a called function, a try, a loop — because a fiber
+  parks by capturing its continuation, not by being rewritten.
+
+  Use thread instead when the body blocks in a way the runtime cannot see
+  (Thread/sleep, a raw fd read, a blocking FFI call): that pins the fiber's
+  carrier, and a real OS thread is the escape."
   [& body]
   `(thread-call (fn [] ~@body) :io))
 

--- a/test/chez/async-io-thread-test.ss
+++ b/test/chez/async-io-thread-test.ss
@@ -1,0 +1,193 @@
+;; test/chez/async-io-thread-test.ss — the io-thread gate (jolt-579).
+;; Run: chez --script test/chez/async-io-thread-test.ss (wired into `make fibers`,
+;; because io-thread's carrier IS a fiber and this asserts that).
+;;
+;; core.async names three carriers and jolt now has all three, with no option to
+;; set: `thread` is a real OS thread, `go` is the CPS pass on whatever
+;; *go-backend* says, and `io-thread` — (thread-call f :io) — is a FIBER. What the
+;; JVM buys with a virtual thread (a blocking-shaped body that is cheap to have
+;; thousands of, and releases its carrier when it blocks on a channel) is what a
+;; fiber is, so :io maps onto fibers and :compute / :mixed stay OS threads.
+;;
+;; Gate checks (in order):
+;;   1. the result channel behaves like thread's: the value lands, a nil body
+;;      just closes
+;;   2. the carrier each name picks — io-thread body IS on a fiber, thread body is
+;;      NOT — and neither honors *go-backend*: an io-thread inside
+;;      (binding [*go-backend* :thread] …) is still a fiber, a thread inside
+;;      :fiber is still a thread. A dispatcher here would make io-thread mean
+;;      "a fiber unless someone above me said otherwise", which is not something
+;;      a caller can use.
+;;   3. the workload table: :io -> fiber, :mixed / :compute / no-arg -> thread,
+;;      anything else throws instead of silently picking one
+;;   4. a park SEVERAL FRAMES DEEP in the body, with no binding and no CPS pass:
+;;      a fiber parks by capturing its continuation, so a blocking-shaped body
+;;      parks from inside a called function — which is the whole point of having
+;;      io-thread as well as go
+;;   5. the check with teeth: N io-thread bodies parked AT THE SAME TIME on ONE
+;;      carrier, all of them resuming. A body that held its carrier instead of
+;;      parking would let exactly one of the N run, so this is what separates a
+;;      fiber from the OS thread io-thread used to be an alias for. The park
+;;      counter (jolt-fiber-chan-parks) is asserted to move by at least N, so
+;;      "they all finished" cannot be satisfied by N bodies that never parked.
+;;   6. a throwing body closes its channel and publishes to go-monitor, exactly
+;;      as a thread-backed one does
+;;   7. the spawner's dynamic bindings reach the body, and its transaction does
+;;      not (the rule async-go-spawn-thread and jolt-fiber-go-spawn both enforce)
+;;
+;; ONE CARRIER for the whole file, pinned before the first spawn: it makes check 5
+;; mean what it says, and it also means any body that pins its carrier hangs
+;; everything after it rather than passing quietly on a machine with cores to
+;; spare. Every wait in here is bounded in the JOLT code (alts!! against a
+;; timeout, via iot-await) so that failure prints as a FAIL and not as a hung CI
+;; job. Nothing in a body blocks the carrier by other means — no Thread/sleep, no
+;; raw fd — because on one carrier that would strand the rest of the file, which
+;; is the documented reason `thread` exists.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define total 0)
+(define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred
+    (set! fails (+ fails 1))
+    (printf "  FAIL: ~a\n" name)))
+
+;; Compile+eval one jolt form in the "user" ns and return its value.
+(define (ev s) (jolt-compile-eval s "user"))
+(define (jv-nth v i) (pvec-nth-d v i jolt-nil))
+(define (kw s) (keyword #f s))
+
+;; Load the real async overlay up front, exactly as the production loader does
+;; (host async.ss + stdlib/clojure/core/async.clj together) — the same setup the
+;; R4/R5 gates use. io-thread and thread-call are overlay definitions over the
+;; host's fiber-spawn / thread-spawn, so a gate for them has to have it loaded.
+(define overlay-src
+  (call-with-input-file "stdlib/clojure/core/async.clj"
+    (lambda (p)
+      (let loop ((acc '()))
+        (let ((c (read-char p)))
+          (if (eof-object? c) (list->string (reverse acc)) (loop (cons c acc))))))))
+(jolt-load-string overlay-src)
+(ev "(require '[clojure.core.async
+                :refer [chan <! >! <!! >!! close! timeout alts!! go
+                        thread thread-call io-thread go-monitor *go-backend*]])")
+
+;; Every wait a check makes is bounded: :timeout instead of a hung gate.
+(ev "(defn iot-await [ch ms]
+       (let [[v p] (alts!! [ch (timeout ms)])]
+         (if (= p ch) v :timeout)))")
+
+;; One carrier, pinned before the first fiber exists — see the header.
+(jolt-fiber-carrier-count-set! 1)
+(jolt-fiber-pool-reset!)
+
+(printf "== io-thread: core.async's third carrier is a fiber ==\n")
+
+;; --- 1. the result channel ---------------------------------------------------
+(printf "\n== 1. value on the channel; a nil body just closes ==\n")
+(ok "1a. the body's value lands on the channel" (eqv? (ev "(<!! (io-thread (+ 1 2)))") 3))
+(ok "1b. a nil body closes the channel (nil is not a channel value)"
+    (jolt-nil? (ev "(iot-await (io-thread nil) 5000)")))
+
+;; --- 2. which carrier each name picks ----------------------------------------
+;; jolt.host/fiber? is the runtime's own answer to "am I on a fiber?" — the same
+;; read <! / >! dispatch on — so this is the carrier, not a proxy for it.
+(printf "\n== 2. io-thread is a fiber, thread is a thread, *go-backend* moves neither ==\n")
+(ok "2a. an io-thread body runs on a fiber" (eq? #t (ev "(<!! (io-thread (jolt.host/fiber?)))")))
+(ok "2b. a thread body does not" (eq? #f (ev "(<!! (thread (jolt.host/fiber?)))")))
+(ok "2c. io-thread under (binding [*go-backend* :thread] …) is still a fiber"
+    (eq? #t (ev "(binding [*go-backend* :thread] (<!! (io-thread (jolt.host/fiber?))))")))
+(ok "2d. thread under (binding [*go-backend* :fiber] …) is still a thread"
+    (eq? #f (ev "(binding [*go-backend* :fiber] (<!! (thread (jolt.host/fiber?))))")))
+
+;; --- 3. the workload table ---------------------------------------------------
+(printf "\n== 3. thread-call's workload selects the carrier ==\n")
+(define r3 (ev "[(<!! (thread-call (fn [] (jolt.host/fiber?)) :io))
+                 (<!! (thread-call (fn [] (jolt.host/fiber?)) :mixed))
+                 (<!! (thread-call (fn [] (jolt.host/fiber?)) :compute))
+                 (<!! (thread-call (fn [] (jolt.host/fiber?))))]"))
+(ok "3a. :io is a fiber" (eq? #t (jv-nth r3 0)))
+(ok "3b. :mixed is a thread" (eq? #f (jv-nth r3 1)))
+(ok "3c. :compute is a thread" (eq? #f (jv-nth r3 2)))
+(ok "3d. no workload defaults to :mixed, a thread" (eq? #f (jv-nth r3 3)))
+;; An unknown workload must not quietly pick one — a caller who misspells :io
+;; would otherwise get a thread and never learn that the fiber they asked for
+;; is not what ran.
+(ok "3e. an unknown workload throws"
+    (jolt=2 (kw "threw")
+            (ev "(try (thread-call (fn [] 1) :bogus) :no-throw
+                      (catch IllegalArgumentException e :threw))")))
+
+;; --- 4. a park several frames deep --------------------------------------------
+;; No *go-backend* binding, no CPS pass: the body calls a function that calls a
+;; function that takes. The >!! on this thread cannot complete until the fiber has
+;; registered as a taker, so the value coming back IS the resume.
+(printf "\n== 4. a park inside a called function ==\n")
+(ev "(defn iot-inner [c] (<!! c))")
+(ev "(defn iot-mid [c] (iot-inner c))")
+(define r4 (ev "(let [c (chan)
+                      g (io-thread (iot-mid c))]
+                  (>!! c 99)
+                  (iot-await g 5000))"))
+(ok "4a. the park resumed with the value, two frames down" (eqv? r4 99))
+
+;; --- 5. N bodies parked at once on ONE carrier --------------------------------
+;; The parks are SIMULTANEOUS by construction: nothing is fed until all N have
+;; announced themselves on `ready`, and each body's next act after announcing is a
+;; take on an empty channel. On one carrier, body i+1 only gets to announce
+;; because body i released the carrier when it parked — an OS-thread-per-body
+;; would pass this too, but the io-thread this replaced could not have, and
+;; neither could a fiber that blocked its carrier: exactly one body would run.
+(printf "\n== 5. 8 bodies parked at the same time, one carrier ==\n")
+(define parks-before (jolt-fiber-chan-parks))
+(define r5 (ev "(let [n 8
+                      ready (chan n)
+                      cs (vec (repeatedly n #(chan)))
+                      gs (mapv (fn [i] (io-thread (>!! ready i) (* 10 (<!! (nth cs i))))) (range n))
+                      arrived (loop [k 0 acc []]
+                                (if (= k n)
+                                  acc
+                                  (let [v (iot-await ready 10000)]
+                                    (if (= v :timeout) acc (recur (inc k) (conj acc v))))))]
+                  (dotimes [i n] (>!! (nth cs i) i))
+                  [(count arrived) (mapv #(iot-await % 10000) gs)])"))
+(ok "5a. all 8 bodies ran and reached their park" (= 8 (jv-nth r5 0)))
+(ok "5b. all 8 resumed with their own value"
+    (jolt=2 (jv-nth r5 1) (jolt-vector 0 10 20 30 40 50 60 70)))
+;; At least the 8 takes; the 8 puts onto a buffered `ready` do not park, and the
+;; helper's own alts!! runs on this thread, not a fiber.
+(ok "5c. the park counter moved by at least 8 (they parked, they did not spin)"
+    (>= (- (jolt-fiber-chan-parks) parks-before) 8))
+
+;; --- 6. a throwing body -------------------------------------------------------
+;; Same contract as a thread-backed body: the channel closes (so a reader gets
+;; nil rather than hanging) and the throwable is published to go-monitor, which is
+;; the only thing that separates "threw" from "returned nil". The report on stderr
+;; is expected output of this section, not a failure.
+(printf "\n== 6. a throwing body closes the channel and reports to go-monitor ==\n")
+(printf "   (the 'Exception in go/fiber body' report below is expected)\n")
+;; The monitor channel conveys the throwable ONCE and closes, so take it once and
+;; ask the value two questions — a second take reads the close, not the failure.
+(define r6 (ev "(let [g (io-thread (throw (ex-info \"iot-boom\" {:k :v})))
+                      m (go-monitor g)
+                      closed (iot-await g 5000)
+                      e (iot-await m 5000)]
+                  [closed (ex-message e) (:k (ex-data e))])"))
+(ok "6a. the channel closed" (jolt-nil? (jv-nth r6 0)))
+(ok "6b. go-monitor carries the throwable" (equal? "iot-boom" (jv-nth r6 1)))
+(ok "6c. with its ex-data" (jolt=2 (kw "v") (jv-nth r6 2)))
+
+;; --- 7. what the body inherits ------------------------------------------------
+(printf "\n== 7. bindings are conveyed, the transaction is not ==\n")
+(ev "(def ^:dynamic *iot-v* :root)")
+(ok "7a. the spawner's dynamic bindings reach the body"
+    (jolt=2 (kw "bound") (ev "(binding [*iot-v* :bound] (<!! (io-thread *iot-v*)))")))
+(ok "7b. the body does not join the spawner's transaction"
+    (eq? #f (ev "(dosync (<!! (io-thread (clojure.lang.LockingTransaction/isRunning))))")))
+
+(printf "\n~a checks, ~a failed\n" total fails)
+(when (> fails 0) (exit 1))
+(printf "io-thread gate: PASS\n")

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -955,6 +955,16 @@
   {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (let [c (a/chan 1 (map inc)) p (future (a/>!! c 1) (a/>!! c 2) (a/>!! c 3) :done)] (Thread/sleep 100) (let [parked (not (realized? p)) v1 (a/<!! c) v2 (a/<!! c) v3 (a/<!! c) result @p] [parked v1 v2 v3 result])))" :expected "[true 2 3 4 :done]"}
   ;; Stage B — pending rendezvous put parks until consumed (does NOT complete on close)
   {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (let [c (a/chan) p (future (a/>!! c :v))] (Thread/sleep 50) (a/close! c) [(a/<!! c) @p]))" :expected "[:v true]"}
+  ;; io-thread is the FIBER carrier (jolt-579): the three names pick the three
+  ;; things — thread an OS thread, io-thread a fiber, go the CPS pass — and
+  ;; jolt.host/fiber? is the runtime's own answer, the same read <! dispatches on.
+  ;; The carrier assertions are here as well as in the io-thread gate because this
+  ;; is the only one that goes through the production loader end to end.
+  {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) [(a/<!! (a/io-thread (+ 1 2))) (a/<!! (a/io-thread (jolt.host/fiber?))) (a/<!! (a/thread (jolt.host/fiber?))) (a/<!! (a/thread-call (fn [] (jolt.host/fiber?)) :compute))])" :expected "[3 true false false]"}
+  ;; a park several frames deep in an io-thread body, and a nil body just closes
+  {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (defn iot-take [c] (a/<!! c)) (let [c (a/chan) g (a/io-thread (iot-take c))] (a/>!! c :deep) [(a/<!! g) (a/<!! (a/io-thread nil))]))" :expected "[:deep nil]"}
+  ;; an unknown workload is refused rather than quietly run on some carrier
+  {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (try (a/thread-call (fn [] 1) :bogus) :no-throw (catch IllegalArgumentException e (ex-message e))))" :expected "\"Invalid workload :bogus — expected :io, :compute or :mixed\""}
   ;; Stage C — pattern-driven tz offset parse applies offset
   {:suite "insttime" :expr "(.getTime (.parse (java.text.SimpleDateFormat. \"yyyy-MM-dd'T'HH:mm:ssX\") \"2024-01-01T00:00:00+05\"))" :expected "1704049200000"}
   {:suite "insttime" :expr "(.getTime (.parse (java.text.SimpleDateFormat. \"yyyy-MM-dd'T'HH:mm:ssX\") \"2024-01-01T00:00:00Z\"))" :expected "1704067200000"}


### PR DESCRIPTION
Closes #579.

core.async names three carriers and jolt has all three now, with no option to set. `thread` is a real OS thread, `go` is the CPS pass on whatever `*go-backend*` says, and `io-thread` is a fiber. Before this, `io-thread` was an alias for `thread`, so asking for the cheap blocking-shaped carrier got you the expensive one, and `thread-call`'s workload argument was accepted and ignored.

The host gains `clojure.core.async/fiber-spawn`, which reaches `jolt-fiber-go-spawn` unconditionally. That is deliberately not a dispatcher: `thread-spawn` asks for an OS thread by name and gets one whatever `*go-backend*` says, so asking for a fiber by name has to work the same way. Otherwise `io-thread` would mean "a fiber, unless something above me bound the backend to `:thread`", which is not a thing a caller can use. `thread-call`'s workload now selects the carrier: `:io` is a fiber, `:mixed` (the default, as on the JVM) and `:compute` are OS threads, and anything else throws instead of quietly running on one of them. `:compute` stays a thread on purpose even though preemption keeps a compute-bound fiber from starving its carrier's queue, because fibers are capped at the carrier count, so N compute bodies on N carriers would leave nothing to run the io-thread bodies that are ready.

There is no CPS pass on an io-thread body. It parks by capturing its continuation, so a park works anywhere in it, including inside a called function, a try or a loop the pass could not rewrite. That is what a blocking-shaped body wants and it is the reason to have `io-thread` as well as `go`. What a fiber does not get is an OS thread of its own, so a body that blocks somewhere the runtime cannot see (`Thread/sleep`, a raw fd read, a blocking FFI call) pins its carrier for the duration. Channel ops park and so does `jolt.socket`, and `thread` is still the escape for everything else. The docstrings say which is which.

```clojure
(require '[clojure.core.async :as a])
(a/<!! (a/io-thread (jolt.host/fiber?)))   ;=> true
(a/<!! (a/thread    (jolt.host/fiber?)))   ;=> false
(a/<!! (a/thread-call (fn [] (jolt.host/fiber?)) :compute))  ;=> false
```

## Testing

`test/chez/async-io-thread-test.ss` is the gate, wired into `make fibers`. It runs with the pool pinned to one carrier, which is what gives its main check teeth: eight io-thread bodies parked at the same time on that single carrier, all of them resuming, and the park counter asserted to have moved by at least eight so "they all finished" cannot be satisfied by bodies that never parked. It also pins the carrier each name picks, that neither `io-thread` nor `thread` follows `*go-backend*`, the workload table, a park two frames deep in the body, a throwing body closing its channel and reporting to `go-monitor`, and what the body inherits from its spawner. Reverting the `:io` arm to `thread-spawn` fails four of its twenty checks.

Three `unit.edn` rows cover the same surface end to end through the production loader. `make ci` passes on this tree (62 targets). Also checked by hand outside the gate: a fiber spawning a fiber, `go` inside an io-thread body and an io-thread inside a `go` body, `thread` inside an io-thread body, 500 io-threads parked on one rendezvous channel, and `pipeline` (which uses `go-loop` and `thread`, untouched).

## Not in this PR

`go`'s default backend is unchanged, so "go is a stackless CPS transform" still needs `(binding [*go-backend* :fiber] ...)` to run on a fiber. Flipping that default is the R6 decision and changes every existing `go`, so it is worth its own change.

While writing the gate I found a pre-existing bug that io-thread makes easier to reach: a fiber's uncaught-throw trace can name frames from a sibling fiber that ran earlier on the same carrier, because the tail-call site lives in a per-thread virtual register that fibers on one carrier share. It reproduces on main with `go` and a `:fiber` binding. Filed as jolt-k5wm with a repro and a fix direction, not fixed here.

No CHANGELOG entry, since 0.7.2 went out today and the changelog is written per release. Happy to add a section if you would rather it land with the feature.
