### PR TITLE
the (timeout ms) timer waits on its condition variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ export LIBRARY_PATH := $(subst $(space),:,$(strip $(CHEZSCHEME-LIB-DIRS)))$(if $
 endif
 
 JOLT-TARGETS-NEEDING-DEPS := \
-  aotcacheperf aotcachesmoke aotfingerprint buildlibsmoke buildsmoke \
+  aotcacheperf aotcachesmoke aotfingerprint asynctimer buildlibsmoke buildsmoke \
   aotcachepathsmoke compilepathsmoke contagion corpus cts dcerefs depssmoke depsunit devboot \
   devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform grenadine \
   gateboot gatebootsmoke gosm httpsfetch infer inline inline-body irvalidate \
@@ -122,7 +122,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp depssmoke depsunit \
   fnform traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck lockcheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
-  certify gambitcheck gambitgencheck grenadinecheck fibers gosm threadsafety
+  certify gambitcheck gambitgencheck grenadinecheck fibers gosm asynctimer threadsafety
 TEST-GATES := submodules selfhost ci
 
 GATE-RECEIPT := target/gate-receipt
@@ -250,6 +250,14 @@ fibers:
 	@$(CHEZ) --script test/chez/fibers-lock-test.ss
 	@$(CHEZ) --script test/chez/fibers-monitor-test.ss
 	@$(CHEZ) --script test/chez/async-io-thread-test.ss
+
+# The one (timeout ms) timer thread (jolt-pe84): a timeout closes on its own
+# deadline however far away the pending ones are, and the thread is forked once.
+# Both were broken by the same three lines — a sleep that left the timer off its
+# condition variable dropped the wake for a nearer deadline, and a fork guard
+# cleared before an idle wait forked a second immortal timer per call.
+asynctimer:
+	@$(CHEZ) --script test/chez/async-timer-test.ss
 
 # The dynamic-var binding stack (jolt-3bo): lookup cost against binding DEPTH and
 # against the number of vars in one frame, push/pop throughput, and the two

--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -453,34 +453,51 @@
   (let ((r (ac-poll! ch))) (if (eq? r ac-poll-empty) cca-none r)))
 
 ;; --- shared timeout timer ---------------------------------------------------
-;; One timer thread serves all (timeout ms) calls — no per-call OS thread.
+;; ONE timer thread serves all (timeout ms) calls — no per-call OS thread.
 ;; Pending timeouts are kept as a sorted list of (deadline-ms . channel) by
-;; ascending deadline. The timer thread sleeps until the nearest deadline,
-;; closes expired channels, and repeats. Inserting a new earliest deadline
-;; signals the condition to wake a sleeping timer.
+;; ascending deadline. The timer closes every channel whose deadline has passed,
+;; then waits for the nearest remaining one; an insert that becomes the HEAD
+;; signals timeout-cv, because that is exactly when the deadline it is waiting
+;; for changed.
+;;
+;; THE WAIT IS A TIMED condition-wait HELD UNDER timeout-mu, AND THE THREAD IS
+;; FORKED ONCE. Both were otherwise, and each was a bug (jolt-pe84):
+;;
+;;   * The timer used to release timeout-mu and `sleep` to the nearest deadline,
+;;     so it was not on timeout-cv when a nearer deadline arrived. The signal
+;;     went nowhere and the new timeout did not fire until the deadline the timer
+;;     was already sleeping to: a (timeout 100) created while a (timeout 3000)
+;;     was pending took 3000ms to close. condition-wait releases the mutex
+;;     atomically with committing to the wait, so an insert can no longer slip
+;;     between the deadline read and the wait on it.
+;;   * timeout-running? used to be cleared before the idle wait, but a timer that
+;;     finds the list empty waits rather than exiting — so the next insert both
+;;     signalled the live thread AND forked another one, and every timer ever
+;;     forked stays alive forever. 100 sequential (timeout 1) calls left 100
+;;     timer threads. The flag now means "the one timer thread exists", which
+;;     once true never stops being true.
 (define timeout-mu (make-mutex))
 (define timeout-cv (make-condition))
 (define timeout-pending '())       ; ((deadline-ms . channel) ...) sorted asc
-(define timeout-running? #f)
+(define timeout-running? #f)       ; the one timer thread has been forked
 
+;; -> #t iff the new entry is the HEAD of the list, i.e. the caller must signal.
 (define (timeout-insert! deadline-ms ch)
   (let loop ((prev '()) (cur timeout-pending))
     (cond ((null? cur)
            (let ((entry (cons deadline-ms ch)))
              (if (null? prev)
                  (set! timeout-pending (list entry))
-                 (begin (set-cdr! prev (list entry))
-                        (set! timeout-pending
-                          (let restore ((h timeout-pending)) h)))))
-           #t)  ; inserted at end (or only entry)
+                 (set-cdr! prev (list entry))))
+           ;; The end is the head only when the list was empty. Appending behind
+           ;; an existing entry leaves the timer's next wake correct as it is.
+           (null? prev))
           ((< deadline-ms (caar cur))
            (let ((entry (cons deadline-ms ch)))
              (if (null? prev)
                  (set! timeout-pending (cons entry cur))
-                 (begin (set-cdr! prev (cons entry cur))
-                        (set! timeout-pending
-                          (let restore ((h timeout-pending)) h))))
-             (null? prev)))  ; #t iff inserted at head
+                 (set-cdr! prev (cons entry cur))))
+           (null? prev))
           (else (loop cur (cdr cur))))))
 
 (define (timeout-thread)
@@ -492,33 +509,28 @@
             (jolt-async-close! (cdar timeout-pending))
             (set! timeout-pending (cdr timeout-pending))
             (cleanup))
