### PR TITLE
A fiber must not occupy its carrier in a poll loop either

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ one form, and it is checked instead of documented.
   `condition-wait` outside the file that defines the two is a build failure.
   (jolt-x1no)
 
+  The same went for the two waits that poll rather than wait on a condition,
+  because there is nothing for them to wait on: `.waitFor` on a subprocess and the
+  stdin readiness check behind `read-line`. Both slept the carrier between probes,
+  for as long as the child ran or until input arrived. `.waitFor` was the worst
+  case in the runtime, because it also held the per-process lock for that whole
+  time, and a carrier holding one of the runtime's locks is not preemptible either
+  — so a `.waitFor` in a `go` block froze every fiber on its carrier beyond the
+  reach of even the preemption that is supposed to be the backstop. It now holds
+  that lock for one `waitpid` attempt and parks between attempts.
+
   One related case is deliberately unchanged: `Thread/sleep` in a `go` block still
   occupies its carrier for the duration, matching what it does in a JVM
   `core.async` go block. It cannot deadlock, since it always makes progress, and

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -712,8 +712,8 @@
 ;; char-ready? promises a CHAR, not a whole line, so a writer that sends half a
 ;; line and then stalls still parks the world for the remainder — a far smaller
 ;; window than "until any input arrives", and the most this port surface offers.
