### PR TITLE
A fiber never leaves the CPU while its carrier holds a lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+The 0.7.4 deadlock had a sibling one lock over, in the loader, and both were
+instances of a rule the runtime stated two contradictory ways. The rule now has
+one form, and it is checked instead of documented.
+
+### Fixed
+
+- **A `require` that has to wait no longer risks wedging the process.** A
+  namespace whose top level blocks, required at the same time by several fibers
+  and by a thread, could stop everything: a waiting fiber parked inside the short
+  critical section that guards the loader's per-namespace claims, which leaves a
+  blocking re-acquire of that lock attached to the fiber's resume. That re-acquire
+  runs inside the scheduler, on the carrier thread, and the carrier can do nothing
+  else until it succeeds, so every fiber on it waits behind a lock that every
+  other load also passes through. Same shape as the object monitor fixed in 0.7.4,
+  found by looking for it rather than by hitting it. (jolt-04ee)
+
+- **`restart-agent` no longer runs the agent's validator while holding the
+  agent's lock.** A validator is user code and may block, which would have
+  released the lock half way through the restart. It now runs inside the agent's
+  object monitor, which is what `synchronized` is on the JVM, so two concurrent
+  restarts still serialize and the error a healthy agent reports is unchanged.
+
+### Changed
+
+- **A fiber can no longer leave the CPU while its carrier holds one of the
+  runtime's locks, and that is now enforced rather than described.** The scheduler
+  already refused to *preempt* a fiber holding a lock, but a voluntary park was
+  allowed subject to a condition about every other user of that lock on the same
+  carrier, which no individual site can check and no reviewer can see. Three bugs
+  arrived through that gap, the last two of them process-wide deadlocks. There is
+  one rule now, it covers both kinds of switch, and it is checked in two places:
+  at the switch itself, where breaking it raises an error naming the rule instead
+  of stopping the process with no output, and over the whole runtime as a build
+  gate that reads the code and rejects the shape before it can run. Waiting for
+  state a lock guards, which is what the exception existed for, is a single
+  primitive that the object monitor, `ReentrantLock`, the loader, the channel
+  waiters and the IO poller all share. (jolt-h9nq)
+
+  For anyone who hit the 0.7.4 class of failure: the symptom to expect from a
+  regression now is an error mentioning that a fiber cannot leave the CPU while a
+  lock is held, rather than a silent hang.
+
 ## [0.7.4] - 2026-08-12
 
 One fix, and it is a deadlock: a monitor contended by a real thread and by fibers

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp depssmoke depsunit \
   transient stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform traceemit traceeval degradedbacktrace \
-  inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck lockcheck irvalidate devbootsmoke \
+  inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck lockcheck parkcheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   certify gambitcheck gambitgencheck grenadinecheck fibers gosm asynctimer threadsafety
 TEST-GATES := submodules selfhost ci
@@ -636,6 +636,17 @@ adaptercheck:
 # allowlist records today's unmigrated sites and must only ever shrink.
 lockcheck:
 	@sh host/chez/lock-check.sh
+
+# The other half of the same rule: a fiber never leaves the CPU while its carrier
+# holds a counted lock. lockcheck above proves the runtime can TELL that a lock is
+# held; this one proves nothing parks while one is. It reads every host .ss as data,
+# closes "can park" over the call graph, and fails on a call to anything in that
+# closure from inside a jolt-with-mutex region — which is what the previous lexical
+# scan could not see, because the park was one call past the region (jolt-04ee). It
+# also fails if a switch point stops calling the runtime assertion, so the two
+# halves cannot be removed independently.
+parkcheck:
+	@sh host/chez/park-lock-check.sh
 
 # Makefile dependency selection: explicit Chez overrides must bypass local
 # Makes provisioning so release jobs retain their chosen compiler and libc.

