### PR TITLE
Tell a failed git ls-remote apart from a tag that is not there

### DIFF
--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -522,6 +522,36 @@ case "$out" in
   *) check "short sha not matching the tag errors" "sha/tag mismatch error" "$(printf '%s' "$out" | head -1)" ;;
 esac
 
+# "the tag is not there" and "we could not go look" are different answers, and
+# saying the first when the second happened sends you to the repo and the pin
+# instead of to the fetch. The v0.7.7 release failed exactly this way: a
+# transient `git ls-remote` failure against github reported a tag that had
+# existed for two weeks as missing. Both cases are offline here — a real repo
+# without the tag, and a URL that is not a repo at all.
+cat > "$tmp/gitproj/deps.edn" <<EOF
+{:paths ["src"]
+ :deps {local/gitdep {:git/url "file://$tmp/gitrepo" :git/tag "v9.9" :git/sha "$short"}}}
+EOF
+out="$(JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 JOLT_GITLIBS="$tmp/gitlibs-notag" "$JOLT" run -m gapp 2>&1)"
+case "$out" in
+  *"tag v9.9 not found"*) check "a tag the repo does not have is reported as not found" ok ok ;;
+  *) check "a tag the repo does not have is reported as not found" "tag v9.9 not found" "$(printf '%s' "$out" | head -2)" ;;
+esac
+
+mkdir -p "$tmp/notarepo"
+cat > "$tmp/gitproj/deps.edn" <<EOF
+{:paths ["src"]
+ :deps {local/gitdep {:git/url "file://$tmp/notarepo" :git/tag "v1.0" :git/sha "$short"}}}
+EOF
+out="$(JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 JOLT_GITLIBS="$tmp/gitlibs-noremote" "$JOLT" run -m gapp 2>&1)"
+case "$out" in
+  *"not found"*) check "a failed ls-remote is not reported as a missing tag" \
+                       "a fetch failure, not 'not found'" "$(printf '%s' "$out" | head -2)" ;;
+  *"could not list"*) check "a failed ls-remote is not reported as a missing tag" ok ok ;;
+  *) check "a failed ls-remote is not reported as a missing tag" \
+           "could not list …" "$(printf '%s' "$out" | head -2)" ;;
+esac
+
 # git cache integrity: only a finished checkout counts as cached. An interrupted
 # fetch used to leave the pre-created sha directory behind empty, and every later
 # run took it for a valid checkout — the dep contributed no source root and the

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -35,15 +35,28 @@
 (defn- getenv [n] (let [v (jolt.host/getenv n)] (when-not (str/blank? v) v)))
 (defn- file-exists? [p] (jolt.host/file-exists? p))
 (defn- sh [cmd] (jolt.host/sh cmd))           ; exit code, inherits stdout/stderr