-(define jolt-stdin-poll-step0 500000)          ; 0.5ms, in nanoseconds
-(define jolt-stdin-poll-step-max (* 20 1000000))   ; 20ms
+(define jolt-stdin-poll-step0 1)               ; 1ms
+(define jolt-stdin-poll-step-max 20)          ; 20ms
 (define jolt-stdin-poll-port (box #f))         ; the port the answer below is about
 (define jolt-stdin-poll-ok (box #f))
 (define (jolt-stdin-wait-ready! in)
@@ -723,7 +723,10 @@
   (when (unbox jolt-stdin-poll-ok)
     (let loop ((step jolt-stdin-poll-step0))
       (unless (char-ready? in)
-        (sleep (make-time 'time-duration step 0))
+        ;; jolt-pause-ms and not (sleep): on a fiber this parks for the step and
+        ;; gives the carrier up, so (read-line) from a go block no longer stops
+        ;; every other fiber placed on that carrier until input arrives.
+        (jolt-pause-ms step)
         (loop (min jolt-stdin-poll-step-max (* step 2)))))))
 
 (def-var! "clojure.core" "__stdin-read-line"

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -614,30 +614,46 @@
 ;; proc-wait-timed already polls for exactly this reason; this is the last caller
 ;; that did not. Backs off 0.2ms -> 10ms so a short-lived child is still reaped
 ;; promptly while a long-lived one costs ~100 wakeups a second.
-(define proc-poll-step-max (* 10 1000000))       ; 10ms, in nanoseconds
+(define proc-poll-step-max 10)                   ; 10ms
+;; ONE reap attempt, under the mutex. -> the exit status, or #f meaning "ask again".
+;; The mutex is what stops two callers reaping the same child at once, and one
+;; attempt is all it has to cover: the exit-box is written under it and read under
+;; it, so a caller that loses the race sees the winner's answer on its next pass.
+(define (proc-reap-once st)
+  (jolt-with-mutex (proc-p-mutex st)
+    (or (unbox (proc-p-exit-box st))
+        (call-with-values (lambda () (proc-waitpid-once (proc-p-pid st) #t))
+          (lambda (rc decoded err)
+            (cond
+              ((and decoded (= rc (proc-p-pid st)))
+               (set-box! (proc-p-exit-box st) decoded) decoded)
+              ;; another caller reaped it between our check and our wait
+              ((unbox (proc-p-exit-box st)))
+              ;; still running (WNOHANG rc = 0), or merely interrupted: both mean
+              ;; "ask again", which is #f here and a pause in the caller.
+              ((or (= rc 0) (and (< rc 0) (= err proc-EINTR))) #f)
+              ;; unwaitable (ECHILD) or waitpid unavailable — no number of retries
+              ;; changes that.
+              (else (let ((c (proc-lost-status st)))
+                      (set-box! (proc-p-exit-box st) c) c))))))))
+
+;; THE PAUSE IS OUTSIDE THE MUTEX, and the loop is out here with it. This used to
+;; hold proc-p-mutex across the entire poll, which is for as long as the child runs.
+;; Two things were wrong with that and the second is the sharper: a counted lock held
+;; for an unbounded time makes the whole CARRIER unpreemptible, because the scheduler
+;; refuses to preempt a fiber while its carrier holds one — so a `.waitFor` from a go
+;; block froze every fiber on that carrier for the life of the subprocess, out of
+;; reach of even the preemption that is supposed to be the backstop. And the pause
+;; itself slept the carrier, so a fiber could not have parked in there anyway
+;; (jolt-x1no). Now the lock covers one waitpid attempt, and jolt-pause-ms parks a
+;; fiber between attempts while a thread sleeps.
 (define (proc-wait-blocking st)
   (let ((code
-          (jolt-with-mutex (proc-p-mutex st)
-            (or (unbox (proc-p-exit-box st))
-                (let loop ((step 200000))        ; 0.2ms
-                  (call-with-values (lambda () (proc-waitpid-once (proc-p-pid st) #t))
-                    (lambda (rc decoded err)
-                      (cond
-                        ((and decoded (= rc (proc-p-pid st)))
-                         (set-box! (proc-p-exit-box st) decoded) decoded)
-                        ;; another caller reaped it between our check and our wait
-                        ((unbox (proc-p-exit-box st)))
-                        ;; still running (WNOHANG rc = 0), or merely interrupted:
-                        ;; both mean "ask again", after a short wait.
-                        ((or (= rc 0) (and (< rc 0) (= err proc-EINTR)))
-                         (sleep (make-time 'time-duration step 0))
-                         (loop (if (< step proc-poll-step-max)
-                                   (min proc-poll-step-max (* step 2))
-                                   proc-poll-step-max)))
-                        ;; unwaitable (ECHILD) or waitpid unavailable — no number of
-                        ;; retries changes that.
-                        (else (let ((c (proc-lost-status st)))
-                                (set-box! (proc-p-exit-box st) c) c))))))))))
+          (let loop ((step 1))                   ; 1ms
+            (or (proc-reap-once st)
+                (begin
+                  (jolt-pause-ms step)
+                  (loop (min proc-poll-step-max (* step 2))))))))
     (for-each proc-latch-wait (unbox (proc-p-inherit-latches st)))
     code))
 
@@ -699,7 +715,8 @@
     (let loop ((remaining ms))
       (cond ((not (proc-alive? st)) #t)
             ((<= remaining 0) #f)
-            (else (sleep (make-time 'time-duration (* step 1000000) 0))
+            ;; a fiber parks for the step rather than sleeping its carrier
+            (else (jolt-pause-ms step)
                   (loop (- remaining step)))))))
 
 ;; --- java.lang.ProcessHandle (destroy-tree) ----------------------------------

--- a/host/chez/locks.ss
+++ b/host/chez/locks.ss
@@ -353,8 +353,39 @@
     (unless (null? fs) (for-each sa-fiber-resume fs))))
 
 ;; Absolute epoch millis -> the absolute time object Chez's condition-wait wants.
+;; Floored to an exact integer first: make-time will not take a flonum field, and a
+;; deadline arriving as one is a caller's arithmetic, not something to trust.
 (define (jolt-millis->time ms)
-  (make-time 'time-utc (* 1000000 (mod ms 1000)) (div ms 1000)))
+  (let ((ms (exact (floor ms))))
+    (make-time 'time-utc (* 1000000 (mod ms 1000)) (div ms 1000))))
+
+;; (jolt-pause-ms ms) — pause THIS execution context for ms, whatever it is: a
+;; thread sleeps, and a fiber parks until the deadline and gives its carrier up in
+;; the meantime.
+;;
+;; For the runtime's own POLL LOOPS, which wait on something no condition variable
+;; can be attached to — a waitpid, a char-ready? on stdin. A poll that sleeps stops
+;; every fiber on the carrier for each nap, and since these loops run until an
+;; external event happens, that is unbounded: a (.waitFor p) from a go block
+;; occupied its carrier for the whole life of the subprocess. ReentrantLock's
+;; bounded tryLock had the same shape and was already fixed to yield instead, for
+;; the same reason; this is that fix with the carrier actually released rather than
+;; merely handed on.
+;;
+;; NOT for Thread/sleep, which is a user-facing request to sleep a thread, matches
+;; a JVM core.async go block as it stands, and has a gate asserting it.
+;;
+;; The mutex and condition are private and fresh, so nothing else can signal them:
+;; the timer's wake is the only one, and the retake's own clock read is what decides
+;; the pause is over. That makes this a park with a deadline expressed in the one
+;; wait protocol the runtime has, rather than a second one written by hand.
+(define (jolt-pause-ms ms)
+  (if (jolt-current-fiber)
+      (let ((mu (make-mutex)) (cv (make-condition)))
+        (jolt-cv-wait mu cv (+ (now-millis) ms)
+          (lambda (timed-out?) (if timed-out? #t jolt-cv-again)))
+        (void))
+      (sleep (ms->duration ms))))
 
 (define (jolt-cv-wait mu cv deadline decide)
   ;; Registered OUTSIDE mu, and only for a fiber. Outside because the timer's

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -535,14 +535,14 @@ else
   fails=$((fails + 1))
 fi
 
-# A fiber must never block its carrier (jolt-x1no). Twelve waits — promise and
-# future deref, Thread.join, CountDownLatch.await, a task Future's get,
-# awaitTermination, a piped stream read, agent await — each exercised by two fibers
-# on ONE carrier: a waiter and, behind it in the queue, the releaser that ends the
-# wait. If the waiter blocks instead of parking, the releaser never runs at all, so
-# every case is a hang rather than a stall. Three of them have no releaser and check
-# the other half, that a fiber parked with a DEADLINE is woken at it. Unfixed this
-# reports 12 of 12.
+# A fiber must never block or occupy its carrier (jolt-x1no). Fourteen checks —
+# promise and future deref, Thread.join, CountDownLatch.await, a task Future's get,
+# awaitTermination, a piped stream read, agent await, .waitFor on a subprocess and
+# read-line — each exercised by two fibers on ONE carrier: a waiter and, behind it in
+# the queue, the releaser or sibling that only runs if the waiter gave the carrier
+# up. If the waiter keeps it, that second fiber never runs at all, so every case is a
+# hang rather than a stall. Three have no releaser and check the other half, that a
+# fiber parked with a DEADLINE is woken at it. Unfixed this reports 12 of 12.
 fb_out="$($jolt run test/chez/fiber-blocking.clj 2>&1)"
 if printf '%s' "$fb_out" | grep -q 'FIBER-BLOCKING OK'; then
   pass=$((pass + 1))

--- a/test/chez/fiber-blocking.clj
+++ b/test/chez/fiber-blocking.clj
@@ -101,6 +101,36 @@
   (send ag (fn [s] (deref p) (inc s)))
   (probe :agent-await (fn [] (await ag) :drained) #(deliver p :go)))
 
+;; 13. .waitFor on a subprocess. Not a condition-variable wait at all — there is
+;; nothing to attach one to, so it polls waitpid — but the same hazard and the worst
+;; version of it: the poll slept the carrier, unboundedly, for the whole life of the
+;; child, AND it held the per-process mutex the whole time, which makes the carrier
+;; unpreemptible too (the scheduler refuses to preempt a fiber whose carrier holds a
+;; counted lock). So this one was out of reach of even the preemption backstop.
+;;
+;; Asserted as ORDER rather than through `probe`, because there is no releaser: the
+;; sibling fiber queued behind the waiter must reach the channel FIRST, while the
+;; child is still running.
+(let [order (a/chan 4)
+      p (.start (ProcessBuilder. ["sh" "-c" "sleep 0.4"]))
+      fs (binding [a/*go-backend* :fiber]
+           [(a/go (let [c (.waitFor p)] (a/>!! order [:waited c])))
+            (a/go (a/>!! order :sibling-ran))])
+      [v port] (a/alts!! [order (a/timeout case-timeout-ms)])]
+  (swap! results conj [:waitfor-yields (if (= port order) v :HUNG)])
+  (mapv a/<!! fs))
+
+;; 14. read-line, whose stdin readiness poll had the same shape. stdin is not
+;; readable under the harness, so this checks the part that is testable here: a
+;; fiber blocked in it does not stop the sibling behind it. The reader is left
+;; parked; the case is over once the sibling has run.
+(let [order (a/chan 4)]
+  (binding [a/*go-backend* :fiber]
+    (a/go (read-line) :read)
+    (a/go (a/>!! order :sibling-ran)))
+  (let [[v port] (a/alts!! [order (a/timeout case-timeout-ms)])]
+    (swap! results conj [:read-line-yields (if (= port order) v :HUNG)])))
+
 (def expected
   {:promise :delivered
    :promise-timed :delivered
@@ -114,7 +144,8 @@
    :executor-await true
    :piped-read 65
    :agent-await :drained
-})
+   :waitfor-yields :sibling-ran
+   :read-line-yields :sibling-ran})
 
 (let [got (into {} @results)
       bad (remove (fn [[k v]] (= v (get expected k))) (seq got))


### PR DESCRIPTION
Third and last of the set (#587, #588). Those two covered a fiber leaving the CPU with a lock held, and a fiber blocking its carrier on a condition variable. This covers the two waits that **poll** instead, because there is nothing for them to wait on, and slept the carrier between probes.

## The two sites

`.waitFor` on a subprocess, and the stdin readiness check behind `read-line`. Neither is bounded by anything the caller asked for — one runs until the child exits, the other until input arrives — so on a fiber they occupied the carrier indefinitely and every other fiber placed on it stopped.

`.waitFor` was the worst case in the runtime, for a second reason on top of the first: it held the per-process mutex across the **entire** poll. A carrier holding one of the runtime's counted locks is not preemptible either, because the scheduler refuses to preempt a fiber while its carrier holds one. So a `.waitFor` from a `go` block froze every fiber on that carrier for the life of the subprocess, out of reach of even the preemption that exists as the backstop for exactly this.

It now holds the mutex for one `waitpid` attempt and pauses outside it. That is a shorter critical section for threads too: two concurrent waiters each poll instead of one queueing behind the other's entire wait, and the cached exit status is what makes that safe, as it already did for the race the old code documented in place.

## The pause

`jolt-pause-ms`: a thread sleeps, a fiber parks until the deadline and gives its carrier up. It is a park with a deadline expressed in the wait protocol #588 introduced rather than a second one written by hand — the fresh mutex and condition per pause are private, so the timer's wake is the only one that can reach them, and the retake's own clock read is what decides the pause is over.

ReentrantLock's bounded `tryLock` had this exact shape and was already fixed once to yield rather than sleep, with a comment explaining that on a fiber the sleep guaranteed the poll would run to its deadline whenever the holder was a sibling. So this is not a new judgement about polls; it is the same one, with the carrier actually released instead of handed on.

**`Thread/sleep` is deliberately not converted**, and `jolt-pause-ms` says so at its definition so the next person does not "finish the job". It is a user-facing request to sleep a thread, it matches what `Thread/sleep` does in a JVM `core.async` go block, it cannot deadlock because it always makes progress, and `fibers-pool-test` asserts the behaviour on purpose. That makes it a semantics decision rather than a bug.

## Tests

`test/chez/fiber-blocking.clj` grows two cases, to 14. Both are asserted as **order** rather than through the shared `probe` helper, because neither has a releaser: the sibling fiber queued behind the waiter must reach the channel first, while the child is still running or stdin is still empty. Mutation-verified by making the pause always sleep the carrier — the waiter comes back first instead.

## Review of the set as a whole

The user asked for a final review, so I checked the property all three changes rest on: **every condition a fiber can park on is only ever woken through `jolt-cv-wake!`**, since a waker that only broadcasts would leave parked fibers with nothing to resume them. Cross-checked the waited set against every remaining raw `condition-broadcast`/`condition-signal` in the runtime. The seven that remain are on conditions only threads ever wait on: a carrier's own idle wait, the loader's thread arm, the two channel waiter conditions, the timer, the tap queue, the monitor's thread arm, and the main pump.

Also confirmed the converse, that no fiber can reach `jolt-condition-wait` and get an error where it used to work: `<!`/`>!`/`<!!`/`>!!` and the CPS'd `__sm-take`/`__sm-put` all dispatch on "am I on a fiber?" at every entry point, and the four go-completion puts are to buffered-1 channels written exactly once, so they never wait.

`make test` green, 64 ci targets. Promise fast path measured to rule out a pathology from routing every `deref` through the new primitive: 80ns for a settled deref, 450ns for a deliver plus deref round trip.
