### PR TITLE
A fiber must never block its carrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@ one form, and it is checked instead of documented.
   object monitor, which is what `synchronized` is on the JVM, so two concurrent
   restarts still serialize and the error a healthy agent reports is unchanged.
 
+- **Blocking from a `go` block on the fiber backend no longer stops the other
+  fibers sharing its carrier, and no longer deadlocks.** `@a-promise`, `@a-future`
+  and their timed forms, `await` on an agent, `.join` on a thread,
+  `CountDownLatch.await`, `.get` and `.awaitTermination` on an executor, reading a
+  piped stream, and waiting on a subprocess all waited by blocking the carrier
+  thread. A carrier runs many fibers and a fiber cannot move to another one, so
+  such a wait also stopped every fiber placed behind it — including, frequently,
+  the one that would have ended the wait. Two fibers on one carrier, one deref'ing
+  a promise the other delivers, hung forever. With more carriers the same code
+  merely stalled, which is harder to see and no more correct.
+
+  Each of those waits now parks the fiber and is resumed by whatever ends the
+  wait; a real thread still blocks, which is what a thread should do. Timed waits
+  park with a deadline registered against the runtime's one timer thread. The
+  loader and `locking` were already doing this, which is why they were not
+  affected, and that is now the only way the runtime knows how to wait: a bare
+  `condition-wait` outside the file that defines the two is a build failure.
+  (jolt-x1no)
+
+  One related case is deliberately unchanged: `Thread/sleep` in a `go` block still
+  occupies its carrier for the duration, matching what it does in a JVM
+  `core.async` go block. It cannot deadlock, since it always makes progress, and
+  jolt has a gate asserting that behaviour on purpose.
+
 ### Changed
 
 - **A fiber can no longer leave the CPU while its carrier holds one of the

--- a/host/chez/fibers.ss
+++ b/host/chez/fibers.ss
@@ -1248,7 +1248,7 @@
     (cond
       ((jolt-carrier-stop? c) (jolt-unlock! (jolt-carrier-mu c)) (void))
       ((jolt-carrier-head c) (jolt-unlock! (jolt-carrier-mu c)) (loop))
-      (else (condition-wait (jolt-carrier-cv c) (jolt-carrier-mu c))
+      (else (jolt-condition-wait (jolt-carrier-cv c) (jolt-carrier-mu c))
             (jolt-unlock! (jolt-carrier-mu c))
             (loop)))))
 