-          (if (null? timeout-pending)
-              (begin
-                (set! timeout-running? #f)
+          (begin
+            (if (null? timeout-pending)
                 (condition-wait timeout-cv timeout-mu)
-                (set! timeout-running? #t)
-                (loop))
-              (let ((wait-ms (- (caar timeout-pending) (now-millis))))
-                (if (> wait-ms 0)
-                    (begin
-                      (jolt-unlock! timeout-mu)
-                      (sleep (ms->duration wait-ms))
-                      (jolt-lock! timeout-mu)))
-                (loop)))))))
+                (let ((wait-ms (- (caar timeout-pending) (now-millis))))
+                  (when (> wait-ms 0)
+                    (condition-wait timeout-cv timeout-mu (ms->duration wait-ms)))))
+            ;; Either deadline or signal, the answer is the same: re-read the
+            ;; head. A spurious wake costs one trip through cleanup.
+            (loop))))))
 
 ;; (timeout ms) — a channel that closes after ms milliseconds.
 (define (jolt-async-timeout ms)
   (let* ((w (ac-make 0 'unbuffered #f))
          (dl (+ (now-millis) (exact (floor ms)))))
     (jolt-lock! timeout-mu)
-    (let ((head? (timeout-insert! dl w)))
-      (when head?
-        (condition-signal timeout-cv))
-      (unless timeout-running?
-        (set! timeout-running? #t)
-        (fork-thread timeout-thread))
-      (jolt-unlock! timeout-mu)
-      w)))
+    (when (timeout-insert! dl w)
+      (condition-signal timeout-cv))
+    (unless timeout-running?
+      (set! timeout-running? #t)
+      (fork-thread timeout-thread))
+    (jolt-unlock! timeout-mu)
+    w))
 
 ;; (put! ch v [cb [on-caller?]]) — async put, optional completion callback. If the
 ;; put completes immediately and on-caller? (default #t), the callback runs on the

--- a/test/chez/async-timer-test.ss
+++ b/test/chez/async-timer-test.ss
@@ -1,0 +1,115 @@
+;; test/chez/async-timer-test.ss — the shared (timeout ms) timer (jolt-pe84).
+;; Run: chez --script test/chez/async-timer-test.ss (wired into `make asynctimer`).
+;;
+;; One timer thread serves every (timeout ms) in the process, which makes the two
+;; things asserted here properties of the WHOLE channel surface: alts! against a
+;; timeout, core.async's own timeout-driven operators, and a fiber parked on a
+;; timeout all resume when this timer says so.
+;;
+;;   1. A timeout closes on ITS OWN deadline, whatever else is pending. The timer
+;;      used to sleep to the nearest deadline with timeout-mu released, so it was
+;;      not on timeout-cv when a nearer deadline was inserted; the signal was
+;;      dropped and the new timeout fired at the OLD deadline. (timeout 100)
+;;      behind a pending (timeout 3000) took 3000ms. That is what the lateness
+;;      checks are for, and why each one is measured against a far pending
+;;      deadline rather than in isolation.
+;;   2. The timer thread is forked ONCE. It waits rather than exiting when the
+;;      pending list empties, so clearing timeout-running? before that wait made
+;;      the next insert both signal the live thread AND fork another: 100
+;;      sequential (timeout 1) calls left 100 live timer threads. The flag is the
+;;      fork guard, so asserting it stays set across a drain to empty IS the
+;;      no-leak check — Chez gives a script no way to count its own threads.
+;;
+;; White-box on purpose: the interesting states (an empty pending list, a far
+;; deadline pending) are not reachable from a black-box read of a channel, and
+;; timeout-pending / timeout-running? are top-level defines in async.ss, which
+;; this gate loads into the same environment.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define total 0) (define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred (set! fails (+ fails 1)) (printf "  FAIL: ~a\n" name)))
+
+;; Wall clock around a take, in ms. now-millis is the timer's own clock, so a
+;; measurement here and a deadline there cannot disagree about the unit.
+(define (take-ms ch)
+  (let ((t0 (now-millis)))
+    (jolt-async-take ch)
+    (- (now-millis) t0)))
+
+;; Read the timer's state the way the timer writes it. The entry for a closed
+;; channel is removed under timeout-mu BEFORE the mutex drops, so by the time a
+;; take has returned and this can acquire it, a fired timeout is already gone.
+(define (pending-count) (jolt-with-mutex timeout-mu (length timeout-pending)))
+
+(printf "== the shared (timeout ms) timer ==\n")
+
+;; --- 1. a lone timeout, and the drain to empty --------------------------------
+(printf "\n== 1. one timeout: fires on time, leaves nothing pending ==\n")
+(ok "1a. no timer thread before the first (timeout ms)" (not timeout-running?))
+(let ((ms (take-ms (jolt-async-timeout 100))))
+  (ok "1b. (timeout 100) closes at ~100ms" (and (>= ms 90) (< ms 1000))))
+(ok "1c. the fired entry is off the pending list" (= 0 (pending-count)))
+;; THE NO-LEAK CHECK: the list just drained to empty, so the timer is parked on
+;; timeout-cv with nothing pending — the exact state in which it used to declare
+;; itself gone and let the next insert fork a second immortal thread.
+(ok "1d. the timer thread is still claimed after the list drained to empty"
+    timeout-running?)
+
+;; --- 2. a nearer deadline behind a farther one --------------------------------
+;; far stays pending for the rest of the gate: every check below is therefore
+;; made in the state that used to break them, not in isolation.
+(printf "\n== 2. a nearer deadline arriving behind a far one ==\n")
+(define far (jolt-async-timeout 60000))
+(ok "2a. the far timeout is pending" (= 1 (pending-count)))
+(let ((ms (take-ms (jolt-async-timeout 100))))
+  (ok "2b. (timeout 100) behind a pending (timeout 60000) closes at ~100ms"
+      (and (>= ms 90) (< ms 2000))))
+(ok "2c. the far timeout is still pending, untouched" (= 1 (pending-count)))
+;; Twice in a row: the second insert is a head insert against a timer that has
+;; just been woken, which is where a lost signal would show up as ONE late one.
+(let ((ms (take-ms (jolt-async-timeout 100))))
+  (ok "2d. and again" (and (>= ms 90) (< ms 2000))))
+
+;; --- 3. many deadlines, inserted out of order ---------------------------------
+;; Inserted farthest-first, so every insert after the first is a head insert and
+;; each one has to displace the deadline the timer is already waiting for.
+(printf "\n== 3. deadlines inserted out of order all fire on time ==\n")
+(define t300 (jolt-async-timeout 300))
+(define t200 (jolt-async-timeout 200))
+(define t100 (jolt-async-timeout 100))
+(ok "3a. three more are pending, plus far" (= 4 (pending-count)))
+(let* ((m1 (take-ms t100))
+       (m2 (take-ms t200))
+       (m3 (take-ms t300)))
+  ;; Taken in deadline order, so each take's own wait is short; what is asserted
+  ;; is the SUM, which is the time from the first insert to the last close.
+  (ok "3b. all three closed within ~300ms of the first insert"
+      (< (+ m1 m2 m3) 2000))
+  (ok "3c. the 100ms one closed first" (< m1 250)))
+(ok "3d. only the far one is left" (= 1 (pending-count)))
+
+;; --- 4. the sequential shape that leaked a thread per call --------------------
+(printf "\n== 4. 100 sequential timeouts ==\n")
+(let ((t0 (now-millis)))
+  (let loop ((k 0))
+    (when (< k 100)
+      (jolt-async-take (jolt-async-timeout 1))
+      (loop (+ k 1))))
+  ;; 100 × 1ms of deadline. A generous ceiling: the point is that none of them
+  ;; waited for `far`, which would be 100 × 60s.
+  (ok "4a. 100 × (timeout 1) finished promptly" (< (- (now-millis) t0) 10000)))
+(ok "4b. still one timer thread, still claimed" timeout-running?)
+(ok "4c. and nothing but far is pending" (= 1 (pending-count)))
+
+;; --- 5. a deadline already in the past ----------------------------------------
+(printf "\n== 5. a deadline in the past closes immediately ==\n")
+(let ((ms (take-ms (jolt-async-timeout 0))))
+  (ok "5a. (timeout 0) closes at once" (< ms 1000)))
+
+(printf "\n~a checks, ~a failed\n" total fails)
+(when (> fails 0) (exit 1))
+(printf "async-timer gate: PASS\n")

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -965,6 +965,13 @@
   {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (defn iot-take [c] (a/<!! c)) (let [c (a/chan) g (a/io-thread (iot-take c))] (a/>!! c :deep) [(a/<!! g) (a/<!! (a/io-thread nil))]))" :expected "[:deep nil]"}
   ;; an unknown workload is refused rather than quietly run on some carrier
   {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (try (a/thread-call (fn [] 1) :bogus) :no-throw (catch IllegalArgumentException e (ex-message e))))" :expected "\"Invalid workload :bogus — expected :io, :compute or :mixed\""}