+(defn- sh-out*
+  "Run a shell command, capturing stdout and stderr separately:
+  {:exit n :out s :err s}. Captures through temp files (jolt.host/sh inherits
+  stdio). Use this wherever \"the command failed\" and \"the command ran and
+  found nothing\" are different answers to the caller — sh-out below collapses
+  them, which is only right when they mean the same thing."
+  [cmd]
+  (let [stamp (str (System/currentTimeMillis) "-" (rand-int 100000))
+        out-f (str "/tmp/jolt-deps-" stamp ".out")
+        err-f (str "/tmp/jolt-deps-" stamp ".err")
+        code (sh (str cmd " > " (pr-str out-f) " 2> " (pr-str err-f)))
+        read-f (fn [p] (when (file-exists? p) (str/trim (slurp p))))
+        r {:exit code :out (read-f out-f) :err (read-f err-f)}]
+    (sh (str "rm -f " (pr-str out-f) " " (pr-str err-f)))
+    r))
+
 (defn- sh-out
   "Run a shell command, returning its trimmed stdout, or nil on a non-zero
-  exit. Captures through a temp file (jolt.host/sh inherits stdio)."
+  exit — for callers to which a failure and an empty result mean the same."
   [cmd]
-  (let [tmp (str "/tmp/jolt-deps-" (System/currentTimeMillis) "-" (rand-int 100000) ".out")
-        code (sh (str cmd " > " (pr-str tmp) " 2>/dev/null"))
-        out (when (file-exists? tmp) (str/trim (slurp tmp)))]
-    (sh (str "rm -f " (pr-str tmp)))
-    (when (zero? code) out)))
+  (let [{:keys [exit out]} (sh-out* cmd)]
+    (when (zero? exit) out)))
 (defn- warn [& xs] (binding [*out* *err*] (println (str "[jolt.deps] " (apply str xs)))))
 ;; Progress / informational lines (fetching, using-cache, skipping, added-natives)
 ;; print only when JOLT_DEBUG is set — otherwise a routine run (e.g. a ys-generated
@@ -161,10 +174,23 @@
                       (let [[commit obj] (str/split (str/trim (slurp cache)) #"\s+")]
                         (when obj [commit (when (not= obj "-") obj)])))]
       cached
-      (when-let [out (sh-out (str "git ls-remote " (pr-str url) " "
-                                  (pr-str (str "refs/tags/" tag)) " "
-                                  (pr-str (str "refs/tags/" tag "^{}"))))]
-        (let [lines (str/split-lines out)
+      ;; "the tag is not there" and "we could not go look" are different answers.
+      ;; Collapsing them reported a transient ls-remote failure — a reset, a rate
+      ;; limit, an unreachable host — as a tag that does not exist, which sends
+      ;; the reader to the repository and the pin instead of to the fetch. (The
+      ;; v0.7.7 release failed this way against a tag two weeks old.) Same
+      ;; distinction the Maven path makes below, and for the same reason.
+      (let [{:keys [exit out err]} (sh-out* (str "git ls-remote " (pr-str url) " "
+                                                 (pr-str (str "refs/tags/" tag)) " "
+                                                 (pr-str (str "refs/tags/" tag "^{}"))))]
+        (when-not (zero? exit)
+          (throw (ex-info (str "git dep: could not list " url " (git ls-remote exited "
+                               exit (when-not (str/blank? err)
+                                      (str ": " (first (str/split-lines err))))
+                               ")")
+                          {:type :jolt.deps/git-ls-remote-failed
+                           :url url :tag tag :exit exit :err err})))
+        (let [lines (str/split-lines (or out ""))
               parse (fn [suffix]
                       (some (fn [l] (let [[sha ref] (str/split l #"\s+")]
                                       (when (and ref (str/ends-with? ref suffix)) sha)))


### PR DESCRIPTION
`sh-out` collapsed every non-zero exit into `nil`, and `resolve-git-tag` turned that
`nil` into:

```
git dep <coord>: tag <t> not found in <url>
```

So a reset, a rate limit or an unreachable host read as *the tag does not exist* —
which sends you to the repository and the pin instead of to the fetch.

The v0.7.7 release failed exactly this way: the examples job reported
`jolt-lang/nrepl v0.1.0` missing, a tag that has existed since Aug 1 and that the
0.7.6 release resolved six hours earlier. Re-running the job passed with nothing
changed.

The Maven path in the same file already draws this distinction, and says why:

> ERRORS carries the repos that failed for a reason OTHER than "no such artifact".
> Every repo answering 404 is a real "not found" and says so; a reset or a 503 is
> not, and reporting it as absent sent people looking for a dependency that was
> published years ago.

## The change

`sh-out*` returns `{:exit :out :err}` — stdout and stderr captured separately, exit
code preserved. `sh-out` stays exactly as it was, built on top, for the callers
where a failure and an empty result genuinely mean the same thing (the `find` for a
packaged `pom.xml`). `resolve-git-tag` uses `sh-out*` and throws a distinct error,
carrying git's own words, when `ls-remote` did not run:

```
git dep: could not list file:///tmp/notarepo (git ls-remote exited 128: fatal:
'/tmp/notarepo' does not appear to be a git repository)
```

with `{:type :jolt.deps/git-ls-remote-failed :url :tag :exit :err}` in ex-data. A
tag the repository genuinely lacks still reports "tag not found", unchanged.

## Tests

Both halves, offline, in `make depssmoke` (which already builds a local git repo
fixture): a real repo asked for a tag it does not have, and a URL that is not a
repository at all. The second fails on `main` with the misleading message — it is
the CI failure reproduced locally.

`make test` green (65 ci targets); deps smoke 100 passed, 0 failed.