--- a/host/chez/java/async.ss
+++ b/host/chez/java/async.ss
@@ -302,7 +302,7 @@
                     (let ((r (ac-xrf-apply ch v)))
                       (when (jolt-reduced? r) (ac-close! ch))
                       #t))
-                   (else (condition-wait (async-chan-cv ch) (async-chan-mu ch)) (loop))))
+                   (else (jolt-condition-wait (async-chan-cv ch) (async-chan-mu ch)) (loop))))
            ;; Unbuffered with xform: apply immediately (output goes to rendezvous queue)
            (let ((r (ac-xrf-apply ch v)))
              (when (jolt-reduced? r) (ac-close! ch))
@@ -322,14 +322,14 @@
                  (cond ((async-chan-closed? ch) #f)
                        ((< (ac-qlen ch) (async-chan-cap ch))
                         (ac-qpush! ch (cons v #f)) (ac-notify! ch) #t)
-                       (else (condition-wait (async-chan-cv ch) (async-chan-mu ch)) (loop))))
+                       (else (jolt-condition-wait (async-chan-cv ch) (async-chan-mu ch)) (loop))))
                (let ((box (vector #f)))                        ; unbuffered: rendezvous
                  (ac-qpush! ch (cons v box))
                  (ac-notify! ch)
                   (let loop ()
                    (if (vector-ref box 0)
                        #t
-                       (begin (condition-wait (async-chan-cv ch) (async-chan-mu ch)) (loop))))))))))))
+                       (begin (jolt-condition-wait (async-chan-cv ch) (async-chan-mu ch)) (loop))))))))))))
 
 ;; remove + return the head value, waking a parked rendezvous putter.
 (define (ac-take-head! ch)
@@ -378,7 +378,7 @@
 ;; unbuffered channel can see that a taker is ready.
 (define (ac-take-wait ch)
   (async-chan-takew-set! ch (fx+ 1 (async-chan-takew ch)))
-  (condition-wait (async-chan-cv ch) (async-chan-mu ch))
+  (jolt-condition-wait (async-chan-cv ch) (async-chan-mu ch))
   (async-chan-takew-set! ch (fx- (async-chan-takew ch) 1)))
 
 ;; non-blocking take for alts!/poll!: a value, jolt-nil (closed+empty), or ac-poll-empty.
@@ -452,13 +452,27 @@
 (define (jolt-async-poll! ch)
   (let ((r (ac-poll! ch))) (if (eq? r ac-poll-empty) cca-none r)))
 
-;; --- shared timeout timer ---------------------------------------------------
-;; ONE timer thread serves all (timeout ms) calls — no per-call OS thread.
-;; Pending timeouts are kept as a sorted list of (deadline-ms . channel) by
-;; ascending deadline. The timer closes every channel whose deadline has passed,
-;; then waits for the nearest remaining one; an insert that becomes the HEAD
-;; signals timeout-cv, because that is exactly when the deadline it is waiting
-;; for changed.
+;; --- the shared timer -------------------------------------------------------
+;; ONE timer thread serves every deadline in the runtime — no per-call OS thread.
+;; Pending entries are kept as a sorted list of (deadline-ms . thunk) by ascending
+;; deadline. The timer runs every thunk whose deadline has passed, then waits for
+;; the nearest remaining one; an insert that becomes the HEAD signals timeout-cv,
+;; because that is exactly when the deadline it is waiting for changed.
+;;
+;; A THUNK AND NOT A CHANNEL. (timeout ms) is one caller and closes a channel;
+;; the other is a fiber in a timed wait on a condition variable, which needs
+;; waking at the deadline (jolt-cv-wait, host/chez/locks.ss). Nothing about a
+;; deadline is specific to channels, and a second timer thread for the second
+;; kind of deadline would be a second thing to get wrong — this one already had
+;; two bugs of its own (jolt-pe84).
+;;
+;; THE THUNKS RUN OUTSIDE timeout-mu. They used to run under it, which was
+;; survivable while the only thunk was a channel close, and is not survivable in
+;; general: a thunk that takes a lock while the timer holds timeout-mu puts
+;; timeout-mu above that lock in the order, and any code that registers a deadline
+;; while holding it closes a cycle. Collecting the due entries under the lock and
+;; running them after it is released means the timer holds nothing while calling
+;; out, so registering a deadline from inside any critical section stays safe.
 ;;
 ;; THE WAIT IS A TIMED condition-wait HELD UNDER timeout-mu, AND THE THREAD IS
 ;; FORKED ONCE. Both were otherwise, and each was a bug (jolt-pe84):
@@ -478,14 +492,14 @@
 ;;     once true never stops being true.
 (define timeout-mu (make-mutex))
 (define timeout-cv (make-condition))
-(define timeout-pending '())       ; ((deadline-ms . channel) ...) sorted asc
+(define timeout-pending '())       ; ((deadline-ms . thunk) ...) sorted asc
 (define timeout-running? #f)       ; the one timer thread has been forked
 
 ;; -> #t iff the new entry is the HEAD of the list, i.e. the caller must signal.
-(define (timeout-insert! deadline-ms ch)
+(define (timeout-insert! deadline-ms thunk)
   (let loop ((prev '()) (cur timeout-pending))
     (cond ((null? cur)
-           (let ((entry (cons deadline-ms ch)))
+           (let ((entry (cons deadline-ms thunk)))
              (if (null? prev)
                  (set! timeout-pending (list entry))
                  (set-cdr! prev (list entry))))
@@ -493,43 +507,62 @@
            ;; an existing entry leaves the timer's next wake correct as it is.
            (null? prev))
           ((< deadline-ms (caar cur))
-           (let ((entry (cons deadline-ms ch)))
+           (let ((entry (cons deadline-ms thunk)))
              (if (null? prev)
                  (set! timeout-pending (cons entry cur))
                  (set-cdr! prev (cons entry cur))))
            (null? prev))
           (else (loop cur (cdr cur))))))
 
+;; Everything due, removed from the list, newest deadline last. Called with
+;; timeout-mu held; answers '() after waiting when nothing is due yet, so the
+;; caller's loop is "collect, release, run, repeat".
+(define (timeout-collect-due!)
+  (let due ((acc '()))
+    (cond
+      ((and (pair? timeout-pending) (<= (caar timeout-pending) (now-millis)))
+       (let ((entry (car timeout-pending)))
+         (set! timeout-pending (cdr timeout-pending))
+         (due (cons (cdr entry) acc))))
+      ((pair? acc) (reverse acc))
+      (else
+       (if (null? timeout-pending)
+           (jolt-condition-wait timeout-cv timeout-mu)
+           (let ((wait-ms (- (caar timeout-pending) (now-millis))))
+             (when (> wait-ms 0)
+               (jolt-condition-wait timeout-cv timeout-mu (ms->duration wait-ms)))))
+       ;; Either deadline or signal, the answer is the same: come back and re-read
+       ;; the head. A spurious wake costs one empty trip.
+       '()))))
+
 (define (timeout-thread)
-  (jolt-lock! timeout-mu)
   (let loop ()
-    (let cleanup ()
-      (if (and (pair? timeout-pending) (<= (caar timeout-pending) (now-millis)))
-          (begin
-            (jolt-async-close! (cdar timeout-pending))
-            (set! timeout-pending (cdr timeout-pending))
-            (cleanup))
-          (begin
-            (if (null? timeout-pending)
-                (condition-wait timeout-cv timeout-mu)
-                (let ((wait-ms (- (caar timeout-pending) (now-millis))))
-                  (when (> wait-ms 0)
-                    (condition-wait timeout-cv timeout-mu (ms->duration wait-ms)))))
-            ;; Either deadline or signal, the answer is the same: re-read the
-            ;; head. A spurious wake costs one trip through cleanup.
-            (loop))))))
+    (let ((due (jolt-with-mutex timeout-mu (timeout-collect-due!))))
+      (for-each (lambda (fire)
+                  ;; One thunk must not be able to stop the timer for everything
+                  ;; else. A channel close cannot raise; a wake takes a lock it does
+                  ;; not own the discipline of, so this is the seam where a bug in
+                  ;; somebody else's deadline stays theirs.
+                  (guard (e (#t #f)) (fire)))
+                due)
+      (loop))))
+
+;; (jolt-timer-at! deadline-ms thunk) — run thunk on the timer thread once the
+;; epoch-millisecond deadline has passed. The one deadline facility in the runtime.
+(define (jolt-timer-at! deadline-ms thunk)
+  (jolt-lock! timeout-mu)
+  (when (timeout-insert! deadline-ms thunk)
+    (condition-signal timeout-cv))
+  (unless timeout-running?
+    (set! timeout-running? #t)
+    (fork-thread timeout-thread))
+  (jolt-unlock! timeout-mu))
 
 ;; (timeout ms) — a channel that closes after ms milliseconds.
 (define (jolt-async-timeout ms)
-  (let* ((w (ac-make 0 'unbuffered #f))
-         (dl (+ (now-millis) (exact (floor ms)))))
-    (jolt-lock! timeout-mu)
-    (when (timeout-insert! dl w)
-      (condition-signal timeout-cv))
-    (unless timeout-running?
-      (set! timeout-running? #t)
-      (fork-thread timeout-thread))
-    (jolt-unlock! timeout-mu)
+  (let ((w (ac-make 0 'unbuffered #f)))
+    (jolt-timer-at! (+ (now-millis) (exact (floor ms)))
+                    (lambda () (jolt-async-close! w)))
     w))
 
 ;; (put! ch v [cb [on-caller?]]) — async put, optional completion callback. If the
@@ -821,7 +854,7 @@
                               (let ((mb (alt-handler-mailbox h)))
                                 (let wait-loop ()
                                   (unless (vector-ref mb 0)
-                                    (condition-wait (alt-handler-wcv h) (alt-handler-wmu h))
+                                    (jolt-condition-wait (alt-handler-wcv h) (alt-handler-wmu h))
                                     (wait-loop)))))
                             (unregister!)
                             (let ((mb (alt-handler-mailbox h)))

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -23,6 +23,11 @@
          (nanos (* (remainder ms* 1000) 1000000)))
     (make-time 'time-duration nanos secs)))
 (define (ms->deadline ms) (add-duration (current-time 'time-utc) (ms->duration ms)))
+;; The same deadline as an absolute epoch millisecond count, which is the form
+;; jolt-cv-wait takes: a thread's condition-wait wants a Chez time object, but a
+;; fiber's deadline has to be comparable against the clock, and against the entries
+;; in the shared timer. One conversion, so the two cannot drift apart.
+(define (ms->deadline-millis ms) (+ (now-millis) (exact (floor ms))))
 
 ;; --- java.util.concurrent.TimeUnit ------------------------------------------
 ;; A TimeUnit is a scale, so each constant is an object carrying its name and its
@@ -101,7 +106,7 @@
              (jolt-future-ok?-set! f (car r))
              (jolt-future-payload-set! f (cdr r))
              (jolt-future-done?-set! f #t))
-           (condition-broadcast (jolt-future-cv f))))))
+           (jolt-cv-wake! (jolt-future-cv f))))))
     f))
 
 ;; Final value of a settled future (called OUTSIDE the lock): wrap a captured
@@ -117,24 +122,30 @@
                           (jolt-str-render-one cause)
                           cause))))))
 
+;; jolt-cv-wait and not a bare condition-wait, here and at every other wait in this
+;; file: @a-future from a go block used to block the fiber's CARRIER, so every other
+;; fiber on it stopped until the future settled, and if the thing that would settle
+;; it was itself a fiber on that carrier the two deadlocked (jolt-x1no). A fiber
+;; parks now and the settle resumes it; a thread still blocks, which is what a
+;; thread should do.
 (define (jolt-future-deref f)
-  (jolt-with-mutex (jolt-future-mu f)
-    (let loop ()
-      (unless (jolt-future-done? f)
-        (condition-wait (jolt-future-cv f) (jolt-future-mu f))
-        (loop))))
+  (jolt-cv-wait (jolt-future-mu f) (jolt-future-cv f) #f
+    (lambda (_timed-out?)
+      (if (jolt-future-done? f) #t jolt-cv-again)))
   (jolt-future-finish f))
 
 ;; (deref f timeout-ms timeout-val): wait up to timeout-ms; return timeout-val if
 ;; it has not settled by the absolute deadline.
 (define (jolt-future-deref-timed f ms timeout-val)
-  (let* ((deadline (ms->deadline ms))
-         (settled (jolt-with-mutex (jolt-future-mu f)
-                    (let loop ()
-                      (cond ((jolt-future-done? f) #t)
-                            ((condition-wait (jolt-future-cv f) (jolt-future-mu f) deadline)
-                             (loop))                       ; woken — recheck
-                            (else (jolt-future-done? f))))))) ; timed out: final check
+  (let ((settled (jolt-cv-wait (jolt-future-mu f) (jolt-future-cv f)
+                               (ms->deadline-millis ms)
+                   (lambda (timed-out?)
+                     ;; done? FIRST on both paths: a future that settled as the
+                     ;; deadline passed is not a timeout, which is the re-check the
+                     ;; old (else (jolt-future-done? f)) arm was there for.
+                     (cond ((jolt-future-done? f) #t)
+                           (timed-out? #f)
+                           (else jolt-cv-again))))))
     (if settled (jolt-future-finish f) timeout-val)))
 
 ;; future-cancel: the running thread can't be interrupted, but the future object
@@ -146,7 +157,7 @@
                          #f
                          (begin (jolt-future-cancelled?-set! f #t)
                                 (jolt-future-done?-set! f #t)
-                                (condition-broadcast (jolt-future-cv f))
+                                (jolt-cv-wake! (jolt-future-cv f))
                                 #t)))))
     cancelled))
 
@@ -179,27 +190,24 @@
                        #f
                        (begin (jolt-promise-value-set! p v)
                               (jolt-promise-delivered?-set! p #t)
-                              (condition-broadcast (jolt-promise-cv p))
+                              (jolt-cv-wake! (jolt-promise-cv p))
                               #t)))))
         (if won p jolt-nil))
       (jolt-throw (jolt-ex-info "deliver requires a promise" (jolt-hash-map)))))
 
 (define (jolt-promise-deref p)
-  (jolt-with-mutex (jolt-promise-mu p)
-    (let loop ()
-      (unless (jolt-promise-delivered? p)
-        (condition-wait (jolt-promise-cv p) (jolt-promise-mu p))
-        (loop))))
+  (jolt-cv-wait (jolt-promise-mu p) (jolt-promise-cv p) #f
+    (lambda (_timed-out?)
+      (if (jolt-promise-delivered? p) #t jolt-cv-again)))
   (jolt-promise-value p))
 
 (define (jolt-promise-deref-timed p ms timeout-val)
-  (let* ((deadline (ms->deadline ms))
-         (got (jolt-with-mutex (jolt-promise-mu p)
-                (let loop ()
-                  (cond ((jolt-promise-delivered? p) #t)
-                        ((condition-wait (jolt-promise-cv p) (jolt-promise-mu p) deadline)
-                         (loop))
-                        (else (jolt-promise-delivered? p)))))))
+  (let ((got (jolt-cv-wait (jolt-promise-mu p) (jolt-promise-cv p)
+                           (ms->deadline-millis ms)
+               (lambda (timed-out?)
+                 (cond ((jolt-promise-delivered? p) #t)
+                       (timed-out? #f)
+                       (else jolt-cv-again))))))
     (if got (jolt-promise-value p) timeout-val)))
 
 ;; --- agents (async, per-agent serialized dispatch) --------------------------
@@ -327,7 +335,7 @@
     (let ((act (jolt-with-mutex (jolt-agent-mu a)
                  (if (or (not (jolt-nil? (jolt-agent-err a))) (jagent-q-empty? a))
                      (begin (jolt-agent-running?-set! a #f)
-                            (condition-broadcast (jolt-agent-cv a)) #f)
+                            (jolt-cv-wake! (jolt-agent-cv a)) #f)
                      (jagent-q-pop! a)))))
       (when act
         (parameterize ((*agent-nested* (box '())))
@@ -352,7 +360,7 @@
                   (when (eq? (jolt-agent-err-mode a) 'fail)
                     (jolt-with-mutex (jolt-agent-mu a)
                       (jolt-agent-err-set! a err)
-                      (condition-broadcast (jolt-agent-cv a)))))
+                      (jolt-cv-wake! (jolt-agent-cv a)))))
                 (jolt-release-pending-sends))))   ; success: flush nested sends
         (loop)))))
 
@@ -398,19 +406,20 @@
   (jolt-throw (jolt-host-throwable "java.lang.RuntimeException"
                                    "Agent is failed, needs restart"
                                    (jolt-agent-err a))))
+;; The err check runs on every pass rather than once before the wait and once after
+;; it, which is the same two cases the retake makes one: the agent failed before we
+;; got here, or it failed while we waited (the worker halts and wakes us). Either
+;; way the JVM throws on a failed agent rather than returning normally.
 (define (jolt-agent-await . agents)
   (jolt-agent-await-check)
   (for-each
     (lambda (a)
-      (jolt-with-mutex (jolt-agent-mu a)
-        (unless (jolt-nil? (jolt-agent-err a)) (jolt-agent-failed-throw a))
-        (let loop ()
-          (when (and (jolt-nil? (jolt-agent-err a))
-                     (or (jolt-agent-running? a) (not (jagent-q-empty? a))))
-            (condition-wait (jolt-agent-cv a) (jolt-agent-mu a)) (loop)))
-        ;; the agent failed while we waited (worker halted + broadcast): the JVM
-        ;; throws on a failed agent, so re-check rather than returning normally.
-        (unless (jolt-nil? (jolt-agent-err a)) (jolt-agent-failed-throw a))))
+      (jolt-cv-wait (jolt-agent-mu a) (jolt-agent-cv a) #f
+        (lambda (_timed-out?)
+          (cond
+            ((not (jolt-nil? (jolt-agent-err a))) (jolt-agent-failed-throw a))
+            ((or (jolt-agent-running? a) (not (jagent-q-empty? a))) jolt-cv-again)
+            (else #t)))))
     agents)
   jolt-nil)
 (define (jolt-agent-await-for ms . agents)
@@ -418,26 +427,25 @@
     (jolt-throw (jolt-host-throwable "java.lang.IllegalStateException" "await-for in transaction")))
   (when (jolt-in-agent-action?)
     (jolt-throw (jolt-host-throwable "java.lang.Exception" "Can't await in agent action")))
-  (let ((deadline (ms->deadline ms)) (ok #t))
+  (let ((deadline (ms->deadline-millis ms)) (ok #t))
     (for-each
       (lambda (a)
         (when ok
-          (jolt-with-mutex (jolt-agent-mu a)
-            (unless (jolt-nil? (jolt-agent-err a)) (jolt-agent-failed-throw a))
-            (let loop ()
-              (when (and (jolt-nil? (jolt-agent-err a))
-                         (or (jolt-agent-running? a) (not (jagent-q-empty? a))))
-                (if (condition-wait (jolt-agent-cv a) (jolt-agent-mu a) deadline)
-                    (loop)
-                    ;; re-check the drain predicate on a wakeup-at-deadline race:
-                    ;; a drain that completed as the deadline hit is not a timeout
-                    (when (and (jolt-nil? (jolt-agent-err a))
-                               (or (jolt-agent-running? a) (not (jagent-q-empty? a))))
-                      (set! ok #f)))))
-            ;; failure during the wait throws (JVM parity); only a clean drain or
-            ;; a genuine timeout returns.
-            (unless (or (not ok) (jolt-nil? (jolt-agent-err a)))
-              (jolt-agent-failed-throw a)))))
+          (unless
+            (jolt-cv-wait (jolt-agent-mu a) (jolt-agent-cv a) deadline
+              (lambda (timed-out?)
+                (cond
+                  ;; DRAINED is tested before the deadline on purpose: a drain that
+                  ;; completed as the deadline hit is not a timeout. Failure during
+                  ;; the wait throws here, as it did before (JVM parity).
+                  ((not (or (jolt-agent-running? a) (not (jagent-q-empty? a))))
+                   (if (jolt-nil? (jolt-agent-err a)) #t (jolt-agent-failed-throw a)))
+                  ;; ...and a genuine timeout answers #f without throwing, even for
+                  ;; an agent that failed, which is what the old arm ordering did.
+                  (timed-out? #f)
+                  ((not (jolt-nil? (jolt-agent-err a))) (jolt-agent-failed-throw a))
+                  (else jolt-cv-again))))
+            (set! ok #f))))
       agents)
     ok))
 
@@ -553,7 +561,7 @@
            (jolt-tap-queue-out-set! tapq (cdr (jolt-tap-queue-out tapq)))
            (jolt-tap-queue-len-set! tapq (fx- (jolt-tap-queue-len tapq) 1))
            v))
-        (else (condition-wait (jolt-tap-queue-cv tapq) (jolt-tap-queue-mu tapq)) (loop))))))
+        (else (jolt-condition-wait (jolt-tap-queue-cv tapq) (jolt-tap-queue-mu tapq)) (loop))))))
 
 ;; The delivery thread starts lazily on the first add-tap/tap>, like the JVM's
 ;; `(delay (doto (Thread. …) (.start)))`.
@@ -924,7 +932,7 @@
           (jolt-fiber-state-set! f 'parked)
           jolt-lock-parked)
         (begin
-          (condition-wait (vector-ref m monitor-i-cv) (vector-ref m monitor-i-bk))
+          (jolt-condition-wait (vector-ref m monitor-i-cv) (vector-ref m monitor-i-bk))
           #f))))
 
 ;; The decision is made under bk; a fiber's SWITCH is made outside it, and then the
@@ -1290,7 +1298,7 @@
                 (let ((th (vector-ref st 0))) (when th (jolt-invoke th))))
               (jolt-with-mutex (vector-ref st 2)
                  (vector-set! st 1 #t)
-                 (condition-broadcast (vector-ref st 3)))))
+                 (jolt-cv-wake! (vector-ref st 3)))))
             jolt-nil)))
         (cons "run" (lambda (self) (let ((th (vector-ref (jhost-state self) 0))) (when th (jolt-invoke th))) jolt-nil))
         ;; join() and join(0) wait indefinitely; join(ms) waits at most ms and
@@ -1306,17 +1314,16 @@
             (when (and ms (negative? ms))
               (jolt-throw (jolt-host-throwable "java.lang.IllegalArgumentException"
                                                "timeout value is negative")))
-            (jolt-with-mutex (vector-ref st 2)
-              (if (or (not ms) (= ms 0))
-                  (let loop () (when (jthread-alive? st)
-                                 (condition-wait (vector-ref st 3) (vector-ref st 2))
-                                 (loop)))
-                  ;; An absolute deadline, so a spurious wakeup resumes waiting for
-                  ;; what is LEFT of the timeout rather than restarting it.
-                  (let ((deadline (ms->deadline ms)))
-                    (let loop () (when (jthread-alive? st)
-                                   (when (condition-wait (vector-ref st 3) (vector-ref st 2) deadline)
-                                     (loop))))))))
+            ;; An absolute deadline, so a spurious wakeup resumes waiting for what
+            ;; is LEFT of the timeout rather than restarting it. A joining FIBER
+            ;; parks: blocking its carrier would stop every other fiber on it until
+            ;; the thread it joins exits.
+            (jolt-cv-wait (vector-ref st 2) (vector-ref st 3)
+                          (and ms (not (= ms 0)) (ms->deadline-millis ms))
+              (lambda (timed-out?)
+                (cond ((not (jthread-alive? st)) #t)
+                      (timed-out? #f)
+                      (else jolt-cv-again)))))
           jolt-nil))
         (cons "isAlive" (lambda (self) (jthread-alive? (jhost-state self))))
         (cons "interrupt" (lambda (self . _) (set-box! (vector-ref (jhost-state self) 4) #t) jolt-nil))
@@ -1331,7 +1338,7 @@
           (let ((st (jhost-state self)))
             (jolt-with-mutex (vector-ref st 1)
               (when (> (vector-ref st 0) 0) (vector-set! st 0 (- (vector-ref st 0) 1)))
-              (when (= (vector-ref st 0) 0) (condition-broadcast (vector-ref st 2)))))
+              (when (= (vector-ref st 0) 0) (jolt-cv-wake! (vector-ref st 2)))))
           jolt-nil))
         ;; await() waits indefinitely and is void; await(timeout, unit) waits at most
         ;; that long and answers whether the count reached zero. The timeout used to
@@ -1340,20 +1347,16 @@
         (cons "await" (lambda (self . args)
           (let ((st (jhost-state self))
                 (ms (tu-args->ms args)))
-            (jolt-with-mutex (vector-ref st 1)
-              (if (not ms)
-                  (begin
-                    (let loop () (when (> (vector-ref st 0) 0)
-                                   (condition-wait (vector-ref st 2) (vector-ref st 1))
-                                   (loop)))
-                    jolt-nil)
-                  ;; absolute deadline, so a spurious wakeup resumes waiting for what
-                  ;; is left of the timeout rather than restarting it
-                  (let ((deadline (ms->deadline ms)))
-                    (let loop ()
-                      (cond ((<= (vector-ref st 0) 0) #t)
-                            ((condition-wait (vector-ref st 2) (vector-ref st 1) deadline) (loop))
-                            (else (<= (vector-ref st 0) 0))))))))))
+            ;; absolute deadline, so a spurious wakeup resumes waiting for what is
+            ;; left of the timeout rather than restarting it
+            (let ((reached (jolt-cv-wait (vector-ref st 1) (vector-ref st 2)
+                                         (and ms (ms->deadline-millis ms))
+                             (lambda (timed-out?)
+                               (cond ((<= (vector-ref st 0) 0) #t)
+                                     (timed-out? #f)
+                                     (else jolt-cv-again))))))
+              ;; await() is void; await(timeout, unit) answers whether it reached zero
+              (if ms reached jolt-nil)))))
          (cons "getCount" (lambda (self) (vector-ref (jhost-state self) 0)))))
 
 ;; --- java.util.concurrent.ExecutorService / Executors ----------------------
@@ -1370,7 +1373,7 @@
       (jolt-with-mutex (vector-ref st 3)
         (unless (vector-ref st 2) (vector-set! st 1 r))
         (vector-set! st 0 #t)
-        (condition-broadcast (vector-ref st 4))))))
+        (jolt-cv-wake! (vector-ref st 4))))))
 (register-host-methods! "j-future"
   ;; get() waits for the task; get(timeout, unit) gives up at the deadline and throws
   ;; TimeoutException, like the JVM. The timeout used to be discarded, so the bounded
@@ -1378,18 +1381,12 @@
   (list (cons "get" (lambda (self . args)
           (let* ((st (jhost-state self))
                  (ms (tu-args->ms args))
-                 (done (jolt-with-mutex (vector-ref st 3)
-                         (if (not ms)
-                             (begin
-                               (let loop () (unless (vector-ref st 0)
-                                              (condition-wait (vector-ref st 4) (vector-ref st 3))
-                                              (loop)))
-                               #t)
-                             (let ((deadline (ms->deadline ms)))
-                               (let loop ()
-                                 (cond ((vector-ref st 0) #t)
-                                       ((condition-wait (vector-ref st 4) (vector-ref st 3) deadline) (loop))
-                                       (else (vector-ref st 0)))))))))
+                 (done (jolt-cv-wait (vector-ref st 3) (vector-ref st 4)
+                                     (and ms (ms->deadline-millis ms))
+                         (lambda (timed-out?)
+                           (cond ((vector-ref st 0) #t)
+                                 (timed-out? #f)
+                                 (else jolt-cv-again))))))
             (cond ((not done)
                    (jolt-throw (jolt-host-throwable "java.util.concurrent.TimeoutException"
                                                     "timed out waiting for the task")))
@@ -1424,12 +1421,12 @@
                                         (set-car! q (cdr out))
                                         (car out)))
                                      ((vector-ref st 0) #f)   ; shutdown + empty -> exit
-                                     (else (condition-wait (vector-ref st 3) (vector-ref st 2)) (poll))))))))
+                                     (else (jolt-condition-wait (vector-ref st 3) (vector-ref st 2)) (poll))))))))
                 (if job
                     (begin (job) (loop))
                     (jolt-with-mutex (vector-ref st 2)
                       (vector-set! st 4 (fx- (vector-ref st 4) 1))
-                      (condition-broadcast (vector-ref st 3))))))))
+                      (jolt-cv-wake! (vector-ref st 3))))))))
           (spawn (- k 1))))
       self)))
 (define (executor-enqueue! self job)
@@ -1437,7 +1434,7 @@
     (jolt-with-mutex (vector-ref st 2)
       (let ((q (unbox (vector-ref st 1))))
         (set-cdr! q (cons job (cdr q))))
-      (condition-broadcast (vector-ref st 3)))))
+      (jolt-cv-wake! (vector-ref st 3)))))
 (let ((single (lambda _ (make-executor 1)))
       (fixed  (lambda (n . _) (make-executor (max 1 (jnum->exact n)))))
       ;; per-task / cached / virtual: enough workers to not serialize; a generous
@@ -1464,11 +1461,11 @@
                 (jolt-invoke thunk)))))
           jolt-nil))
         (cons "shutdown" (lambda (self) (let ((st (jhost-state self)))
-          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (condition-broadcast (vector-ref st 3)))) jolt-nil))
+          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) jolt-nil))
         (cons "shutdownNow" (lambda (self) (let ((st (jhost-state self)))
-          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (condition-broadcast (vector-ref st 3)))) (jolt-vector)))
+          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) (jolt-vector)))
         (cons "close" (lambda (self) (let ((st (jhost-state self)))
-          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (condition-broadcast (vector-ref st 3)))) jolt-nil))
+          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) jolt-nil))
         (cons "isShutdown" (lambda (self) (vector-ref (jhost-state self) 0)))
         (cons "isTerminated" (lambda (self) (let* ((st (jhost-state self)) (q (unbox (vector-ref st 1))))
           (and (vector-ref st 0) (null? (car q)) (null? (cdr q)) (fx=? 0 (vector-ref st 4))))))