+  ;; a timeout closes on ITS OWN deadline, not on the nearest pending one's
+  ;; (jolt-pe84). One thread serves every (timeout ms); it used to sleep to the
+  ;; nearest deadline with its mutex released, so it was not on the condition
+  ;; variable when a nearer deadline arrived and the wake was dropped — this
+  ;; 50ms one took the 30s one's deadline. A park on a timeout is the shape
+  ;; every alts! guard has, so the bound is the interesting part, both ways.
+  {:suite "core.async" :expr "(do (require '[clojure.core.async :as a]) (let [far (a/timeout 30000) t0 (System/currentTimeMillis) _ (a/<!! (a/timeout 50)) el (- (System/currentTimeMillis) t0)] [(>= el 40) (< el 5000)]))" :expected "[true true]"}
   ;; Stage C — pattern-driven tz offset parse applies offset
   {:suite "insttime" :expr "(.getTime (.parse (java.text.SimpleDateFormat. \"yyyy-MM-dd'T'HH:mm:ssX\") \"2024-01-01T00:00:00+05\"))" :expected "1704049200000"}
   {:suite "insttime" :expr "(.getTime (.parse (java.text.SimpleDateFormat. \"yyyy-MM-dd'T'HH:mm:ssX\") \"2024-01-01T00:00:00Z\"))" :expected "1704067200000"}


