### PR TITLE
*in* reads through System/in, and available() answers a real count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp depssmoke depsunit \
   fnform traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck lockcheck parkcheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
+  systemstreams \
   certify gambitcheck gambitgencheck grenadinecheck fibers gosm asynctimer threadsafety
 TEST-GATES := submodules selfhost ci
 
@@ -831,6 +832,12 @@ devbootsmoke: devboot
 # check that two runtimes sharing a version string still key separately.
 aotcachesmoke: testbin
 	@sh test/chez/aot-cache-smoke.sh
+
+# System/in, System/out, System/err: the process streams and the classes the JVM
+# reports for them. Needs a real pipe on stdin, so it is a script rather than a
+# corpus row.
+systemstreams:
+	@sh test/chez/system-streams-smoke.sh
 
 # Smoke test: clojure.core/compile writes artifacts under *compile-path* and a
 # later PROCESS loads them — including with the source removed, which is the point

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ JOLT-TARGETS-NEEDING-DEPS := \
   devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform grenadine \
   gateboot gatebootsmoke gosm httpsfetch infer inline inline-body irvalidate \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
-  narrow numeric numwp oparity pic protoret printperf remint sci selfhost shakelocal \
+  narrow numeric numwp oparity pic protoret printperf remint sbperf sci selfhost shakelocal \
   traceemit \
   shakesmoke smoke staticnativesmoke stateimage test testbin transient unit unitcontext \
   threadsafety values wp ci
@@ -872,3 +872,10 @@ aotcacheperf:
 # on loaded CI. See the header of the script for how to read the numbers.
 printperf:
 	@$(CHEZ) --script test/chez/print-throughput.ss
+
+# StringBuilder.append must stay amortised O(1). Asserts a SCALING RATIO rather
+# than a wall-clock floor — 4x the appends should cost ~4x, not ~16x — so unlike
+# the probes above it is meaningful on a loaded machine. Still manual, to keep
+# the default gate free of timing. See the script header.
+sbperf:
+	@$(CHEZ) --script test/chez/string-builder-perf.ss

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -132,14 +132,13 @@
 ;; `build` — the script driver loads the build driver from the repo, the
 ;; standalone binary materializes its bundled boots/stub (build.ss itself is
 ;; already inlined there).
-;; Read all of stdin as a string (a `-` program / expression source).
+;; Read all of stdin as a string (a `-` program / expression source). Through the
+;; one port jolt opens on fd 0 (io-streams.ss), the same one System/in and
+;; read-line read: a second port on that descriptor buffers ahead on its own, and
+;; the program source would take input the program then went looking for.
 (define (jolt-read-all-stdin)
-  (let ((out (open-output-string)) (in (current-input-port)))
-    (let loop ()
-      (let ((c (read-char in)))
-        (if (eof-object? c)
-            (get-output-string out)
-            (begin (write-char c out) (loop)))))))
+  (let ((bv (get-bytevector-all (jolt-stdin-binary-port))))
+    (if (eof-object? bv) "" (utf8->string bv))))
 
 ;; Evaluate EXPR (a string of one-or-more forms) with *command-line-args* bound
 ;; to app-args. print? echoes the final value (blank for nil), as `-e` does; a

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -261,7 +261,9 @@
             "java.util.List" "java.util.Set" "java.util.Collection" "java.util.Map"
             "java.util.Iterator" "java.lang.Iterable" "java.lang.CharSequence"
             "java.lang.Appendable" "java.lang.Comparable" "java.lang.Runnable"
-            "java.util.concurrent.Callable" "java.io.Serializable"))
+            "java.util.concurrent.Callable" "java.io.Serializable"
+            "java.lang.AutoCloseable" "java.io.Closeable" "java.io.Flushable"
+            "java.lang.Readable"))
 
 ;; ---- seed the built-in graph: direct supers only, faithful to the JVM ---------
 ;; core clojure.lang interfaces