@@ -1478,18 +1475,18 @@
         (cons "awaitTermination" (lambda (self ms . rest)
           (let* ((st (jhost-state self))
                  (deadline (+ (now-millis) (tu->ms ms (if (null? rest) #f (car rest))))))
-            ;; check under the mutex, but SLEEP OUTSIDE it — a worker's exit
-            ;; decrement needs this mutex, so sleeping while holding it starves
-            ;; the very transition awaited (the wait always rode to deadline).
-            (let waiting ()
-              (let ((done (jolt-with-mutex (vector-ref st 2)
-                            (and (vector-ref st 0) (fx=? 0 (vector-ref st 4))))))
-                (cond (done #t)
-                      ((> (now-millis) deadline) #f)
-                      (else
-                       (let ((remaining (- deadline (now-millis))))
-                         (sleep (ms->duration (max 10 (min remaining 100))))
-                         (waiting)))))))))))
+            ;; A WAIT AND NOT A POLL. This used to check under the mutex and sleep
+            ;; outside it in 10-100ms steps, because sleeping while HOLDING the mutex
+            ;; starves the worker exit it waits for. A condition wait releases the
+            ;; mutex atomically with blocking, so it needs neither the poll nor the
+            ;; care: the workers already broadcast this condition as each one exits,
+            ;; and shutdown broadcasts it too. It also stops a fiber calling this from
+            ;; sleeping its carrier in 100ms chunks.
+            (jolt-cv-wait (vector-ref st 2) (vector-ref st 3) deadline
+              (lambda (timed-out?)
+                (cond ((and (vector-ref st 0) (fx=? 0 (vector-ref st 4))) #t)
+                      (timed-out? #f)
+                      (else jolt-cv-again)))))))))
 
 ;; java.util.concurrent.locks.ReentrantLock — a reentrant mutual-exclusion lock.
 ;; State: #(monitor), one MONITOR record of its own (make-monitor above), not the
@@ -1635,11 +1632,12 @@
         (if (not job)
             (jolt-invoke thunk)         ; no pump (or stopped) — inline, like -M:run
             (begin
-              (jolt-with-mutex (jolt-main-job-mu job)
-                (let wait ()
-                  (unless (jolt-main-job-done? job)
-                    (condition-wait (jolt-main-job-cv job) (jolt-main-job-mu job))
-                    (wait))))
+              ;; A fiber parks here: the pump is another thread, but blocking the
+              ;; carrier would stop every other fiber on it for as long as the main
+              ;; thread takes to run the job.
+              (jolt-cv-wait (jolt-main-job-mu job) (jolt-main-job-cv job) #f
+                (lambda (_timed-out?)
+                  (if (jolt-main-job-done? job) #t jolt-cv-again)))
               (if (jolt-main-job-ok? job)
                   (jolt-main-job-val job)
                   (raise (jolt-main-job-val job))))))))
@@ -1722,7 +1720,7 @@
                   (jolt-main-job-ok?-set! job (car r))
                   (jolt-main-job-val-set! job (cdr r))
                   (jolt-main-job-done?-set! job #t)
-                  (condition-broadcast (jolt-main-job-cv job))))
+                  (jolt-cv-wake! (jolt-main-job-cv job))))
               ;; idle: sleep — an interrupt-checked syscall — so a pending ^C fires.
               (sleep (ms->duration jolt-park-poll-ms)))
           (loop))))