--- a/host/chez/fibers.ss
+++ b/host/chez/fibers.ss
@@ -562,6 +562,13 @@
 ;; can never hand a fiber to the wrong scheduler). The fiber's state is set by
 ;; the caller BEFORE the switch (yield -> 'ready + enqueue; park -> 'parked).
 (define (jolt-fiber-to-scheduler! f)
+  ;; The invariant locks.ss states: no counted lock may be held here. Checked at
+  ;; the switch and not at the parking sites, because this is where every one of
+  ;; them arrives — yield, park, the preemption, the channel waiters, the object
+  ;; monitor, the poller, a load that waits — and because the sites that break it
+  ;; are the ones nobody counted as parking sites. Before the first mutation, so
+  ;; a violation leaves the switch untaken.
+  (jolt-locks-assert-none! 'jolt-fiber-to-scheduler!)
   (set-virtual-register! jolt-vreg-current-fiber 0)
   (call/1cc
     (lambda (k)

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -459,23 +459,46 @@
 ;; new-state must pass the validator (else the agent stays failed); :clear-actions
 ;; discards the held queue, otherwise the queued actions resume. Watchers are NOT
 ;; notified (per the JVM contract).
+;; THE VALIDATOR IS USER CODE, so it does not run under the bookkeeping mutex.
+;; Agent.restart is `synchronized` on the JVM and its whole body — the error check,
+;; the validate, and the writes — is one critical section. A mutex cannot be that
+;; section here: a validator that parks would have it released mid-way by the unwind
+;; (and now raises instead, see locks.ss). So the section is the agent's own OBJECT
+;; MONITOR, which is what `synchronized` is, and which tolerates a park because
+;; ownership is a field rather than an OS mutex. The bookkeeping mutex stays for what
+;; it is for — the field reads and writes, with no user code between an acquire and
+;; its release.
+;;
+;; Both properties the one big mutex was providing survive. Two concurrent restarts
+;; still serialize, on the monitor, so the JVM's "the second is told the agent does
+;; not need a restart" still holds; and the error check still precedes the validate,
+;; so which of the two errors a healthy agent with an invalid value reports is
+;; unchanged. Validating before taking anything would have reversed that, and
+;; re-checking under a re-taken mutex would have let two restarts through.
+;;
+;; Same choice and the same reason as the object monitor (jolt-3a87), the delay
+;; (jolt-232k) and the transaction (jolt-pb2s): the locks in this runtime that wrap
+;; code they did not write are the ones that cannot be OS mutexes.
 (define (jolt-agent-restart a new-state . opts)
   (let ((clear? (and (pair? opts) (keyword-t? (car opts))
                      (string=? (keyword-t-name (car opts)) "clear-actions")
                      (pair? (cdr opts)) (eq? (cadr opts) #t))))
-    (jolt-with-mutex (jolt-agent-mu a)
-      (when (jolt-nil? (jolt-agent-err a))
-        (jolt-throw (jolt-host-throwable "java.lang.RuntimeException"
-                                         "Agent does not need a restart")))
-      (let ((vf (jolt-agent-validator a)))
-        (when (and (not (jolt-nil? vf)) (jolt-not (jolt-invoke vf new-state)))
-          (jolt-iref-state-throw)))
-      (jolt-agent-state-set! a new-state)
-      (jolt-agent-err-set! a jolt-nil)
-      (cond (clear? (jagent-q-clear! a))
-            ((and (not (jagent-q-empty? a)) (not (jolt-agent-running? a)))
-             (jolt-agent-running?-set! a #t)
-             (fork-thread (lambda () (*txn* #f) (jolt-agent-worker a)))))))
+    (jolt-with-monitor a
+      (lambda ()
+        (jolt-with-mutex (jolt-agent-mu a)
+          (when (jolt-nil? (jolt-agent-err a))
+            (jolt-throw (jolt-host-throwable "java.lang.RuntimeException"
+                                             "Agent does not need a restart"))))
+        (let ((vf (jolt-agent-validator a)))
+          (when (and (not (jolt-nil? vf)) (jolt-not (jolt-invoke vf new-state)))
+            (jolt-iref-state-throw)))
+        (jolt-with-mutex (jolt-agent-mu a)
+          (jolt-agent-state-set! a new-state)
+          (jolt-agent-err-set! a jolt-nil)
+          (cond (clear? (jagent-q-clear! a))
+                ((and (not (jagent-q-empty? a)) (not (jolt-agent-running? a)))
+                 (jolt-agent-running?-set! a #t)
+                 (fork-thread (lambda () (*txn* #f) (jolt-agent-worker a)))))))))
   a)
 
 ;; --- taps (tap>/add-tap/remove-tap) -----------------------------------------
@@ -799,8 +822,12 @@
 ;; the switch belongs to a fiber that is already 'parked, and
 ;; jolt-fiber-preempt-handler refuses to preempt a fiber that is not 'running.
 ;;
-;; loader.ss's load claims (ldr-load-mu / ldr-load-cv / ldr-fiber-waiters) still have
-;; the older shape and the same exposure; jolt-04ee tracks it.
+;; It is not open-coded here any more. Five sites needed this protocol and four of
+;; them had written it out, which is four chances to write a fifth — and loader.ss's
+;; load claims were that fifth (jolt-04ee). It is now jolt-lock-wait in
+;; host/chez/locks.ss, where the rule it keeps is also stated: a fiber never leaves
+;; the CPU while its carrier holds a counted lock, checked at both switch points, so
+;; breaking it raises at the park instead of wedging the process.
 ;;
 ;; NOT the JEP 491 reimplementation locks.ss rules out. That paragraph is about the
 ;; runtime's own locks, of which there are many and all short. The locks that wrap
@@ -885,46 +912,45 @@
 ;;   a FIBER must not touch the condition variable (condition-wait would block the
 ;;   carrier, and the holder may be a fiber on that same carrier). It registers on the
 ;;   monitor's waiter list and COMMITS to 'parked, both under bk so monitor-exit!
-;;   cannot run between them and no wakeup can be lost. It answers ITSELF, and the
-;;   caller switches it out AFTER bk is released: the park must not happen inside this
-;;   region, or the resume's re-acquire deadlocks the carrier (see the header,
-;;   jolt-dfuo).
+;;   cannot run between them and no wakeup can be lost. It answers jolt-lock-parked,
+;;   which is jolt-lock-wait's instruction to release bk and switch it out THERE: the
+;;   park must not happen inside this region, or the resume's re-acquire deadlocks the
+;;   carrier (see the header, jolt-dfuo).
 (define (monitor-wait! m)
   (let ((f (jolt-current-fiber)))
     (if f
         (begin
           (vector-set! m monitor-i-fibers (cons f (vector-ref m monitor-i-fibers)))
           (jolt-fiber-state-set! f 'parked)
-          f)
+          jolt-lock-parked)
         (begin
           (condition-wait (vector-ref m monitor-i-cv) (vector-ref m monitor-i-bk))
           #f))))
 
 ;; The decision is made under bk; a fiber's SWITCH is made outside it, and then the
-;; whole decision is retaken, because a resume says only that something changed.
+;; whole decision is retaken, because a resume says only that something changed. All
+;; three of those are jolt-lock-wait (host/chez/locks.ss), which is this protocol
+;; named once rather than open-coded at each of the sites that needs it.
 (define (monitor-enter! m)
   (let ((me (monitor-self)))
-    (let retake ()
-      (let ((park
-             (jolt-with-mutex (vector-ref m monitor-i-bk)
-               (let loop ()
-                 (let ((owner (vector-ref m monitor-i-owner)))
-                   (cond
-                     ((eq? owner me)
-                      (vector-set! m monitor-i-count (fx+ 1 (vector-ref m monitor-i-count)))
-                      #f)
-                     ((not owner)
-                      (vector-set! m monitor-i-owner me)
-                      (vector-set! m monitor-i-box (current-interrupt-box))
-                      (vector-set! m monitor-i-count 1)
-                      #f)
-                     ;; a thread's wait ends under this same bk, so it loops HERE;
-                     ;; a fiber comes back out to be switched out below.
-                     (else (let ((f (monitor-wait! m)))
-                             (if f f (loop))))))))))
-        (when park
-          (jolt-fiber-to-scheduler! park)
-          (retake))))))
+    (jolt-lock-wait (vector-ref m monitor-i-bk)
+      (lambda ()
+        (let loop ()
+          (let ((owner (vector-ref m monitor-i-owner)))
+            (cond
+              ((eq? owner me)
+               (vector-set! m monitor-i-count (fx+ 1 (vector-ref m monitor-i-count)))
+               #f)
+              ((not owner)
+               (vector-set! m monitor-i-owner me)
+               (vector-set! m monitor-i-box (current-interrupt-box))
+               (vector-set! m monitor-i-count 1)
+               #f)
+              ;; a thread's wait ends under this same bk, so it loops HERE; a fiber
+              ;; answers jolt-lock-parked and jolt-lock-wait retakes this decision
+              ;; from the top once something has resumed it.
+              (else (or (monitor-wait! m) (loop))))))))
+    (void)))
 
 ;; The same decision without the wait: #t if this context now holds the monitor,
 ;; #f if something else does. ReentrantLock.tryLock is the caller, and the reason

--- a/host/chez/java/sm.ss
+++ b/host/chez/java/sm.ss
@@ -103,6 +103,11 @@
   ;; unreachable, both ops check before they touch the channel; kept because this
   ;; is the point the invariant is actually load-bearing
   (jolt-sm-check-driver! 'jolt-sm-park! f)
+  ;; The other switch point, and the same invariant (locks.ss). A cheap park is
+  ;; the worse of the two to break it from: it does not rewind, so a lock the
+  ;; escape released is never retaken, and the resumed step runs on believing it
+  ;; still holds one.
+  (jolt-locks-assert-none! 'jolt-sm-park!)
   (jolt-fiber-bump-sm-parks! f)
   (jolt-fiber-sm-set! f resume)
   (jolt-fiber-k-set! f #f)

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -1219,10 +1219,13 @@
 ;;                      breaks the invariant, putting two threads in one load body.
 ;;   No lost wakeup     a blocked waiter always has an owner left to wake it. Rests
 ;;                      on the wait committing before the lock drops — condition-wait
-;;                      releases ldr-load-mu atomically with blocking, and a fiber's
-;;                      park sets 'parked and captures its continuation while the
-;;                      lock is still held — so no ldr-end-load! fits between the
-;;                      owner check and the wait, and on ldr-end-load! broadcasting
+;;                      releases ldr-load-mu atomically with blocking, and a fiber
+;;                      registers itself and sets its own state to 'parked while the
+;;                      lock is still held (its SWITCH is outside the lock, which is
+;;                      a separate matter and jolt-lock-wait's; what this property
+;;                      needs is the commit, not the switch) — so no ldr-end-load!
+;;                      fits between the owner check and the wait, and on
+;;                      ldr-end-load! broadcasting
 ;;                      AND resuming from dynamic-wind's after thunk, which runs on
 ;;                      every exit. The LOADER's own park is not an exit and is
 ;;                      skipped there, which keeps the property rather than weakening
@@ -1234,8 +1237,14 @@
 ;;                      wait-for graph being FUNCTIONAL (one namespace per blocked
 ;;                      context, one owner per namespace) and on the pre-state being
 ;;                      acyclic, which holds because every earlier wait was checked.
-;;   No deadlock        the lock graph is acyclic. The one edge that is not the
-;;                      loader's to remove is stm-lock -> the load a parked
+;;   No deadlock        the lock graph is acyclic, and the edge that is hardest to
+;;                      see is the one a park used to add: a fiber parked inside this
+;;                      critical section left a blocking re-acquire of ldr-load-mu on
+;;                      its resume, which runs in the scheduler and puts every fiber
+;;                      on that carrier behind it. That edge is gone rather than
+;;                      argued about — the switch happens with the lock released, and
+;;                      locks.ss checks it at both switch points (jolt-04ee). The one
+;;                      edge that is not the loader's to remove is stm-lock -> the load a parked
 ;;                      transaction is waiting for, because jolt-sync holds
 ;;                      stm-lock across a whole dosync body. So no load may acquire
 ;;                      stm-lock — see ldr-libs-update!, where that cycle was real
@@ -1262,9 +1271,11 @@
 (define (ldr-ctx-str ctx)
   (if (jolt-fiber? ctx) "a fiber" (string-append "thread " (number->string ctx))))
 
-;; Wait for the load of `name` to end. Call with ldr-load-mu HELD; returns with it
-;; held again, and the caller re-checks — a wakeup is "something changed", never
-;; "the namespace is yours".
+;; Wait for the load of `name` to end. Runs inside jolt-lock-wait's decision, so
+;; ldr-load-mu is HELD. Answers #f when the wait is over and the caller should
+;; re-check under the lock, or jolt-lock-parked when this fiber has committed to a
+;; park that jolt-lock-wait will perform once it has released the lock. A wakeup is
+;; "something changed", never "the namespace is yours", either way.
 ;;
 ;; A fiber must not use the condition variable. condition-wait blocks the CARRIER
 ;; thread, and the load it is waiting for is very likely parked on that same carrier
@@ -1272,23 +1283,32 @@
 ;; another thread it stalls every unrelated fiber the carrier is running. It parks
 ;; instead, and ldr-end-load! resumes it.
 ;;
-;; The park is committed while the mutex is still held — jolt-fiber-park! sets
-;; 'parked and captures the continuation, and only the escape past with-mutex's
-;; dynamic-wind releases the lock — so ldr-end-load! cannot run between the
-;; registration and the park, and there is no wakeup to lose. The resume then
-;; re-acquires through the same dynamic-wind's before thunk. That release-on-park /
-;; re-acquire-on-resume is the one thing here that leans on with-mutex being a
-;; dynamic-wind: it is what makes a park inside this critical section safe, and it is
-;; the opposite of what load-namespace*'s own after thunk wants, which is why that
-;; one asks jolt-park-unwinding? and this one must not.
+;; NO WAKEUP IS LOST, and the reason is the registration and the 'parked commit both
+;; happening under ldr-load-mu, which ldr-end-load! must take: a release either lands
+;; before them and is seen by the re-check, or after them and finds a fiber to resume.
+;; The SWITCH is the one part that happens outside the lock (jolt-04ee). It used to
+;; happen right here, inside the critical section, leaning on jolt-with-mutex being a
+;; dynamic-wind to release the lock on the way out and re-acquire it on the resume.
+;; That is not safe, for the reason host/chez/locks.ss now states as a rule: the
+;; re-acquire runs from Chez's rewind, on the carrier thread, at the interrupt depth
+;; the fiber parked at, and the carrier can do nothing else until it succeeds — so the
+;; park attaches a blocking acquire to a point in the scheduler, and every fiber on
+;; that carrier is behind it. Every fiber and thread requiring any namespace passes
+;; through this same region, so the precondition that would have licensed it does not
+;; hold here any more than it held for the object monitor (jolt-3a87, jolt-dfuo).
+;;
+;; Committing here and switching there is also what keeps load-namespace*'s after
+;; thunk honest: the escape is still a park and still not an exit, so that one still
+;; asks jolt-park-unwinding? and keeps the claim across it.
 (define (ldr-wait-for-load! name)
   (let ((f (jolt-current-fiber)))
     (if f
         (begin
           (hashtable-set! ldr-fiber-waiters name
                           (cons f (hashtable-ref ldr-fiber-waiters name '())))
-          (jolt-fiber-park!))
-        (condition-wait ldr-load-cv ldr-load-mu))))
+          (jolt-fiber-state-set! f 'parked)
+          jolt-lock-parked)
+        (begin (condition-wait ldr-load-cv ldr-load-mu) #f))))
 
 ;; Call with ldr-load-mu HELD. Would `me` waiting on `name` (owned by `owner`) close
 ;; a cycle? Follow owner -> what it waits on -> who owns that -> …; if the chain
@@ -1323,34 +1343,50 @@
                              (ldr-ctx-str (caar c))
                              " waits on " (cdar c))))))
 
+;; Every way out of the decision below leaves the wait-for graph as it found it.
+;; Deleting on the way out rather than immediately after each wait is what lets the
+;; entry STAND while this context is parked, which is the point of recording it: a
+;; cycle is only visible to another context's walk if the waits in it are all on the
+;; table at once. A delete with nothing to delete is a no-op, so the first-iteration
+;; exits (steps 3 and 4) cost one lookup and say what they mean.
+(define (ldr-decided! me v) (hashtable-delete! ldr-waiting me) v)
+
 ;; -> 'loaded | 'recursive | 'claimed. Steps 1-6.
+;;
+;; The whole decision is jolt-lock-wait's `decide`: it runs under ldr-load-mu, and a
+;; fiber that has to wait answers jolt-lock-parked, is switched out with the lock
+;; RELEASED, and then runs this again from the top. Retaking it rather than resuming
+;; into the middle of it is the same thing step 2 always did on a thread's wakeup —
+;; the loop below — and it is now the same code path for both contenders.
 (define (ldr-begin-load! name force?)
   (let ((me (ldr-load-ctx)))
-    (jolt-with-mutex ldr-load-mu
-      (let loop ()
-        (let ((owner (hashtable-ref ldr-loading name #f)))
-          (cond
-            ((and owner (eqv? owner me)) 'recursive)          ; step 3
-            (owner                                            ; step 2
-             (let ((chain (ldr-wait-cycle owner me)))
-               (when chain
-                 (throw-jvm (quote IllegalStateException)
-                   (string-append
-                     "Deadlocked require: " (ldr-ctx-str me)
-                     " is about to wait on " name " (held by "
-                     (ldr-ctx-str owner) "), and " (ldr-wait-chain-str chain)
-                     ", which closes back on " (ldr-ctx-str me) ". "
-                     (number->string (fx+ 1 (length chain)))
-                     " loads entered a require cycle from different ends; break"
-                     " the cycle or require these namespaces from one thread."))))
-             (hashtable-set! ldr-waiting me name)
-             (ldr-wait-for-load! name)
-             (hashtable-delete! ldr-waiting me)
-             (loop))
-            ((and (not force?) (not (ldr-reload-all?)) (ns-dedup-loaded? name))
-             'loaded)                                         ; step 4
-            (else (hashtable-set! ldr-loading name me)        ; step 6
-                  'claimed)))))))
+    (jolt-lock-wait ldr-load-mu
+      (lambda ()
+        (let loop ()
+          (let ((owner (hashtable-ref ldr-loading name #f)))
+            (cond
+              ((and owner (eqv? owner me))                    ; step 3
+               (ldr-decided! me 'recursive))
+              (owner                                          ; step 2
+               (let ((chain (ldr-wait-cycle owner me)))
+                 (when chain
+                   (throw-jvm (quote IllegalStateException)
+                     (string-append
+                       "Deadlocked require: " (ldr-ctx-str me)
+                       " is about to wait on " name " (held by "
+                       (ldr-ctx-str owner) "), and " (ldr-wait-chain-str chain)
+                       ", which closes back on " (ldr-ctx-str me) ". "
+                       (number->string (fx+ 1 (length chain)))
+                       " loads entered a require cycle from different ends; break"
+                       " the cycle or require these namespaces from one thread."))))
+               (hashtable-set! ldr-waiting me name)
+               ;; a thread's wait ends under this lock, so it loops HERE; a fiber
+               ;; answers jolt-lock-parked and comes back in at the top.
+               (or (ldr-wait-for-load! name) (loop)))
+              ((and (not force?) (not (ldr-reload-all?)) (ns-dedup-loaded? name))
+               (ldr-decided! me 'loaded))                     ; step 4
+              (else (hashtable-set! ldr-loading name me)      ; step 6
+                    (ldr-decided! me 'claimed)))))))))
 
 ;; Step 11: drop the claim and wake everyone waiting on this namespace. Broadcast
 ;; and not signal — the waiters re-check a condition that may not be true for all

--- a/host/chez/locks.ss
+++ b/host/chez/locks.ss
@@ -76,26 +76,49 @@
 ;; lock-check.sh requires the explicit name, so the migration is visible and the
 ;; count can only go down.
 ;;
-;; WHEN A FIBER MAY PARK INSIDE THE BODY. It is legal, and loader.ss's
-;; ldr-wait-for-load! depends on it: the after-thunk releases on the way out and
-;; the before-thunk re-acquires when the continuation is resumed, so the lock is
-;; not held across the park. What that costs is a blocking mutex-acquire on the
-;; RESUME — run from Chez's rewind, on the carrier thread, at the interrupt depth
-;; the fiber parked at, where the preemption timer is not polled and the carrier
-;; can do nothing else until it succeeds. So the precondition is not "the region
-;; is short", it is:
+;; A FIBER MAY NOT PARK INSIDE THE BODY, and that is a rule rather than a
+;; guideline: the count above is what the preempt handler reads to refuse an
+;; INVOLUNTARY switch, and a voluntary one is not different in kind. So there is
+;; one rule, and it covers both:
 ;;
-;;   a fiber may park inside jolt-with-mutex only if no fiber on its carrier can
-;;   be holding m while this one is off the CPU.
+;;   a fiber never leaves the CPU while its carrier holds a counted lock.
 ;;
-;; ldr-load-mu satisfies it because the only park inside that critical section is
-;; the wait itself, which gives the lock up on the way out, so a sibling fiber
-;; can never be parked holding it. A mutex a fiber can hold across a park would
-;; deadlock the carrier instead: the holder is queued behind the resume that is
-;; blocked waiting for it, and a fiber cannot migrate off its carrier to escape.
-;; A CHEAP park (java/sm.ss) is not allowed here at all — it never rewinds, so
-;; the lock would be released and never retaken. The CPS pass keeps them apart by
-;; treating every form that takes a thunk as opaque; see jolt-sm-park!.
+;; jolt-locks-assert-none! below is that rule, and every switch point calls it —
+;; jolt-fiber-to-scheduler! (which is yield, park, and the preemption) and
+;; jolt-sm-park! (the cheap park). So a violation raises at the park instead of
+;; wedging a process with no error and no output.
+;;
+;; IT USED TO BE AN EXCEPTION, which is how the same bug arrived three times
+;; (jolt-3a87, jolt-dfuo, jolt-04ee). Parking inside the body was legal,
+;; licensed by dynamic-wind: the after-thunk releases on the way out and the
+;; before-thunk re-acquires when the continuation is resumed, so the lock is not
+;; held ACROSS the park. What that reading leaves out is WHERE the re-acquire
+;; runs. It runs from Chez's rewind, on the carrier thread, at the interrupt
+;; depth the fiber parked at, where the preemption timer is not polled, the
+;; carrier can do nothing else until it succeeds, and nothing can make it give
+;; up. So a park does not merely release a lock and retake it. It attaches a
+;; blocking acquire to a point in the SCHEDULER, and the wait edge that creates
+;; belongs to every fiber on that carrier, not to the one that parked.
+;;
+;; The precondition that makes that safe is non-local to match: no fiber on the
+;; carrier may be holding m while this one is off the CPU. A parking site cannot
+;; check that, and a reviewer cannot see it, because it is a statement about
+;; every OTHER user of m that shares the carrier. For the object monitor it was
+;; read as the weaker "no fiber is parked while HOLDING m", which is true and
+;; insufficient; one run in twelve of a contended monitor wedged the whole
+;; process, and one of those was a ninety-minute `make test` (jolt-8tma). The
+;; rule above is the same guarantee with nothing left to read wrong, and unlike
+;; the precondition it replaces it is checkable — at the switch, and statically
+;; over the whole runtime (host/chez/park-lock-check.ss).
+;;
+;; WAITING FOR STATE THIS LOCK GUARDS is what the exception existed for, and it
+;; never needed one: commit under the lock, switch outside it. That is
+;; jolt-lock-wait, below.
+;;
+;; A CHEAP park (java/sm.ss) was never allowed here even under the old reading —
+;; it does not rewind, so the lock would be released and never retaken. The CPS
+;; pass keeps them apart by treating every form that takes a thunk as opaque;
+;; see jolt-sm-park!.
 (define-syntax jolt-with-mutex
   (syntax-rules ()
     ((_ m e1 e2 ...)
@@ -121,3 +144,92 @@
        (unless got (jolt-locks-exit!))
        got))))
 (define (jolt-unlock! mu) (mutex-release mu) (jolt-locks-exit!))
+
+;; --- the invariant, checked where it can be broken ---------------------------
+;; (jolt-locks-assert-none! who) — raise unless this carrier holds no counted
+;; lock. Called by every switch point rather than by the sites that park, and
+;; that placement is the point: there are two switch points and a growing number
+;; of parking sites, and the ones that go wrong are the ones nobody thought of as
+;; parking sites at all (a `locking` body, a validator, a load that waits).
+;;
+;; Complete for parks that HAPPEN, in a way the static check cannot be: it does
+;; not care whether the park is lexically inside the region, one call away
+;; (jolt-04ee), or inside user code the lock never wrote (jolt-3a87). If a fiber
+;; is about to leave the CPU with a lock held, this is on the path.
+;;
+;; It RAISES, and the alternative is worth naming: the failure it replaces is a
+;; process that stops dead with no error and no output, on some fraction of runs,
+;; needing a sampling profiler to diagnose. Raising costs the fiber (its guard
+;; marks it dead) and reports the invariant, the count, and a stack. That trade
+;; is not close. The check runs before the caller's first mutation at both sites,
+;; so the raise leaves the switch untaken rather than half-taken.
+;;
+;; Always on, never behind a flag: a check that is off in the build people ship is
+;; not a check, and the cost is one virtual-register read and a fixnum compare
+;; against a switch that costs ~136 ns. Measured rather than asserted, on
+;; bench/fibers: the scheduler yield+slice figure spans 135.8-137.7 ns over three
+;; runs with the check and reads 136.6 ns without it, so it is inside the
+;; run-to-run spread; channel ping-pong and fan-in move the same way.
+(define (jolt-locks-assert-none! who)
+  (let ((n (jolt-locks-held)))
+    (when (fx>? n 0)
+      (error who
+        (string-append
+         "a fiber cannot leave the CPU while its carrier holds a counted lock ("
+         (number->string n)
+         " held). Commit under the lock and switch outside it — jolt-lock-wait,"
+         " host/chez/locks.ss.")))))
+
+;; --- waiting for state a lock guards ----------------------------------------
+;; (jolt-lock-wait mu decide) -> whatever decide returns
+;;
+;; The one sanctioned way for a fiber to wait on state that a mutex guards, and
+;; the protocol five sites had hand-rolled between them: the channel waiters
+;; (java/fibers-async.ss, java/sm.ss), the object monitor and ReentrantLock
+;; (java/concurrency.ss), jolt.io-poller/wait-fiber, and the load claims in
+;; loader.ss — which is the one that got it wrong (jolt-04ee). Four correct
+;; copies of an unnamed protocol are four chances to write a fifth.
+;;
+;; decide runs with mu HELD and answers either
+;;
+;;   jolt-lock-parked   "I have registered myself where my waker will look and
+;;                       set my own state to 'parked. Switch me out, and call me
+;;                       again when something resumes me."
+;;   anything else       the decision, returned to the caller as-is.
+;;
+;; Three properties, and each one is where a hand-rolled copy can go wrong:
+;;
+;;   THE SWITCH IS OUTSIDE mu, so no resume carries a mutex re-acquire and the
+;;   invariant above holds by construction. It is also lexically outside the
+;;   jolt-with-mutex below, which is what the static check reads, so every caller
+;;   inherits a shape that check can see through.
+;;
+;;   NO WAKEUP CAN BE LOST, because registering and committing to 'parked both
+;;   happen under the same mu the waker must take. A resume landing in the window
+;;   between the release and the switch finds the fiber 'parked, moves it to
+;;   'ready and enqueues it; the switch then stores its continuation and the
+;;   carrier dispatches it. A preemption in that window is refused, because
+;;   jolt-fiber-preempt-handler refuses to preempt a fiber that is not 'running —
+;;   which is why this needs no interrupt disable of its own.
+;;
+;;   THE DECISION IS RETAKEN, not resumed into. A wakeup means something changed,
+;;   never "it is yours", so decide runs again from the top with mu held. That is
+;;   also why decide must be safe to run more than once.
+;;
+;; A THREAD needs none of this and is not sent a different way: inside decide it
+;; waits on a condition variable, which releases mu atomically with blocking and
+;; holds it again on return, loops there, and answers a real value — so it never
+;; reaches the branch below. One function serves both contenders and the entire
+;; difference between them is that one branch.
+(define jolt-lock-parked (list 'jolt-lock-parked))   ; unique; never a decision
+
+(define (jolt-lock-wait mu decide)
+  (let retake ()
+    (let ((r (jolt-with-mutex mu (decide))))
+      (if (eq? r jolt-lock-parked)
+          ;; mu is released here. jolt-current-fiber still answers this fiber —
+          ;; the switch is what clears that register — and the state it needs is
+          ;; already 'parked, set by decide under mu.
+          (begin (jolt-fiber-to-scheduler! (jolt-current-fiber))
+                 (retake))
+          r))))

--- a/host/chez/park-lock-allowlist.txt
+++ b/host/chez/park-lock-allowlist.txt
@@ -1,0 +1,8 @@
+# host/chez/park-lock-allowlist.txt — generated. Regenerate with:
+#   sh host/chez/park-lock-check.sh --regen
+# Lines: <file> <definition> <kind> <callee> <count>, for a call made from
+# inside a jolt-with-mutex region. kind `park` is a callee that can reach
+# one of the runtime's park primitives; kind `user-code` is a call into code
+# the lock did not write. A count that DROPS is stale and fails the gate, so
+# fixing a site must update this file. Empty is the goal and the current
+# state: no fiber leaves the CPU while its carrier holds a counted lock.

--- a/host/chez/park-lock-check.sh
+++ b/host/chez/park-lock-check.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# park-lock-check.sh — wrapper for the park/lock discipline gate (POSIX sh).
+#
+# Runs host/chez/park-lock-check.ss under the build's Chez. The checker reads every
+# handwritten host .ss file as data, closes "can park" over the call graph from the
+# two switch points, and fails on a call to anything in that closure from inside a
+# jolt-with-mutex region — the shape that wedged a process three times (jolt-3a87,
+# jolt-dfuo, jolt-04ee). It also fails if a switch point stops calling
+# jolt-locks-assert-none!, which is the runtime half of the same rule.
+#
+#   --regen   rewrite host/chez/park-lock-allowlist.txt from reality
+#
+# Chez resolution mirrors host/chez/portability-check.sh: JOLT_CHEZ wins (the
+# Makefile hands down the interpreter it selected), then a PATH search.
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root" || exit 1
+
+if [ -z "${JOLT_CHEZ:-}" ]; then
+  for c in chez chezscheme; do
+    if command -v "$c" >/dev/null 2>&1; then
+      JOLT_CHEZ="$c"
+      break
+    fi
+  done
+  if [ -z "${JOLT_CHEZ:-}" ]; then
+    echo "park/lock check: no Chez Scheme executable found on PATH" >&2
+    exit 1
+  fi
+fi
+
+exec "$JOLT_CHEZ" --script host/chez/park-lock-check.ss "$@"

--- a/host/chez/park-lock-check.ss
+++ b/host/chez/park-lock-check.ss
@@ -1,0 +1,493 @@
+;; park-lock-check.ss — no fiber may leave the CPU while its carrier holds a
+;; counted lock, checked as a SHAPE before it can run.
+;;
+;; THE RULE, which host/chez/locks.ss states and both switch points enforce:
+;;
+;;   a fiber never leaves the CPU while its carrier holds a counted lock.
+;;
+;; The runtime check (jolt-locks-assert-none!) is sound and complete for parks
+;; that HAPPEN — it sees a park one call away, or inside user code the lock never
+;; wrote, because it reads the lock count at the switch. What it cannot do is see
+;; a park that nothing exercises. jolt-04ee was exactly that: loader.ss parked a
+;; waiting fiber inside ldr-load-mu for two releases, and the window needed
+;; concurrent requires of one namespace from several fibers and threads at once,
+;; so it sat there reported-but-unreproduced. This check is the half that does not
+;; need the window. It reads the code.
+;;
+;; WHAT IT DOES. Every handwritten host .ss file is read AS DATA (comments and
+;; strings cannot lie that way, and the previous mechanism was grep). Then:
+;;
+;;   1. build the call graph over host definitions — every symbol in OPERATOR
+;;      position in each definition's body, with quote bodies, binding names and
+;;      case datums walked past so a local named like a primitive is not a call to
+;;      it.
+;;   2. close "can park" over that graph from the two switch points and their
+;;      wrappers, to a fixpoint. So a helper that parks is a parker, and so is
+;;      anything that calls the helper, however deep.
+;;   3. report every call to a parker that is lexically inside a jolt-with-mutex
+;;      body, naming the file, the enclosing definition and the callee.
+;;
+;; Step 2 is the whole value: the lexical scan this replaces found NOTHING in the
+;; pre-fix loader, because ldr-begin-load!'s region called ldr-wait-for-load! and
+;; the park was in there. One level of indirection was enough to hide it.
+;;
+;; TWO KINDS OF FINDING, because the two hazards are found two different ways and
+;; mixing them made the check useless before it made it wrong:
+;;
+;;   park       a call, at any depth in the call graph, to one of the runtime's own
+;;              park primitives. This is jolt-04ee, and the transitive closure is
+;;              what sees it.
+;;   user-code  jolt-invoke named directly inside the region: the lock hands
+;;              control to code it did not write, and that code may park anywhere.
+;;              Three bugs in this family were exactly that (jolt-3a87 the object
+;;              monitor, jolt-232k the delay, jolt-pb2s the transaction).
+;;
+;; user-code is deliberately LEXICAL and not closed over the call graph, which was
+;; tried first and reported 27 sites across nine files. The reason is not that the
+;; long chains are false — (swap! …) under the atom lock reaches jolt= reaches a
+;; record's user-defined equality — it is that "calls something that can eventually
+;; call user code" is true of most of the runtime, so closing over it produces a
+;; list nobody can act on and an allowlist that hides the two entries that matter.
+;; Named directly in the region, it is a decision somebody made at that spot.
+;;
+;; WHAT IT DOES NOT DO, stated rather than left to be discovered:
+;;
+;;   - a lock held by HAND (jolt-lock! … jolt-unlock!) is not a region it can
+;;     read, because whether the unlock precedes the park is a question about
+;;     control flow, not about nesting. The channel ops (java/fibers-async.ss) are
+;;     that shape on purpose — they hold the channel mutex by hand precisely so
+;;     they can release it before parking — and a scan that guessed would either
+;;     accuse them or learn nothing. Those sites are the runtime check's.
+;;   - a park through a value rather than a name — a hook, a var, a record field
+;;     holding a procedure — is invisible here. Also the runtime check's.
+;;
+;; So neither half is sufficient and the pair is: this one rejects the shape
+;; before it runs, and the other one catches what a static reading cannot see.
+;;
+;; It also checks its own teeth. If jolt-locks-assert-none! ever stops being
+;; called from a switch point, the runtime half is gone and every gate still
+;; passes — so the switch points are checked BY NAME for that call, and losing it
+;; fails here.
+;;
+;;   sh host/chez/park-lock-check.sh          check against the allowlist
+;;   sh host/chez/park-lock-check.sh --regen  regenerate it (review the diff!)
+(import (chezscheme))
+
+(define scope-roots '("host/chez" "host/chez/java"))
+(define allowlist-file "host/chez/park-lock-allowlist.txt")
+
+;; The two switch points. Every park in the runtime ends at one of them, and each
+;; one must call the assertion — checked below, because a check nobody calls is
+;; indistinguishable from a check that passes.
+(define switch-points '(jolt-fiber-to-scheduler! jolt-sm-park!))
+(define assertion 'jolt-locks-assert-none!)
+
+;; The closure's seeds: the switch points themselves and the two wrappers that
+;; exist only to reach them.
+(define park-seeds
+  '(jolt-fiber-to-scheduler! jolt-sm-park! jolt-fiber-park! sa-fiber-yield))
+
+;; Calling into code the lock did not write. Counted wherever it appears in a
+;; region, not only in operator position, because (apply jolt-invoke f args) is
+;; every bit as much a call.
+(define user-code-calls '(jolt-invoke))
+
+;; The lock region. Only jolt-with-mutex: a MONITOR is not a counted lock —
+;; ownership is a field, which is what lets a fiber hold one across a park — so
+;; jolt-with-monitor bodies are not regions and must not be flagged.
+(define lock-form 'jolt-with-mutex)
+
+;; ---------------------------------------------------------------------------
+;; small helpers
+;; ---------------------------------------------------------------------------
+
+(define (has-suffix? s p)
+  (let ((ls (string-length s)) (lp (string-length p)))
+    (and (>= ls lp) (string=? (substring s (- ls lp) ls) p))))
+
+(define (sort-list lst cmp) (sort cmp lst))
+
+(define (files-in dir)
+  (let loop ((es (directory-list dir)) (acc '()))
+    (cond
+      ((null? es) acc)
+      ((and (has-suffix? (car es) ".ss")
+            (not (file-directory? (string-append dir "/" (car es)))))
+       (loop (cdr es) (cons (string-append dir "/" (car es)) acc)))
+      (else (loop (cdr es) acc)))))
+
+(define (find-files)
+  (sort-list
+    (let loop ((ds scope-roots) (acc '()))
+      (if (null? ds) acc (loop (cdr ds) (append (files-in (car ds)) acc))))
+    string<?))
+
+(define (read-datums path)
+  (let ((p (open-input-file path)))
+    (let loop ((acc '()))
+      (let ((x (read p)))
+        (if (eof-object? x)
+            (begin (close-port p) (reverse acc))
+            (loop (cons x acc)))))))
+
+;; ---------------------------------------------------------------------------
+;; the walk
+;; ---------------------------------------------------------------------------
+;; One walker, three jobs, distinguished by what the caller does with each
+;; emission: the call graph (operator position), the park findings (operator
+;; position inside a region), and the user-code findings (any position inside a
+;; region). Written once so the three can never disagree about what a call is.
+;;
+;; emit is called as (emit sym in-lock? operator?) for every symbol reached, with
+;; quote bodies, binding names, lambda formals and case datums walked past.
+
+(define (walk-forms forms in-lock? emit)
+  (for-each (lambda (f) (walk f in-lock? emit)) forms))
+
+;; binding lists: walk the INITS, not the names. (let ((jolt-invoke 1)) …) binds a
+;; local; it is not a call, and a scan that counted it would be answered with an
+;; allowlist entry rather than a fix.
+(define (walk-bindings bs in-lock? emit)
+  (for-each (lambda (b) (when (and (pair? b) (pair? (cdr b)))
+                          (walk (cadr b) in-lock? emit)))
+            bs))
+
+(define (walk-let d in-lock? emit)
+  (let* ((named? (and (pair? (cdr d)) (symbol? (cadr d))))
+         (bs (if named? (caddr d) (cadr d)))
+         (body (if named? (cdddr d) (cddr d))))
+    (when (list? bs) (walk-bindings bs in-lock? emit))
+    (walk-forms body in-lock? emit)))
+
+(define (walk-lambda-body d in-lock? emit)
+  ;; (lambda formals body …) — formals are names, never calls
+  (walk-forms (cddr d) in-lock? emit))
+
+(define (walk-case-lambda d in-lock? emit)
+  (for-each (lambda (cl) (when (pair? cl) (walk-forms (cdr cl) in-lock? emit)))
+            (cdr d)))
+
+(define (walk-define d in-lock? emit)
+  ;; (define (name . formals) body …) or (define name expr)
+  (if (pair? (cadr d))
+      (walk-forms (cddr d) in-lock? emit)
+      (walk-forms (cddr d) in-lock? emit)))
+
+(define (walk-case d in-lock? emit)
+  ;; (case key ((datum …) expr …) … (else expr …)) — the datum lists are DATA
+  (walk (cadr d) in-lock? emit)
+  (for-each (lambda (cl) (when (pair? cl) (walk-forms (cdr cl) in-lock? emit)))
+            (cddr d)))
+
+(define (walk-do d in-lock? emit)
+  (for-each (lambda (b)
+              (when (and (pair? b) (pair? (cdr b)))
+                (walk (cadr b) in-lock? emit)
+                (when (pair? (cddr b)) (walk (caddr b) in-lock? emit))))
+            (cadr d))
+  (when (pair? (cddr d))
+    (walk-forms (caddr d) in-lock? emit)
+    (walk-forms (cdddr d) in-lock? emit)))
+
+(define (walk x in-lock? emit)
+  (cond
+    ((symbol? x) (emit x in-lock? #f))   ; a value position: (apply jolt-invoke …)
+    ((not (pair? x)) (void))
+    ((not (list? x))                     ; improper: (a . b) — walk both halves
+     (walk (car x) in-lock? emit)
+     (walk (cdr x) in-lock? emit))
+    (else
+     (let ((head (car x)))
+       (case head
+         ((quote) (void))                ; data, not code
+         ((let let* letrec letrec* let-values let*-values) (walk-let x in-lock? emit))
+         ((lambda) (walk-lambda-body x in-lock? emit))
+         ((case-lambda) (walk-case-lambda x in-lock? emit))
+         ((define define-syntax) (walk-define x in-lock? emit))
+         ((case) (walk-case x in-lock? emit))
+         ((do) (walk-do x in-lock? emit))
+         (else
+          (cond
+            ;; THE REGION. (jolt-with-mutex mu body …): the mutex expression is
+            ;; evaluated before the lock is taken, the body under it.
+            ((eq? head lock-form)
+             (when (pair? (cdr x)) (walk (cadr x) in-lock? emit))
+             (when (pair? (cdr x)) (walk-forms (cddr x) #t emit)))
+            (else
+             (if (symbol? head)
+                 (emit head in-lock? #t)
+                 ;; the head may itself be a form: ((f x) y)
+                 (walk head in-lock? emit))
+             (walk-forms (cdr x) in-lock? emit)))))))))
+
+;; ---------------------------------------------------------------------------
+;; per-file collection
+;; ---------------------------------------------------------------------------
+;; A "unit" is one top-level definition: (file name calls locked-calls locked-any).
+;; calls is every operator-position symbol in the body (the call graph edge set),
+;; locked-calls the operator-position subset inside a jolt-with-mutex, and
+;; locked-any every symbol inside one in any position. Top-level forms that are not
+;; definitions are collected under the name |toplevel| so a lock region at file
+;; scope is still read.
+
+(define (unit-file u) (car u))
+(define (unit-name u) (cadr u))
+(define (unit-calls u) (caddr u))
+(define (unit-locked u) (cadddr u))
+(define (unit-locked-any u) (car (cddddr u)))
+
+(define (definition-name d)
+  (and (pair? d) (eq? 'define (car d)) (pair? (cdr d))
+       (if (pair? (cadr d)) (car (cadr d)) (cadr d))))
+
+(define (collect-unit file name forms)
+  (let ((calls '()) (locked '()) (locked-any '()))
+    (walk-forms forms #f
+      (lambda (sym in-lock? operator?)
+        (when operator? (set! calls (cons sym calls)))
+        (when (and in-lock? operator?) (set! locked (cons sym locked)))
+        (when in-lock? (set! locked-any (cons sym locked-any)))))
+    (list file name calls locked locked-any)))
+
+(define (collect-file file)
+  (let loop ((ds (read-datums file)) (acc '()))
+    (cond
+      ((null? ds) (reverse acc))
+      (else
+       (let* ((d (car ds))
+              (nm (definition-name d)))
+         (loop (cdr ds)
+               (cons (if nm
+                         (collect-unit file nm (cddr d))
+                         (collect-unit file '|toplevel| (list d)))
+                     acc)))))))
+
+;; ---------------------------------------------------------------------------
+;; the closure: which host definitions can park
+;; ---------------------------------------------------------------------------
+;; Seeded with the switch points and jolt-invoke, then grown to a fixpoint: a
+;; definition parks if it calls anything that parks. This is what sees a park one
+;; call away from a lock region, which is the shape a lexical scan misses and the
+;; shape jolt-04ee actually had.
+;;
+;; Deliberately name-based and therefore over-approximate in one direction: two
+;; definitions with one name in different files are one node. The runtime has no
+;; such pair (the host is one flat namespace, so it could not), and erring towards
+;; "parks" is the safe direction for a check whose false answers should be
+;; false ALARMS, not false silence.
+
+(define (build-parkers units)
+  (let ((parks (make-eq-hashtable)))
+    (for-each (lambda (s) (hashtable-set! parks s #t)) park-seeds)
+    (let grow ()
+      (let ((changed #f))
+        (for-each
+          (lambda (u)
+            (unless (hashtable-ref parks (unit-name u) #f)
+              (when (let loop ((cs (unit-calls u)))
+                      (cond ((null? cs) #f)
+                            ((hashtable-ref parks (car cs) #f) #t)
+                            (else (loop (cdr cs)))))
+                (hashtable-set! parks (unit-name u) #t)
+                (set! changed #t))))
+          units)
+        (when changed (grow))))
+    parks))
+
+;; ---------------------------------------------------------------------------
+;; findings
+;; ---------------------------------------------------------------------------
+;; (file definition kind callee count), sorted, one line each.
+
+(define (tally syms keep?)
+  (let ((t (make-eq-hashtable)))
+    (for-each (lambda (s) (when (keep? s) (hashtable-set! t s (+ 1 (hashtable-ref t s 0)))))
+              syms)
+    t))
+
+(define (tally->findings file name kind t)
+  (map (lambda (c) (list file name kind c (hashtable-ref t c 0)))
+       (sort-list (vector->list (hashtable-keys t))
+                  (lambda (a b) (string<? (symbol->string a) (symbol->string b))))))
+
+(define (findings units parks)
+  (sort-list
+    (let loop ((us units) (out '()))
+      (if (null? us)
+          out
+          (let ((u (car us)))
+            (loop (cdr us)
+                  (append
+                    (tally->findings (unit-file u) (unit-name u) 'park
+                      (tally (unit-locked u) (lambda (s) (hashtable-ref parks s #f))))
+                    (tally->findings (unit-file u) (unit-name u) 'user-code
+                      (tally (unit-locked-any u) (lambda (s) (memq s user-code-calls))))
+                    out)))))
+    (lambda (a b) (string<? (finding->line a) (finding->line b)))))
+
+(define (finding->line f)
+  (string-append (car f) " " (symbol->string (cadr f)) " " (symbol->string (caddr f))
+                 " " (symbol->string (cadddr f)) " "
+                 (number->string (car (cddddr f)))))
+
+;; ---------------------------------------------------------------------------
+;; the teeth check: the switch points must still call the assertion
+;; ---------------------------------------------------------------------------
+
+(define (missing-assertions units)
+  (let loop ((sps switch-points) (missing '()))
+    (cond
+      ((null? sps) (reverse missing))
+      (else
+       (let* ((sp (car sps))
+              (defs (let f ((us units) (acc '()))
+                      (cond ((null? us) acc)
+                            ((eq? (unit-name (car us)) sp) (cons (car us) acc))
+                            (else (f (cdr us) acc))))))
+         (loop (cdr sps)
+               (cond
+                 ((null? defs) (cons (cons sp "not defined anywhere") missing))
+                 ((let g ((ds defs))
+                    (cond ((null? ds) #f)
+                          ((memq assertion (unit-calls (car ds))) #t)
+                          (else (g (cdr ds)))))
+                  missing)
+                 (else (cons (cons sp "does not call the assertion") missing)))))))))
+
+;; ---------------------------------------------------------------------------
+;; allowlist
+;; ---------------------------------------------------------------------------
+
+(define (allowlist-lines)
+  (if (file-exists? allowlist-file)
+      (let ((p (open-input-file allowlist-file)))
+        (let loop ((acc '()))
+          (let ((l (get-line p)))
+            (cond
+              ((eof-object? l) (close-port p) (reverse acc))
+              ((or (string=? l "")
+                   (and (> (string-length l) 0) (char=? #\# (string-ref l 0))))
+               (loop acc))
+              (else (loop (cons l acc)))))))
+      '()))
+
+(define (write-allowlist! lines)
+  (let ((p (open-output-file allowlist-file 'truncate)))
+    (for-each (lambda (l) (put-string p l) (put-string p "\n"))
+      (list "# host/chez/park-lock-allowlist.txt — generated. Regenerate with:"
+            "#   sh host/chez/park-lock-check.sh --regen"
+            "# Lines: <file> <definition> <kind> <callee> <count>, for a call made from"
+            "# inside a jolt-with-mutex region. kind `park` is a callee that can reach"
+            "# one of the runtime's park primitives; kind `user-code` is a call into code"
+            "# the lock did not write. A count that DROPS is stale and fails the gate, so"
+            "# fixing a site must update this file. Empty is the goal and the current"
+            "# state: no fiber leaves the CPU while its carrier holds a counted lock."))
+    (for-each (lambda (l) (put-string p l) (put-string p "\n")) lines)
+    (close-port p)))
+
+;; ---------------------------------------------------------------------------
+;; main
+;; ---------------------------------------------------------------------------
+
+;; A line is "<file> <definition> <kind> <callee> <count>". The KEY is everything
+;; but the count, so a site keeps its identity while its count moves.
+(define (last-space l)
+  (let loop ((i (- (string-length l) 1)))
+    (cond ((< i 0) #f)
+          ((char=? #\space (string-ref l i)) i)
+          (else (loop (- i 1))))))
+
+(define (line-key l)
+  (let ((i (last-space l))) (if i (substring l 0 i) l)))
+
+(define (line-count l)
+  (let ((i (last-space l)))
+    (if i (or (string->number (substring l (+ i 1) (string-length l))) 0) 0)))
+
+;; "…/loader.ss ldr-begin-load! park ldr-wait-for-load! 1" -> the kind field
+(define (line-kind l)
+  (let loop ((i 0) (spaces 0) (start 0))
+    (cond
+      ((>= i (string-length l)) "")
+      ((char=? #\space (string-ref l i))
+       (cond ((= spaces 2) (substring l start i))
+             (else (loop (+ i 1) (+ spaces 1) (+ i 1)))))
+      (else (loop (+ i 1) spaces start)))))
+
+(define (fix-hint l)
+  (if (string=? "user-code" (line-kind l))
+      (string-append " — this region hands control to code the lock did not write,"
+                     " which may park; move the call out of the region")
+      (string-append " — commit under the lock and switch outside it"
+                     " (jolt-lock-wait, host/chez/locks.ss)")))
+
+(define (find-line key lines)
+  (let loop ((ls lines))
+    (cond ((null? ls) #f)
+          ((string=? key (line-key (car ls))) (car ls))
+          (else (loop (cdr ls))))))
+
+(define (main args)
+  (let* ((files (find-files))
+         (units (let loop ((fs files) (acc '()) (errs '()))
+                  (if (null? fs)
+                      (cons acc (reverse errs))
+                      (guard (e (#t (loop (cdr fs) acc
+                                          (cons (car fs) errs))))
+                        (loop (cdr fs) (append (collect-file (car fs)) acc) errs)))))
+         (bad-reads (cdr units))
+         (units (car units)))
+    ;; A file that will not read is a HOLE, not something to skip past.
+    (unless (null? bad-reads)
+      (for-each (lambda (f) (printf "  UNREADABLE: ~a\n" f)) bad-reads)
+      (printf "park/lock check: FAILED\n")
+      (exit 1))
+    (let* ((parks (build-parkers units))
+           (got (map finding->line (findings units parks)))
+           (missing (missing-assertions units)))
+      (cond
+        ((and (pair? args) (string=? (car args) "--regen"))
+         (write-allowlist! got)
+         (printf "park/lock check: regenerated ~a entries\n" (length got))
+         (exit 0))
+        (else
+         (let ((want (allowlist-lines)) (problems '()))
+           (define (add! s) (set! problems (cons s problems)))
+           ;; the teeth first: without the runtime half this check is a lint
+           (for-each
+             (lambda (m)
+               (add! (string-append "  SWITCH POINT UNGUARDED: " (symbol->string (car m))
+                                    " " (cdr m) " — the runtime half of the rule is"
+                                    " gone (host/chez/locks.ss)")))
+             missing)
+           (for-each
+             (lambda (g)
+               (let ((w (find-line (line-key g) want)))
+                 (cond
+                   ((not w)
+                    (add! (string-append "  NEW site: " g (fix-hint g))))
+                   ((> (line-count g) (line-count w))
+                    (add! (string-append "  MORE of them: " g " (was "
+                                         (number->string (line-count w)) ")"
+                                         (fix-hint g)))))))
+             got)
+           (for-each
+             (lambda (w)
+               (let ((g (find-line (line-key w) got)))
+                 (when (< (if g (line-count g) 0) (line-count w))
+                   (add! (string-append "  STALE allowlist entry: " w " -> "
+                                        (number->string (if g (line-count g) 0))
+                                        " — rerun with --regen")))))
+             want)
+           (cond
+             ((pair? problems)
+              (for-each (lambda (p) (printf "~a\n" p)) (reverse problems))
+              (printf "park/lock check: FAILED\n")
+              (exit 1))
+             (else
+              (printf "park/lock check: passed (~a files, ~a definitions, ~a can park, ~a allowlisted sites, target is 0)\n"
+                      (length files) (length units)
+                      (vector-length (hashtable-keys parks)) (length got))
+              (exit 0)))))))))
+
+(main (cdr (command-line)))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -535,6 +535,24 @@ else
   fails=$((fails + 1))
 fi
 
+# The same shape one lock over: a namespace whose load PARKS, required at once by
+# fibers spread across eight carriers and by a thread (jolt-04ee). Here for the same
+# reason as the case above — a regression used to wedge the process, so the cap is
+# the report — and at eight carriers for the same reason too, since the hazard needs
+# several of them rewinding parked waiters at once. concurrent-require.clj covers the
+# parked load in depth but pins ONE carrier, which is the configuration where this
+# cannot happen. Now that the rule is checked at the switch, a regression fails this
+# deterministically (16 of 17 askers, verified by reverting the loader) rather than
+# on some fraction of runs.
+rc_out="$($jolt run test/chez/require-contention.clj 2>&1)"
+if printf '%s' "$rc_out" | grep -q 'REQUIRE-CONTENTION OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a parked load contended by fibers on many carriers and a thread"
+  echo "    $(printf '%s' "$rc_out" | tail -1)"
+  fails=$((fails + 1))
+fi
+
 # One paren too many must FAIL the file, not truncate it. The loader read forms
 # with the non-top-level reader, which parks on a stray `)` rather than raising,
 # and the loop read a parked position as end of input: everything after the paren

--- a/test/chez/fibers-lock-test.ss
+++ b/test/chez/fibers-lock-test.ss
@@ -748,6 +748,156 @@
 
 (jolt-fiber-pool-reset!)
 
+;; --- 10. the rule the four sections above are instances of (jolt-h9nq) ---------
+;; Everything above fixes one lock at a time. This section is the rule itself:
+;;
+;;   a fiber never leaves the CPU while its carrier holds a counted lock.
+;;
+;; It used to have an exception for a voluntary park, licensed by a precondition
+;; about every OTHER user of the mutex on the same carrier — which no site can check
+;; and no reviewer can see. Three bugs arrived through it (jolt-3a87 the monitor,
+;; jolt-dfuo again, jolt-04ee the loader). What the exception was for is waiting on
+;; state a lock guards, and that never needed one: commit under the lock, switch
+;; outside it, retake the decision. jolt-lock-wait is that, and 10d/10e are it
+;; working for both kinds of contender.
+;;
+;; WHY THIS IS ASSERTED AS A RAISE. The failure it replaces is a process that stops
+;; dead with no error and no output on some fraction of runs. So the check is not
+;; "the wedge no longer happens" (unobservable, and how jolt-04ee sat unreproduced);
+;; it is that the violation is REPORTED, at the park, naming the rule.
+(jolt-fiber-carrier-count-set! 1)
+(jolt-fiber-preempt-ticks-set! #f)
+
+;; 10a. the check itself, on this thread, where the count is readable.
+(define (string-contains? s sub)
+  (let ((ls (string-length s)) (lb (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> (+ i lb) ls) #f)
+            ((string=? (substring s i (+ i lb)) sub) #t)
+            (else (loop (+ i 1)))))))
+(define (raises-lock-rule? thunk)
+  (guard (e (#t (let ((m (guard (_ (#t "")) (condition-message e))))
+                  (and (string? m) (string-contains? m "cannot leave the CPU")))))
+    (thunk)
+    #f))
+(define l10-mu (make-mutex))
+(ok "10a. the assertion passes when no lock is held"
+    (not (raises-lock-rule? (lambda () (jolt-locks-assert-none! 'test)))))
+(ok "10a. and raises while one is"
+    (jolt-with-mutex l10-mu
+      (raises-lock-rule? (lambda () (jolt-locks-assert-none! 'test)))))
+(ok "10a. the region still released it" (mutex-acquire l10-mu #f))
+(mutex-release l10-mu)
+(ok "10a. and left nothing counted on this thread" (= 0 (jolt-locks-held)))
+
+;; 10b. the shape itself: a fiber parking inside a counted region. This is the
+;; pre-fix loader and the pre-fix monitor, reduced to the two lines they had in
+;; common. It must raise rather than wedge, and the carrier must be usable
+;; afterwards — the raise unwinds through the region, so the mutex is released and
+;; the count given back, and 10c is that stated as behaviour rather than inferred.
+(define l10-mu2 (make-mutex))
+(define l10-ch (ac-make 1 'fixed #f))
+(define l10-bad
+  (sa-fiber-spawn
+   (lambda ()
+     (jolt-with-mutex l10-mu2
+       (jolt-fiber-<! l10-ch)))))
+(jolt-fiber-ensure-carrier!)
+(define l10-died
+  (wait-until (lambda () (memq (jolt-fiber-state l10-bad) '(done dead))) 5.0
+              "10b. a fiber parking inside a counted lock ended"))
+(ok "10b. a fiber parking inside a counted lock does not wedge" l10-died)
+(ok "10b. it died rather than completing" (eq? 'dead (jolt-fiber-state l10-bad)))
+(ok "10b. and the error names the rule"
+    (and (condition? (jolt-fiber-error l10-bad))
+         (raises-lock-rule? (lambda () (raise (jolt-fiber-error l10-bad))))))
+(ok "10b. the mutex it parked inside is free" (mutex-acquire l10-mu2 #f))
+(mutex-release l10-mu2)
+
+;; 10c. the carrier recovered. A stale lock count would leave EVERY later fiber on
+;; this carrier unable to park (and unpreemptible), so a fiber that parks and is
+;; resumed normally afterwards is the check that the failure was contained.
+(define l10-ch2 (ac-make 1 'fixed #f))
+(define l10-after
+  (sa-fiber-spawn (lambda () (jolt-fiber-<! l10-ch2))))
+(sleep (make-time 'time-duration 50000000 0))
+(jolt-async-give l10-ch2 'ok)
+(define l10-recovered
+  (wait-until (lambda () (eq? 'done (jolt-fiber-state l10-after))) 5.0
+              "10c. the carrier still runs fibers afterwards"))
+(ok "10c. the carrier still parks and resumes fibers afterwards" l10-recovered)
+
+;; 10d. jolt-lock-wait from a FIBER: the sanctioned way to do what 10b cannot.
+;; Asserted on the three properties the hand-rolled copies each got wrong somewhere:
+;; the decision is retaken (decide runs more than once), the lock is FREE while the
+;; fiber is parked (this is the property whose absence deadlocks the carrier), and
+;; the answer comes back from the retake.
+(define l10-wmu (make-mutex))
+(define l10-ready (box #f))
+(define l10-runs (box 0))
+(define l10-waiter (box #f))
+(define l10-free-while-parked (box 'unset))
+(define l10-lw
+  (sa-fiber-spawn
+   (lambda ()
+     (jolt-lock-wait l10-wmu
+       (lambda ()
+         (set-box! l10-runs (+ 1 (unbox l10-runs)))
+         (cond
+           ((unbox l10-ready) 'got-it)
+           (else (set-box! l10-waiter (jolt-current-fiber))
+                 (jolt-fiber-state-set! (jolt-current-fiber) 'parked)
+                 jolt-lock-parked)))))))
+(jolt-fiber-ensure-carrier!)
+(wait-until (lambda () (eq? 'parked (jolt-fiber-state l10-lw))) 5.0
+            "10d. the fiber committed to its park")
+;; the whole point: another context can take the mutex while the waiter is parked
+(set-box! l10-free-while-parked (and (mutex-acquire l10-wmu #f) #t))
+(when (eq? #t (unbox l10-free-while-parked))
+  (set-box! l10-ready #t)
+  (mutex-release l10-wmu))
+(sa-fiber-resume (unbox l10-waiter))
+(define l10-lw-done
+  (wait-until (lambda () (eq? 'done (jolt-fiber-state l10-lw))) 5.0
+              "10d. the resumed fiber retook the decision"))
+(ok "10d. jolt-lock-wait releases the lock while the fiber is parked"
+    (eq? #t (unbox l10-free-while-parked)))
+(ok "10d. the resumed fiber came back and finished" l10-lw-done)
+(ok "10d. it retook the whole decision rather than resuming into it"
+    (>= (unbox l10-runs) 2))
+(ok "10d. and returned the decision" (eq? 'got-it (jolt-fiber-result l10-lw)))
+
+;; 10e. jolt-lock-wait from a THREAD, which must never reach the sentinel: it waits
+;; on a condition variable inside decide, loops there, and answers a real value. One
+;; function, both contenders, and the difference is one branch.
+(define l10-tmu (make-mutex))
+(define l10-tcv (make-condition))
+(define l10-tstate (box #f))
+(define l10-tanswer (box 'unset))
+(define l10-tparked (box #f))
+(define l10-t
+  (fork-thread
+   (lambda ()
+     (set-box! l10-tanswer
+       (jolt-lock-wait l10-tmu
+         (lambda ()
+           (let loop ()
+             (cond
+               ((unbox l10-tstate) 'thread-got-it)
+               (else (set-box! l10-tparked #t)
+                     (condition-wait l10-tcv l10-tmu)
+                     (loop))))))))))
+(wait-until (lambda () (unbox l10-tparked)) 5.0 "10e. the thread reached its wait")
+(jolt-with-mutex l10-tmu
+  (set-box! l10-tstate #t)
+  (condition-broadcast l10-tcv))
+(thread-join l10-t)
+(ok "10e. a thread through the same primitive answers without parking"
+    (eq? 'thread-got-it (unbox l10-tanswer)))
+(ok "10e. and left nothing counted on this thread" (= 0 (jolt-locks-held)))
+
+(jolt-fiber-pool-reset!)
+
 (printf "\nfibers-lock-test: ~a checks, ~a failure(s)\n" total fails)
 (if (= fails 0)
     (begin (printf "fibers-lock-test: PASS — monitors across a fiber switch\n") (exit 0))

--- a/test/chez/require-contention.clj
+++ b/test/chez/require-contention.clj
@@ -1,0 +1,99 @@
+;; test/chez/require-contention.clj — one namespace whose load PARKS, required at
+;; once by many fibers across many carriers and by a real thread (jolt-04ee). Run
+;; through jolt; wired into host/chez/smoke.sh, which caps every case.
+;;
+;; WHY THIS EXISTS, and why concurrent-require.clj was not already it.
+;; concurrent-require.clj covers the parked load thoroughly (its properties H and I)
+;; but pins the pool to ONE carrier, because what it is testing there is that two
+;; fibers sharing a thread id do not read each other's claim. One carrier is the
+;; configuration in which this file's hazard cannot happen: ldr-begin-load! used to
+;; park a waiting fiber INSIDE the (jolt-with-mutex ldr-load-mu) region, and the
+;; damage that does is a blocking re-acquire of that mutex attached to the fiber's
+;; resume — which runs from Chez's rewind, on the carrier thread, at the interrupt
+;; depth the fiber parked at, where the carrier can do nothing else until it
+;; succeeds. Several carriers rewinding parked waiters at the same time is what makes
+;; that reachable. The object monitor's version of the same shape wedged 8 runs in 12
+;; at 8 carriers and 0 in 12 at 2 (jolt-dfuo), so the count is the teeth.
+;;
+;; WHAT IT ASSERTS. The load runs exactly once however many contexts asked for it
+;; (the target counts its own loads with defonce + swap!), every asker returns, and
+;; every asker sees the form AFTER the park — a namespace that is marked loaded but
+;; half-built is the failure the load protocol exists to prevent, and it is silent.
+;;
+;; HOW IT FAILS NOW, which is the part worth having. Since the rule became a rule
+;; (host/chez/locks.ss: a fiber never leaves the CPU while its carrier holds a
+;; counted lock, checked at both switch points), a regression to the old shape does
+;; not need the window at all: the first fiber that waits for a parked load raises,
+;; the go block reports it, and this case fails deterministically instead of wedging
+;; 1 run in 12. Verified in that direction by reverting the loader.
+(require '[clojure.core.async :as a])
+
+(alter-var-root #'clojure.core.async/*fiber-carrier-count* (constantly 8))
+
+(def askers 16)
+(def tmp-root (str "/tmp/jolt-reqcont-" (System/currentTimeMillis)))
+
+;; The target parks at top level: the channel is fed by a real thread after a delay,
+;; so the take cannot complete inline and the load is genuinely suspended half-run.
+;; `after` is the last form, so an asker that returned early is visible. The delay is
+;; long enough that every asker is waiting before the load can finish.
+(def target-src
+  (str "(ns reqcont.target (:require [clojure.core.async :as a]))\n"
+       "(defonce loads (atom 0))\n"
+       "(swap! loads inc)\n"
+       "(def ch (a/chan 1))\n"
+       "(a/thread (Thread/sleep 300) (a/>!! ch :fed))\n"
+       "(def got (a/<!! ch))\n"
+       "(def after :ran)\n"))
+
+(defn- write-source! []
+  (let [dir (str tmp-root "/reqcont")]
+    (.mkdirs (java.io.File. dir))
+    (spit (str dir "/target.clj") target-src)))
+
+(defn- clean-up! []
+  (doseq [p [(str tmp-root "/reqcont/target.clj") (str tmp-root "/reqcont") tmp-root]]
+    (try (.delete (java.io.File. p)) (catch Throwable _ nil))))
+
+(write-source!)
+(jolt.host/set-source-roots! (vec (cons tmp-root (jolt.host/source-roots))))
+
+;; Whole? is asked AFTER require returns, which is the caller's view: the namespace
+;; must be complete by then, not merely claimed.
+(defn- ask []
+  (try (require 'reqcont.target)
+       (if (resolve 'reqcont.target/after) :whole :half)
+       (catch Throwable e (str (.getMessage e)))))
+
+;; Fibers across all 8 carriers, plus one real thread, all released together. The
+;; fibers are spawned in one go so the round-robin spreads them; the thread is there
+;; because a thread waits on the condition variable while the fibers park, and both
+;; kinds of waiter have to be woken by the same release.
+(def gate (a/chan))
+(def fibers
+  (binding [a/*go-backend* :fiber]
+    (doall (for [_ (range askers)]
+             (a/go (a/<! gate) (ask))))))
+(def thread-asker (a/thread (ask)))
+
+(Thread/sleep 50)
+(a/close! gate)                          ; every fiber wakes at once
+
+(let [results (conj (mapv a/<!! fibers) (a/<!! thread-asker))
+      loads (deref @(resolve 'reqcont.target/loads))
+      bad (remove #{:whole} results)]
+  (clean-up!)
+  (cond
+    (seq bad)
+    (do (println "REQUIRE-CONTENTION FAILED" (count bad) "of" (count results)
+                 "askers did not get a whole namespace:" (pr-str (vec (distinct bad))))
+        (System/exit 1))
+
+    (not= 1 loads)
+    (do (println "REQUIRE-CONTENTION FAILED the target's top level ran" loads
+                 "times, expected 1")
+        (System/exit 1))
+
+    :else
+    (do (println "REQUIRE-CONTENTION OK" (count results) "askers, 8 carriers, 1 load")
+        (System/exit 0))))


### PR DESCRIPTION
The deadlock fixed in 0.7.4 had a sibling one lock over, in the loader, and both were instances of a rule this runtime stated in two contradictory ways. This fixes the sibling and removes the contradiction.

## The rule, and why it kept being broken

`jolt-fiber-preempt-handler` refuses to switch a fiber while `jolt-locks-held > 0`, because an OS mutex has thread granularity and a fiber is not a thread: if the switch unwinds, the lock is released mid-section, and if it does not, the next fiber on the same carrier acquires it successfully anyway, since Chez mutexes are recursive per thread. `locks.ss` then granted voluntary parks an exception, licensed by dynamic-wind releasing the lock on the way out and re-acquiring it on the resume.

What that reading leaves out is where the re-acquire runs. It runs from Chez's rewind, on the carrier thread, at the interrupt depth the fiber parked at, where the carrier can do nothing else until it succeeds and nothing can make it give up. So a park does not release a lock and retake it; it attaches a blocking acquire to a point inside the scheduler, and the wait edge that creates belongs to every fiber on that carrier rather than to the one that parked. The precondition that makes it safe is non-local to match: no fiber on the carrier may be holding the lock while this one is off the CPU. A parking site cannot check that and a reviewer cannot see it, because it is a claim about every other user of the lock that shares the carrier.

Three bugs came through that gap. jolt-3a87 and jolt-dfuo were the object monitor, and the second wedged `make test` for ninety minutes. jolt-04ee was the loader, filed after #586 and still unreproduced, because it needs concurrent requires of one namespace from several fibers and threads at once.

## What this does instead

Deletes the exception. One rule for both kinds of switch:

> a fiber never leaves the CPU while its carrier holds a counted lock.

Enforced in two places, because the two are complete in different directions and neither is enough alone.

At the switch, `jolt-locks-assert-none!` raises. This is sound and complete for parks that actually happen: it does not care whether the park is lexically inside the region, one call away, or inside user code the lock never wrote. What it replaces is a process that stops dead on some fraction of runs and needs a sampling profiler to diagnose, so raising and losing the fiber is not a close trade. It costs one virtual-register read against a 136 ns switch, measured inside the run-to-run spread on `bench/fibers`, and is always on, because a check that is off in the build people ship is not a check.

Over the whole runtime, `make parkcheck` reads every host `.ss` file as data, builds the call graph, closes "can park" over it from the two switch points, and fails on a call to anything in that closure from inside a `jolt-with-mutex` region. This is the half that does not need the window, which is the whole reason jolt-04ee could sit filed and unreproduced. It is AST-level and transitive on purpose: a lexical scan for park primitives inside lock regions finds **nothing** in the pre-fix loader, because the park was one call past the region. It also fails if a switch point stops calling the assertion, so the two halves cannot be removed independently. The allowlist is empty and the target is zero.

The check reports a second kind of finding, `user-code`: `jolt-invoke` named directly in a lock region, which is the jolt-3a87 / jolt-232k / jolt-pb2s family. That one is deliberately lexical and not closed over the call graph. Closing it was tried and reported 27 sites across nine files, and the long chains are not false, they are unactionable: `swap!` under the atom lock reaches `jolt=` reaches a record's user-defined equality. Named directly in the region it is a decision somebody made at that spot.

## The primitive

Waiting for state a lock guards is what the exception existed for, and it never needed one: commit under the lock, switch outside it, retake the decision. Five sites needed that protocol and four had written it out by hand, which is four chances to write a fifth. It is now `jolt-lock-wait`, and the object monitor and the loader both route through it. A thread does not go a different way: it waits on a condition variable inside the same decision procedure, loops there, and answers a real value, so the entire difference between the two contenders is one branch. The park in `jolt-lock-wait` is lexically outside its own lock region, which is what the static check reads, so every caller inherits a shape the check can see through.

The channel waiters and the IO poller keep their own inlined version. They already satisfy the rule, they sit on the hot path, and the cheap park cannot use the same switch; the runtime assertion covers them, and every fiber gate exercises them.

## Two bugs fixed

The loader's own park (jolt-04ee), and `restart-agent`, which ran the agent's validator under the agent's bookkeeping mutex. A validator is user code and may park. It moves to the agent's object monitor, which is what `synchronized` actually is on the JVM, so two concurrent restarts still serialize and which of the two errors a healthy agent with an invalid value reports is unchanged. Validating before taking anything would have reversed that ordering, and re-checking under a re-taken mutex would have let two restarts through.

## Verification

Every direction mutation-tested, since a gate nobody has seen fail is a gate nobody has tested.

- Reverting the loader fails `concurrent-require` **deterministically on one carrier**, where the wedge it used to risk needed several. The bug that was never reproduced is now caught by an existing test on every run.
- Reverting the monitor fails `monitor-contention` **6 runs of 6** and reports rather than wedging, where the wedge was 8 in 12 at eight carriers and 0 in 12 at two.
- Removing the assertion from a switch point fails `make parkcheck` by name.
- `make parkcheck` names both reverted sites, including the loader's transitive one.

New gate case `test/chez/require-contention.clj`: a namespace whose load parks, required at once by sixteen fibers across eight carriers and by a thread, asserting one load and a whole namespace for every asker. Eight carriers for the same reason `monitor-contention.clj` pins eight, and in the capped smoke suite for the same reason too, since the failure it guards used to be a wedge. `fibers-lock-test` grows a section for the rule itself, including that the carrier recovers: a stale lock count would leave every later fiber on it unable to park, so a normal park and resume afterwards is the check that the failure was contained.

`make test` green, 64 ci targets.

## Deliberately not in scope

A fiber that calls a runtime primitive which waits on a condition variable blocks its **carrier**, so every other fiber on that carrier stalls, and on one carrier it deadlocks outright. Reproduced while sweeping for this change: fiber A does `(deref a-promise)`, fiber B on the same carrier delivers it, and neither finishes. The sites are `jolt-future-deref`, `jolt-promise-deref`, `jolt-agent-await`, the tap queue, and the waits in io-streams and process.

That is a different bug from this one. This is a fiber leaving the CPU with a lock held, which loses exclusion or wedges on the resume; that is a fiber never leaving the CPU at all and starving its siblings. Fixing it means making each blocking primitive fiber-aware, one at a time, which is what JEP 444 had to do for the JDK, and the cheap alternative of raising on a fiber's `condition-wait` would break programs that work today. Filed as jolt-x1no with the reproducer rather than folded in here.