@@ -396,15 +398,28 @@
 (jch-register-supers! "java.lang.Throwable" '())
 (jch-register-supers! "java.lang.Byte" '("java.lang.Number"))
 (jch-register-supers! "java.lang.Short" '("java.lang.Number"))
-(jch-register-supers! "java.io.InputStream" '())
-(jch-register-supers! "java.io.OutputStream" '())
-(jch-register-supers! "java.io.Reader" '())
-(jch-register-supers! "java.io.Writer" '())
+;; java.lang.AutoCloseable / java.io.Closeable / java.io.Flushable — the
+;; interfaces the stream taxonomy actually implements. with-open and every
+;; (instance? java.io.Closeable x) branch reads them, and a stream that reported
+;; no interface at all answered false to a question the JVM answers true.
+(jch-register-supers! "java.lang.AutoCloseable" '())
+(jch-register-supers! "java.io.Closeable" '("java.lang.AutoCloseable"))
+(jch-register-supers! "java.io.Flushable" '())
+(jch-register-supers! "java.io.InputStream" '("java.io.Closeable"))
+(jch-register-supers! "java.io.OutputStream" '("java.io.Closeable" "java.io.Flushable"))
+(jch-register-supers! "java.io.Reader" '("java.io.Closeable" "java.lang.Readable"))
+(jch-register-supers! "java.lang.Readable" '())
+(jch-register-supers! "java.io.Writer" '("java.io.Closeable" "java.io.Flushable" "java.lang.Appendable"))
 (jch-register-supers! "java.io.File" '())
 (jch-register-supers! "java.io.StringReader" '("java.io.Reader"))
 (jch-register-supers! "java.io.PushbackReader" '("java.io.Reader"))
 (jch-register-supers! "clojure.lang.LineNumberingPushbackReader" '("java.io.PushbackReader"))
 (jch-register-supers! "java.io.PrintWriter" '("java.io.Writer"))
+;; System/out and System/err are PrintStreams — byte streams, not the PrintWriter
+;; *out* is. Ported code branches on that (instance? java.io.PrintStream x) and
+;; hands them to anything taking an OutputStream.
+(jch-register-supers! "java.io.FilterOutputStream" '("java.io.OutputStream"))
+(jch-register-supers! "java.io.PrintStream" '("java.io.FilterOutputStream" "java.lang.Appendable"))
 (jch-register-supers! "java.io.OutputStreamWriter" '("java.io.Writer"))
 (jch-register-supers! "java.io.FileWriter" '("java.io.OutputStreamWriter"))
 (jch-register-supers! "java.io.InputStreamReader" '("java.io.Reader"))
@@ -546,6 +561,11 @@
     ;; io writer/reader shims: *out* is a PrintWriter like the JVM REPL's
     ("port-writer" . "java.io.PrintWriter")
     ("print-writer" . "java.io.PrintWriter")
+    ;; …and System/out is a PrintStream, which is a different class from a
+    ;; different branch of the taxonomy. The shim (io-streams.ss) had no row here,
+    ;; so every PrintStream reported (class x) => :object and answered false to
+    ;; (instance? java.io.OutputStream x).
+    ("print-stream" . "java.io.PrintStream")
     ("file-writer" . "java.io.FileWriter")
     ("writer" . "java.io.StringWriter")
     ("string-reader" . "java.io.StringReader")
@@ -576,6 +596,17 @@
 (define (pushback-reader-tag? t)
   (or (string=? t "pushback-reader")
       (string=? t "line-numbering-pushback-reader")))
+
+;; The jhost text sinks: values that take text through their own .write method —
+;; a StringWriter, a FileWriter, the process port-writers, a PrintWriter, a
+;; PrintStream. spit, io/copy and with-open's close all ask this, and for the same
+;; reason as above: the set grew a fifth tag when System/out became a PrintStream,
+;; and three hand-copied literal lists is how one of them silently stops accepting
+;; a value the other two do ((io/copy in System/out) -> "unsupported output type").
+(define (text-sink-tag? t)
+  (or (string=? t "writer") (string=? t "file-writer")
+      (string=? t "port-writer") (string=? t "print-writer")
+      (string=? t "print-stream")))
 ;; the protocol-dispatch / instance? tag list for a jhost value's tag, or #f.
 (define (jhost-value-tags tag)
   (let ((fqn (hashtable-ref jhost-tag->fqn tag #f)))

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -249,32 +249,38 @@
   (cond ((number? x) (string (integer->char (jnum->exact x))))
         ((char-array-arg? x) (char-array->string x))
         (else (render-piece x))))
-;; What a .write argument puts into a stream: writer-piece, plus the byte[] whose
-;; CONTENT write is defined to emit — (.write System/out (.getBytes s)) is how
+;; The bytes a byte[] .write argument carries, with the JVM's 3-arg (off len)
+;; region applied. Out-of-range ends clamp rather than raise: a stream write is
+;; not the place to turn a caller's off-by-one into a crash mid-output.
+(define (byte-array-range x rest)
+  (let ((bv (na-bytearray->bv x)))
+    (if (and (pair? rest) (pair? (cdr rest)))
+        (let* ((off (max 0 (jnum->exact (car rest))))
+               (len (max 0 (jnum->exact (cadr rest))))
+               (start (min off (bytevector-length bv)))
+               (end (min (bytevector-length bv) (+ start len)))
+               (sub (make-bytevector (- end start))))
+          (bytevector-copy! bv start sub 0 (- end start))
+          sub)
+        bv)))
+;; What a .write argument puts into a TEXT sink: writer-piece, plus the byte[]
+;; whose CONTENT write is defined to emit — (.write w (.getBytes s)) is how
 ;; ported code writes raw output, and it used to put "#object[[B …]" in the
-;; stream. Bytes decode as UTF-8, the encoding jolt renders in.
-;;
-;; With (off len) it is the JVM's 3-arg write over a region. A byte[] is sliced
-;; BEFORE decoding, since the offsets are byte offsets and slicing the decoded
-;; string would cut multi-byte characters in the wrong places. Out-of-range ends
-;; clamp rather than raise: a stream write is not the place to turn a caller's
-;; off-by-one into a crash mid-output.
+;; stream. Bytes decode as UTF-8, the encoding jolt renders in; they are sliced
+;; before decoding, since the offsets are byte offsets and cutting the decoded
+;; string would land in the middle of a multi-byte character. A sink with a real
+;; descriptor under it takes the bytes themselves — see pw-write-bytes! below.
 (define (writer-piece-range x rest)
-  (if (and (pair? rest) (pair? (cdr rest)))
-      (let ((off (max 0 (jnum->exact (car rest))))
-            (len (max 0 (jnum->exact (cadr rest)))))
-        (if (byte-array-arg? x)
-            (let* ((bv (na-bytearray->bv x))
-                   (start (min off (bytevector-length bv)))
-                   (end (min (bytevector-length bv) (+ start len)))
-                   (sub (make-bytevector (- end start))))
-              (bytevector-copy! bv start sub 0 (- end start))
-              (utf8->string sub))
-            (let* ((s (writer-piece x))
-                   (start (min off (string-length s)))
-                   (end (min (string-length s) (+ start len))))
-              (substring s start end))))
-      (if (byte-array-arg? x) (utf8->string (na-bytearray->bv x)) (writer-piece x))))
+  (cond
+    ((byte-array-arg? x) (utf8->string (byte-array-range x rest)))
+    ((and (pair? rest) (pair? (cdr rest)))
+     (let* ((s (writer-piece x))
+            (off (max 0 (jnum->exact (car rest))))
+            (len (max 0 (jnum->exact (cadr rest))))
+            (start (min off (string-length s)))
+            (end (min (string-length s) (+ start len))))
+       (substring s start end)))
+    (else (writer-piece x))))
 ;; Same accumulator as StringBuilder, and for the same reason: writing to a
 ;; StringWriter a piece at a time — which is what printStackTrace and every
 ;; print-to-a-writer path does — used to copy the whole buffer per write.
@@ -331,11 +337,49 @@
           ((eq? p 'stdout) port-writer-stdout)
           ((eq? p 'stderr) port-writer-stderr)
           (else p))))
+
+;; The process streams also have a BYTE path. System/out and System/err are
+;; java.io.PrintStreams — OutputStreams — so bytes written to one have to reach
+;; the descriptor as they are, and (io/copy System/in System/out) is the cat.
+;; Decoding them as UTF-8 first replaced every byte that was not text with U+FFFD.
+;; Chez's process port is textual and re-encodes whatever it is given, so the
+;; bytes go out through a second port on the same descriptor. That port is
+;; UNBUFFERED and the textual one is flushed ahead of it, so the two stay in the
+;; order they were written even when stdout is a pipe.
+;;
+;; Only the real process stream takes this path: with-out-str resolves 'out to a
+;; string port, which can only take characters, so a byte[] written there decodes
+;; as before.
+(define pw-byte-port-mu (make-mutex))
+(define pw-stdout-bytes (box #f))
+(define pw-stderr-bytes (box #f))
+(define (pw-byte-port-memo cell open)
+  (unless (unbox cell)
+    (jolt-with-mutex pw-byte-port-mu
+      (unless (unbox cell) (set-box! cell (open (buffer-mode none))))))
+  (unbox cell))
+(define (pw-byte-port port)
+  (cond ((eq? port port-writer-stdout) (pw-byte-port-memo pw-stdout-bytes standard-output-port))
+        ((eq? port port-writer-stderr) (pw-byte-port-memo pw-stderr-bytes standard-error-port))
+        (else #f)))
+;; Writes bv to the descriptor behind a process stream; #f when there is none, so
+;; the caller falls back to writing it as text.
+(define (pw-write-bytes! self bv)
+  (let* ((port (port-writer-port self))
+         (bp (pw-byte-port port)))
+    (and bp
+         (begin (flush-output-port port)
+                (put-bytevector bp bv)
+                #t))))
 ;; print / println / printf are PrintStream's, and System/out is a port-writer, so
 ;; ported code writing (.println System/out …) lands here. println with no argument
 ;; is the bare newline, as on the JVM.
 (register-host-methods! "port-writer"
-  (list (cons "write" (lambda (self x . rest) (display (writer-piece-range x rest) (port-writer-port self)) jolt-nil))
+  (list (cons "write" (lambda (self x . rest)
+                        (unless (and (byte-array-arg? x)
+                                     (pw-write-bytes! self (byte-array-range x rest)))
+                          (display (writer-piece-range x rest) (port-writer-port self)))
+                        jolt-nil))
         (cons "append" (lambda (self x . rest) (display (append-text x rest) (port-writer-port self)) self))
         (cons "print" (lambda (self x) (display (writer-piece x) (port-writer-port self)) jolt-nil))
         (cons "println" (lambda (self . xs)

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -233,10 +233,50 @@
 
 ;; ---- StringWriter -----------------------------------------------------------
 ;; Writer.write(int) writes the CHAR for that code; append(char) appends the char.
-(define (writer-piece x) (if (number? x) (string (integer->char (jnum->exact x))) (render-piece x)))
+;; What one value puts into a stream. A number is the CHARACTER with that code
+;; (write(int) writes one unit, not the digits). A char[] is its characters —
+;; every write and print overload that takes one is defined that way, and it used
+;; to render as "#object[[C …]" straight into the stream. A byte[] is NOT handled
+;; here: print/println have no byte[] overload on the JVM and fall to
+;; print(Object), so it renders as an object, and only write puts its bytes out.
+(define (char-array-arg? x) (and (jolt-array? x) (eq? (jolt-array-kind x) 'char)))
+(define (byte-array-arg? x) (and (jolt-array? x) (eq? (jolt-array-kind x) 'byte)))
+(define (char-array->string x)
+  (list->string (map (lambda (c) (if (char? c) c (integer->char (jnum->exact c))))
+                     (vector->list (jolt-array-vec x)))))
+(define (writer-piece x)
+  (cond ((number? x) (string (integer->char (jnum->exact x))))
+        ((char-array-arg? x) (char-array->string x))
+        (else (render-piece x))))
+;; What a .write argument puts into a stream: writer-piece, plus the byte[] whose
+;; CONTENT write is defined to emit — (.write System/out (.getBytes s)) is how
+;; ported code writes raw output, and it used to put "#object[[B …]" in the
+;; stream. Bytes decode as UTF-8, the encoding jolt renders in.
+;;
+;; With (off len) it is the JVM's 3-arg write over a region. A byte[] is sliced
+;; BEFORE decoding, since the offsets are byte offsets and slicing the decoded
+;; string would cut multi-byte characters in the wrong places. Out-of-range ends
+;; clamp rather than raise: a stream write is not the place to turn a caller's
+;; off-by-one into a crash mid-output.
+(define (writer-piece-range x rest)
+  (if (and (pair? rest) (pair? (cdr rest)))
+      (let ((off (max 0 (jnum->exact (car rest))))
+            (len (max 0 (jnum->exact (cadr rest)))))
+        (if (byte-array-arg? x)
+            (let* ((bv (na-bytearray->bv x))
+                   (start (min off (bytevector-length bv)))
+                   (end (min (bytevector-length bv) (+ start len)))
+                   (sub (make-bytevector (- end start))))
+              (bytevector-copy! bv start sub 0 (- end start))
+              (utf8->string sub))
+            (let* ((s (writer-piece x))
+                   (start (min off (string-length s)))
+                   (end (min (string-length s) (+ start len))))
+              (substring s start end))))
+      (if (byte-array-arg? x) (utf8->string (na-bytearray->bv x)) (writer-piece x))))
 (register-class-ctor! "StringWriter" (lambda args (make-jhost "writer" (vector ""))))
 (register-host-methods! "writer"
-  (list (cons "write" (lambda (self x) (sb-set! self (string-append (sb-str self) (writer-piece x))) jolt-nil))
+  (list (cons "write" (lambda (self x . rest) (sb-set! self (string-append (sb-str self) (writer-piece-range x rest))) jolt-nil))
         (cons "append" (lambda (self x . rest) (sb-set! self (string-append (sb-str self) (append-text x rest))) self))
         (cons "flush" (lambda (self) jolt-nil))
         (cons "close" (lambda (self) jolt-nil))
@@ -253,7 +293,7 @@
 (define (fw-append! self s) (vector-set! (jhost-state self) 1 (string-append (fw-buf self) s)))
 (define (fw-flush! self) (jolt-spit (fw-path self) (fw-buf self)))  ; jolt-spit: io.ss
 (register-host-methods! "file-writer"
-  (list (cons "write" (lambda (self x) (fw-append! self (writer-piece x)) jolt-nil))
+  (list (cons "write" (lambda (self x . rest) (fw-append! self (writer-piece-range x rest)) jolt-nil))
         (cons "append" (lambda (self x . rest) (fw-append! self (append-text x rest)) self))
         (cons "flush" (lambda (self) (fw-flush! self) jolt-nil))
         (cons "close" (lambda (self) (fw-flush! self) jolt-nil))
@@ -270,16 +310,28 @@
 ;; real stdout, so rewrite-clj's (z/print) — which writes via *out* — escaped the
 ;; capture. A stored port object (should any other code make a port-writer) is used
 ;; as-is.
+;;
+;; 'stdout / 'stderr are the other half of that: the PROCESS streams, resolved
+;; once at startup and never again. They back System/out and System/err, which
+;; the JVM does NOT route through *out* — a with-out-str captures (print …) and
+;; leaves (.println System/out …) going to the terminal. Resolving them live
+;; through (current-output-port) like 'out made jolt capture both, so a library
+;; that deliberately writes past the capture (a progress bar, a prompt, a logger
+;; writing to the real stderr) had its output swallowed into the string instead.
+(define port-writer-stdout (current-output-port))
+(define port-writer-stderr (current-error-port))
 (define (port-writer-port self)
   (let ((p (vector-ref (jhost-state self) 0)))
     (cond ((eq? p 'out) (current-output-port))
           ((eq? p 'err) (current-error-port))
+          ((eq? p 'stdout) port-writer-stdout)
+          ((eq? p 'stderr) port-writer-stderr)
           (else p))))
 ;; print / println / printf are PrintStream's, and System/out is a port-writer, so
 ;; ported code writing (.println System/out …) lands here. println with no argument
 ;; is the bare newline, as on the JVM.
 (register-host-methods! "port-writer"
-  (list (cons "write" (lambda (self x) (display (writer-piece x) (port-writer-port self)) jolt-nil))
+  (list (cons "write" (lambda (self x . rest) (display (writer-piece-range x rest) (port-writer-port self)) jolt-nil))
         (cons "append" (lambda (self x . rest) (display (append-text x rest) (port-writer-port self)) self))
         (cons "print" (lambda (self x) (display (writer-piece x) (port-writer-port self)) jolt-nil))
         (cons "println" (lambda (self . xs)
@@ -294,25 +346,29 @@
 (def-dynvar! "clojure.core" "*err*" (make-jhost "port-writer" (vector 'err)))
 
 ;; System/out and System/err — the process's own streams, so unlike *out*/*err*
-;; they are NOT affected by a (binding [*out* …]), matching the JVM. Ported code
-;; writes to them directly ((.println System/out …)); they are the same
-;; port-writers *out*/*err* root to, since jolt models a stream and a writer the
-;; same way.
+;; they are NOT affected by a (binding [*out* …]) or a with-out-str, matching the
+;; JVM. Ported code writes to them directly ((.println System/out …)). They are
+;; port-writers over the 'stdout / 'stderr ports resolved at startup; io-streams.ss
+;; then wraps each in the PrintStream shim, because on the JVM System.out is a
+;; java.io.PrintStream and not the java.io.PrintWriter *out* is, and libraries
+;; branch on that class.
 ;;
 ;; They live in the MUTABLE static cells rather than the plain statics table,
 ;; because setOut/setErr replace them wholesale — clojure.tools.logging's
 ;; log-capture! points them at a PrintStream over a proxy so every write becomes a
 ;; log record. Both spellings get the cell, since a read resolves the class name as
 ;; written.
+(define system-out-writer (make-jhost "port-writer" (vector 'stdout)))
+(define system-err-writer (make-jhost "port-writer" (vector 'stderr)))
 (register-class-statics! "System"
-  (list (cons "out" (make-jhost "port-writer" (vector 'out)))
-        (cons "err" (make-jhost "port-writer" (vector 'err)))))
+  (list (cons "out" system-out-writer)
+        (cons "err" system-err-writer)))
 (define (sys-set-stream! member v)
   (for-each (lambda (c) (vector-set! (mutable-static-cell c member #t) 0 v))
             '("System" "java.lang.System"))
   jolt-nil)
-(for-each (lambda (m) (sys-set-stream! m (make-jhost "port-writer" (vector (string->symbol m)))))
-          '("out" "err"))
+(sys-set-stream! "out" system-out-writer)
+(sys-set-stream! "err" system-err-writer)
 (register-class-statics! "System"
   (list (cons "setOut" (lambda (v) (sys-set-stream! "out" v)))
         (cons "setErr" (lambda (v) (sys-set-stream! "err" v)))))
@@ -344,7 +400,11 @@
 (register-class-ctor! "java.io.PrintWriter"
   (lambda args (make-jhost "print-writer" (vector (if (pair? args) (car args) jolt-nil)))))
 (register-host-methods! "print-writer"
-  (list (cons "write" (lambda (self x . rest) (pw-forward (vector-ref (jhost-state self) 0) (append-text x rest)) jolt-nil))
+  ;; write takes (buf off len) and renders an int as its character; append takes
+  ;; (csq start end) and renders everything as text. Sharing append-text between
+  ;; them read the 3-arg write's LENGTH as an end index and printed (.write w 65)
+  ;; as "65" rather than "A".
+  (list (cons "write" (lambda (self x . rest) (pw-forward (vector-ref (jhost-state self) 0) (writer-piece-range x rest)) jolt-nil))
         (cons "print" (lambda (self x) (pw-forward (vector-ref (jhost-state self) 0) (render-piece x)) jolt-nil))
         (cons "append" (lambda (self x . rest) (pw-forward (vector-ref (jhost-state self) 0) (append-text x rest)) self))
         (cons "flush" (lambda (self) jolt-nil))
@@ -361,8 +421,8 @@
 (define (jolt-print-writer-on flush-fn close-fn)
   (make-jhost "print-writer-on" (vector (box "") flush-fn close-fn)))
 (register-host-methods! "print-writer-on"
-  (list (cons "write" (lambda (self x) (set-box! (pwo-buf self)
-                                  (string-append (unbox (pwo-buf self)) (writer-piece x))) jolt-nil))
+  (list (cons "write" (lambda (self x . rest) (set-box! (pwo-buf self)
+                                  (string-append (unbox (pwo-buf self)) (writer-piece-range x rest))) jolt-nil))
         (cons "append" (lambda (self x . rest) (set-box! (pwo-buf self)
                                   (string-append (unbox (pwo-buf self)) (append-text x rest))) self))
         (cons "flush" (lambda (self)

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -147,11 +147,12 @@
 (register-class-ctor! "StringBuilder"
   (lambda args (make-jhost "string-builder"
     ;; a numeric first arg is a CAPACITY hint, not content.
-    (vector (if (and (pair? args) (not (number? (car args)))) (render-piece (car args)) "")))))
+    (vector (if (and (pair? args) (not (number? (car args)))) (render-piece (car args)) "")
+            '() 0))))
 (register-host-methods! "string-builder"
-  (list (cons "append" (lambda (self x . rest) (sb-set! self (string-append (sb-str self) (append-text x rest))) self))
+  (list (cons "append" (lambda (self x . rest) (sb-append! self (append-text x rest)) self))
         (cons "toString" (lambda (self) (sb-str self)))
-        (cons "length" (lambda (self) (->num (string-length (sb-str self)))))
+        (cons "length" (lambda (self) (->num (sb-length self))))
         (cons "charAt" (lambda (self i) (string-ref (sb-str self) (jnum->exact i))))
         (cons "setLength" (lambda (self n)
                             (let ((cur (sb-str self)) (n (jnum->exact n)))
@@ -159,7 +160,7 @@
                                                 (substring cur 0 n)
                                                 (string-append cur (make-string (- n (string-length cur)) #\nul)))))
                             jolt-nil))
-        (cons "isEmpty" (lambda (self) (= 0 (string-length (sb-str self)))))
+        (cons "isEmpty" (lambda (self) (= 0 (sb-length self))))
         (cons "substring" (lambda (self start . rest)
                             (let* ((cur (sb-str self)) (s (jnum->exact start))
                                    (e (if (null? rest) (string-length cur) (jnum->exact (car rest)))))
@@ -228,7 +229,7 @@
     (if (and (sb-jhost? val) (symbol-t? type-sym))
         (jch-isa? "java.lang.StringBuilder" (symbol-t-name type-sym))
         'pass)))
-(register-count-arm! sb-jhost? (lambda (x) (string-length (sb-str x))))
+(register-count-arm! sb-jhost? (lambda (x) (sb-length x)))
 (register-seq-arm! sb-jhost? (lambda (x) (jolt-seq (sb-str x))))
 
 ;; ---- StringWriter -----------------------------------------------------------
@@ -274,10 +275,13 @@
                    (end (min (string-length s) (+ start len))))
               (substring s start end))))
       (if (byte-array-arg? x) (utf8->string (na-bytearray->bv x)) (writer-piece x))))
-(register-class-ctor! "StringWriter" (lambda args (make-jhost "writer" (vector ""))))
+;; Same accumulator as StringBuilder, and for the same reason: writing to a
+;; StringWriter a piece at a time — which is what printStackTrace and every
+;; print-to-a-writer path does — used to copy the whole buffer per write.
+(register-class-ctor! "StringWriter" (lambda args (make-jhost "writer" (vector "" '() 0))))
 (register-host-methods! "writer"
-  (list (cons "write" (lambda (self x . rest) (sb-set! self (string-append (sb-str self) (writer-piece-range x rest))) jolt-nil))
-        (cons "append" (lambda (self x . rest) (sb-set! self (string-append (sb-str self) (append-text x rest))) self))
+  (list (cons "write" (lambda (self x . rest) (sb-append! self (writer-piece-range x rest)) jolt-nil))
+        (cons "append" (lambda (self x . rest) (sb-append! self (append-text x rest)) self))
         (cons "flush" (lambda (self) jolt-nil))
         (cons "close" (lambda (self) jolt-nil))
         (cons "toString" (lambda (self) (sb-str self)))))
@@ -387,7 +391,7 @@
      (display s (port-writer-port target)))
     ((and (jhost? target) (memv #t (list (string=? (jhost-tag target) "writer")
                                          (string=? (jhost-tag target) "string-builder"))))
-     (sb-set! target (string-append (sb-str target) s)))
+     (sb-append! target s))
     ;; every other host writer knows how to write itself — a file-backed writer, an
     ;; OutputStreamWriter, a nested PrintWriter. Naming them one by one left
     ;; (PrintWriter. (io/writer f)) falling through to the pprint protocol below,

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -868,9 +868,51 @@
               (let ((v (getenv name))) (if v v jolt-nil)))))))
 
 ;; ---- StringBuilder ----------------------------------------------------------
-;; state: a box (1-vector) holding the accumulated string.
-(define (sb-str self) (vector-ref (jhost-state self) 0))
-(define (sb-set! self s) (vector-set! (jhost-state self) 0 s))
+;; state: #(materialised-string pending-chunks-reversed pending-length).
+;;
+;; Appends accumulate as a list of chunks and are joined only when something
+;; reads the buffer. The obvious representation — one string, appended to with
+;; string-append — copies the whole buffer on every append, which makes building
+;; an n-char string O(n^2). That is not theoretical: clojure.data.json reads a
+;; quoted string a character at a time into a StringBuilder, so one 88KB JSON
+;; string value cost 623ms to parse against 30ms for the same bytes spread over
+;; many short values. See test/chez/string-builder-perf.ss.
+;;
+;; Every other method still reads through sb-str, so it flushes first and
+;; behaves exactly as before; only append and the two size reads skip the join.
+(define (sb-str self)
+  (let* ((st (jhost-state self))
+         (pending (vector-ref st 1)))
+    (if (null? pending)
+        (vector-ref st 0)
+        (let* ((base (vector-ref st 0))
+               (blen (string-length base))
+               (out (make-string (+ blen (vector-ref st 2)))))
+          (string-copy! base 0 out 0 blen)
+          (let loop ((cs (reverse pending)) (i blen))
+            (if (null? cs)
+                (begin (vector-set! st 0 out)
+                       (vector-set! st 1 '())
+                       (vector-set! st 2 0)
+                       out)
+                (let* ((c (car cs)) (n (string-length c)))
+                  (string-copy! c 0 out i n)
+                  (loop (cdr cs) (+ i n)))))))))
+(define (sb-set! self s)
+  (let ((st (jhost-state self)))
+    (vector-set! st 0 s)
+    (vector-set! st 1 '())
+    (vector-set! st 2 0)))
+;; O(1): the chunk is retained as-is and nothing is copied until a read.
+(define (sb-append! self piece)
+  (let ((st (jhost-state self)))
+    (vector-set! st 1 (cons piece (vector-ref st 1)))
+    (vector-set! st 2 (+ (vector-ref st 2) (string-length piece)))))
+;; Size without flushing, so the common `while (.length sb) < n: append` shape
+;; does not force a join per iteration and put the O(n^2) straight back.
+(define (sb-length self)
+  (let ((st (jhost-state self)))
+    (+ (string-length (vector-ref st 0)) (vector-ref st 2))))
 (define (render-piece x)
   (cond ((jolt-nil? x) "null") ((char? x) (string x)) ((string? x) x)
         (else (jolt-str-render-one x))))

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -413,13 +413,18 @@
 
 ;; --- clojure.java.io: byte streams + copy / make-parents / delete-file -------
 ;; input-stream/output-stream now yield real byte streams (were char reader/writer).
+;; the file branches announce themselves to the AOT cache (io-note-file-read!,
+;; io.ss): opening a resource for reading at compile time is a read like a slurp.
+(define (jio-open-in-file p)
+  (io-note-file-read! p)
+  (make-in-stream (open-file-input-port p (file-options) (buffer-mode block))))
 (define (jio-input-stream x)
   (cond ((in-stream? x) x)
-        ((jfile? x) (make-in-stream (open-file-input-port (jfile-fs x) (file-options) (buffer-mode block))))
+        ((jfile? x) (jio-open-in-file (jfile-fs x)))
         ((and (jolt-array? x) (eq? (jolt-array-kind x) 'byte)) (make-in-stream (open-bytevector-input-port (na-bytearray->bv x))))
         ((bytevector? x) (make-in-stream (open-bytevector-input-port x)))
-        ((and (jhost? x) (string=? (jhost-tag x) "url")) (make-in-stream (open-file-input-port (url-strip-scheme (url-spec x)) (file-options) (buffer-mode block))))
-        ((string? x) (make-in-stream (open-file-input-port (project-relative x) (file-options) (buffer-mode block))))
+        ((and (jhost? x) (string=? (jhost-tag x) "url")) (jio-open-in-file (url-strip-scheme (url-spec x))))
+        ((string? x) (jio-open-in-file (project-relative x)))
         (else (throw-jvm (quote IllegalArgumentException) (string-append "Cannot open <" (jolt-pr-str x) "> as an InputStream.")))))
 (define (jio-output-stream x . rest)
   (cond ((out-stream? x) x)

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -71,6 +71,15 @@
 ;; longer there for a descriptor handed to a subprocess.
 (define (port-buffered port)
   (fx- (port-input-size port) (port-input-index port)))
+;; What is left of a seekable source, or #f when it is not one. The two
+;; predicates are not a promise: a port over a SOCKET descriptor answers #t to
+;; both and then raises ESPIPE ("illegal seek") from port-position, so this asks
+;; by trying rather than by asking.
+(define (port-remaining port)
+  (guard (_ (#t #f))
+    (and (port-has-port-length? port)
+         (port-has-port-position? port)
+         (max 0 (- (port-length port) (port-position port))))))
 (define (in-stream-available self)
   (let ((port (in-stream-live-port self))
         (p (piped-pipe self)))
@@ -78,8 +87,7 @@
       ;; a piped stream holds its bytes in two places: what the writer has queued
       ;; and what an earlier read already pulled into the port's buffer
       (p (+ (port-buffered port) (pipe-available p)))
-      ((and (port-has-port-length? port) (port-has-port-position? port))
-       (max 0 (- (port-length port) (port-position port))))
+      ((port-remaining port) => values)
       ((fx>? (port-buffered port) 0) (port-buffered port))
       ((guard (_ (#t #f)) (input-port-ready? port))
        (lookahead-u8 port)

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -18,10 +18,13 @@
 ;; The port is resolved through here rather than read straight out of the slot so
 ;; System/in can hold the SYMBOL 'stdin and open the process's standard input on
 ;; first use — the same live-resolution port-writer uses for 'out / 'err. A
-;; program that never touches System/in never opens a second handle on fd 0.
-;; Under a mutex because there must be exactly ONE port on fd 0: two threads each
-;; opening their own would each buffer ahead, and whichever read first would eat
-;; input the other never sees.
+;; program that never touches System/in never opens a handle on fd 0.
+;;
+;; This is the ONLY port jolt opens on fd 0, and everything that reads standard
+;; input goes through it: System/in itself, the *in* reader below it, and the `-`
+;; program source in cli-core.ss. A second port on the same descriptor buffers
+;; ahead on its own, and whichever read first would eat input the other never
+;; sees. Memoized under a mutex for the same reason across threads.
 (define jolt-stdin-port-mu (make-mutex))
 (define jolt-stdin-port-memo #f)
 (define (jolt-stdin-binary-port)
@@ -46,16 +49,24 @@
                  ;; return has to distinguish 0xff from end-of-stream.
                  (let ((b (get-u8 port))) (if (eof-object? b) -1 (->num b)))
                  ;; read(buf …) fills a byte-array, whose elements ARE signed.
+                 ;; Returns as soon as ANY byte is there, which is the JVM's
+                 ;; contract ("blocks until at least one byte is available") and
+                 ;; not "until the buffer is full": filling it first hung a read
+                 ;; over a pipe or a terminal, where the rest of the buffer only
+                 ;; arrives after whatever the program does with these bytes.
                  (let* ((buf (car rest))
                         (vec (jolt-array-vec buf))
                         (off (if (>= (length rest) 3) (jnum->exact (cadr rest)) 0))
-                        (len (if (>= (length rest) 3) (jnum->exact (caddr rest)) (vector-length vec))))
-                   (let loop ((i 0))
-                     (if (>= i len) (->num i)
-                         (let ((b (get-u8 port)))
-                           (if (eof-object? b)
-                               (if (= i 0) -1 (->num i))
-                               (begin (vector-set! vec (+ off i) (na-u8->byte b)) (loop (+ i 1))))))))))))
+                        (len (if (>= (length rest) 3) (jnum->exact (caddr rest)) (vector-length vec)))
+                        (tmp (make-bytevector (max len 1)))
+                        (n (if (<= len 0) 0 (get-bytevector-some! port tmp 0 len))))
+                   (cond
+                     ((<= len 0) (->num 0))
+                     ((eof-object? n) -1)
+                     (else (let loop ((i 0))
+                             (if (>= i n) (->num n)
+                                 (begin (vector-set! vec (+ off i) (na-u8->byte (bytevector-u8-ref tmp i)))
+                                        (loop (+ i 1))))))))))))
    (cons "readAllBytes" (lambda (self) (let ((bv (get-bytevector-all (in-stream-port self))))
                                          (na-byte-array (if (eof-object? bv) (make-bytevector 0) bv)))))
    (cons "skip" (lambda (self n) (let ((bv (get-bytevector-n (in-stream-port self) (jnum->exact n))))
@@ -292,9 +303,8 @@
 ;; System.in is a java.io.InputStream, so it is an in-stream over a binary port on
 ;; fd 0 and not a transcoded view of (current-input-port): an InputStream is
 ;; bytes, and (io/copy System/in out) has to come out byte-identical for input
-;; that isn't UTF-8 text. That port is separate from the textual one (read-line)
-;; reads, so a program should use one or the other and not interleave them — the
-;; two buffer independently.
+;; that isn't UTF-8 text. It is also the one place standard input is read from —
+;; see the *in* seam below.
 ;;
 ;; System.out and System.err are java.io.PrintStreams, NOT the java.io.PrintWriter
 ;; *out* is; ported code branches on the class and hands them to anything taking
@@ -310,14 +320,152 @@
   (list (cons "in" system-in-stream)
         (cons "setIn" (lambda (v) (sys-set-in! v)))))
 (sys-set-in! system-in-stream)
-;; io.ss's read-line compares the cell against this to decide whether System/in
-;; has been replaced; it could not build the stream itself (no byte streams yet).
-;; The default keeps the tuned textual path there — char-ready? polling and
-;; fiber-friendly parking — and only a replacement is read through .read.
-(set! stdin-default-stream system-in-stream)
 (for-each (lambda (p)
             (sys-set-stream! (car p) (make-jhost "print-stream" (vector (cdr p) #t))))
           (list (cons "out" system-out-writer) (cons "err" system-err-writer)))
+
+;; --- *in*: the reader over System/in ----------------------------------------
+;; The JVM stacks the two rather than putting them side by side — System.in is the
+;; byte stream, and *in* is a Reader built over it (RT.in is a
+;; LineNumberingPushbackReader over an InputStreamReader over System.in) — so
+;; read-line ultimately pulls its bytes out of System.in. jolt has the same shape:
+;; the clojure.core *in* reader (50-io.clj) drives read-line / read / read+string
+;; through this one seam, and this seam reads System/in.
+;;
+;; Standard input is therefore buffered in exactly one place, the Chez port on
+;; fd 0, which is the layer the JVM's BufferedInputStream is. What jolt does not
+;; add is the JVM's SECOND buffer: an InputStreamReader decodes into 8K of its
+;; own, which is why (.read System/in) after a (read-line) answers -1 there with
+;; the rest of stdin sitting inside the reader. Nothing here reads past the line
+;; it returns, so that same read answers the next byte of the input.
+;;
+;; The other difference is that System/setIn redirects read-line, because the
+;; stream is read out of the static on every line. The JVM builds *in* over
+;; whatever System.in was at RT class-init, so a later setIn does not reach it and
+;; with-in-str is the only way to feed read-line. Both differences are supersets:
+;; on the JVM, mixing the two loses input and redirecting read-line is impossible.
+;;
+;; Waits in a nap, NOT inside the read. Chez's blocking read holds the whole
+;; Scheme world while it waits: no other thread runs at all, so a future stopped
+;; ticking and an agent stopped draining the moment the main thread reached a
+;; prompt, and the SIGTERM watcher (concurrency.ss) could not wake to run the
+;; shutdown hooks either. On the JVM those all keep running while a thread sits in
+;; System.in.read(). The nap is collect-safe, so parking THERE and reading only
+;; once the port has something leaves every other thread alive (jolt-p9ua). Backs
+;; off 1ms -> 20ms, the shape proc-wait-blocking uses.
+;;
+;; Whether a port can answer input-port-ready? at all is settled ONCE per port
+;; rather than under a guard per line — the guard was most of the cost when this
+;; was measured. A port that cannot answer (a custom port, e.g. a pipe) reads the
+;; blocking way. input-port-ready? and not char-ready?, which is textual only.
+(define jolt-stdin-poll-step0 1)              ; 1ms
+(define jolt-stdin-poll-step-max 20)          ; 20ms
+(define jolt-stdin-poll-port (box #f))        ; the port the answer below is about
+(define jolt-stdin-poll-ok (box #f))
+(define (jolt-stdin-wait-ready! in)
+  (unless (eq? (unbox jolt-stdin-poll-port) in)
+    (set-box! jolt-stdin-poll-ok (guard (_ (#t #f)) (input-port-ready? in) #t))
+    (set-box! jolt-stdin-poll-port in))
+  (when (unbox jolt-stdin-poll-ok)
+    (let loop ((step jolt-stdin-poll-step0))
+      (unless (input-port-ready? in)
+        ;; jolt-pause-ms and not (sleep): on a fiber this parks for the step and
+        ;; gives the carrier up, so (read-line) from a go block no longer stops
+        ;; every other fiber placed on that carrier until input arrives.
+        (jolt-pause-ms step)
+        (loop (min jolt-stdin-poll-step-max (* step 2)))))))
+
+;; readLine ends a line on \n, on \r, or on \r\n. A \r ends the line at once; the
+;; \n that may follow is taken then and there when the stream already has it, and
+;; otherwise left for the next read to skip. Waiting to see whether one follows
+;; would keep a terminal's last line from being returned until the user typed
+;; something more, which is why BufferedReader keeps this flag; taking the byte
+;; when it IS there keeps a stray \n out of what (.read System/in) sees next. The
+;; flag names the stream it belongs to, so a System/setIn between the two halves
+;; of a CRLF cannot make the new stream swallow a leading newline.
+(define stdin-pending-lf (box #f))
+(define stdin-cell (mutable-static-cell "System" "in" #t))
+(define stdin-line-cap0 128)
+
+;; The first byte of a line, minus the \n owed by a \r that ended the last one.
+(define (stdin-first-byte v get)
+  (if (eq? (unbox stdin-pending-lf) v)
+      (begin (set-box! stdin-pending-lf #f)
+             (let ((b (get))) (if (eqv? b 10) (get) b)))
+      (get)))
+(define (stdin-line-string buf i)
+  (let ((out (make-bytevector i)))
+    (bytevector-copy! buf 0 out 0 i)
+    (utf8->string out)))
+
+;; The \n of a CRLF, when the port can say it is already sitting there. A port
+;; that cannot answer, or that has nothing yet, leaves it to the flag: peeking
+;; would block, and blocking here is what this must not do.
+(define (stdin-take-crlf! v port)
+  (if (and (unbox jolt-stdin-poll-ok)
+           (eq? (unbox jolt-stdin-poll-port) port)
+           (input-port-ready? port))
+      (when (eqv? (lookahead-u8 port) 10) (get-u8 port))
+      (set-box! stdin-pending-lf v)))
+
+;; System/in is an ordinary in-stream, so its bytes come straight off the port.
+;; The dispatched twin below is the same loop over .read; kept apart because this
+;; one is the one a piped read-line loop runs a million times, and reading the
+;; byte through a passed-in procedure instead of inline costs it a quarter.
+(define (stdin-line-from-port v port)
+  (jolt-stdin-wait-ready! port)
+  (let loop ((b (stdin-first-byte v (lambda () (get-u8 port))))
+             (buf (make-bytevector stdin-line-cap0))
+             (cap stdin-line-cap0)
+             (i 0))
+    (cond
+      ((eof-object? b) (if (fx=? i 0) jolt-nil (stdin-line-string buf i)))
+      ((fx=? b 10) (stdin-line-string buf i))
+      ((fx=? b 13) (stdin-take-crlf! v port) (stdin-line-string buf i))
+      ((fx=? i cap)
+       (let ((grown (make-bytevector (fx* cap 2))))
+         (bytevector-copy! buf 0 grown 0 cap)
+         (bytevector-u8-set! grown i b)
+         (loop (get-u8 port) grown (fx* cap 2) (fx+ i 1))))
+      (else
+        (bytevector-u8-set! buf i b)
+        (loop (get-u8 port) buf cap (fx+ i 1))))))
+
+;; Anything else System/setIn was handed — a proxy, a library's stream shim — is
+;; read through its own .read, so an override is seen. One byte at a time, so the
+;; line takes nothing the caller did not ask for.
+(define (stream-read-byte v)
+  (let ((b (record-method-dispatch v "read" jolt-nil)))
+    (if (or (jolt-nil? b) (not (number? b)) (< (jnum->exact b) 0))
+        (eof-object)
+        (bitwise-and (jnum->exact b) #xff))))
+(define (stdin-line-from-stream v)
+  (let ((get (lambda () (stream-read-byte v))))
+    (let loop ((b (stdin-first-byte v get))
+               (buf (make-bytevector stdin-line-cap0))
+               (cap stdin-line-cap0)
+               (i 0))
+      (cond
+        ((eof-object? b) (if (fx=? i 0) jolt-nil (stdin-line-string buf i)))
+        ((fx=? b 10) (stdin-line-string buf i))
+        ((fx=? b 13) (set-box! stdin-pending-lf v) (stdin-line-string buf i))
+        ((fx=? i cap)
+         (let ((grown (make-bytevector (fx* cap 2))))
+           (bytevector-copy! buf 0 grown 0 cap)
+           (bytevector-u8-set! grown i b)
+           (loop (get) grown (fx* cap 2) (fx+ i 1))))
+        (else
+          (bytevector-u8-set! buf i b)
+          (loop (get) buf cap (fx+ i 1)))))))
+
+;; The next line of System/in, its terminator stripped, or nil at end of input.
+;; Without this seam (read-line) and the REPL call nil.
+(def-var! "clojure.core" "__stdin-read-line"
+  (lambda ()
+    (let ((v (vector-ref stdin-cell 0)))
+      (if (in-stream? v)
+          (stdin-line-from-port v (in-stream-port v))
+          (stdin-line-from-stream v)))))
 
 (reg-ctor! '("ByteArrayOutputStream" "java.io.ByteArrayOutputStream")
   (lambda _
@@ -331,11 +479,28 @@
       (make-char-writer (transcoded-port (open-file-output-port (path-of src)
                           (if append? (file-options no-fail no-truncate append) (file-options no-fail))
                           (buffer-mode block)) utf8-tx)))))
-;; InputStreamReader / OutputStreamWriter take ownership of the wrapped byte
-;; stream's port and transcode it (UTF-8 default; an explicit charset is honored
-;; only as UTF-8 here).
+;; InputStreamReader / OutputStreamWriter decode / encode the wrapped byte stream
+;; (UTF-8 default; an explicit charset is honored only as UTF-8 here).
+;;
+;; A byte port that pulls each block through the stream's OWN read method,
+;; whatever kind of stream it is. Dispatching rather than transcoding the
+;; stream's port directly is what lets a proxy's override see the read, and it
+;; leaves the wrapped stream OPEN — R6RS transcoded-port takes ownership of the
+;; port it is given, so (io/reader System/in) used to take standard input away
+;; from System/in, and from read-line with it, the moment it was called.
+(define (in-stream-source-port in)
+  (make-custom-binary-input-port
+   "stream-source"
+   (lambda (bv start count)
+     (let* ((arr (na-byte-array (make-bytevector count)))
+            (n (jnum->exact (record-method-dispatch in "read"
+                              (list->cseq (list arr (->num 0) (->num count)))))))
+       (if (<= n 0)
+           0                                   ; the custom-port way of saying EOF
+           (begin (bytevector-copy! (na-bytearray->bv arr) 0 bv start n) n))))
+   #f #f (lambda () #f)))
 (reg-ctor! '("InputStreamReader" "java.io.InputStreamReader")
-  (lambda (in . _) (make-char-reader (transcoded-port (in-stream-port in) utf8-tx))))
+  (lambda (in . _) (make-char-reader (transcoded-port (in-stream-source-port in) utf8-tx))))
 ;; A byte port that hands each encoded block to the stream's OWN write method,
 ;; whatever kind of stream it is — a port-backed out-stream, a PrintStream, or a
 ;; proxy over one. Dispatching rather than writing to the stream's port directly
@@ -453,7 +618,7 @@
   (set! jolt-io-reader
         (lambda (x)
           (if (in-stream? x)
-              (make-char-reader (transcoded-port (in-stream-port x) utf8-tx))
+              (make-char-reader (transcoded-port (in-stream-source-port x) utf8-tx))
               (prev x)))))
 (let ((prev jolt-io-writer))
   (set! jolt-io-writer
@@ -513,6 +678,13 @@
      (put-bytevector (out-stream-port output)
                      (or (input-bytes input) (string->utf8 (input-text input)))))
     ((char-writer? output) (put-string (char-writer-port output) (input-text input)))
+    ;; A PrintStream is a java.io.OutputStream, so a byte source reaches it byte
+    ;; for byte — (io/copy System/in System/out) is the cat. The other text sinks
+    ;; are java.io.Writers and take characters, as they do on the JVM.
+    ((print-stream? output)
+     (let ((bv (input-bytes input)))
+       (record-method-dispatch output "write"
+         (list->cseq (list (if bv (na-bv->bytearray bv) (input-text input)))))))
     ((and (jhost? output) (text-sink-tag? (jhost-tag output)))
      (record-method-dispatch output "write" (list->cseq (list (input-text input)))))
     ((or (jfile? output) (string? output))

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -61,16 +61,54 @@
 ;; is ready keeps whatever it has buffered, because a lookahead there would
 ;; block, and blocking is the one thing available must not do.
 ;;
-;; Two consequences of counting through the port rather than asking the kernel,
-;; which is what the JVM does (ioctl FIONREAD, and ioctl is variadic, so it is
-;; not reachable through the FFI on arm64). The answer for a pipe is capped by
-;; the port's buffer — 4096, where the JVM reports the whole 65536 a pipe holds —
-;; so it under-promises rather than over-promises, which is the safe direction
-;; for a caller sizing a read. And the probe does perform a read(2): the bytes
-;; move from the kernel into the port, still readable through this stream, but no
-;; longer there for a descriptor handed to a subprocess.
+;; The lookahead is the LAST resort. A descriptor is asked directly first —
+;; ioctl(FIONREAD), the same syscall the JVM's available() makes — which is both
+;; exact and free of side effects. Filling the buffer is a real read(2): the
+;; bytes move from the kernel into the port, still readable through this stream
+;; but no longer there for a descriptor handed to a subprocess, and the answer
+;; is capped by the buffer. That is where a target without ioctl ends up.
 (define (port-buffered port)
   (fx- (port-input-size port) (port-input-index port)))
+
+;; FIONREAD — the kernel's own count of what can be read from a descriptor, the
+;; same question the JVM's available() asks. It is the only way to answer for a
+;; pipe or a terminal: those have no length, so everything else jolt can see is
+;; what it has already buffered.
+;;
+;; ioctl is (int fd, unsigned long request, ...), and the binding says so. A
+;; fixed-arity one puts the third argument in a register where Apple arm64's
+;; callee reads the stack, and the call then returns SUCCESS with the
+;; out-parameter untouched — a wrong count that looks like a right one.
+;;
+;; Resolved once and lazily, and #f when there is no ioctl to call: available
+;; falls back to what it can see itself, which is what every platform without
+;; this syscall gets.
+(define fionread-request
+  (if (eq? (sa-os-family) 'macos) #x4004667F #x541B))
+(define fionread-fn 'unresolved)
+(define (fionread-proc)
+  (when (eq? fionread-fn 'unresolved)
+    ;; a duplicate on a race is the same procedure, so this needs no lock
+    (set! fionread-fn
+          (and (not (eq? (sa-os-family) 'windows))
+               (jolt-foreign-proc-safe (__varargs_after 2) "ioctl" '(int unsigned-long void*) 'int))))
+  fionread-fn)
+
+;; The count for PORT's descriptor, or #f when it cannot be had — no ioctl, no
+;; descriptor behind the port, or a descriptor that does not answer FIONREAD (a
+;; regular file on macOS says ENOTTY).
+(define (port-fionread port)
+  (let ((f (fionread-proc))
+        (fd (guard (_ (#t #f)) (port-file-descriptor port))))
+    (and f fd (fixnum? fd) (fx>=? fd 0)
+         (let* ((out (sa-foreign-alloc 4))
+                (n (guard (_ (#t #f))
+                     (sa-foreign-set! 'int out 0 0)
+                     (and (>= (f fd fionread-request out) 0)
+                          (let ((c (sa-foreign-ref 'int out 0)))
+                            (and (>= c 0) c))))))
+           (sa-foreign-free out)
+           n))))
 ;; What is left of a seekable source, or #f when it is not one. The two
 ;; predicates are not a promise: a port over a SOCKET descriptor answers #t to
 ;; both and then raises ESPIPE ("illegal seek") from port-position, so this asks
@@ -88,6 +126,9 @@
       ;; and what an earlier read already pulled into the port's buffer
       (p (+ (port-buffered port) (pipe-available p)))
       ((port-remaining port) => values)
+      ;; the kernel's count plus whatever was already pulled out of it into the
+      ;; port's buffer — the bytes live in two places, as they do for a pipe
+      ((port-fionread port) => (lambda (n) (+ (port-buffered port) n)))
       ((fx>? (port-buffered port) 0) (port-buffered port))
       ((guard (_ (#t #f)) (input-port-ready? port))
        (lookahead-u8 port)

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -15,7 +15,24 @@
 ;; __close so the new readers/streams flow through slurp / line-seq / with-open.
 
 ;; --- byte input stream ------------------------------------------------------
-(define (in-stream-port self) (vector-ref (jhost-state self) 0))
+;; The port is resolved through here rather than read straight out of the slot so
+;; System/in can hold the SYMBOL 'stdin and open the process's standard input on
+;; first use — the same live-resolution port-writer uses for 'out / 'err. A
+;; program that never touches System/in never opens a second handle on fd 0.
+;; Under a mutex because there must be exactly ONE port on fd 0: two threads each
+;; opening their own would each buffer ahead, and whichever read first would eat
+;; input the other never sees.
+(define jolt-stdin-port-mu (make-mutex))
+(define jolt-stdin-port-memo #f)
+(define (jolt-stdin-binary-port)
+  (unless jolt-stdin-port-memo
+    (jolt-with-mutex jolt-stdin-port-mu
+      (unless jolt-stdin-port-memo
+        (set! jolt-stdin-port-memo (standard-input-port (buffer-mode block))))))
+  jolt-stdin-port-memo)
+(define (in-stream-port self)
+  (let ((p (vector-ref (jhost-state self) 0)))
+    (if (eq? p 'stdin) (jolt-stdin-binary-port) p)))
 (define (make-in-stream port) (make-jhost "in-stream" (vector port)))
 (define (in-stream? x) (and (jhost? x) (string=? (jhost-tag x) "in-stream")))
 (register-host-methods! "in-stream"
@@ -266,6 +283,42 @@
     (make-jhost "print-stream"
                 (vector out (and (pair? rest) (jolt-truthy? (car rest)))))))
 
+;; --- System/in, System/out, System/err ---------------------------------------
+;; The three streams the JVM hands every program. jolt had out and err as bare
+;; port-writers and no `in` at all, so a namespace that read stdin the ordinary
+;; ported way — (slurp System/in), (io/reader System/in), (io/copy System/in
+;; System/out) — failed to LOAD: "No matching field or method: System/in".
+;;
+;; System.in is a java.io.InputStream, so it is an in-stream over a binary port on
+;; fd 0 and not a transcoded view of (current-input-port): an InputStream is
+;; bytes, and (io/copy System/in out) has to come out byte-identical for input
+;; that isn't UTF-8 text. That port is separate from the textual one (read-line)
+;; reads, so a program should use one or the other and not interleave them — the
+;; two buffer independently.
+;;
+;; System.out and System.err are java.io.PrintStreams, NOT the java.io.PrintWriter
+;; *out* is; ported code branches on the class and hands them to anything taking
+;; an OutputStream. They wrap the process port-writers registered in
+;; host-static-classes.ss, which is where the underlying ports resolve.  autoFlush
+;; is on, as it is for the JVM's two.
+(define system-in-stream (make-jhost "in-stream" (vector 'stdin)))
+(define (sys-set-in! v)
+  (for-each (lambda (c) (vector-set! (mutable-static-cell c "in" #t) 0 v))
+            '("System" "java.lang.System"))
+  jolt-nil)
+(register-class-statics! "System"
+  (list (cons "in" system-in-stream)
+        (cons "setIn" (lambda (v) (sys-set-in! v)))))
+(sys-set-in! system-in-stream)
+;; io.ss's read-line compares the cell against this to decide whether System/in
+;; has been replaced; it could not build the stream itself (no byte streams yet).
+;; The default keeps the tuned textual path there — char-ready? polling and
+;; fiber-friendly parking — and only a replacement is read through .read.
+(set! stdin-default-stream system-in-stream)
+(for-each (lambda (p)
+            (sys-set-stream! (car p) (make-jhost "print-stream" (vector (cdr p) #t))))
+          (list (cons "out" system-out-writer) (cons "err" system-err-writer)))
+
 (reg-ctor! '("ByteArrayOutputStream" "java.io.ByteArrayOutputStream")
   (lambda _
     (call-with-values open-bytevector-output-port
@@ -343,8 +396,7 @@
              (jolt-close target) jolt-nil)
             ;; the StringWriter / PrintWriter family (io.ss) accumulates through
             ;; its own .write method.
-            ((and (jhost? target)
-                  (member (jhost-tag target) '("writer" "file-writer" "port-writer" "print-writer")))
+            ((and (jhost? target) (text-sink-tag? (jhost-tag target)))
              (record-method-dispatch target "write" (jolt-list (jolt-str-render-one content)))
              (jolt-close target) jolt-nil)
             (else (apply prev target content opts)))))
@@ -378,9 +430,36 @@
            (make-out-stream (open-file-output-port (path-of x)
                               (if append? (file-options no-fail no-truncate append) (file-options no-fail))
                               (buffer-mode block)))))
+        ;; System/out and System/err are already byte streams — pass them through,
+        ;; the way an out-stream passes through.
+        ((and (jhost? x) (text-sink-tag? (jhost-tag x))) x)
         (else (throw-jvm (quote IllegalArgumentException) (string-append "Cannot open <" (jolt-pr-str x) "> as an OutputStream.")))))
 (def-var! "clojure.java.io" "input-stream" jio-input-stream)
 (def-var! "clojure.java.io" "output-stream" jio-output-stream)
+
+;; io/reader and io/writer over a BYTE stream are an InputStreamReader and an
+;; OutputStreamWriter on the JVM: the bytes, decoded / encoded. io.ss's coercions
+;; predate the byte streams in this file and knew neither, so (io/reader
+;; System/in) — the ordinary ported way to read stdin — and (io/writer
+;; (FileOutputStream. f)) both raised "Cannot open <…> as a Reader/Writer".
+;; A value that is already a reader/writer passes through, as io/reader and
+;; io/writer do for every other reader/writer.
+(let ((prev jolt-io-reader))
+  (set! jolt-io-reader
+        (lambda (x)
+          (if (in-stream? x)
+              (make-char-reader (transcoded-port (in-stream-port x) utf8-tx))
+              (prev x)))))
+(let ((prev jolt-io-writer))
+  (set! jolt-io-writer
+        (lambda (x)
+          (cond ((char-writer? x) x)
+                ((out-stream? x) (make-char-writer (transcoded-port (out-stream-sink-port x) utf8-tx)))
+                ((and (jhost? x) (text-sink-tag? (jhost-tag x))) x)
+                (else (prev x))))))
+;; re-bound: the clojure.java.io vars hold the VALUE these names had when io.ss
+;; ran, so a set! above would not reach them.
+(def-var! "clojure.java.io" "writer" jolt-io-writer)
 
 ;; io/make-parents: create the parent directories of the last path segment.
 (define (jio-make-parents . args)
@@ -429,7 +508,7 @@
      (put-bytevector (out-stream-port output)
                      (or (input-bytes input) (string->utf8 (input-text input)))))
     ((char-writer? output) (put-string (char-writer-port output) (input-text input)))
-    ((and (jhost? output) (member (jhost-tag output) '("writer" "file-writer" "port-writer" "print-writer")))
+    ((and (jhost? output) (text-sink-tag? (jhost-tag output)))
      (record-method-dispatch output "write" (list->cseq (list (input-text input)))))
     ((or (jfile? output) (string? output))
      ;; a string INPUT is its characters (io/copy's text source), never a filename

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -38,11 +38,59 @@
     (if (eq? p 'stdin) (jolt-stdin-binary-port) p)))
 (define (make-in-stream port) (make-jhost "in-stream" (vector port)))
 (define (in-stream? x) (and (jhost? x) (string=? (jhost-tag x) "in-stream")))
+
+;; The port behind a stream, or the JVM's IOException when it has been closed.
+;; Reading a closed Chez port raises a classless host error instead, which no
+;; (catch java.io.IOException …) can see and which prints with no class on it.
+;; A piped stream does not close its port (it marks the shared pipe), so this
+;; leaves those to pipe-read!'s own "Pipe closed".
+(define (in-stream-live-port self)
+  (let ((port (in-stream-port self)))
+    (if (port-closed? port) (io-throw "Stream closed") port)))
+
+;; InputStream.available: how many bytes can be read without blocking. jolt
+;; answered 0, which the JVM's contract permits ("an estimate") but which leaves
+;; (pos? (.available in)) false forever, so a loop written to drain what has
+;; arrived never runs a single iteration.
+;;
+;; A seekable source knows its remainder exactly, and that is what
+;; FileInputStream and ByteArrayInputStream answer. A pipe or a terminal has no
+;; length, so the count is what Chez has buffered — and when the buffer is empty
+;; but the descriptor is ready, one lookahead fills it: that consumes nothing and
+;; turns the kernel's read into a real count. A port that cannot say whether it
+;; is ready keeps whatever it has buffered, because a lookahead there would
+;; block, and blocking is the one thing available must not do.
+;;
+;; Two consequences of counting through the port rather than asking the kernel,
+;; which is what the JVM does (ioctl FIONREAD, and ioctl is variadic, so it is
+;; not reachable through the FFI on arm64). The answer for a pipe is capped by
+;; the port's buffer — 4096, where the JVM reports the whole 65536 a pipe holds —
+;; so it under-promises rather than over-promises, which is the safe direction
+;; for a caller sizing a read. And the probe does perform a read(2): the bytes
+;; move from the kernel into the port, still readable through this stream, but no
+;; longer there for a descriptor handed to a subprocess.
+(define (port-buffered port)
+  (fx- (port-input-size port) (port-input-index port)))
+(define (in-stream-available self)
+  (let ((port (in-stream-live-port self))
+        (p (piped-pipe self)))
+    (cond
+      ;; a piped stream holds its bytes in two places: what the writer has queued
+      ;; and what an earlier read already pulled into the port's buffer
+      (p (+ (port-buffered port) (pipe-available p)))
+      ((and (port-has-port-length? port) (port-has-port-position? port))
+       (max 0 (- (port-length port) (port-position port))))
+      ((fx>? (port-buffered port) 0) (port-buffered port))
+      ((guard (_ (#t #f)) (input-port-ready? port))
+       (lookahead-u8 port)
+       (port-buffered port))
+      (else 0))))
+
 (register-host-methods! "in-stream"
   (list
    (cons "read"
          (lambda (self . rest)
-           (let ((port (in-stream-port self)))
+           (let ((port (in-stream-live-port self)))
              (if (null? rest)
                  ;; InputStream.read() returns the byte as an UNSIGNED int 0..255
                  ;; (-1 at EOF) — the one place a byte is not signed, because the
@@ -67,11 +115,11 @@
                              (if (>= i n) (->num n)
                                  (begin (vector-set! vec (+ off i) (na-u8->byte (bytevector-u8-ref tmp i)))
                                         (loop (+ i 1))))))))))))
-   (cons "readAllBytes" (lambda (self) (let ((bv (get-bytevector-all (in-stream-port self))))
+   (cons "readAllBytes" (lambda (self) (let ((bv (get-bytevector-all (in-stream-live-port self))))
                                          (na-byte-array (if (eof-object? bv) (make-bytevector 0) bv)))))
-   (cons "skip" (lambda (self n) (let ((bv (get-bytevector-n (in-stream-port self) (jnum->exact n))))
+   (cons "skip" (lambda (self n) (let ((bv (get-bytevector-n (in-stream-live-port self) (jnum->exact n))))
                                    (->num (if (eof-object? bv) 0 (bytevector-length bv))))))
-   (cons "available" (lambda (self) (->num 0)))
+   (cons "available" (lambda (self) (->num (in-stream-available self))))
    ;; A piped stream marks its shared pipe instead of closing the Chez port: a
    ;; read after close has to raise the JVM's IOException, and a closed Chez port
    ;; raises a classless host error before the port's own reader is consulted.
@@ -795,12 +843,12 @@
   (nongenerative jpipe-v1))
 (define (new-jpipe) (make-jpipe (make-mutex) (make-condition) '() 0 #f #f))
 
-(define (pipe-io-throw msg) (jolt-throw (jolt-host-throwable "java.io.IOException" msg)))
+(define (io-throw msg) (jolt-throw (jolt-host-throwable "java.io.IOException" msg)))
 
 (define (pipe-write! p bv start count)
   (jolt-with-mutex (jpipe-mu p)
-    (when (jpipe-rclosed? p) (pipe-io-throw "Read end dead"))
-    (when (jpipe-wclosed? p) (pipe-io-throw "Pipe closed"))
+    (when (jpipe-rclosed? p) (io-throw "Read end dead"))
+    (when (jpipe-wclosed? p) (io-throw "Pipe closed"))
     (let ((chunk (make-bytevector count)))
       (bytevector-copy! bv start chunk 0 count)
       (jpipe-chunks-set! p (append (jpipe-chunks p) (list chunk)))
@@ -815,7 +863,7 @@
   (jolt-cv-wait (jpipe-mu p) (jpipe-cv p) #f
     (lambda (_timed-out?)
       (cond
-        ((jpipe-rclosed? p) (pipe-io-throw "Pipe closed"))
+        ((jpipe-rclosed? p) (io-throw "Pipe closed"))
         ((pair? (jpipe-chunks p))
          (let* ((head (car (jpipe-chunks p)))
                 (avail (- (bytevector-length head) (jpipe-pos p)))
@@ -827,6 +875,17 @@
            n))
         ((jpipe-wclosed? p) 0)                      ; writer done: end of stream
         (else jolt-cv-again)))))
+
+;; PipedInputStream.available: what the writer has queued and the reader has not
+;; taken yet. The queue IS the buffer here, so this is exact rather than an
+;; estimate.
+(define (pipe-available p)
+  (jolt-with-mutex (jpipe-mu p)
+    (when (jpipe-rclosed? p) (io-throw "Pipe closed"))
+    (let loop ((cs (jpipe-chunks p)) (n 0))
+      (if (null? cs)
+          (max 0 (- n (jpipe-pos p)))
+          (loop (cdr cs) (+ n (bytevector-length (car cs))))))))
 
 (define (pipe-close-write! p)
   (jolt-with-mutex (jpipe-mu p)
@@ -848,7 +907,7 @@
 ;; buffer rather than one adopting the other's.
 (define (pipe-connect! a b)
   (let ((ca (piped-cell a)) (cb (piped-cell b)))
-    (unless (and ca cb) (pipe-io-throw "Not a piped stream"))
+    (unless (and ca cb) (io-throw "Not a piped stream"))
     (let ((shared (unbox ca)))
       (set-box! cb shared))))
 

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -514,7 +514,35 @@
           (if r (car r) (apply %io-host-call method target args)))
         (apply %io-host-call method target args))))
 
+;; --- the files a load READ ---------------------------------------------------
+;; Every file the io layer opens on behalf of USER code announces itself here.
+;;
+;; The AOT cache (loader.ss) binds the sink while it compiles a namespace: a
+;; macro that slurps an external file bakes that file's CONTENTS into the
+;; artifact exactly the way it bakes a macro expansion, so the file belongs in the
+;; cache key. Keying on the .clj alone left an edited SQL migration serving the
+;; previous build's statements out of the cache, silently — the namespace source
+;; is untouched, so its hash still matches (jolt#576).
+;;
+;; A file that does NOT exist is announced too. (io/resource "migrations/003.sql")
+;; answering nil is a compile-time answer like any other, and it stops being the
+;; right one the moment someone adds the file.
+;;
+;; It lives here rather than beside the cache because rt.ss is loaded in contexts
+;; that never load loader.ss (bootstrap, devboot, the .ss unit tests), and the io
+;; layer must not reference a name those don't have. Unbound (#f) in every
+;; ordinary run — the cost off the compile path is one thread-parameter read.
+(define io-file-read-sink (make-thread-parameter #f))
+(define (io-note-file-read! path)
+  (let ((sink (io-file-read-sink)))
+    (when (and (vector? sink) (string? path)
+               (not (member path (vector-ref sink 0))))
+      (vector-set! sink 0 (cons path (vector-ref sink 0))))))
+
 ;; --- slurp / spit / flush ---------------------------------------------------
+;; NOT announced: the loader reads namespace SOURCE through this too, and those
+;; are described by the cache key already. slurp-path / io/resource / io/reader —
+;; the entry points user code reaches — announce for themselves.
 (define (read-file-string path)
   (with-port (open-input-file path)
     (lambda (p) (let ((s (get-string-all p))) (if (eof-object? s) "" s)))))
@@ -589,6 +617,7 @@
 ;; a file by slurping and catching FNF. A raw Chez open-input-file condition is not
 ;; catchable as that class, so the caller's fallback never runs.
 (define (slurp-path path)
+  (io-note-file-read! path)
   (unless (file-exists? path)
     (throw-jvm (quote java.io.FileNotFoundException)
                (string-append path " (No such file or directory)")))
@@ -832,12 +861,15 @@
 (define (jolt-io-reader x)
   (cond
     ((reader-jhost? x) x)
-    ((jfile? x) (host-new "StringReader" (read-file-string (jfile-fs x))))
+    ((jfile? x) (io-note-file-read! (jfile-fs x))
+                (host-new "StringReader" (read-file-string (jfile-fs x))))
     ((embedded-res? x)
      (let ((c (embedded-res-content x)))
        (host-new "StringReader" (if (bytevector? c) (utf8->string c) c))))
     ((url-jhost? x) (host-new "StringReader" (url-content x)))
-    ((string? x) (host-new "StringReader" (read-file-string (project-relative x))))
+    ((string? x) (let ((p (project-relative x)))
+                   (io-note-file-read! p)
+                   (host-new "StringReader" (read-file-string p))))
     ((or (cseq? x) (empty-list-t? x) (pvec? x))
      (host-new "StringReader" (seq-source->string x)))
     ;; anything else is not a source, and quietly rendering it would read as empty
@@ -898,15 +930,25 @@
                   rel)))
     (make-url (string-append "file:" (jfile-abs rel)))))
 
+;; Every candidate probed is announced to the AOT cache (io-note-file-read!),
+;; not just the one that answered — including the ones that were not there. Which
+;; root wins is part of the answer, so a file appearing at an EARLIER root has to
+;; invalidate; and a lookup that found nothing at all has to invalidate when the
+;; resource is finally added (a new migration is exactly that). An embedded
+;; resource is baked into the binary and covered by the runtime fingerprint, so it
+;; contributes nothing here.
 (define (jolt-io-resource name)
   (let* ((nm (jolt-str-render-one name))
          (emb (hashtable-ref embedded-resources nm #f)))
     (if emb (make-embedded-res nm emb)
         (let loop ((roots (get-source-roots)))
-          (cond ((null? roots) jolt-nil)
-                ((file-exists? (string-append (car roots) "/" nm))
-                 (resource-file-url (car roots) nm))
-                (else (loop (cdr roots))))))))
+          (if (null? roots)
+              jolt-nil
+              (let ((cand (string-append (car roots) "/" nm)))
+                (io-note-file-read! cand)
+                (if (file-exists? cand)
+                    (resource-file-url (car roots) nm)
+                    (loop (cdr roots)))))))))
 (def-var! "clojure.java.io" "resource" jolt-io-resource)
 ;; as-url honors a library-registered URL class (e.g. jolt-lang/http-client's full
 ;; java.net.URL shim) so io/as-url and (URL. spec) agree; else the file-only jhost.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -717,81 +717,8 @@
 ;; str of a jfile is its path (Clojure's File.toString).
 (register-str-render! jfile? jfile-path)
 
-;; stdin line seam: the clojure.core *in* reader (50-io.clj) drives read-line /
-;; read / read+string through __stdin-read-line. Return the next line (newline
-;; stripped) or nil at EOF. Without this, (read-line) and the REPL call nil.
-;;
-;; Waits in `sleep`, NOT inside the read. Chez's blocking read holds the whole
-;; Scheme world while it waits: no other thread runs at all, so a future stopped
-;; ticking and an agent stopped draining the moment the main thread reached a
-;; prompt, and the SIGTERM watcher (concurrency.ss) could not wake to run the
-;; shutdown hooks either. On the JVM those all keep running while a thread sits in
-;; System.in.read(). sleep is collect-safe, so parking THERE and reading only once
-;; the port has something leaves every other thread alive (jolt-p9ua). Backs off
-;; 0.5ms -> 20ms, the shape proc-wait-blocking uses.
-;;
-;; A line already in the buffer costs one char-ready? and no sleep at all, so a
-;; piped read-line loop keeps its throughput: 1326 -> 1386 ns/line, medians of
-;; four 300k-line runs each with the wait compiled out and back in, 1.045x.
-;; Whether the port can answer char-ready? at all is settled ONCE per port rather
-;; than under a guard per line — the guard was most of the cost and took the same
-;; measurement to 1460 ns/line, 1.10x, which is the ceiling rather than a rounding
-;; error. A port that cannot answer reads the old, blocking way.
-;;
-;; char-ready? promises a CHAR, not a whole line, so a writer that sends half a
-;; line and then stalls still parks the world for the remainder — a far smaller
-;; window than "until any input arrives", and the most this port surface offers.
-(define jolt-stdin-poll-step0 1)               ; 1ms
-(define jolt-stdin-poll-step-max 20)          ; 20ms
-(define jolt-stdin-poll-port (box #f))         ; the port the answer below is about
-(define jolt-stdin-poll-ok (box #f))
-(define (jolt-stdin-wait-ready! in)
-  (unless (eq? (unbox jolt-stdin-poll-port) in)
-    (set-box! jolt-stdin-poll-ok (guard (_ (#t #f)) (char-ready? in) #t))
-    (set-box! jolt-stdin-poll-port in))
-  (when (unbox jolt-stdin-poll-ok)
-    (let loop ((step jolt-stdin-poll-step0))
-      (unless (char-ready? in)
-        ;; jolt-pause-ms and not (sleep): on a fiber this parks for the step and
-        ;; gives the carrier up, so (read-line) from a go block no longer stops
-        ;; every other fiber placed on that carrier until input arrives.
-        (jolt-pause-ms step)
-        (loop (min jolt-stdin-poll-step-max (* step 2)))))))
-
-;; read-line reads System/in, so System/setIn has to redirect it — that is how a
-;; test fixture or a REPL harness feeds a program its input.
-;;
-;; The stream System/in holds by DEFAULT is built by io-streams.ss, which owns the
-;; byte streams and loads after this file; it fills stdin-default-stream in when it
-;; does. The comparison is by identity and the cell is resolved once, so the
-;; default path costs one vector-ref and one eq? per line — this loop is tuned
-;; (see jolt-stdin-wait-ready! above) and a per-line hashtable lookup would show.
-;; Until io-streams.ss runs, the cell holds nil and nothing matches #f, so the
-;; default branch is taken either way.
-(define stdin-default-stream #f)
-(define stdin-cell (mutable-static-cell "System" "in" #t))
-;; A replaced System/in is read a byte at a time through its own .read; \n ends a
-;; line and the \r of a CRLF is dropped, as readLine does.
-(define (stdin-read-line-from v)
-  (let loop ((acc '()))
-    (let ((b (record-method-dispatch v "read" jolt-nil)))
-      (cond
-        ((or (jolt-nil? b) (not (number? b)) (< (jnum->exact b) 0))
-         (if (null? acc) jolt-nil (stdin-line->string acc)))
-        ((= (jnum->exact b) 10) (stdin-line->string acc))
-        (else (loop (cons (bitwise-and (jnum->exact b) #xff) acc)))))))
-(define (stdin-line->string acc)      ; acc is reversed, so the \r is at the head
-  (utf8->string (u8-list->bytevector (reverse (if (and (pair? acc) (= (car acc) 13))
-                                                  (cdr acc)
-                                                  acc)))))
-(def-var! "clojure.core" "__stdin-read-line"
-  (lambda ()
-    (let ((v (vector-ref stdin-cell 0)))
-      (if (eq? v stdin-default-stream)
-          (let ((in (current-input-port)))
-            (jolt-stdin-wait-ready! in)
-            (let ((l (get-line in))) (if (eof-object? l) jolt-nil l)))
-          (stdin-read-line-from v)))))
+;; The stdin line seam (__stdin-read-line, the *in* reader's source) lives in
+;; io-streams.ss, next to the System/in stream it reads.
 
 ;; (type f) -> :jolt/file (the tagged-file :jolt/type). Registered through the
 ;; type-arm registry (natives-meta.ss) so the dispatcher picks it up.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -729,11 +729,40 @@
         (jolt-pause-ms step)
         (loop (min jolt-stdin-poll-step-max (* step 2)))))))
 
+;; read-line reads System/in, so System/setIn has to redirect it — that is how a
+;; test fixture or a REPL harness feeds a program its input.
+;;
+;; The stream System/in holds by DEFAULT is built by io-streams.ss, which owns the
+;; byte streams and loads after this file; it fills stdin-default-stream in when it
+;; does. The comparison is by identity and the cell is resolved once, so the
+;; default path costs one vector-ref and one eq? per line — this loop is tuned
+;; (see jolt-stdin-wait-ready! above) and a per-line hashtable lookup would show.
+;; Until io-streams.ss runs, the cell holds nil and nothing matches #f, so the
+;; default branch is taken either way.
+(define stdin-default-stream #f)
+(define stdin-cell (mutable-static-cell "System" "in" #t))
+;; A replaced System/in is read a byte at a time through its own .read; \n ends a
+;; line and the \r of a CRLF is dropped, as readLine does.
+(define (stdin-read-line-from v)
+  (let loop ((acc '()))
+    (let ((b (record-method-dispatch v "read" jolt-nil)))
+      (cond
+        ((or (jolt-nil? b) (not (number? b)) (< (jnum->exact b) 0))
+         (if (null? acc) jolt-nil (stdin-line->string acc)))
+        ((= (jnum->exact b) 10) (stdin-line->string acc))
+        (else (loop (cons (bitwise-and (jnum->exact b) #xff) acc)))))))
+(define (stdin-line->string acc)      ; acc is reversed, so the \r is at the head
+  (utf8->string (u8-list->bytevector (reverse (if (and (pair? acc) (= (car acc) 13))
+                                                  (cdr acc)
+                                                  acc)))))
 (def-var! "clojure.core" "__stdin-read-line"
   (lambda ()
-    (let ((in (current-input-port)))
-      (jolt-stdin-wait-ready! in)
-      (let ((l (get-line in))) (if (eof-object? l) jolt-nil l)))))
+    (let ((v (vector-ref stdin-cell 0)))
+      (if (eq? v stdin-default-stream)
+          (let ((in (current-input-port)))
+            (jolt-stdin-wait-ready! in)
+            (let ((l (get-line in))) (if (eof-object? l) jolt-nil l)))
+          (stdin-read-line-from v)))))
 
 ;; (type f) -> :jolt/file (the tagged-file :jolt/type). Registered through the
 ;; type-arm registry (natives-meta.ss) so the dispatcher picks it up.
@@ -767,8 +796,8 @@
   (cond
     ((jolt-nil? x) jolt-nil)
     ((and (jhost? x) (or (pushback-reader-tag? (jhost-tag x))
-                         (member (jhost-tag x) '("string-reader" "writer"
-                                                 "file-writer" "port-writer" "print-writer"))))
+                         (text-sink-tag? (jhost-tag x))
+                         (string=? (jhost-tag x) "string-reader")))
      (record-method-dispatch x "close" jolt-nil) jolt-nil)
     ;; a library's stream shim (tagged-table) closes via its registered .close
     ;; method (a no-op for in-memory streams); absent method -> no-op.

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -272,6 +272,7 @@
         (let ((n (file-length port))) (close-port port) n))))
 
 (define (nio-read-bv fp)
+  (io-note-file-read! fp)          ; a compile-time read belongs in the AOT key (io.ss)
   (let ((port (open-file-input-port fp)))
     (let ((bv (get-bytevector-all port)))
       (close-port port)
@@ -351,7 +352,9 @@
         (cons "deleteIfExists"(lambda (p) (nio-delete1 (nfp p) #t)))
         (cons "readAllBytes"  (lambda (p) (na-bv->bytearray (nio-read-bv (nfp p)))))
         (cons "readAllLines"  (lambda (p . _) (nio-read-lines (nfp p))))
-        (cons "newInputStream"(lambda (p . _) (make-in-stream (open-file-input-port (nfp p)))))
+        (cons "newInputStream"(lambda (p . _) (let ((fp (nfp p)))
+                                                (io-note-file-read! fp)
+                                                (make-in-stream (open-file-input-port fp)))))
         (cons "createTempFile"      (lambda args (nio-files-create-temp args #f)))
         (cons "createTempDirectory" (lambda args (nio-files-create-temp args #t))))))
   (set! files-accum (append files-accum files-statics)))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -509,6 +509,18 @@
                 (fxlogand (fx* (fxlogxor h (char->integer (string-ref s i)))
                                16777619)
                           #xFFFFFFFF))))))
+;; The same hash over BYTES. A file a compile read is whatever the program said it
+;; was — a .sql migration, an .edn config, a PNG — so it cannot be decoded as text
+;; first; the third would raise.
+(define (aot-bytes-hash bv)
+  (let ((n (bytevector-length bv)))
+    (let loop ((i 0) (h 2166136261))
+      (if (fx=? i n)
+          h
+          (loop (fx+ i 1)
+                (fxlogand (fx* (fxlogxor h (bytevector-u8-ref bv i))
+                               16777619)
+                          #xFFFFFFFF))))))
 (define (aot-source-fingerprint)
   (let loop ((dirs aot-runtime-source-dirs) (h 17) (n 0))
     (if (null? dirs)
@@ -680,6 +692,56 @@
         (filter (lambda (s) (fx>? (string-length s) 0))
                 (bld-string-lines-like (read-file-string path))))
       '()))
+;; --- files read at compile time ----------------------------------------------
+;; The same argument as the dependency closure, for the other thing a compile can
+;; bake in. A macro that slurps a SQL migration embeds that file's CONTENTS in the
+;; artifact; keying on the .clj alone left every consumer serving the previous
+;; build's statements out of the cache, with nothing to notice — the .clj is
+;; untouched, so its hash still matches (jolt#576).
+;;
+;; The reads are RECORDED during the compile, the way the requires are: io.ss's
+;; io-file-read-sink is bound around the capture load and every user-facing read
+;; (slurp, io/reader, io/input-stream, io/resource, Files/read*) announces its
+;; path. That covers a path spelled any of the ways a program can spell one,
+;; without the loader having to know which.
+;;
+;; The sidecar is written only when the namespace actually read something, so the
+;; ordinary namespace carries no extra file — and it is DELETED when a recompile
+;; reads nothing, since it is named by the own hash and a stale one would
+;; otherwise still be found under an unchanged source.
+(define (aot-res-sidecar base) (string-append base ".res"))
+(define (aot-write-res-list! path paths)
+  (if (null? paths)
+      (guard (e (else #f)) (delete-file path #f))
+      (aot-write-dep-list! path paths)))
+;; What one recorded file contributes: its length and content, or 0 when it isn't
+;; there. ABSENT has to be a value of its own rather than "no contribution":
+;; (io/resource "003.sql") answering nil is a compile-time answer, and adding the
+;; file has to move the key. An empty file hashes to something else (the fold of a
+;; zero length with FNV's basis), so the two never collide.
+(define (aot-file-digest path)
+  (guard (e (else 0))
+    (if (file-exists? path)
+        (let ((bv (read-file-bytes path)))
+          (aot-hash-mix (bytevector-length bv) (aot-bytes-hash bv)))
+        0)))
+;; The PATH is folded alongside its content, so gaining or losing an entry moves
+;; the digest even when the contents happen to coincide. Sorted, like the deps, so
+;; the result doesn't depend on the order the reads happened to be recorded in.
+(define (aot-res-fold paths)
+  (fold-left (lambda (h p)
+               (aot-hash-mix (aot-hash-mix h (aot-content-hash p)) (aot-file-digest p)))
+             17 (sort string<? paths)))
+;; A dependency's recorded reads, for the transitive fold. Memoized per process
+;; like the dep digest — a namespace required from several places is hashed once.
+(define aot-res-digest-memo (make-hashtable string-hash string=?))
+(define (aot-res-digest name own)
+  (or (hashtable-ref aot-res-digest-memo name #f)
+      (let ((d (aot-res-fold (aot-read-dep-list
+                               (aot-res-sidecar (aot-base-for-own name own))))))
+        (jolt-with-mutex ldr-tbl-mu (hashtable-set! aot-res-digest-memo name d))
+        d)))
+
 ;; local line splitter — build.ss's is not loaded on the run path.
 (define (bld-string-lines-like s)
   (let ((n (string-length s)))
@@ -722,11 +784,13 @@
 (define (aot-inflight-key name)
   (string-append (number->string (get-thread-id)) "\x0;" name))
 (define (aot-ns-digest name)
-  ;; a namespace's whole contribution: its own hash folded with its deps'
+  ;; a namespace's whole contribution: its own hash, the files its compile read,
+  ;; and its deps'. All three so a change anywhere below reaches every consumer.
   (let ((own (aot-own-key name)))
     (if (not own)
         0
-        (aot-hash-mix (equal-hash own) (aot-dep-digest name own)))))
+        (aot-hash-mix (aot-hash-mix (equal-hash own) (aot-res-digest name own))
+                      (aot-dep-digest name own)))))
 (define (aot-dep-digest name own)
   (or (hashtable-ref aot-dep-digest-memo name #f)
       (let ((ik (aot-inflight-key name)))
@@ -743,14 +807,17 @@
                   (hashtable-delete! aot-dep-inflight ik)
                   (hashtable-set! aot-dep-digest-memo name d))
                 d))))))
-;; The full cache base: own hash, then the dep digest. A namespace with no
-;; recorded deps (or none cacheable) folds to the digest of the empty list, so the
-;; suffix is constant for the whole leaf case rather than absent.
-(define (aot-base-full name own deps)
+;; The full cache base: own hash, then the dep digest folded with the digest of
+;; the files this compile read. A namespace with no recorded deps or reads (or
+;; none cacheable) folds to the digest of the empty list, so the suffix is
+;; constant for the whole leaf case rather than absent.
+(define (aot-base-full name own deps res)
   (string-append (aot-base-for-own name own) "-"
                  (number->string
-                   (fold-left (lambda (h dep) (aot-hash-mix h (aot-ns-digest dep))) 17
-                              (sort string<? deps))
+                   (aot-hash-mix
+                     (fold-left (lambda (h dep) (aot-hash-mix h (aot-ns-digest dep))) 17
+                                (sort string<? deps))
+                     (aot-res-fold res))
                    16)))
 ;; Tee the per-form emitted Scheme (compile-eval.ss jolt-aot-capture) while running
 ;; the normal load loop, so a cache miss reproduces the EXACT interleaved analyze
@@ -799,25 +866,34 @@
 ;; would strand the fasl — the next run computes the key WITH deps and misses it,
 ;; paying a second compile for every namespace that requires anything.
 (define (aot-compile-and-cache name file src own)
-  (let ((sink (aot-new-dep-sink)))
-    (let ((captured (parameterize ((aot-dep-sink sink)) (aot-capture-load file src))))
+  (let ((sink (aot-new-dep-sink))
+        ;; the files this compile reads, collected the same way and for the same
+        ;; reason (io.ss io-file-read-sink). A nested require binds its own, so a
+        ;; dependency's reads are recorded against the dependency.
+        (res-sink (vector '())))
+    (let ((captured (parameterize ((aot-dep-sink sink) (io-file-read-sink res-sink))
+                      (aot-capture-load file src))))
       (unless (and (string? captured) (fx>? (string-length captured) 0))
         (aot-info (string-append "nothing captured for " name ", not caching")))
       (when (and (string? captured) (fx>? (string-length captured) 0))
         (let* ((deps (filter aot-cacheable-file (vector-ref sink 0)))
-               (base (aot-base-full name own deps))
+               (res (vector-ref res-sink 0))
+               (base (aot-base-full name own deps res))
                (scm (string-append base ".scm"))
                (so  (string-append base ".so"))
                (pid (number->string (get-process-id)))
                (tmp-scm (string-append base ".tmp" pid ".scm"))
                (tmp-so  (string-append base ".tmp" pid ".so")))
           (aot-mkdir-p (path-parent base))
-          ;; the sidecar is named by the own hash alone, so the next run can read
-          ;; it back before it is able to compute the full key.
+          ;; the sidecars are named by the own hash alone, so the next run can read
+          ;; them back before it is able to compute the full key.
           (aot-write-dep-list! (aot-dep-sidecar (aot-base-for-own name own)) deps)
-          ;; this run already computed a digest for `name` from the OLD sidecar;
-          ;; drop it so a later require in the same process sees the new deps.
-          (jolt-with-mutex ldr-tbl-mu (hashtable-delete! aot-dep-digest-memo name))
+          (aot-write-res-list! (aot-res-sidecar (aot-base-for-own name own)) res)
+          ;; this run already computed digests for `name` from the OLD sidecars;
+          ;; drop them so a later require in the same process sees the new ones.
+          (jolt-with-mutex ldr-tbl-mu
+            (hashtable-delete! aot-dep-digest-memo name)
+            (hashtable-delete! aot-res-digest-memo name))
           (guard (e (else (aot-info (string-append "compile failed for " name))
                           (delete-file tmp-scm #f) (delete-file tmp-so #f) #f))
             (let ((out (open-output-file tmp-scm 'replace)))
@@ -854,23 +930,25 @@
            ;; no fingerprint = we can't tell this runtime from another one, so
            ;; there is no key that would be safe to reuse.
            (aot-runtime-fingerprint))
-      ;; the deps this ns's own load records belong to IT, not to whoever is
-      ;; requiring it — bind a fresh sink so a nested load can't append to the
-      ;; enclosing one. A hit binds #f: the fasl it loads re-runs the requires,
-      ;; and those are already described by this namespace's own sidecar.
+      ;; the deps and reads this ns's own load records belong to IT, not to
+      ;; whoever is requiring it — bind fresh sinks so a nested load can't append
+      ;; to the enclosing one. A hit binds #f on both: the fasl it loads re-runs
+      ;; the requires and re-does the reads, and those are already described by
+      ;; this namespace's own sidecars.
       (let* ((src (ldr-read-source file))
              (own (aot-cache-key src))
+             (obase (aot-base-for-own name own))
              (base (aot-base-full name own
-                                  (aot-read-dep-list
-                                    (aot-dep-sidecar (aot-base-for-own name own)))))
+                                  (aot-read-dep-list (aot-dep-sidecar obase))
+                                  (aot-read-dep-list (aot-res-sidecar obase))))
              (so (string-append base ".so")))
         (if (file-exists? so)
             (begin (aot-info (string-append "hit " name))
-                   (parameterize ((aot-dep-sink #f))
+                   (parameterize ((aot-dep-sink #f) (io-file-read-sink #f))
                      (aot-safe-load-or-recompile name file src own base)))
             (begin (aot-info (string-append "miss " name))
                    (aot-compile-and-cache name file src own))))
-      (parameterize ((aot-dep-sink #f)) (load-jolt-file file))))
+      (parameterize ((aot-dep-sink #f) (io-file-read-sink #f)) (load-jolt-file file))))
 
 ;; Mark a namespace as loaded in both the host hashtable and the *loaded-libs* ref.
 (define (ldr-mark-loaded! name)

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -69,6 +69,24 @@
                    (sa-load-shared-object #f)
                    (and (sa-foreign-entry? name)
                         (sa-foreign-procedure name args res)))))
+         #'(if (eq? (sa-os-family) 'windows) win unx)))
+      ;; With a calling convention — (__varargs_after n) for a VARIADIC C
+      ;; function like ioctl or fcntl. The convention is what puts the variadic
+      ;; arguments where the callee's va_list reads them: Apple arm64 passes
+      ;; them on the stack, and a fixed-arity binding leaves them in registers,
+      ;; so the call returns SUCCESS having read whatever was on the stack.
+      ;; The Windows branch drops it — x64 passes variadic and named arguments
+      ;; alike there, and the runtime (eval) construction has no slot for one.
+      ((_ conv name (quote args) (quote res))
+       (with-syntax
+           ((win #'(guard (e (#t #f))
+                   (sa-load-shared-object #f)
+                   (and (sa-foreign-entry? name)
+                        (sa-foreign-procedure-runtime name (quote args) (quote res) #f))))
+            (unx #'(guard (e (#t #f))
+                   (sa-load-shared-object #f)
+                   (and (sa-foreign-entry? name)
+                        (sa-foreign-procedure conv name args res)))))
          #'(if (eq? (sa-os-family) 'windows) win unx))))))
 
 ;; Same, for an entry point that BLOCKS (a pipe read, sigwait). The call must be

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -8,9 +8,9 @@
   InetAddress and the socket stream classes with the host class registry.
 
   Deliberate divergences from the JVM (test/conformance/known-divergences.edn):
-  .available is capped by its peek window, a recv error reads as EOF (-1)
-  rather than throwing, .connect ignores its timeout argument (always
-  blocking), and toString formats are approximate. IPv4 only."
+  a recv error reads as EOF (-1) rather than throwing, .connect ignores its
+  timeout argument (always blocking), and toString formats are approximate.
+  IPv4 only."
   (:require [jolt.ffi :as ffi]
             [jolt.io-poller :as poller]
             [clojure.string :as str]))
@@ -30,6 +30,11 @@
 (ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t :blocking)
 (ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t :blocking)
 (ffi/defcfn c-close       "close"       [:int] :int)
+;; ioctl is (int fd, unsigned long request, ...) — the :varargs marker puts the
+;; third argument where the callee's va_list reads it. Binding it fixed-arity
+;; instead is what makes Apple arm64 return SUCCESS with the out-parameter
+;; untouched, since variadic arguments travel on the stack there.
+(ffi/defcfn c-ioctl       "ioctl"       [:int :ulong :varargs :pointer] :int)
 (ffi/defcfn c-inet-addr   "inet_addr"   [:pointer] :uint)
 (ffi/defcfn c-gethostbyname "gethostbyname" [:pointer] :pointer :blocking)
 
@@ -43,7 +48,7 @@
 (def ^:private so-reuse     (if macos? 4 2))
 (def ^:private so-nosigpipe 0x1022)
 (def ^:private msg-nosignal (if macos? 0 0x4000))
-(def ^:private msg-peek 2)
+(def ^:private fionread (if macos? 0x4004667F 0x541B))
 
 ;; -- sockaddr helpers ---------------------------------------------------------
 
@@ -280,44 +285,26 @@
       {:n n :bytes (ffi/read-array buf n)}
       {:n -1 :bytes nil})))
 
-;; InputStream.available. The JVM asks the kernel through ioctl(FIONREAD), which
-;; is out of reach: ioctl is variadic, and on Apple's arm64 ABI a variadic
-;; argument travels on the stack where the FFI puts it in a register — the call
-;; then RETURNS SUCCESS with the out-parameter untouched, which is a wrong count
-;; that looks like a right one. (It happens to work on Linux aarch64, where
-;; variadic and named arguments are passed alike. One platform's silent lie is
-;; enough to keep the whole approach out.)
-;;
-;; MSG_PEEK reports what has arrived and consumes none of it, and it is correct
-;; on both. Never waits: every fd here is O_NONBLOCK (guard-fd!), so a peek with
-;; nothing there is EAGAIN, and this deliberately bypasses io-call, whose whole
-;; job is to wait for readiness.
-;;
-;; The answer is capped by the window — java.io documents available as an
-;; estimate, and this is the same bound the byte streams over Chez ports report
-;; (their port buffer). It under-promises, which is the safe direction for a
-;; caller sizing a read.
-(def ^:private peek-window 4096)
-
+;; InputStream.available — the same question the JVM asks, through the same
+;; syscall: ioctl(fd, FIONREAD, &n) reports what has arrived without reading it
+;; or waiting for more. The binding is what has to be right; see c-ioctl above.
 (defn- socket-available [self]
   ;; Closed is an error on both, and here it is a KNOWN one — the socket carries
   ;; the flag — so it raises rather than answering, where a recv error can only
-  ;; read as EOF. Java raises SocketException, a subclass of this, so ported code
-  ;; catching java.io.IOException sees it on either. Peeking is also not an
+  ;; read as EOF. SocketException is the class Java raises and a subclass of
+  ;; IOException, so a catch of either sees it. Asking the kernel is also not an
   ;; option once the fd is closed: the number is free to be reused by the next
   ;; socket, and the count would be somebody else's.
   (when (jolt.host/ref-get (jolt.host/ref-get self :socket) :closed?)
-    (throw (java.io.IOException. "Socket closed")))
+    (throw (java.net.SocketException. "Socket closed")))
   (let [fd (jolt.host/ref-get self :fd)
-        buf (ffi/alloc peek-window)]
+        out (ffi/alloc 4)]
     (try
-      (loop []
-        (let [n (c-recv fd buf peek-window msg-peek)]
-          (cond
-            (pos? n) n
-            (and (neg? n) (poller/eintr?)) (recur)
-            :else 0)))
-      (finally (ffi/free buf)))))
+      (ffi/write out :int 0 0)
+      ;; a failed ioctl reads as "nothing there", the way a failed recv reads as
+      ;; EOF — errno is not reachable to say more
+      (if (neg? (c-ioctl fd fionread out)) 0 (max 0 (ffi/read out :int 0)))
+      (finally (ffi/free out)))))
 
 (def ^:private socket-input-stream-methods
   {"read"

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -8,9 +8,9 @@
   InetAddress and the socket stream classes with the host class registry.
 
   Deliberate divergences from the JVM (test/conformance/known-divergences.edn):
-  .available answers 0, a recv error reads as EOF (-1) rather than throwing,
-  .connect ignores its timeout argument (always blocking), and toString
-  formats are approximate. IPv4 only."
+  .available is capped by its peek window, a recv error reads as EOF (-1)
+  rather than throwing, .connect ignores its timeout argument (always
+  blocking), and toString formats are approximate. IPv4 only."
   (:require [jolt.ffi :as ffi]
             [jolt.io-poller :as poller]
             [clojure.string :as str]))
@@ -43,6 +43,7 @@
 (def ^:private so-reuse     (if macos? 4 2))
 (def ^:private so-nosigpipe 0x1022)
 (def ^:private msg-nosignal (if macos? 0 0x4000))
+(def ^:private msg-peek 2)
 
 ;; -- sockaddr helpers ---------------------------------------------------------
 
@@ -279,6 +280,45 @@
       {:n n :bytes (ffi/read-array buf n)}
       {:n -1 :bytes nil})))
 
+;; InputStream.available. The JVM asks the kernel through ioctl(FIONREAD), which
+;; is out of reach: ioctl is variadic, and on Apple's arm64 ABI a variadic
+;; argument travels on the stack where the FFI puts it in a register — the call
+;; then RETURNS SUCCESS with the out-parameter untouched, which is a wrong count
+;; that looks like a right one. (It happens to work on Linux aarch64, where
+;; variadic and named arguments are passed alike. One platform's silent lie is
+;; enough to keep the whole approach out.)
+;;
+;; MSG_PEEK reports what has arrived and consumes none of it, and it is correct
+;; on both. Never waits: every fd here is O_NONBLOCK (guard-fd!), so a peek with
+;; nothing there is EAGAIN, and this deliberately bypasses io-call, whose whole
+;; job is to wait for readiness.
+;;
+;; The answer is capped by the window — java.io documents available as an
+;; estimate, and this is the same bound the byte streams over Chez ports report
+;; (their port buffer). It under-promises, which is the safe direction for a
+;; caller sizing a read.
+(def ^:private peek-window 4096)
+
+(defn- socket-available [self]
+  ;; Closed is an error on both, and here it is a KNOWN one — the socket carries
+  ;; the flag — so it raises rather than answering, where a recv error can only
+  ;; read as EOF. Java raises SocketException, a subclass of this, so ported code
+  ;; catching java.io.IOException sees it on either. Peeking is also not an
+  ;; option once the fd is closed: the number is free to be reused by the next
+  ;; socket, and the count would be somebody else's.
+  (when (jolt.host/ref-get (jolt.host/ref-get self :socket) :closed?)
+    (throw (java.io.IOException. "Socket closed")))
+  (let [fd (jolt.host/ref-get self :fd)
+        buf (ffi/alloc peek-window)]
+    (try
+      (loop []
+        (let [n (c-recv fd buf peek-window msg-peek)]
+          (cond
+            (pos? n) n
+            (and (neg? n) (poller/eintr?)) (recur)
+            :else 0)))
+      (finally (ffi/free buf)))))
+
 (def ^:private socket-input-stream-methods
   {"read"
    (fn
@@ -304,7 +344,7 @@
                 (let [{:keys [n bytes]} (do-recv fd buf len)]
                   (if (pos? n) (do (dotimes [i n] (aset b (+ off i) (nth bytes i))) n) -1))
                 (finally (ffi/free buf))))))))
-   "available" (fn [self] 0)
+   "available" (fn [self] (socket-available self))
    "close"     (fn [self] (socket-close! (jolt.host/ref-get self :socket)))})
 
 ;; -- SocketOutputStream ------------------------------------------------------

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -407,6 +407,141 @@ else
   fails=$((fails+1))
 fi
 
+# --- Phase 5: files read at compile time invalidate their reader --------------
+# A macro that slurps an external file bakes that file's CONTENTS into the
+# artifact, exactly the way it bakes a macro expansion. The key folded in the
+# source and the required namespaces but nothing the compile read, so editing an
+# embedded SQL migration (and nothing else) left every consumer serving the old
+# statements out of the cache — silently, since the .clj is untouched and its
+# hash still matches (jolt#576).
+
+# (p) slurp of a path at macro-expansion time
+p="$tmp/p"; mkdir -p "$p/src/proj"
+printf 'v1' > "$p/mig.sql"
+cat > "$p/src/proj/core.clj" <<CLJ
+(ns proj.core)
+(defmacro embed [] (slurp "$p/mig.sql"))
+(defn run [] (embed))
+CLJ
+prun() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$jolt" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'proj/proj {:local/root \"$p\"}}})
+    (require 'proj.core) (println (proj.core/run))" 2>/dev/null | tail -1
+}
+p_cold="$(prun)"
+printf 'v2' > "$p/mig.sql"
+p_warm="$(prun)"
+if [ "$p_cold" = "v1" ] && [ "$p_warm" = "v2" ]; then
+  echo "PASS: (p) slurped file edit invalidated its reader (v1 -> v2)"; pass=$((pass+1))
+else
+  echo "FAIL: (p) cold='$p_cold' (want v1) after-resource-edit='$p_warm' (want v2)"; fails=$((fails+1))
+fi
+
+# (q) io/resource — the classpath spelling, resolved against the source roots
+q="$tmp/q"; mkdir -p "$q/src/proj" "$q/resources"
+printf '{:paths ["src" "resources"]}' > "$q/deps.edn"
+printf 'r1' > "$q/resources/mig.sql"
+cat > "$q/src/proj/core.clj" <<'CLJ'
+(ns proj.core (:require [clojure.java.io :as io]))
+(defmacro embed [] (slurp (io/resource "mig.sql")))
+(defn run [] (embed))
+CLJ
+qrun() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$jolt" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'proj/proj {:local/root \"$q\"}}})
+    (require 'proj.core) (println (proj.core/run))" 2>/dev/null | tail -1
+}
+q_cold="$(qrun)"
+printf 'r2' > "$q/resources/mig.sql"
+q_warm="$(qrun)"
+if [ "$q_cold" = "r1" ] && [ "$q_warm" = "r2" ]; then
+  echo "PASS: (q) io/resource edit invalidated its reader (r1 -> r2)"; pass=$((pass+1))
+else
+  echo "FAIL: (q) cold='$q_cold' (want r1) after-resource-edit='$q_warm' (want r2)"; fails=$((fails+1))
+fi
+
+# (q2) a resource that did not exist yet — adding one (a new migration) has to
+# invalidate the namespace that probed for it and found nothing.
+printf '(ns proj.opt (:require [clojure.java.io :as io]))\n(defmacro embed [] (if-let [u (io/resource "opt.sql")] (slurp u) "none"))\n(defn run [] (embed))\n' > "$q/src/proj/opt.clj"
+q2run() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$jolt" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'proj/proj {:local/root \"$q\"}}})
+    (require 'proj.opt) (println (proj.opt/run))" 2>/dev/null | tail -1
+}
+q2_cold="$(q2run)"
+printf 'appeared' > "$q/resources/opt.sql"
+q2_warm="$(q2run)"
+if [ "$q2_cold" = "none" ] && [ "$q2_warm" = "appeared" ]; then
+  echo "PASS: (q2) an added resource invalidated the ns that probed for it"; pass=$((pass+1))
+else
+  echo "FAIL: (q2) cold='$q2_cold' (want none) after-add='$q2_warm' (want appeared)"; fails=$((fails+1))
+fi
+
+# (r) the read happens while compiling the CONSUMER (the macro lives one
+# namespace away), so the resource belongs to the consumer's key, and editing it
+# has to move that key even though neither .clj changed.
+r="$tmp/r"; mkdir -p "$r/src/chain"
+printf 'w1' > "$r/mig.sql"
+cat > "$r/src/chain/mac.clj" <<CLJ
+(ns chain.mac)
+(defmacro embed [] (slurp "$r/mig.sql"))
+CLJ
+cat > "$r/src/chain/top.clj" <<'CLJ'
+(ns chain.top (:require [chain.mac :as m]))
+(defn run [] (m/embed))
+CLJ
+rrun() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$jolt" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'chain/chain {:local/root \"$r\"}}})
+    (require 'chain.top) (println (chain.top/run))" 2>/dev/null | tail -1
+}
+r_cold="$(rrun)"
+printf 'w2' > "$r/mig.sql"
+r_warm="$(rrun)"
+if [ "$r_cold" = "w1" ] && [ "$r_warm" = "w2" ]; then
+  echo "PASS: (r) cross-namespace macro read invalidated the consumer (w1 -> w2)"; pass=$((pass+1))
+else
+  echo "FAIL: (r) cold='$r_cold' (want w1) after-resource-edit='$r_warm' (want w2)"; fails=$((fails+1))
+fi
+
+# (s) a resource baked into a REQUIRED namespace's own artifact propagates
+# through the chain the way an edit to that namespace's source does: deep.low
+# expands the slurp into its OWN .so, and deep.top's key has to fold that in.
+s="$tmp/s"; mkdir -p "$s/src/deep"
+printf 'd1' > "$s/mig.sql"
+cat > "$s/src/deep/low.clj" <<CLJ
+(ns deep.low)
+(defmacro mig [] (slurp "$s/mig.sql"))
+(def payload (mig))
+CLJ
+cat > "$s/src/deep/top.clj" <<'CLJ'
+(ns deep.top (:require [deep.low :as l]))
+(defn run [] l/payload)
+CLJ
+srun() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$jolt" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'deep/deep {:local/root \"$s\"}}})
+    (require 'deep.top) (println (deep.top/run))" 2>/dev/null | tail -1
+}
+s_cold="$(srun)"
+printf 'd2' > "$s/mig.sql"
+s_warm="$(srun)"
+if [ "$s_cold" = "d1" ] && [ "$s_warm" = "d2" ]; then
+  echo "PASS: (s) a required ns's resource edit reached the chain (d1 -> d2)"; pass=$((pass+1))
+else
+  echo "FAIL: (s) cold='$s_cold' (want d1) after-resource-edit='$s_warm' (want d2)"; fails=$((fails+1))
+fi
+
+# (t) a namespace that reads nothing writes no resource sidecar — the record is
+# per-namespace, not a global list every artifact then keys on.
+t_res="$(find "$cache" -name 'mylib.core-*.res' 2>/dev/null | wc -l | tr -d ' ')"
+p_res="$(find "$cache" -name 'proj.core-*.res' 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$t_res" = "0" ] && [ "$p_res" -ge 1 ]; then
+  echo "PASS: (t) resource sidecars are per-namespace ($p_res for readers, 0 for mylib.core)"; pass=$((pass+1))
+else
+  echo "FAIL: (t) mylib.core sidecars=$t_res (want 0), proj.core sidecars=$p_res (want >=1)"; fails=$((fails+1))
+fi
+
 # Phase 4 (cold-vs-warm speedup) lives in aot-cache-perf.sh — a timing
 # measurement doesn't belong in this deterministic correctness gate.
 

--- a/test/chez/socket-test.clj
+++ b/test/chez/socket-test.clj
@@ -168,6 +168,67 @@
     (.close (.getInputStream conn))
     (check-eq "stream close closes socket" (.isClosed conn) true)))
 
+;; available() is a real byte count. It answered 0 always, which java.io permits
+;; ("an estimate") but which leaves (pos? (.available in)) false forever. The
+;; JVM asks ioctl(FIONREAD); ioctl is variadic and an FFI cannot express that, so
+;; this peeks with MSG_PEEK instead — same answer, consumes nothing, and never
+;; waits because every fd here is O_NONBLOCK. The JVM prints [0 14 9 0] for this.
+(with-pair
+  (fn [server client conn]
+    (let [in (.getInputStream conn)
+          msg (.getBytes "hello over tcp" "UTF-8")]
+      (check-eq "available before anything is sent" (.available in) 0)
+      (.write (.getOutputStream client) msg 0 (alength msg))
+      ;; loopback delivery is not instant; wait for it rather than assume it
+      (loop [tries 0]
+        (when (and (zero? (.available in)) (< tries 100))
+          (Thread/sleep 10)
+          (recur (inc tries))))
+      (check-eq "available counts what arrived" (.available in) 14)
+      (.read in (byte-array 5) 0 5)
+      (check-eq "available drops by what was read" (.available in) 9)
+      (.read in (byte-array 64) 0 64)
+      (check-eq "available is 0 once drained" (.available in) 0))))
+
+;; the peek window caps the answer — 4096, the same bound the byte streams over
+;; Chez ports report. The JVM says 20000 here (known-divergences).
+(with-pair
+  (fn [server client conn]
+    (let [in (.getInputStream conn)]
+      (.write (.getOutputStream client) (byte-array 20000) 0 20000)
+      (loop [tries 0]
+        (when (and (< (.available in) 4096) (< tries 100))
+          (Thread/sleep 10)
+          (recur (inc tries))))
+      (check-eq "available caps at the peek window" (.available in) 4096))))
+
+;; a peer that closed leaves its bytes readable, and the count with them
+(let [server (java.net.ServerSocket. 0)
+      client (java.net.Socket. "127.0.0.1" (.getLocalPort server))
+      conn   (.accept server)
+      in     (.getInputStream conn)]
+  (.write (.getOutputStream client) (.getBytes "tail" "UTF-8") 0 4)
+  (.close client)
+  (loop [tries 0]
+    (when (and (zero? (.available in)) (< tries 100))
+      (Thread/sleep 10)
+      (recur (inc tries))))
+  (check-eq "available after the peer closed" (.available in) 4)
+  (.read in (byte-array 8) 0 8)
+  (check-eq "available at end of stream" (.available in) 0)
+  (.close conn) (.close server))
+
+;; and a CLOSED socket raises, as Java's SocketException does. Peeking a closed
+;; fd would be worse than wrong: the number is free to be reused by the next
+;; socket, so the count would be somebody else's.
+(with-pair
+  (fn [server client conn]
+    (let [in (.getInputStream conn)]
+      (.close conn)
+      (check-eq "available on a closed socket"
+                (try (.available in) (catch java.io.IOException e (.getMessage e)))
+                "Socket closed"))))
+
 (if (empty? @failures)
   (println "SOCKET-TEST OK")
   (do (doseq [f @failures] (println "FAIL:" f))

--- a/test/chez/socket-test.clj
+++ b/test/chez/socket-test.clj
@@ -168,11 +168,12 @@
     (.close (.getInputStream conn))
     (check-eq "stream close closes socket" (.isClosed conn) true)))
 
-;; available() is a real byte count. It answered 0 always, which java.io permits
-;; ("an estimate") but which leaves (pos? (.available in)) false forever. The
-;; JVM asks ioctl(FIONREAD); ioctl is variadic and an FFI cannot express that, so
-;; this peeks with MSG_PEEK instead — same answer, consumes nothing, and never
-;; waits because every fd here is O_NONBLOCK. The JVM prints [0 14 9 0] for this.
+;; available() is a real byte count, from the same ioctl(FIONREAD) the JVM asks.
+;; It answered 0 always, which java.io permits ("an estimate") but which leaves
+;; (pos? (.available in)) false forever. ioctl is variadic, and binding it
+;; fixed-arity is what made it look unreachable: on Apple arm64 the call returns
+;; SUCCESS with the out-parameter untouched. jolt.ffi's :varargs marker puts the
+;; argument where the callee reads it. The JVM prints [0 14 9 0] for this.
 (with-pair
   (fn [server client conn]
     (let [in (.getInputStream conn)
@@ -190,17 +191,17 @@
       (.read in (byte-array 64) 0 64)
       (check-eq "available is 0 once drained" (.available in) 0))))
 
-;; the peek window caps the answer — 4096, the same bound the byte streams over
-;; Chez ports report. The JVM says 20000 here (known-divergences).
+;; and it is not bounded by any buffer of jolt's — the kernel's whole count,
+;; which is what the JVM answers here too
 (with-pair
   (fn [server client conn]
     (let [in (.getInputStream conn)]
       (.write (.getOutputStream client) (byte-array 20000) 0 20000)
       (loop [tries 0]
-        (when (and (< (.available in) 4096) (< tries 100))
+        (when (and (< (.available in) 20000) (< tries 100))
           (Thread/sleep 10)
           (recur (inc tries))))
-      (check-eq "available caps at the peek window" (.available in) 4096))))
+      (check-eq "available counts past any buffer" (.available in) 20000))))
 
 ;; a peer that closed leaves its bytes readable, and the count with them
 (let [server (java.net.ServerSocket. 0)
@@ -218,16 +219,17 @@
   (check-eq "available at end of stream" (.available in) 0)
   (.close conn) (.close server))
 
-;; and a CLOSED socket raises, as Java's SocketException does. Peeking a closed
-;; fd would be worse than wrong: the number is free to be reused by the next
-;; socket, so the count would be somebody else's.
+;; and a CLOSED socket raises SocketException, as Java's does. Asking the kernel
+;; about a closed fd would be worse than wrong: the number is free to have been
+;; reused by the next socket, so the count would be somebody else's.
 (with-pair
   (fn [server client conn]
     (let [in (.getInputStream conn)]
       (.close conn)
       (check-eq "available on a closed socket"
-                (try (.available in) (catch java.io.IOException e (.getMessage e)))
-                "Socket closed"))))
+                (try (.available in)
+                     (catch java.io.IOException e [(class e) (.getMessage e)]))
+                [java.net.SocketException "Socket closed"]))))
 
 (if (empty? @failures)
   (println "SOCKET-TEST OK")

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -27,7 +27,12 @@
       (set! fails (+ fails 1))
       (printf "FAIL: ~a\n  expected: ~a\n  actual:   ~a\n" name expect got))))
 
-(define tmp (string-append "/tmp/jolt-image-test-" (number->string (fx+ 1 (random 100000))) ".jimg"))
+;; Keyed by PID, the way aot-fingerprint-test.ss does it. (random 100000) is not
+;; random across PROCESSES — Chez seeds its generator the same way every start,
+;; so every run of this file picked the identical name and two concurrent runs
+;; deleted each other's image ("image: no such file", from whichever lost).
+(define tmp (string-append "/tmp/jolt-image-test-" (number->string (get-process-id)) ".jimg"))
+(define refstub-tmp (string-append "/tmp/jolt-image-refstub-" (number->string (get-process-id)) ".txt"))
 (define (cleanup!) (when (file-exists? tmp) (delete-file tmp)))
 
 ;; --- Chez substrate the format depends on ------------------------------------
@@ -824,7 +829,7 @@
 ;; a stub inside a REF's val resolves through the in-place substitution walk
 ;; (the walk previously passed refs through untouched — resolved stubs never
 ;; landed inside a ref)
-(let ((sp (open-file-output-port "/tmp/jolt-image-refstub.txt" (file-options no-fail))))
+(let ((sp (open-file-output-port refstub-tmp (file-options no-fail))))
   (jolt-compile-eval "(def holder nil)" "r11.world")
   (let ((cell (jolt-var "r11.world" "holder")))
     (var-cell-root-set! cell (jolt-ref-new sp)))
@@ -841,7 +846,7 @@
                  (equal? "PORT-AGAIN"
                          (jolt-ref-val (var-cell-root (jolt-var "r11.world" "holder")))))))))
   (close-port sp)
-  (delete-file "/tmp/jolt-image-refstub.txt"))
+  (delete-file refstub-tmp))
 
 ;; resolver pre-registered: the stub never materializes
 ;; kind strings match the STUBBED OBJECT's class (a port's, here), so a

--- a/test/chez/string-builder-perf.ss
+++ b/test/chez/string-builder-perf.ss
@@ -1,0 +1,93 @@
+;; string-builder-perf.ss — StringBuilder.append must not be quadratic.
+;; Run: chez --script test/chez/string-builder-perf.ss (or `make sbperf`).
+;;
+;; `.append` was (string-append (sb-str self) piece): it copied the entire
+;; accumulated buffer on every call, so building an n-char string cost O(n^2).
+;; That is not a micro-optimisation. clojure.data.json reads a quoted string one
+;; character at a time into a StringBuilder, so in veriframe a single 88KB JSON
+;; string value took 623ms to parse while the same 88KB spread over many short
+;; values took 30ms — a 20x gap that is pure append copying. Every accumulator
+;; built this way paid it.
+;;
+;; The assertion is a SCALING RATIO, not a wall-clock floor. Quadrupling the
+;; append count costs ~4x when append is amortised O(1) and ~16x when it is not,
+;; and that ratio survives a loaded machine where an absolute threshold would be
+;; flaky. The bar is 8x: well above linear-with-noise, well below quadratic.
+;; Timing stays out of the default gate for the reason printperf documents.
+(import (chezscheme))
+(load "host/chez/rt.ss")
+(set-chez-ns! "clojure.core")
+(load "host/chez/seed/prelude.ss")
+(load "host/chez/post-prelude.ss")
+(set-chez-ns! "user")
+(load "host/chez/host-contract.ss")
+(load "host/chez/seed/image.ss")
+(load "host/chez/compile-eval.ss")
+
+(define (now-ms)
+  (let ((t (current-time 'time-monotonic)))
+    (+ (* 1000.0 (time-second t)) (/ (time-nanosecond t) 1000000.0))))
+
+(define runs 3)
+(define (best-ms expr)
+  (let loop ((i 0) (best +inf.0))
+    (if (fx>= i runs)
+        best
+        (let ((t0 (now-ms)))
+          (jolt-compile-eval expr "user")
+          (loop (fx+ i 1) (min best (- (now-ms) t0)))))))
+
+(define (build-expr n)
+  (string-append "(let [sb (StringBuilder.)]"
+                 "  (dotimes [_ " (number->string n) "] (.append sb \"abcdefgh\"))"
+                 "  (.length (.toString sb)))"))
+
+(define failed? #f)
+(define (fail! msg) (set! failed? #t) (printf "  FAIL: ~a\n" msg))
+
+;; Correctness first: a buffer that appends nothing would time beautifully.
+;; Each check evaluates to a string, so the comparison is plain Scheme.
+(define (check! label expr want)
+  (let ((got (jolt-compile-eval expr "user")))
+    (unless (equal? got want)
+      (fail! (format "~a: expected ~s, got ~s" label want got)))))
+
+(check! "append returns the buffer and renders its content"
+        "(.toString (-> (StringBuilder.) (.append \"a\") (.append \\b) (.append 1)))"
+        "ab1")
+(check! "5000 appends build the whole string"
+        "(str (.length (.toString (let [sb (StringBuilder.)] (dotimes [_ 5000] (.append sb \"xy\")) sb))))"
+        "10000")
+;; A read part-way through must see the pending appends, not only what was
+;; already materialised: the failure mode a lazy buffer introduces is .length
+;; or .charAt answering from a stale cache.
+(check! "a read mid-build sees the pending appends"
+        "(pr-str (let [sb (StringBuilder.)] (.append sb \"abc\") [(.length sb) (.charAt sb 1) (do (.append sb \"de\") [(.length sb) (str sb)])]))"
+        "[3 \\b [5 \"abcde\"]]")
+;; Mutators have to flush pending appends before they index into the buffer.
+(check! "setLength/deleteCharAt/insert see pending appends"
+        "(pr-str [(str (doto (StringBuilder.) (.append \"abcd\") (.setLength 2))) (str (doto (StringBuilder.) (.append \"abcdef\") (.deleteCharAt 2))) (str (doto (StringBuilder.) (.append \"abcdef\") (.insert 3 \"XY\"))) (str (doto (StringBuilder.) (.append \"abcdef\") (.reverse)))])"
+        "[\"ab\" \"abdef\" \"abcXYdef\" \"fedcba\"]")
+
+;; StringWriter shares the accumulator, and a PrintWriter over either one writes
+;; through it — which is the path printStackTrace and print-to-a-writer take.
+(check! "StringWriter accumulates"
+        "(let [w (StringWriter.)] (.write w \"a\") (.append w \\b) (.toString w))"
+        "ab")
+(check! "PrintWriter writes through to both accumulators"
+        "(pr-str [(let [w (StringWriter.)] (.print (PrintWriter. w) \"xy\") (str w)) (let [b (StringBuilder.)] (.print (PrintWriter. b) \"zw\") (str b))])"
+        "[\"xy\" \"zw\"]")
+
+;; Warm up so the first measurement is not paying one-time costs.
+(jolt-compile-eval (build-expr 2000) "user")
+
+(let* ((small (best-ms (build-expr 8000)))
+       (large (best-ms (build-expr 32000)))
+       (ratio (/ large (max small 0.001))))
+  (printf " 8000 appends: ~a ms\n" (/ (round (* 100 small)) 100.0))
+  (printf "32000 appends: ~a ms\n" (/ (round (* 100 large)) 100.0))
+  (printf "4x the appends cost ~ax the time (linear ~~4x, quadratic ~~16x)\n"
+          (/ (round (* 10 ratio)) 10.0))
+  (when (> ratio 8.0) (fail! "append is superlinear")))
+
+(if failed? (exit 1) (begin (printf "PASS\n") (exit 0)))

--- a/test/chez/system-streams-smoke.sh
+++ b/test/chez/system-streams-smoke.sh
@@ -6,6 +6,11 @@
 # through it ("No matching field or method: System/in") failed to load. The
 # streams also have to report the classes the JVM's do — System.out is a
 # PrintStream, not the PrintWriter *out* is — because libraries branch on that.
+#
+# The stacking matters as much as the classes. The JVM builds *in* as a Reader
+# over System.in and *out* as a PrintWriter over System.out, so a program that
+# uses both sees one stream; jolt read standard input through a second port of
+# its own, and the two buffered independently (jolt-6wad).
 
 set -e
 
@@ -94,6 +99,100 @@ check i2 "$(run '(System/setIn (java.io.ByteArrayInputStream. (.getBytes "xy")))
 
 # --- (j) the default System/in is restored-able and reads real stdin ---------
 check j "$(run '(let [orig System/in] (System/setIn (java.io.ByteArrayInputStream. (.getBytes ""))) (System/setIn orig) (println (slurp System/in)))' 'back')" "back"
+
+# --- (m) *in* reads THROUGH System/in: one buffer, not two -------------------
+# The JVM stacks them (RT.in is a Reader over System.in) and jolt has the same
+# shape, so read-line and the stream agree on where the input is up to. They used
+# to be two ports on fd 0 buffering independently, and whichever read first ate
+# input the other never saw. jolt goes one better than the JVM here: nothing is
+# read past the line returned, where an InputStreamReader decodes into 8K of its
+# own and leaves (.read System/in) answering -1 with the rest of stdin inside it.
+check m1 "$(run '(println (pr-str [(read-line) (.read System/in) (read-line)]))' 'alpha
+beta
+')" "[\"alpha\" 98 \"eta\"]"
+# and the other way round: a byte taken first, then the rest of that line
+check m2 "$(run '(println (pr-str [(.read System/in) (read-line)]))' 'abc
+')" "[97 \"bc\"]"
+# slurp / readAllBytes pick up exactly where read-line stopped
+check m3 "$(run '(println (pr-str [(read-line) (slurp System/in)]))' 'one
+two
+three
+')" "[\"one\" \"two\nthree\n\"]"
+check m4 "$(run '(println (pr-str [(read-line) (String. (.readAllBytes System/in))]))' 'head
+tail
+')" "[\"head\" \"tail\n\"]"
+# a replaced stream is read the same way — through its own .read, one byte at a
+# time, so setIn does not reintroduce a second buffer either
+check m5 "$(run '(do (System/setIn (java.io.ByteArrayInputStream. (.getBytes "redirected\nsecond\n"))) (println (pr-str [(read-line) (.read System/in) (read-line)])))')" "[\"redirected\" 115 \"econd\"]"
+# with-in-str still wins over both: it rebinds *in*, which is not System/in
+check m6 "$(run '(println (pr-str [(with-in-str "from-string" (read-line)) (read-line)]))' 'from-stdin
+')" "[\"from-string\" \"from-stdin\"]"
+
+# --- (n) the three line terminators readLine has -----------------------------
+# \n, \r, and \r\n all end a line (JVM: (read-line) over "a\rb\nc\r\nd\n" is
+# a, b, c, d). jolt used to end a line on \n alone, so a \r came back inside the
+# string and a CR-only file read as one enormous line.
+check n1 "$(run '(println (pr-str [(read-line) (read-line) (read-line) (read-line) (read-line)]))' 'a
+b
+c
+d
+')" "[\"a\" \"b\" \"c\" \"d\" nil]"
+check n2 "$(run '(println (pr-str [(read-line) (read-line) (read-line)]))' "$(printf 'a\rb\r\nc')")" "[\"a\" \"b\" \"c\"]"
+# a CRLF is one terminator, so the stream's next byte is the one after it, not a
+# stray \n left behind for (.read System/in)
+check n3 "$(run '(println (pr-str [(read-line) (.read System/in) (read-line)]))' "$(printf 'a\r\nbc\n')")" "[\"a\" 98 \"c\"]"
+# a line longer than the reader's initial 128-byte buffer, and a multi-byte
+# character that must not be cut where the buffer grows
+n4_long=""
+while [ "${#n4_long}" -lt 200 ]; do n4_long="${n4_long}xxxxxxxxxx"; done
+check n4 "$(run '(let [l (read-line)] (println (pr-str [(count l) (subs l 200 203)])))' "${n4_long}héllo
+")" "[205 \"hél\"]"
+
+# a stream that is not one of jolt's own — a proxy over java.io.InputStream — is
+# read through its .read, so the override is what feeds read-line, and the CRLF
+# it cannot peek at is carried to the next line by the flag rather than coming
+# back as an empty one
+check n5 "$(run '(do (def bs (atom (seq (.getBytes "px\r\ny\n")))) (System/setIn (proxy [java.io.InputStream] [] (read [] (if-let [s @bs] (let [b (first s)] (swap! bs next) (bit-and b 255)) -1)))) (println (pr-str [(read-line) (read-line) (read-line)])))')" "[\"px\" \"y\" nil]"
+
+# --- (o) a Reader over System/in does not take the stream away ---------------
+# R6RS transcoded-port takes ownership of the port it wraps, so building the
+# reader used to CLOSE standard input: the next read of System/in — or the next
+# read-line, which is the same port — died on a closed port. The reader pulls
+# through the stream's own .read now, which is also what lets a proxy's override
+# be seen. It does buffer ahead, exactly as the JVM's InputStreamReader does, so
+# read-line after it correctly sees end of input rather than an error.
+check o "$(run '(let [r (clojure.java.io/reader System/in)] (println (pr-str [(.readLine r) (read-line)])))' 'one
+two
+')" "[\"one\" nil]"
+
+# --- (p) io/copy System/in -> System/out is byte-exact ------------------------
+# A PrintStream is an OutputStream, so the cat has to come out byte for byte.
+# Routing it through the text sink decoded the bytes as UTF-8 first and replaced
+# every one that was not text with U+FFFD.
+check p "$(printf '\000\377\376A' | JOLT_QUIET=1 "$jolt" -e '(clojure.java.io/copy System/in System/out) (flush)' 2>/dev/null | od -An -tx1 | tr -d ' \n')" "00fffe41"
+# raw bytes and printed text reach the descriptor in the order they were written
+check p2 "$(run '(do (print "A") (.write System/out (.getBytes "B")) (print "C") (flush))')" "ABC"
+# a byte[] written to a captured *out* is still text — a string port has no bytes
+check p3 "$(run '(println (pr-str (with-out-str (.write *out* (.getBytes "hi")))))')" "\"hi\""
+
+# --- (q) InputStream.read(buf off len) returns as soon as a byte is there -----
+# The JVM blocks "until at least one byte is available", not until the buffer is
+# full; filling it first hung on a pipe whose writer was waiting for a response.
+# The writer sends five bytes and then just holds the pipe open, so this is a
+# question about blocking and not a race against startup: filling the buffer
+# first cannot answer until the writer gives up, and returning what arrived
+# answers at once.
+q_fifo="${TMPDIR:-/tmp}/jolt-sysin-q-$$"
+rm -f "$q_fifo" "$q_fifo.pid"
+mkfifo "$q_fifo"
+# started from a subshell that exits at once, so this shell has no job to report
+# when the writer is killed below
+( { printf 'abcde'; sleep 30; } > "$q_fifo" & echo $! > "$q_fifo.pid" )
+check q "$(JOLT_QUIET=1 "$jolt" -e '(let [b (byte-array 4096) n (.read System/in b 0 4096)] (println (pr-str [n (String. b 0 n)])))' < "$q_fifo" 2>/dev/null | tail -1)" "[5 \"abcde\"]"
+kill "$(cat "$q_fifo.pid")" 2>/dev/null || true
+rm -f "$q_fifo" "$q_fifo.pid"
+# it still reports -1 at end of input, and fills across several calls
+check q2 "$(run '(let [b (byte-array 8)] (println (pr-str [(.read System/in b 0 8) (String. b 0 3) (.read System/in b 0 8)])))' 'xyz')" "[3 \"xyz\" -1]"
 
 echo ""
 echo "system-streams smoke: $pass passed, $fails failed"

--- a/test/chez/system-streams-smoke.sh
+++ b/test/chez/system-streams-smoke.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# System/in, System/out, System/err — the process's own streams.
+#
+# System.in is an InputStream the JVM hands every program; jolt had System/out
+# and System/err but no System/in at all, so any ported code that read stdin
+# through it ("No matching field or method: System/in") failed to load. The
+# streams also have to report the classes the JVM's do — System.out is a
+# PrintStream, not the PrintWriter *out* is — because libraries branch on that.
+
+set -e
+
+pass=0
+fails=0
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+
+jolt="bin/jolt"
+
+# run <expr> [stdin-text]: evaluate and print the LAST line of stdout.
+run() {
+  if [ "$#" -ge 2 ]; then
+    printf '%s' "$2" | JOLT_QUIET=1 "$jolt" -e "$1" 2>/dev/null | tail -1
+  else
+    JOLT_QUIET=1 "$jolt" -e "$1" </dev/null 2>/dev/null | tail -1
+  fi
+}
+
+check() {
+  clabel="$1"; cgot="$2"; cwant="$3"
+  if [ "$cgot" = "$cwant" ]; then
+    echo "PASS: ($clabel) $cgot"; pass=$((pass+1))
+  else
+    echo "FAIL: ($clabel) got '$cgot', want '$cwant'"; fails=$((fails+1))
+  fi
+}
+
+# --- (a) System/in exists and is an InputStream ------------------------------
+check a "$(run '(println (instance? java.io.InputStream System/in))')" "true"
+check a2 "$(run '(println (class System/in))')" "java.io.InputStream"
+
+# --- (b) slurp / read / line-seq over piped stdin -----------------------------
+check b "$(run '(println (slurp System/in))' 'hello stdin')" "hello stdin"
+check c "$(run '(println (pr-str (vec (line-seq (clojure.java.io/reader System/in)))))' 'a
+b
+c
+')" "[\"a\" \"b\" \"c\"]"
+# InputStream.read() is the next byte as an unsigned int, -1 at EOF.
+check d "$(run '(println [(.read System/in) (.read System/in)])' 'AB')" "[65 66]"
+check d2 "$(run '(println (.read System/in))')" "-1"
+
+# --- (e) io/copy System/in -> System/out (the babashka.process wd.clj echo) ---
+check e "$(run '(clojure.java.io/copy System/in System/out) (flush)' 'echoed')" "echoed"
+
+# --- (f) the classes the JVM reports -----------------------------------------
+# System.out / System.err are PrintStreams (java.io.OutputStream), NOT the
+# PrintWriter *out* is. Ported code does (instance? java.io.PrintStream x) and
+# (.write System/out bytes).
+check f  "$(run '(println (class System/out))')" "java.io.PrintStream"
+check f2 "$(run '(println (class System/err))')" "java.io.PrintStream"
+check f3 "$(run '(println [(instance? java.io.PrintStream System/out) (instance? java.io.OutputStream System/out) (instance? java.io.Closeable System/out)])')" "[true true true]"
+# *out* stays a PrintWriter, as on the JVM — the two are different objects there
+# and jolt must not collapse their classes.
+check g  "$(run '(println (class *out*))')" "java.io.PrintWriter"
+check g2 "$(run '(println [(instance? java.io.Writer *out*) (instance? java.io.PrintStream *out*)])')" "[true false]"
+
+# --- (h) System/out is the PROCESS stream: a with-out-str does not capture it --
+# "direct" goes to the terminal, so the captured string is "captured" alone —
+# resolving System/out through (current-output-port) like *out* used to swallow
+# it into the capture instead, giving "direct\ncaptured".
+check h "$(run '(let [s (with-out-str (.println System/out "direct") (print "captured"))] (println (pr-str s)))')" "\"captured\""
+# and a (binding [*out* …]) does not move it either
+check h2 "$(run '(let [w (java.io.StringWriter.)] (binding [*out* w] (.println System/out "direct")) (println (pr-str (str w))))')" "\"\""
+
+# --- (k) .write on a stream: bytes, chars, an int, and a region ---------------
+# (.write System/out (.getBytes s)) is the ordinary way ported code writes raw
+# output to a PrintStream; the array used to render as "#object[[B …]" into the
+# stream. write(int) is the CHARACTER with that code on both PrintStream and
+# PrintWriter, and the 3-arg form is (buf off len), not (buf start end).
+check k  "$(run '(.write System/out (.getBytes "bytes-out")) (flush)')" "bytes-out"
+check k2 "$(run '(.write System/out (.getBytes "0123456789") 2 3) (flush)')" "234"
+check k3 "$(run '(do (.write System/out 65) (.write System/out 66) (flush))')" "AB"
+# the same three through a StringWriter, so the writer family agrees with the
+# stream family instead of each rendering its own way
+check k4 "$(run '(let [w (java.io.StringWriter.)] (.write w (.getBytes "abc")) (.write w 68) (.write w "0123456789" 2 3) (println (str w)))')" "abcD234"
+# a char[] is its characters for write AND print (the JVM has an overload for
+# both); a byte[] only for write, since print(Object) is all it can reach.
+check k5 "$(run '(let [w (java.io.StringWriter.)] (.write w (char-array [\x \y])) (.write w (char-array [\z]) 0 1) (println (str w)))')" "xyz"
+
+# --- (i) setIn replaces the stream -------------------------------------------
+# read-line reads System/in, so setIn has to redirect it (clojure.test fixtures
+# and REPL harnesses drive input this way).
+check i "$(run '(System/setIn (java.io.ByteArrayInputStream. (.getBytes "line1\nline2\n"))) (println (pr-str [(read-line) (read-line) (read-line)]))')" "[\"line1\" \"line2\" nil]"
+check i2 "$(run '(System/setIn (java.io.ByteArrayInputStream. (.getBytes "xy"))) (println (slurp System/in))')" "xy"
+
+# --- (j) the default System/in is restored-able and reads real stdin ---------
+check j "$(run '(let [orig System/in] (System/setIn (java.io.ByteArrayInputStream. (.getBytes ""))) (System/setIn orig) (println (slurp System/in)))' 'back')" "back"
+
+echo ""
+echo "system-streams smoke: $pass passed, $fails failed"
+[ "$fails" -eq 0 ]

--- a/test/chez/system-streams-smoke.sh
+++ b/test/chez/system-streams-smoke.sh
@@ -210,6 +210,14 @@ check r4 "$(run '(let [f (java.io.FileInputStream. "README.md")] (println (pr-st
 check r5 "$(JOLT_QUIET=1 "$jolt" -e '(println (.available System/in))' < README.md 2>/dev/null | tail -1)" "$(wc -c < README.md | tr -d ' ')"
 # which makes the drain idiom work — this read one byte, or nothing at all
 check r6 "$(run '(let [n (.available System/in) b (byte-array n)] (.read System/in b 0 n) (println (String. b)))' 'drain-me')" "drain-me"
+# and it is not capped by any buffer of jolt's. The count for a pipe comes from
+# ioctl(FIONREAD) — the syscall the JVM's available() makes — so it is the whole
+# amount waiting, not the 4096 a port buffer holds. A target with no ioctl falls
+# back to filling the buffer, which is where the cap came from.
+r9_big=""
+while [ "${#r9_big}" -lt 8000 ]; do r9_big="${r9_big}${n4_long}"; done
+check r9 "$(run '(do (loop [tries 0] (when (and (< (.available System/in) 8000) (< tries 200)) (Thread/sleep 5) (recur (inc tries)))) (println (.available System/in)))' "$r9_big")" "8000"
+
 # a closed stream raises the JVM IOException rather than a classless host error
 check r7 "$(run '(let [b (java.io.ByteArrayInputStream. (.getBytes "hi"))] (.close b) (println (try (.available b) (catch java.io.IOException e (.getMessage e)))))')" "Stream closed"
 check r8 "$(run '(let [o (java.io.PipedOutputStream.) i (java.io.PipedInputStream. o)] (.close i) (println (try (.available i) (catch java.io.IOException e (.getMessage e)))))')" "Pipe closed"

--- a/test/chez/system-streams-smoke.sh
+++ b/test/chez/system-streams-smoke.sh
@@ -194,6 +194,26 @@ rm -f "$q_fifo" "$q_fifo.pid"
 # it still reports -1 at end of input, and fills across several calls
 check q2 "$(run '(let [b (byte-array 8)] (println (pr-str [(.read System/in b 0 8) (String. b 0 3) (.read System/in b 0 8)])))' 'xyz')" "[3 \"xyz\" -1]"
 
+# --- (r) available() is a real byte count ------------------------------------
+# It used to answer 0 for every stream. That is a legal JVM answer ("an
+# estimate"), but it leaves (pos? (.available in)) false forever, so the loop
+# that drains what has arrived never runs. A seekable source answers its exact
+# remainder, as FileInputStream and ByteArrayInputStream do; a pipe answers what
+# is really there, by filling the port's buffer with a lookahead that consumes
+# nothing. All four of these agree with the JVM value for value.
+check r1 "$(run '(let [b (java.io.ByteArrayInputStream. (.getBytes "hello"))] (println (pr-str [(.available b) (do (.read b) (.available b)) (do (.readAllBytes b) (.available b))])))')" "[5 4 0]"
+check r2 "$(run '(let [o (java.io.PipedOutputStream.) i (java.io.PipedInputStream. o)] (.write o (.getBytes "abcdef")) (println (pr-str [(.available i) (do (.read i) (.available i)) (do (.write o (.getBytes "gh")) (.available i))])))')" "[6 5 7]"
+check r3 "$(run '(println (pr-str [(.available System/in) (do (.read System/in) (.available System/in))]))' 'abcdefgh
+')" "[9 8]"
+# a file, whether opened directly or redirected onto stdin, knows its remainder
+check r4 "$(run '(let [f (java.io.FileInputStream. "README.md")] (println (pr-str [(> (.available f) 1000) (let [a (.available f)] (.read f) (- a (.available f)))])))')" "[true 1]"
+check r5 "$(JOLT_QUIET=1 "$jolt" -e '(println (.available System/in))' < README.md 2>/dev/null | tail -1)" "$(wc -c < README.md | tr -d ' ')"
+# which makes the drain idiom work — this read one byte, or nothing at all
+check r6 "$(run '(let [n (.available System/in) b (byte-array n)] (.read System/in b 0 n) (println (String. b)))' 'drain-me')" "drain-me"
+# a closed stream raises the JVM IOException rather than a classless host error
+check r7 "$(run '(let [b (java.io.ByteArrayInputStream. (.getBytes "hi"))] (.close b) (println (try (.available b) (catch java.io.IOException e (.getMessage e)))))')" "Stream closed"
+check r8 "$(run '(let [o (java.io.PipedOutputStream.) i (java.io.PipedInputStream. o)] (.close i) (println (try (.available i) (catch java.io.IOException e (.getMessage e)))))')" "Pipe closed"
+
 echo ""
 echo "system-streams smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -410,6 +410,16 @@
    :jvm "blocks forever (the failed agent never runs the latch action)"
    :jolt "throws RuntimeException \"Agent is failed, needs restart\""
    :note "await entered on an ALREADY-failed agent throws identically on both. jolt returning normally (pre-R4) was the silent-success worst case."}
+  ;; available() over a PIPE counts through the port rather than asking the
+  ;; kernel: the JVM uses ioctl FIONREAD, and ioctl is variadic, so it is not
+  ;; reachable through the FFI on arm64. A seekable source — a file, a redirect,
+  ;; a byte array — answers its exact remainder on both, as does a piped stream,
+  ;; whose queue jolt owns. Pinned by test/chez/system-streams-smoke.sh (r1-r6).
+  {:category :host-model
+   :behavior "(.available System/in) with more than 4096 bytes waiting in a pipe"
+   :jvm "the pipe's whole count, up to the 65536 one holds"
+   :jolt "4096 — the port's buffer, filled by one lookahead that consumes nothing"
+   :note "Both are legal estimates and jolt's under-promises, which is the safe direction for a caller sizing a read. It is also a read(2): the bytes move into the port, still readable through the stream but no longer there for a descriptor handed to a subprocess."}
   ;; *in* is a Reader over System/in on both, but the JVM's InputStreamReader
   ;; decodes into 8K of its own, so the first (read-line) pulls the whole of a
   ;; small stdin into the reader and the stream underneath reads as exhausted.

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -354,14 +354,19 @@
    :jolt "absent; the call raises \"No matching method getMemoryMXBean\""
    :note "Runtime.totalMemory/freeMemory/maxMemory ARE present over Chez's collector accounting. What is missing is JMX itself. Affects criterium's benchmark reporting, not its timing."}
   ;; jolt.socket (stdlib, require-gated): java.net.Socket over POSIX fds. The
-  ;; stream's available() would need ioctl(FIONREAD), and ioctl is variadic —
-  ;; variadic C calls through the FFI are unsafe on arm64 — so it answers 0.
-  ;; InputStream.available()=0 is a legal Java answer callers must handle anyway.
+  ;; count comes from a non-consuming MSG_PEEK rather than the JVM's
+  ;; ioctl(FIONREAD): ioctl is variadic, and on Apple's arm64 ABI a variadic
+  ;; argument travels on the stack where an FFI puts it in a register, so the
+  ;; call returns SUCCESS with the out-parameter untouched. Measured both ways —
+  ;; correct on Linux aarch64, silently wrong on Darwin arm64, and one platform
+  ;; answering a wrong count that looks right is enough to keep it out. What the
+  ;; peek costs is a bound: the same 4096 the byte streams over Chez ports report.
+  ;; Pinned by test/chez/socket-test.clj.
   {:category :host-model
-   :behavior "(.available (.getInputStream socket)) — requires (require 'jolt.socket)"
-   :jvm "the number of bytes readable without blocking"
-   :jolt "always 0"
-   :note "FIONREAD needs ioctl, which is variadic and so FFI-unsafe on arm64. Loop-on-read code is unaffected; code that polls available() to avoid blocking will block."}
+   :behavior "(.available (.getInputStream socket)) with more than 4096 bytes queued — requires (require 'jolt.socket)"
+   :jvm "the whole queued count"
+   :jolt "4096 — the peek window"
+   :note "Both are legal estimates (java.io documents available as one) and jolt's under-promises, which is the safe direction for a caller sizing a read. Under the window the two agree exactly, including across a peer's close; a closed socket raises on both."}
   ;; A recv error reads as EOF: errno is not reachable through the FFI, so
   ;; ECONNRESET (Java: SocketException) cannot be told from EINTR (Java: retry).
   {:category :host-model

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -410,6 +410,24 @@
    :jvm "blocks forever (the failed agent never runs the latch action)"
    :jolt "throws RuntimeException \"Agent is failed, needs restart\""
    :note "await entered on an ALREADY-failed agent throws identically on both. jolt returning normally (pre-R4) was the silent-success worst case."}
+  ;; *in* is a Reader over System/in on both, but the JVM's InputStreamReader
+  ;; decodes into 8K of its own, so the first (read-line) pulls the whole of a
+  ;; small stdin into the reader and the stream underneath reads as exhausted.
+  ;; jolt reads exactly the line it returns, so the two agree on where the input
+  ;; is up to. Pinned by test/chez/system-streams-smoke.sh (m1-m4).
+  {:category :host-model
+   :behavior "(.read System/in) after a (read-line)"
+   :jvm "-1 — the reader on top of System.in has already buffered the rest"
+   :jolt "the next byte of the input"
+   :note "A superset: mixing the two loses input on the JVM. jolt's only buffer for standard input is the one port on fd 0, which is the layer the JVM's BufferedInputStream is; what it does not add is the reader's second buffer."}
+  ;; RT.in is built over whatever System.in was at class-init, so the JVM's
+  ;; read-line cannot be redirected after startup. jolt reads the static every
+  ;; line, which is what makes a test fixture's setIn work.
+  {:category :host-model
+   :behavior "(System/setIn s) followed by (read-line)"
+   :jvm "reads the ORIGINAL stdin — *in* was bound over System.in at RT class-init"
+   :jolt "reads s"
+   :note "A superset: on the JVM with-in-str is the only way to feed read-line. Reading the static per line costs one vector-ref."}
   ;; InetSocketAddress.toString is host:port; the JVM renders hostname/ip:port.
   {:category :host-model
    :behavior "(str (java.net.InetSocketAddress. \"127.0.0.1\" 80)) — requires (require 'jolt.socket)"

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -401,16 +401,6 @@
    :jvm "blocks forever (the failed agent never runs the latch action)"
    :jolt "throws RuntimeException \"Agent is failed, needs restart\""
    :note "await entered on an ALREADY-failed agent throws identically on both. jolt returning normally (pre-R4) was the silent-success worst case."}
-  ;; available() over a PIPE counts through the port rather than asking the
-  ;; kernel: the JVM uses ioctl FIONREAD, and ioctl is variadic, so it is not
-  ;; reachable through the FFI on arm64. A seekable source — a file, a redirect,
-  ;; a byte array — answers its exact remainder on both, as does a piped stream,
-  ;; whose queue jolt owns. Pinned by test/chez/system-streams-smoke.sh (r1-r6).
-  {:category :host-model
-   :behavior "(.available System/in) with more than 4096 bytes waiting in a pipe"
-   :jvm "the pipe's whole count, up to the 65536 one holds"
-   :jolt "4096 — the port's buffer, filled by one lookahead that consumes nothing"
-   :note "Both are legal estimates and jolt's under-promises, which is the safe direction for a caller sizing a read. It is also a read(2): the bytes move into the port, still readable through the stream but no longer there for a descriptor handed to a subprocess."}
   ;; *in* is a Reader over System/in on both, but the JVM's InputStreamReader
   ;; decodes into 8K of its own, so the first (read-line) pulls the whole of a
   ;; small stdin into the reader and the stream underneath reads as exhausted.

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -353,20 +353,6 @@
    :jvm "returns a MemoryMXBean reporting heap/non-heap usage, GC counts, and more"
    :jolt "absent; the call raises \"No matching method getMemoryMXBean\""
    :note "Runtime.totalMemory/freeMemory/maxMemory ARE present over Chez's collector accounting. What is missing is JMX itself. Affects criterium's benchmark reporting, not its timing."}
-  ;; jolt.socket (stdlib, require-gated): java.net.Socket over POSIX fds. The
-  ;; count comes from a non-consuming MSG_PEEK rather than the JVM's
-  ;; ioctl(FIONREAD): ioctl is variadic, and on Apple's arm64 ABI a variadic
-  ;; argument travels on the stack where an FFI puts it in a register, so the
-  ;; call returns SUCCESS with the out-parameter untouched. Measured both ways —
-  ;; correct on Linux aarch64, silently wrong on Darwin arm64, and one platform
-  ;; answering a wrong count that looks right is enough to keep it out. What the
-  ;; peek costs is a bound: the same 4096 the byte streams over Chez ports report.
-  ;; Pinned by test/chez/socket-test.clj.
-  {:category :host-model
-   :behavior "(.available (.getInputStream socket)) with more than 4096 bytes queued — requires (require 'jolt.socket)"
-   :jvm "the whole queued count"
-   :jolt "4096 — the peek window"
-   :note "Both are legal estimates (java.io documents available as one) and jolt's under-promises, which is the safe direction for a caller sizing a read. Under the window the two agree exactly, including across a peer's close; a closed socket raises on both."}
   ;; A recv error reads as EOF: errno is not reachable through the FFI, so
   ;; ECONNRESET (Java: SocketException) cannot be told from EINTR (Java: retry).
   {:category :host-model


### PR DESCRIPTION
Standard input had two readers. `System/in` was a binary port on fd 0 and
`read-line` read the textual `(current-input-port)`, so the two buffered
independently and whichever read first ate input the other never saw. The JVM
stacks them instead — `*in*` is a Reader built over `System.in` — and jolt does
now: one port on fd 0, read through the stream the static currently holds, and
nothing read past the line returned. That last part is better than the JVM,
where the reader's own 8K buffer leaves `(.read System/in)` answering -1 with
the rest of stdin inside it.

Doing it in one place turned up the rest of this branch. `read-line` ended a
line on `\n` alone, where `readLine` ends on `\r` and `\r\n` too.
`(io/reader System/in)` closed standard input under everything else, because
R6RS `transcoded-port` takes ownership of the port it wraps.
`InputStream.read(buf off len)` filled the buffer instead of returning what had
arrived, so it hung on a pipe whose writer was waiting for a response. And
`available()` answered 0 for every stream — legal, since java.io documents it as
an estimate, but it leaves `(pos? (.available in))` false forever.

`available()` now answers the same number the JVM does, from the same
`ioctl(FIONREAD)`, for byte streams and sockets alike. That syscall looked out of
reach: ioctl is variadic, and binding it fixed-arity makes Apple arm64 return
success with the out-parameter untouched — a wrong count that looks like a right
one. jolt.ffi has had a `:varargs` boundary marker since 46ab3c1e and io_poller
has been binding fcntl through it all along; the core runtime's
`jolt-foreign-proc-safe` grew the same convention arity here. Both
known-divergences entries for `available` are deleted rather than rewritten.

Also on the branch: a file read at macro-expansion time now belongs to the AOT
cache key (#576), so editing a SQL migration a macro slurps invalidates the
cache; and `System/out` is the `java.io.PrintStream` it is on the JVM rather
than reporting `*out*`'s `PrintWriter` class.

Gates: `make test` green (65 CI + 3 test targets), `make libconformance`
46 ok / 0 regressed, portability and dce-refs green. `system-streams-smoke.sh`
is new and in CI-GATES at 48 cases; the socket suite gained 8.

Two fixes to the gates themselves, both found here rather than hit: a Chez port
over a socket answers `#t` to `port-has-port-length?` and then raises ESPIPE, so
`available` asks by trying; and `state-image-test` named its temp image with
`(random 100000)`, which is the same number every run, so two concurrent runs
deleted each other's file.

Closes jolt-6wad. Fixes #576.