@@ -1754,7 +1752,7 @@
                           ;; critical section so no job can be enqueued after.
                           (set-box! jolt-main-pump-active #f)
                           #f)
-                         (else (condition-wait jolt-main-queue-cv jolt-main-queue-mu)
+                         (else (jolt-condition-wait jolt-main-queue-cv jolt-main-queue-mu)
                                (wait)))))))
           (when job
             (let ((r (dynamic-wind
@@ -1767,7 +1765,7 @@
                 (jolt-main-job-ok?-set! job (car r))
                 (jolt-main-job-val-set! job (cdr r))
                 (jolt-main-job-done?-set! job #t)
-                (condition-broadcast (jolt-main-job-cv job))))
+                (jolt-cv-wake! (jolt-main-job-cv job))))
             (loop)))))
     (lambda ()
       (jolt-with-mutex jolt-main-queue-mu (set-box! jolt-main-pump-active #f))))

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -548,15 +548,16 @@
     (let ((chunk (make-bytevector count)))
       (bytevector-copy! bv start chunk 0 count)
       (jpipe-chunks-set! p (append (jpipe-chunks p) (list chunk)))
-      (condition-broadcast (jpipe-cv p))))
+      (jolt-cv-wake! (jpipe-cv p))))
   count)
 
-;; Blocks while the pipe is empty and the writer is still open. condition-wait
-;; releases the mutex and deactivates the thread, so a writer can run and the
-;; collector is not held up by a parked reader.
+;; Waits while the pipe is empty and the writer is still open. A THREAD blocks,
+;; which releases the mutex so a writer can run; a FIBER parks, because blocking
+;; its carrier would stop every other fiber on it until the writer wrote — and if
+;; the writer is a fiber on that same carrier, forever (jolt-x1no).
 (define (pipe-read! p bv start count)
-  (jolt-with-mutex (jpipe-mu p)
-    (let loop ()
+  (jolt-cv-wait (jpipe-mu p) (jpipe-cv p) #f
+    (lambda (_timed-out?)
       (cond
         ((jpipe-rclosed? p) (pipe-io-throw "Pipe closed"))
         ((pair? (jpipe-chunks p))
@@ -569,16 +570,16 @@
                (jpipe-pos-set! p (+ (jpipe-pos p) n)))
            n))
         ((jpipe-wclosed? p) 0)                      ; writer done: end of stream
-        (else (condition-wait (jpipe-cv p) (jpipe-mu p)) (loop))))))
+        (else jolt-cv-again)))))
 
 (define (pipe-close-write! p)
   (jolt-with-mutex (jpipe-mu p)
     (jpipe-wclosed?-set! p #t)
-    (condition-broadcast (jpipe-cv p))))
+    (jolt-cv-wake! (jpipe-cv p))))
 (define (pipe-close-read! p)
   (jolt-with-mutex (jpipe-mu p)
     (jpipe-rclosed?-set! p #t)
-    (condition-broadcast (jpipe-cv p))))
+    (jolt-cv-wake! (jpipe-cv p))))
 
 ;; The shared pipe behind a stream, or #f when it is an ordinary file/array stream.
 (define (piped-cell x)

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -304,12 +304,15 @@
         (guard (e (#t #f))
           (let loop () (when (proc-copy-chunk src dst) (loop))))
         (when close-dst? (guard (e (#t #f)) (close-port dst)))
-        (jolt-with-mutex m (set-box! done #t) (condition-broadcast c))))
+        (jolt-with-mutex m (set-box! done #t) (jolt-cv-wake! c))))
     (vector m c done)))
+;; A fiber waiting for a subprocess's output collector PARKS. Blocking the carrier
+;; would stop every other fiber on it for the life of the subprocess, which is
+;; exactly the kind of wait a go block is the natural place for (jolt-x1no).
 (define (proc-latch-wait latch)
-  (jolt-with-mutex (vector-ref latch 0)
-    (let loop () (unless (unbox (vector-ref latch 2))
-                   (condition-wait (vector-ref latch 1) (vector-ref latch 0)) (loop)))))
+  (jolt-cv-wait (vector-ref latch 0) (vector-ref latch 1) #f
+    (lambda (_timed-out?)
+      (if (unbox (vector-ref latch 2)) #t jolt-cv-again))))
 
 ;; --- fd-level spawn (the primary path) ---------------------------------------
 ;; A child fd that gets no file action IS the parent's descriptor — tty answers

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -1308,7 +1308,7 @@
                           (cons f (hashtable-ref ldr-fiber-waiters name '())))
           (jolt-fiber-state-set! f 'parked)
           jolt-lock-parked)
-        (begin (condition-wait ldr-load-cv ldr-load-mu) #f))))
+        (begin (jolt-condition-wait ldr-load-cv ldr-load-mu) #f))))
 
 ;; Call with ldr-load-mu HELD. Would `me` waiting on `name` (owned by `owner`) close
 ;; a cycle? Follow owner -> what it waits on -> who owns that -> …; if the chain

--- a/host/chez/lock-check.sh
+++ b/host/chez/lock-check.sh
@@ -14,7 +14,17 @@
 # one tightened quantum at a time. So the obligation is checked here rather than
 # documented and hoped for.
 #
-# The scan covers the three mutex PRIMITIVES and nothing else. It used to also
+# condition-wait is scanned for the SAME reason one lock over (jolt-x1no). It
+# blocks the calling thread, and on a carrier that is every fiber placed on it,
+# so a fiber reaching one stops siblings it cannot see — and if the thing that
+# would end the wait is one of them, forever. The runtime has two waits now:
+# jolt-condition-wait, which refuses on a fiber, and jolt-cv-wait, which parks a
+# fiber and blocks a thread. Both live in locks.ss, so a bare condition-wait
+# anywhere else is a site that has not chosen, which is how twelve of them came
+# to block: each one was correct for the threads it was written for and nobody
+# revisited them when fibers arrived.
+#
+# The scan covers the mutex PRIMITIVES and condition-wait, and nothing else. It used to also
 # scan monitor-enter!/monitor-exit! by name, because jolt-with-monitor is the
 # user-facing `locking` and therefore jolt's analogue of the `synchronized` case
 # that pinned Loom's virtual threads until JEP 491. Those two now take their
@@ -48,16 +58,28 @@ SANCTIONED='host/chez/locks.ss'
 # space or a close paren, which is the spelling every site happens to use, so the
 # hole only opened for someone wrapping a long lock expression. That is exactly
 # the quiet kind: the gate would have gone on reporting zero.
-PRIMS='(mutex-acquire|mutex-release|with-mutex)'
+PRIMS='(mutex-acquire|mutex-release|with-mutex|condition-wait)'
+
+# COMMENTS ARE NOT CODE, and this gate reads text rather than data, so it has to
+# say so. Everything from the first `;` on a line is dropped before matching, with
+# line numbers preserved so a hit still reports its own line. Without it the header
+# of any file that DISCUSSES one of these primitives becomes a finding — which
+# condition-wait made immediate, since the rule about it is written out in prose in
+# three files. The residual hole is a `;` inside a string literal ahead of a real
+# call on the same line, which would hide that call; there is no such line, and the
+# alternative is reading Scheme as data, which is what host/chez/park-lock-check.ss
+# does for the check that needs structure.
+strip_comments() { sed 's/;.*//' "$1"; }
 
 scan() {
   for f in host/chez/*.ss host/chez/java/*.ss; do
     case " $SANCTIONED " in *" $f "*) continue ;; esac
-    grep -nE "\\($PRIMS([^a-zA-Z0-9!?*<>=/-]|\$)" "$f" 2>/dev/null \
+    strip_comments "$f" \
+      | grep -nE "\\($PRIMS([^a-zA-Z0-9!?*<>=/-]|\$)" 2>/dev/null \
       | while IFS=: read -r ln _; do
           # the matched fragment is "(<prim><delimiter>"; the second grep pulls
           # the name back out of it, whatever the delimiter turned out to be
-          op=$(sed -n "${ln}p" "$f" \
+          op=$(strip_comments "$f" | sed -n "${ln}p" \
                  | grep -oE "\\($PRIMS([^a-zA-Z0-9!?*<>=/-]|\$)" | head -1 \
                  | grep -oE "$PRIMS" | head -1)
           [ -n "$op" ] && echo "$f $op"

--- a/host/chez/locks.ss
+++ b/host/chez/locks.ss
@@ -233,3 +233,148 @@
           (begin (jolt-fiber-to-scheduler! (jolt-current-fiber))
                  (retake))
           r))))
+
+;; --- blocking, and who is allowed to do it ----------------------------------
+;; The rule above is about a fiber that leaves the CPU while holding a lock. This
+;; is its mirror image, and it was a bug of its own (jolt-x1no):
+;;
+;;   a fiber must never block its carrier.
+;;
+;; condition-wait blocks the THREAD. On a carrier that is every fiber placed on it,
+;; and a fiber cannot migrate away, so the wait also blocks whatever the carrier
+;; would have run — including, often enough, the very thing that would have ended
+;; the wait. Measured on one carrier: fiber A does (deref a-promise), fiber B
+;; delivers it, and neither ever finishes. With more carriers the same code is a
+;; stall rather than a deadlock, which is worse to diagnose, not better.
+;;
+;; So the runtime has two waits, and they are not interchangeable:
+;;
+;;   jolt-condition-wait   for a THREAD. Refuses on a fiber, by name, instead of
+;;                         quietly taking its carrier away.
+;;   jolt-cv-wait          for either. A thread blocks; a fiber parks and is
+;;                         resumed by the wake.
+;;
+;; The loader and the object monitor already chose per waiter by hand, which is why
+;; those two were not affected. Everything else in the runtime blocked
+;; unconditionally: promise and future deref, agent await, Thread.join,
+;; CountDownLatch.await, a task Future's get, a piped stream read, and waiting on a
+;; subprocess. All of those are reachable from a go block on the fiber backend.
+(define (jolt-blocking-refuse who)
+  (error who
+    (string-append
+     "a fiber cannot block its carrier on a condition variable: it would stop every"
+     " other fiber placed on that carrier, including whatever would have ended this"
+     " wait. Use jolt-cv-wait (host/chez/locks.ss), which parks a fiber and blocks"
+     " a thread.")))
+
+;; Chez's condition-wait for the paths that are only ever reached by a real thread —
+;; a carrier's own idle wait, the timer thread, an executor worker, the thread arm
+;; inside a jolt-cv-wait or jolt-lock-wait decision. The check is what makes "only
+;; ever reached by a thread" a fact rather than an intention: every one of these was
+;; documented as thread-only, and the four that were wrong about it were found by
+;; asking rather than by reading.
+(define jolt-condition-wait
+  (case-lambda
+    ((cv mu)
+     (when (jolt-current-fiber) (jolt-blocking-refuse 'jolt-condition-wait))
+     (condition-wait cv mu))
+    ((cv mu abs-time)
+     (when (jolt-current-fiber) (jolt-blocking-refuse 'jolt-condition-wait))
+     (condition-wait cv mu abs-time))))
+
+;; --- waiting for a condition, from a thread OR a fiber ----------------------
+;; (jolt-cv-wait mu cv deadline decide) -> whatever decide returns
+;;
+;; decide runs with mu HELD and is passed one argument, whether the deadline has
+;; passed. It answers jolt-cv-again to wait for a change, or any other value to
+;; finish. deadline is epoch milliseconds, or #f for an unbounded wait.
+;;
+;; This is jolt-lock-wait with the two waiter kinds filled in, so it inherits the
+;; properties that primitive exists for: the switch happens with mu released, the
+;; registration and the 'parked commit happen under the mu the waker must take so
+;; no wakeup is lost, and the decision is RETAKEN rather than resumed into — which
+;; is what makes a spurious wake harmless and is why decide must be re-runnable.
+;;
+;; WHERE THE PARKED FIBERS LIVE. In a table keyed by the condition variable, not in
+;; a field on each waitable, because the waitables are a future record, a promise
+;; record, an agent record, four different jhost vectors, a pipe and a process
+;; latch. Keying on the condition they already have means none of those shapes
+;; change. The table's own mutex is a leaf — taken around one hashtable operation
+;; with nothing inside it — so it cannot be part of a cycle, the same argument
+;; object-monitor's table lock rests on.
+;;
+;; THE DEADLINE IS THE CLOCK, NOT A FLAG, and that is what closes the race a timed
+;; park would otherwise have. A fiber has nothing to wake it at the deadline, so one
+;; is registered with the shared timer (java/async.ss) to poke this condition. If
+;; that poke lands before the fiber parks, there is nothing to resume — which would
+;; be a fiber parked forever if "timed out" were a flag the timer set. It is not:
+;; decide reads the clock, and the timer fires at the deadline, so any decide that
+;; runs after the timer has fired already sees the deadline as passed and does not
+;; park at all. The poke is only ever a wakeup, never information.
+;;
+;; A thread needs no such registration — its condition-wait takes the deadline
+;; directly — so it does not pay for one.
+(define jolt-cv-again (list 'jolt-cv-again))
+
+(define jolt-cv-waiters (make-weak-eq-hashtable))   ; condition -> parked fibers
+(define jolt-cv-waiters-mu (make-mutex))
+
+(define (jolt-cv-register! cv f)
+  (jolt-with-mutex jolt-cv-waiters-mu
+    (hashtable-set! jolt-cv-waiters cv
+                    (cons f (hashtable-ref jolt-cv-waiters cv '())))))
+
+;; Drained as it is read, so a fiber that goes on to wait again registers itself
+;; afresh and no resume is ever delivered twice.
+(define (jolt-cv-take-waiters! cv)
+  (jolt-with-mutex jolt-cv-waiters-mu
+    (let ((fs (hashtable-ref jolt-cv-waiters cv '())))
+      (unless (null? fs) (hashtable-delete! jolt-cv-waiters cv))
+      fs)))
+
+;; (jolt-cv-wake! cv) — call with mu HELD, after changing the state decide reads.
+;; The replacement for a bare condition-broadcast on any condition a fiber can wait
+;; on: it wakes both kinds of waiter, and a waker that forgets the fiber half would
+;; leave them parked with nothing to resume them.
+;;
+;; Broadcast and not signal, for the reason the loader gives: waiters re-check a
+;; condition that may be true for only one of them, so exactly one of them getting
+;; the wake is not something the waker can decide.
+;;
+;; Resuming while mu is held is deliberate and safe. sa-fiber-resume only enqueues,
+;; on the resumed fiber's own carrier, taking that carrier's run-queue mutex, which
+;; is last in the order. The resumed fiber's retake will block on mu for as long as
+;; this critical section lasts — and no longer, because a lock in this runtime can
+;; no longer be held across a park at all, so every holder of mu is running and
+;; releases in bounded time.
+(define (jolt-cv-wake! cv)
+  (condition-broadcast cv)
+  (let ((fs (jolt-cv-take-waiters! cv)))
+    (unless (null? fs) (for-each sa-fiber-resume fs))))
+
+;; Absolute epoch millis -> the absolute time object Chez's condition-wait wants.
+(define (jolt-millis->time ms)
+  (make-time 'time-utc (* 1000000 (mod ms 1000)) (div ms 1000)))
+
+(define (jolt-cv-wait mu cv deadline decide)
+  ;; Registered OUTSIDE mu, and only for a fiber. Outside because the timer's
+  ;; thunks run with timeout-mu released but registering takes it, so doing this
+  ;; under mu would order mu above timeout-mu here and below it there.
+  (when (and deadline (jolt-current-fiber))
+    (jolt-timer-at! deadline (lambda () (jolt-with-mutex mu (jolt-cv-wake! cv)))))
+  (jolt-lock-wait mu
+    (lambda ()
+      (let loop ()
+        (let ((r (decide (and deadline (>= (now-millis) deadline)))))
+          (cond
+            ((not (eq? r jolt-cv-again)) r)
+            ((jolt-current-fiber)
+             => (lambda (f)
+                  (jolt-cv-register! cv f)
+                  (jolt-fiber-state-set! f 'parked)
+                  jolt-lock-parked))
+            (else
+             (if deadline
+                 (jolt-condition-wait cv mu (jolt-millis->time deadline))
+                 (jolt-condition-wait cv mu))
+             (loop))))))))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -535,6 +535,23 @@ else
   fails=$((fails + 1))
 fi
 
+# A fiber must never block its carrier (jolt-x1no). Twelve waits — promise and
+# future deref, Thread.join, CountDownLatch.await, a task Future's get,
+# awaitTermination, a piped stream read, agent await — each exercised by two fibers
+# on ONE carrier: a waiter and, behind it in the queue, the releaser that ends the
+# wait. If the waiter blocks instead of parking, the releaser never runs at all, so
+# every case is a hang rather than a stall. Three of them have no releaser and check
+# the other half, that a fiber parked with a DEADLINE is woken at it. Unfixed this
+# reports 12 of 12.
+fb_out="$($jolt run test/chez/fiber-blocking.clj 2>&1)"
+if printf '%s' "$fb_out" | grep -q 'FIBER-BLOCKING OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a fiber blocked its carrier on a condition variable"
+  echo "    $(printf '%s' "$fb_out" | tail -1)"
+  fails=$((fails + 1))
+fi
+
 # The same shape one lock over: a namespace whose load PARKS, required at once by
 # fibers spread across eight carriers and by a thread (jolt-04ee). Here for the same
 # reason as the case above — a regression used to wedge the process, so the cap is

--- a/test/chez/fiber-blocking.clj
+++ b/test/chez/fiber-blocking.clj
@@ -1,0 +1,136 @@
+;; test/chez/fiber-blocking.clj — a fiber must never block its carrier (jolt-x1no).
+;; Run through jolt; wired into host/chez/smoke.sh, which caps every case.
+;;
+;; WHAT WAS WRONG. Every wait in the runtime except the loader's and the object
+;; monitor's was a bare condition-wait, which blocks the THREAD. On a carrier that
+;; is every fiber placed on it, and a fiber cannot migrate away, so the wait also
+;; stopped whatever the carrier would have run next — including, often enough, the
+;; very thing that would have ended the wait. @a-promise from a go block was enough.
+;;
+;; THE SHAPE OF EVERY CASE, and why it is a deadlock rather than a slow test. The
+;; pool is pinned to ONE carrier, and each case runs two fibers on it: a WAITER,
+;; spawned first, and a RELEASER behind it in the queue. If the waiter parks, the
+;; carrier runs the releaser, the waiter is resumed and the case answers. If the
+;; waiter blocks, the releaser never runs at all and nothing can ever end the wait.
+;; So one carrier is not a way of making the bug likelier — it is what turns a
+;; stall into a hang, which is the only version of this a test can catch reliably.
+;; (With the default pool the releaser lands on another carrier and every one of
+;; these passes while still stalling every OTHER fiber on the waiter's carrier,
+;; which is the part no assertion can see.)
+;;
+;; The three TIMED cases have no releaser at all. They cover the other half of a
+;; parked wait, which is that something must wake a fiber AT its deadline: a thread
+;; hands the deadline to condition-wait, and a fiber has nothing to do that, so
+;; jolt-cv-wait registers with the shared timer. A fiber that parks with a deadline
+;; and is never woken is a hang too, and it would pass a test that only checked the
+;; untimed paths.
+(require '[clojure.core.async :as a])
+(import '[java.util.concurrent CountDownLatch Executors TimeUnit])
+
+(alter-var-root #'clojure.core.async/*fiber-carrier-count* (constantly 1))
+
+(def results (atom []))
+(def case-timeout-ms 5000)
+
+;; The waiter's answer, or :HUNG if the carrier stopped. Both fibers land on the
+;; one carrier, waiter first, so the releaser only ever runs if the waiter parked.
+(defn- probe [k waiter releaser]
+  (let [w (binding [a/*go-backend* :fiber] (a/go (waiter)))]
+    (when releaser
+      (binding [a/*go-backend* :fiber] (a/go (releaser))))
+    (let [[v port] (a/alts!! [w (a/timeout case-timeout-ms)])]
+      (swap! results conj [k (if (= port w) v :HUNG)]))))
+
+;; 1-3. promise deref: the shortest path to the bug, and the one people hit.
+(let [p (promise)]
+  (probe :promise #(deref p) #(deliver p :delivered)))
+(let [p (promise)]
+  (probe :promise-timed #(deref p 3000 :timed-out) #(deliver p :delivered)))
+(let [p (promise)]
+  (probe :promise-deadline #(deref p 150 :timed-out) nil))
+
+;; 4-5. future deref. The future's body runs on its own thread, so a blocked
+;; carrier would not stop it by itself — the body waits on a promise only the
+;; RELEASER fiber can deliver, which puts the carrier back in the cycle.
+(let [p (promise)
+      f (future (deref p))]
+  (probe :future #(deref f) #(deliver p :from-future)))
+(let [f (future (deref (promise)))]        ; never settles
+  (probe :future-deadline #(deref f 150 :timed-out) nil))
+
+;; 6. Thread.join, over a thread that cannot exit until the releaser runs.
+(let [p (promise)
+      t (Thread. (fn [] (deref p)))]
+  (.start t)
+  (probe :thread-join (fn [] (.join t) :joined) #(deliver p :go)))
+
+;; 7-8. CountDownLatch, the await/countDown pair and its bounded form.
+(let [latch (CountDownLatch. 1)]
+  (probe :latch (fn [] (.await latch) :counted) #(.countDown latch)))
+(let [latch (CountDownLatch. 1)]
+  (probe :latch-deadline
+         (fn [] (.await latch 150 TimeUnit/MILLISECONDS))
+         nil))
+
+;; 9-10. An executor task's Future, and awaitTermination — which was a sleep poll,
+;; so a fiber calling it used to sleep its carrier in 100ms slices.
+(let [p (promise)
+      ex (Executors/newSingleThreadExecutor)
+      fut (.submit ex (fn [] (deref p)))]
+  (probe :executor-get (fn [] (.get fut)) #(deliver p :from-task))
+  (.shutdown ex))
+(let [p (promise)
+      ex (Executors/newSingleThreadExecutor)]
+  (.submit ex (fn [] (deref p)))
+  (.shutdown ex)
+  (probe :executor-await
+         (fn [] (.awaitTermination ex 3 TimeUnit/SECONDS))
+         #(deliver p :from-task)))
+
+;; 11. A piped stream: the reader waits for bytes the releaser writes.
+(let [in (PipedInputStream.)
+      out (PipedOutputStream. in)]
+  (probe :piped-read
+         (fn [] (.read in))
+         (fn [] (.write out 65) (.flush out) :wrote)))
+
+;; 12. agent await, over an action that cannot finish until the releaser runs. The
+;; action is on the agent's worker thread; the await is what used to block.
+(let [p (promise)
+      ag (agent 0)]
+  (send ag (fn [s] (deref p) (inc s)))
+  (probe :agent-await (fn [] (await ag) :drained) #(deliver p :go)))
+
+(def expected
+  {:promise :delivered
+   :promise-timed :delivered
+   :promise-deadline :timed-out
+   :future :from-future
+   :future-deadline :timed-out
+   :thread-join :joined
+   :latch :counted
+   :latch-deadline false
+   :executor-get :from-task
+   :executor-await true
+   :piped-read 65
+   :agent-await :drained
+})
+
+(let [got (into {} @results)
+      bad (remove (fn [[k v]] (= v (get expected k))) (seq got))
+      missing (remove (fn [k] (contains? got k)) (keys expected))]
+  (cond
+    (seq missing)
+    (do (println "FIBER-BLOCKING FAILED cases did not run:" (pr-str (vec missing)))
+        (System/exit 1))
+
+    (seq bad)
+    (do (doseq [[k v] bad]
+          (println "FAIL:" k "->" (pr-str v) "expected" (pr-str (get expected k))
+                   (if (= :HUNG v) "(the waiter blocked its carrier)" "")))
+        (println "FIBER-BLOCKING FAILED" (count bad) "of" (count expected))
+        (System/exit 1))
+
+    :else
+    (do (println "FIBER-BLOCKING OK" (count expected) "waits give up the carrier, on 1 carrier")
+        (System/exit 0))))


### PR DESCRIPTION
Follow-up to #587, which fixed a fiber leaving the CPU with a lock held. This is the mirror image: a fiber that never leaves the CPU at all and starves its siblings. I found it sweeping for #587 and filed it as jolt-x1no rather than folding it in; this is that fix.

## The bug

Every wait in the runtime except the loader's and the object monitor's was a bare `condition-wait`, which blocks the calling **thread**. A carrier runs many fibers and a fiber cannot migrate to another carrier, so such a wait also stopped whatever the carrier would have run next, including, frequently, the very thing that would have ended the wait.

```clojure
(alter-var-root #'clojure.core.async/*fiber-carrier-count* (constantly 1))
(def p (promise))
(binding [a/*go-backend* :fiber]
  [(a/go @p)                                    ; blocks the carrier
   (a/go (Thread/sleep 50) (deliver p :v))])    ; never runs
```

Neither fiber ever finishes. With the default pool the releaser lands on another carrier and this particular shape completes, while still stalling every other fiber on the waiter's carrier for the duration, which is harder to see and no more correct.

Twelve waits were reachable from a `go` block: promise and future deref plus their timed forms, `await` and `await-for` on an agent, `Thread.join`, `CountDownLatch.await`, an executor task Future's `.get`, `.awaitTermination`, a piped stream read, and waiting on a subprocess.

## The fix

One primitive, `jolt-cv-wait`, which parks a fiber and blocks a thread. It is `jolt-lock-wait` from #587 with the two waiter kinds filled in, so it inherits that primitive's properties rather than restating them: the switch happens with the mutex released, the registration and the `'parked` commit happen under the same mutex the waker must take (so no wakeup is lost), and the decision is **retaken** rather than resumed into, which is what makes a spurious wake harmless. The wake side, `jolt-cv-wake!`, resumes parked fibers as well as broadcasting; a waker that did only half of that would leave fibers parked with nothing to resume them.

Where the parked fibers live is worth a note: in a table keyed by the condition variable, not in a field on each waitable. The waitables here are a future record, a promise record, an agent record, four different `jhost` vectors, a pipe and a process latch, and keying on the condition they already have means none of those shapes change. The table's mutex is a leaf, taken around one hashtable operation with nothing inside it, which is the same argument `object-monitor`'s table lock rests on.

**Timed waits.** A thread hands its deadline to `condition-wait`; a fiber has nothing to wake it, so one is registered with the runtime's single timer thread. That timer is generalized from "close this channel at T" to "run this thunk at T" — nothing about a deadline was ever channel-specific, and a second timer for the second kind of deadline would be a second thing to get wrong. It now also runs those thunks with `timeout-mu` **released**: holding it while calling out puts it above every lock a callback touches, and any code registering a deadline from inside a critical section would then close a cycle. It used to run the callback under the lock, which was survivable only while the callback was a channel close.

Timing out is decided by **reading the clock**, not by a flag the timer sets. That is what closes the race a timed park would otherwise have: if the poke arrives before the fiber parks there is nothing to resume, and with a flag that fiber would park forever. Reading the clock means any decision running after the timer fired already sees the deadline as passed and does not park at all, so the poke is only ever a wakeup and never information.

`awaitTermination` stops being a 10-100ms sleep poll on the way past. The workers already broadcast as each one exits, so it waits on that, which also removes the reason the poll had to sleep outside the mutex.

## Making the class closed rather than fixing twelve instances

The remaining `condition-wait`s are thread-only by construction: a carrier's own idle wait, the timer thread, an executor worker, the tap delivery thread, the main pump, and the thread arm inside a `jolt-cv-wait` decision. Those go through `jolt-condition-wait`, which **refuses on a fiber by name** rather than quietly taking its carrier away. Every one of the twelve was documented as thread-only too; the difference is that this is now checked rather than intended.

`lock-check.sh` scans bare `condition-wait` alongside the mutex primitives, allowlist at zero, so a site that has not chosen between the two waits cannot be added. Mutation-verified: reintroducing one bare wait fails the gate by name. The scan also learned to strip comments, because the rule about `condition-wait` is written out in prose in three files and this gate reads text rather than data — the first version of the change reported a header paragraph as a finding.

## Verification

`test/chez/fiber-blocking.clj`, in the capped smoke suite: all twelve waits on **one carrier**, each as a waiter fiber plus a releaser queued behind it. If the waiter blocks, the releaser never runs, so every case is a hang rather than a stall — one carrier is not a way of making the bug likelier, it is what makes it detectable at all. Three cases have no releaser and cover the deadline half, which would otherwise pass while a parked fiber was never woken.

Mutation-verified by making every wait block again (forcing the thread arm and disabling the refusal): **12 of 12 hang**. `make test` green, 64 ci targets.

## One case deliberately left alone

`Thread/sleep` in a `go` block still occupies its carrier. It is the same hazard through a different primitive, and I did convert it before backing it out: `fibers-pool-test` asserts the current behaviour on purpose ("a fiber that blocks its carrier (Thread/sleep)"), it matches what `Thread/sleep` does in a JVM `core.async` go block, and it cannot deadlock because it always makes progress. That makes it a semantics decision rather than a bug fix, so it should be yours to make, not mine to slip into a bug PR. If you want it, it is a small change now that the timer can wake a parked fiber: a sleeping fiber becomes a park with a deadline, matching Loom rather than core.async.