### PR DESCRIPTION
Found while reviewing #583, pre-existing and unrelated to it. Filed as jolt-pe84.

One timer thread serves every `clojure.core.async/(timeout ms)` in the process, and two things were wrong with the three lines around its wait.

It slept to the nearest deadline with `timeout-mu` released, so it was not waiting on `timeout-cv` when an insert put a nearer deadline at the head. The `condition-signal` went nowhere and the new timeout did not close until the deadline the timer was already sleeping to:

```clojure
(a/<!! (a/timeout 100))     ;; 104 ms
(def far (a/timeout 3000))
(a/<!! (a/timeout 100))     ;; 2998 ms  (want ~100)
```

Every `alts!` timeout guard, every operator built on one, and every fiber parked on one inherits that. The wait is now a timed `condition-wait` held under `timeout-mu`, which releases the mutex atomically with committing to the wait, so an insert cannot land between the deadline read and the wait on it.

Separately, a timer that finds the pending list empty waits rather than exiting, but `timeout-running?` was cleared before that wait. The next insert therefore both signalled the live thread and forked another one, and since no timer ever exits they accumulate: 100 sequential `(timeout 1)` calls left 100 live timer threads, measured with `ps -M` against 1 thread at baseline. Two timers alive also means two threads draining the same pending list, which is how a far deadline could close early. The flag now means "the one timer thread exists", which once true never stops being true.

`timeout-insert!` also reported an append behind existing entries as a head insert, so a timeout that changed nothing about the next wake signalled anyway. It now reports only real head inserts, and the two no-op self-assignments to `timeout-pending` in its `set-cdr!` branches are gone.

## Testing

`test/chez/async-timer-test.ss` is the gate, wired into `make ci` as `asynctimer`. Two things give it teeth. Every deadline is asserted against a far pending one rather than in isolation, because isolation is the one state in which the old timer was correct. And it reads `timeout-running?` directly across a drain to empty, because that flag is the fork guard and Chez gives a script no way to count its own threads. Seven of its sixteen checks fail on the old timer. One `unit.edn` row covers the lateness end to end through the production loader, bounded both ways so an early close fails it too.

`make ci` passes on this tree, 63 targets. I also reran the io-thread probes from the #583 review: a fiber parked on a `timeout`, two timeouts in a row in one body, and a `:fiber` `go` on a timeout all failed intermittently before this and pass now, which is what a dropped wake looks like from inside a fiber.