### PR TITLE
A monitor contended by a thread and by fibers no longer deadlocks

### DIFF
--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -774,13 +774,33 @@
 ;; A contender WAITS, and how it waits depends on what it is. A fiber parks on the
 ;; monitor's own waiter list and the release resumes it — never a condition-wait,
 ;; which would block the carrier that may be the very thing the holder needs in order
-;; to reach its release. A thread waits on the condition variable. This is the shape
-;; loader.ss already uses for its load claims (ldr-load-mu / ldr-load-cv /
-;; ldr-fiber-waiters) and it rests on the same two facts: the registration and the
-;; commit-to-park both happen under the bookkeeping lock that the release also takes,
-;; so no wakeup can be lost, and the only park inside that lock is this wait, which
-;; gives the lock up on the way out — so no fiber is ever parked HOLDING it, which is
-;; the precondition locks.ss puts on parking inside jolt-with-mutex at all.
+;; to reach its release. A thread waits on the condition variable. Both are woken by
+;; the release, and neither can lose a wakeup, because the registration happens under
+;; the bookkeeping lock that the release also takes.
+;;
+;; WHERE THE FIBER'S SWITCH HAPPENS, and why it is not inside bk (jolt-dfuo). The
+;; fiber registers itself and commits to 'parked under bk, and then bk is RELEASED and
+;; the switch runs outside it. It used to park inside the region and lean on
+;; jolt-with-mutex being a dynamic-wind to release on the way out and re-acquire on
+;; the resume. That reading of locks.ss's precondition was too weak: it is not "no
+;; fiber is parked while HOLDING bk", it is that no fiber on the carrier may be
+;; holding bk while this one is off the CPU, because the re-acquire runs from Chez's
+;; rewind, on the carrier thread, at the interrupt depth the fiber parked at, and the
+;; carrier can do nothing else until it succeeds. A monitor's bk does not satisfy
+;; that: several fibers on one carrier, plus any number of threads, all pass through
+;; this region for the same monitor. Measured: one OS thread and eight fibers taking
+;; the same monitor in a loop wedged the whole process in 1 run of 12, with bk left
+;; held by a carrier whose fiber had parked in the wait and every other carrier
+;; blocked in that re-acquire (the process it wedged was `make test`, jolt-8tma).
+;;
+;; Committing under the lock and switching outside it is what the channel waiters
+;; (java/fibers-async.ss jolt-fiber-<!) and jolt.io-poller/wait-fiber already do, for
+;; this reason. It also needs no interrupt disable: the window between the release and
+;; the switch belongs to a fiber that is already 'parked, and
+;; jolt-fiber-preempt-handler refuses to preempt a fiber that is not 'running.
+;;
+;; loader.ss's load claims (ldr-load-mu / ldr-load-cv / ldr-fiber-waiters) still have
+;; the older shape and the same exposure; jolt-04ee tracks it.
 ;;
 ;; NOT the JEP 491 reimplementation locks.ss rules out. That paragraph is about the
 ;; runtime's own locks, of which there are many and all short. The locks that wrap
@@ -854,38 +874,57 @@
              (memq (jolt-fiber-state owner) '(done dead))
              #t))))
 
-;; Call with bk HELD; returns with it held again, and the caller RE-CHECKS — a wakeup
-;; means "something changed", never "the monitor is yours".
+;; Call with bk HELD. Two different answers, because the two contenders wait in
+;; different places:
 ;;
-;; A fiber must not use the condition variable. condition-wait blocks the carrier
-;; thread, and the holder may be a fiber on that same carrier, so blocking there is a
-;; deadlock; even when the holder is elsewhere it stalls every unrelated fiber the
-;; carrier is running. It parks, and monitor-exit! resumes it. The park is committed
-;; while bk is still held — jolt-fiber-park! sets 'parked and captures the
-;; continuation, and only the escape past jolt-with-mutex's dynamic-wind releases bk
-;; — so no release can fit between the registration and the park, and the resume
-;; re-acquires bk through the same wind's before thunk.
+;;   a THREAD waits here, on the condition variable, which releases bk atomically
+;;   with blocking and holds it again on return. Answers #f: bk is held, and the
+;;   caller re-checks under it — a wakeup means "something changed", never "the
+;;   monitor is yours".
+;;
+;;   a FIBER must not touch the condition variable (condition-wait would block the
+;;   carrier, and the holder may be a fiber on that same carrier). It registers on the
+;;   monitor's waiter list and COMMITS to 'parked, both under bk so monitor-exit!
+;;   cannot run between them and no wakeup can be lost. It answers ITSELF, and the
+;;   caller switches it out AFTER bk is released: the park must not happen inside this
+;;   region, or the resume's re-acquire deadlocks the carrier (see the header,
+;;   jolt-dfuo).
 (define (monitor-wait! m)
   (let ((f (jolt-current-fiber)))
     (if f
         (begin
           (vector-set! m monitor-i-fibers (cons f (vector-ref m monitor-i-fibers)))
-          (jolt-fiber-park!))
-        (condition-wait (vector-ref m monitor-i-cv) (vector-ref m monitor-i-bk)))))
+          (jolt-fiber-state-set! f 'parked)
+          f)
+        (begin
+          (condition-wait (vector-ref m monitor-i-cv) (vector-ref m monitor-i-bk))
+          #f))))
 
+;; The decision is made under bk; a fiber's SWITCH is made outside it, and then the
+;; whole decision is retaken, because a resume says only that something changed.
 (define (monitor-enter! m)
   (let ((me (monitor-self)))
-    (jolt-with-mutex (vector-ref m monitor-i-bk)
-      (let loop ()
-        (let ((owner (vector-ref m monitor-i-owner)))
-          (cond
-            ((eq? owner me)
-             (vector-set! m monitor-i-count (fx+ 1 (vector-ref m monitor-i-count))))
-            ((not owner)
-             (vector-set! m monitor-i-owner me)
-             (vector-set! m monitor-i-box (current-interrupt-box))
-             (vector-set! m monitor-i-count 1))
-            (else (monitor-wait! m) (loop))))))))
+    (let retake ()
+      (let ((park
+             (jolt-with-mutex (vector-ref m monitor-i-bk)
+               (let loop ()
+                 (let ((owner (vector-ref m monitor-i-owner)))
+                   (cond
+                     ((eq? owner me)
+                      (vector-set! m monitor-i-count (fx+ 1 (vector-ref m monitor-i-count)))
+                      #f)
+                     ((not owner)
+                      (vector-set! m monitor-i-owner me)
+                      (vector-set! m monitor-i-box (current-interrupt-box))
+                      (vector-set! m monitor-i-count 1)
+                      #f)
+                     ;; a thread's wait ends under this same bk, so it loops HERE;
+                     ;; a fiber comes back out to be switched out below.
+                     (else (let ((f (monitor-wait! m)))
+                             (if f f (loop))))))))))
+        (when park
+          (jolt-fiber-to-scheduler! park)
+          (retake))))))
 
 ;; The same decision without the wait: #t if this context now holds the monitor,
 ;; #f if something else does. ReentrantLock.tryLock is the caller, and the reason

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -520,6 +520,21 @@ else
   fails=$((fails + 1))
 fi
 
+# One monitor, contended by a real thread and by fibers at once (jolt-dfuo). This
+# case lives HERE rather than in `make fibers` because a regression wedges every
+# thread in the process, so the report has to come from outside it: the per-case
+# cap above turns the wedge into a named failing case, which is the whole reason
+# cap.sh exists (jolt-8tma). The case checks exclusion as well as liveness — its
+# counter is a plain array element, so a lost increment is a lost monitor.
+mc_out="$($jolt run test/chez/monitor-contention.clj 2>&1)"
+if printf '%s' "$mc_out" | grep -q 'MONITOR-CONTENTION OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a monitor contended by a thread and fibers did not complete"
+  echo "    $(printf '%s' "$mc_out" | tail -1)"
+  fails=$((fails + 1))
+fi
+
 # One paren too many must FAIL the file, not truncate it. The loader read forms
 # with the non-top-level reader, which parks on a stray `)` rather than raising,
 # and the loop read a parked position as end of input: everything after the paren

--- a/test/chez/monitor-contention.clj
+++ b/test/chez/monitor-contention.clj
@@ -1,0 +1,78 @@
+;; test/chez/monitor-contention.clj — one monitor, contended by a real THREAD and
+;; by FIBERS at the same time (jolt-dfuo). Run through jolt (wired into
+;; host/chez/smoke.sh, which caps every case — see below for why the cap is the
+;; only thing that can report this failure).
+;;
+;; WHY THIS EXISTS. monitor-enter! (host/chez/java/concurrency.ss) used to park a
+;; waiting fiber INSIDE the critical section that guards the monitor's own
+;; bookkeeping, leaning on jolt-with-mutex being a dynamic-wind to release that
+;; mutex on the way out and re-acquire it on the resume. locks.ss's precondition
+;; for parking inside a jolt-with-mutex is stronger than that reading: no fiber on
+;; the carrier may be holding the mutex while this one is off the CPU, because the
+;; re-acquire runs from Chez's rewind, on the carrier thread, at the interrupt
+;; depth the fiber parked at, and the carrier can do nothing else until it
+;; succeeds. A monitor's bookkeeping mutex does not satisfy it: every fiber on the
+;; carrier and every thread passes through that region for the same monitor. One
+;; run in twelve of this workload wedged the whole process, with that mutex left
+;; held by a carrier whose fiber had parked in the wait and every other carrier
+;; blocked in the re-acquire. It is what wedged a `make test` for ninety minutes
+;; (jolt-8tma).
+;;
+;; THE CAP IS THE REPORT. A regression here does not fail, it WEDGES: every thread
+;; ends up parked, nothing is left in a poller or a timer, and an in-process
+;; watchdog cannot fire either — one that only sleeps and reads an atom was tried
+;; and went down with the rest. So this case has no internal deadline and relies on
+;; smoke.sh's per-case cap (host/chez/cap.sh), which turns the wedge into a named
+;; failing case. That is the same lesson jolt-8tma left, applied to its own cause.
+;;
+;; WHAT IT ASSERTS, and why it is not just "everything finished". The counter is a
+;; plain array element read and written back, NOT an atom: the only thing keeping
+;; those increments from being lost is the monitor's mutual exclusion, so the total
+;; is an exclusion check as well as a liveness one. Losing exclusion is the other
+;; half of the same trapdoor (an OS mutex has thread granularity, a fiber is not a
+;; thread), and it is what a "fix" that simply stopped parking would reintroduce.
+;;
+;; CARRIERS ARE PINNED TO 8, not left to the processor count, so the case behaves
+;; the same on a laptop and on a one-core CI box. The count is what gives it teeth
+;; and it is not a guess: against the pre-fix runtime, 8 carriers wedge 8 runs in
+;; 12, 4 carriers wedge 2 in 12, and 2 carriers wedge none at all — the hazard
+;; needs enough carriers to be rewinding parked fibers concurrently.
+(require '[clojure.core.async :as a])
+
+(alter-var-root #'clojure.core.async/*fiber-carrier-count* (constantly 8))
+
+(def fibers 8)
+(def per-fiber 2000)
+(def thread-iters 20000)
+(def expected (+ thread-iters (* fibers per-fiber)))
+
+(def o (Object.))
+(def counter (int-array 1))
+
+;; Read-modify-write with no atomicity of its own: exclusion has to come from the
+;; monitor, so a lost increment is a lost exclusion.
+(defn- bump! []
+  (locking o (aset counter 0 (inc (aget counter 0)))))
+
+(def t (a/thread (dotimes [_ thread-iters] (bump!)) :thread-done))
+
+(def gs (binding [a/*go-backend* :fiber]
+          (doall (for [_ (range fibers)]
+                   (a/go (dotimes [_ per-fiber] (bump!)) :fiber-done)))))
+
+(let [tv (a/<!! t)
+      fvs (mapv a/<!! gs)
+      got (aget counter 0)]
+  (cond
+    (not= :thread-done tv)
+    (do (println "MONITOR-CONTENTION THREAD DID NOT FINISH" (pr-str tv)) (System/exit 1))
+
+    (not= (repeat fibers :fiber-done) (seq fvs))
+    (do (println "MONITOR-CONTENTION FIBERS DID NOT FINISH" (pr-str fvs)) (System/exit 1))
+
+    (not= expected got)
+    (do (println (str "MONITOR-CONTENTION LOST " (- expected got) " of " expected
+                      " increments (exclusion broken)"))
+        (System/exit 1))
+
+    :else (do (println "MONITOR-CONTENTION OK" got) (System/exit 0))))


### PR DESCRIPTION
Closes jolt-dfuo, and root-causes jolt-8tma.

One OS thread and eight fibers taking the same monitor in a loop wedge the whole process, one run in twelve:

```clojure
(def o (Object.))
(a/thread (dotimes [_ 20000] (locking o :x)))
(binding [a/*go-backend* :fiber]
  (dotimes [_ 8] (a/go (dotimes [_ 2000] (locking o :x)))))
```

Every thread ends up parked. Nothing is left in a poller, nothing in a timer, nothing runnable, and an in-process watchdog cannot report it either: one that only sleeps and reads an atom went down with the rest. This is what sat on a `make test` for ninety minutes, and the socket poller case that wedge was blamed on turns out to have been a bystander. The `(timeout ms)` timer, which the 0.7.3 notes floated as a candidate, is not involved either: that case's 320 timeouts are all tail inserts, with one head insert and one timer fork, so neither timer bug can fire in it.

`monitor-enter!` parked a waiting fiber **inside** the critical section that guards the monitor's own bookkeeping, leaning on `jolt-with-mutex` being a dynamic-wind to release that mutex on the way out and re-acquire it on the resume. `locks.ss` states the precondition for parking inside a `jolt-with-mutex`, and it is stronger than that reading: not "no fiber is parked while holding the mutex", but that no fiber on the carrier may be holding it while this one is off the CPU, because the re-acquire runs from Chez's rewind, on the carrier thread, at the interrupt depth the fiber parked at, where the carrier can do nothing else until it succeeds. A monitor's bookkeeping mutex does not satisfy that: every fiber on the carrier and every thread passes through the region for the same monitor.

A diagnostic build with bounded acquires, per-thread acquire/release logs and monitor state caught it exactly there:

```
LOCKSTUCK tid=7 mu=#497 name=monitor-bk owner=8 owner-last=monitor-wait-fiber
  held=1 state=(owner-is-fiber #f count 0 fiber-waiters 0)
  owner-log=((a . 497) (r . 2365) (a . 2365) ...)
```

The monitor itself is free. What is stuck is its bookkeeping mutex, held by a carrier whose fiber had parked in the wait, with every other carrier blocked in the re-acquire.

## The fix

The fiber registers itself and commits to `'parked` under the bookkeeping mutex, and the switch runs outside it, after which the whole decision is retaken, because a resume says only that something changed. That is what the channel waiters and `jolt.io-poller/wait-fiber` already do. It needs no interrupt disable: the window between the release and the switch belongs to a fiber that is already `'parked`, and the preempt handler refuses to preempt a fiber that is not `'running`. The thread arm is unchanged, since `condition-wait` releases the mutex atomically with blocking.

## Testing

`test/chez/monitor-contention.clj` is the gate case, wired into `smoke.sh` rather than `make fibers` because a regression wedges every thread in the process, so the report has to come from outside it. The per-case cap is what turns the wedge into a named failure, which is why `cap.sh` exists. Carriers are pinned to 8 rather than left to the processor count, and that number is what gives the case teeth: against the pre-fix runtime, 8 carriers wedge 8 runs in 12, 4 carriers wedge 2, and 2 carriers wedge none at all. It checks exclusion as well as liveness, since its counter is a plain array element that only the monitor keeps consistent.

Measured after the fix: the gate case passes 15 of 15, the isolated repro 30 of 30 (1 in 12 wedged before), and the pre-watchdog `poller-registration` file 300 of 300 (7 in 300 wedged before). `make test` passes: 63 ci targets plus the self-host byte fixpoint, and `make gate-status` covers this tree.

## Not in this PR

`loader.ss`'s load claims still have the older shape and the same exposure, filed as jolt-04ee. It is not reproduced, it needs concurrent requires of one namespace from fibers and threads at once, and its critical section does more than the monitor's did, so the split is not as mechanical and wants its own change.

No CHANGELOG entry, since 0.7.3 shipped and the changelog is written per release. Main already carries a correction to the 0.7.3 note that had guessed at the timer.