### PR TITLE
Retry the git network steps, and check the nREPL socket is close-on-exec

### DIFF
--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -552,6 +552,51 @@ case "$out" in
            "could not list …" "$(printf '%s' "$out" | head -2)" ;;
 esac
 
+# ...and a transient one is retried rather than reported. A `git` shim ahead of
+# the real one on PATH fails the first ls-remote the way a reset does, then gets
+# out of the way — so the dep resolves only if the failure was retried. The
+# counter file is what makes it observable: an unretried run leaves it at 1.
+mkdir -p "$tmp/fakebin"
+cat > "$tmp/fakebin/git" <<'SHIM'
+#!/bin/sh
+# Count ls-remote invocations; fail the first one, delegate the rest.
+for a in "$@"; do
+  if [ "$a" = "ls-remote" ]; then
+    n=$(cat "$FAKE_GIT_COUNT" 2>/dev/null || echo 0)
+    n=$((n+1)); printf '%s' "$n" > "$FAKE_GIT_COUNT"
+    if [ "$n" -le "${FAKE_GIT_FAILS:-1}" ]; then
+      echo "fatal: unable to access: Connection reset by peer" >&2
+      exit 128
+    fi
+    break
+  fi
+done
+exec "$REAL_GIT" "$@"
+SHIM
+chmod +x "$tmp/fakebin/git"
+export REAL_GIT="$(command -v git)"
+cat > "$tmp/gitproj/deps.edn" <<EOF
+{:paths ["src"]
+ :deps {local/gitdep {:git/url "file://$tmp/gitrepo" :git/tag "v1.0" :git/sha "$short"}}}
+EOF
+export FAKE_GIT_COUNT="$tmp/fakegit.count"; : > "$FAKE_GIT_COUNT"
+check "a transient ls-remote failure is retried" "git dep: tagged" \
+      "$(PATH="$tmp/fakebin:$PATH" FAKE_GIT_FAILS=1 JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 \
+         JOLT_GITLIBS="$tmp/gitlibs-retry" "$JOLT" run -m gapp 2>&1 | tail -1)"
+check "  and the retry actually happened (ls-remote ran twice)" "2" "$(cat "$FAKE_GIT_COUNT")"
+
+# The cap is real: a failure that outlasts it reports, it does not spin.
+: > "$FAKE_GIT_COUNT"
+out="$(PATH="$tmp/fakebin:$PATH" FAKE_GIT_FAILS=99 JOLT_PWD="$tmp/gitproj" JOLT_QUIET=1 \
+       JOLT_GITLIBS="$tmp/gitlibs-retry2" "$JOLT" run -m gapp 2>&1)"
+case "$out" in
+  *"could not list"*) check "a persistent ls-remote failure reports after the cap" ok ok ;;
+  *) check "a persistent ls-remote failure reports after the cap" "could not list …" \
+           "$(printf '%s' "$out" | head -2)" ;;
+esac
+check "  and it stopped at the attempt cap" "3" "$(cat "$FAKE_GIT_COUNT")"
+unset REAL_GIT FAKE_GIT_COUNT
+
 # git cache integrity: only a finished checkout counts as cached. An interrupted
 # fetch used to leave the pre-created sha directory behind empty, and every later
 # run took it for a valid checkout — the dep contributed no source root and the

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1201,5 +1201,22 @@ check '(.nextLong (java.util.Random. 12345))' '6674089274190705457'
 check_no '(dotimes [_ 100] (random-uuid))' 'no OS entropy'
 check '(let [u (str (random-uuid))] [(count u) (nth u 14) (contains? #{\8 \9 \a \b} (nth u 19))])' '[36 \4 true]'
 
+# The nREPL listen socket must be close-on-exec. Without it every subprocess
+# spawned from a process running an nREPL inherits a duplicate, and the port
+# stays bound for as long as any of them lives — so killing the server leaves the
+# next start unable to bind, against a server that is already gone. Nothing else
+# checked it, and the failure surfaces much later as a port that outlived its
+# server, which nobody attributes to the right change.
+#
+# Asks the descriptor itself — fcntl(F_GETFD) & FD_CLOEXEC — on an ephemeral
+# port, so no subprocess and no fixed port number are involved. It asserts the
+# PROPERTY, not one mechanism: macOS reaches it through the fcntl in
+# close-on-exec! (verified: removing that call turns this red here), Linux
+# through SOCK_CLOEXEC on socket() as well, so each platform checks the path it
+# actually relies on. POSIX only — Windows has no FD_CLOEXEC (it controls
+# inheritance with HANDLE_FLAG_INHERIT), so there this asserts nothing rather
+# than asserting the wrong thing.
+check '(do (require (quote jolt.nrepl)) (if jolt.nrepl/windows? :close-on-exec (let [fd (jolt.nrepl/listen-socket 0) flags (jolt.nrepl/c-fcntl fd 1 0)] (jolt.nrepl/c-close fd) (if (pos? (bit-and flags 1)) :close-on-exec :inheritable))))' ':close-on-exec'
+
 echo "cli smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -58,6 +58,32 @@
   (let [{:keys [exit out]} (sh-out* cmd)]
     (when (zero? exit) out)))
 (defn- warn [& xs] (binding [*out* *err*] (println (str "[jolt.deps] " (apply str xs)))))
+
+;; --- retrying the network steps ---------------------------------------------
+;; A git command that talks to a remote fails transiently more often than not — a
+;; reset, a rate limit, a DNS blip — and the cost of finding out is one more
+;; round trip. The HTTPS fetch already works this way (jolt/mvn_http.clj); these
+;; are the git-side equivalents, and they matter for the same reason: a flake
+;; here fails a whole build, and a release with it.
+(def ^:private net-attempts 3)
+;; Deliberately short, same reasoning as the fetch's: this sits in front of a
+;; developer waiting on a build, and the failures it covers clear in well under a
+;; second. A long backoff trades a rare recovery for a guaranteed stall on the
+;; genuinely-unreachable case.
+(def ^:private net-backoff-ms [200 600])
+
+(defn- with-net-retries
+  "Call ATTEMPT until `ok?` accepts its result, at most net-attempts times, with
+  a short backoff between. Returns the LAST result either way — still a failing
+  one when the cap is reached, so the caller reports the failure it actually got
+  rather than treating the cap as a different kind of answer."
+  [ok? attempt]
+  (loop [n 1]
+    (let [r (attempt)]
+      (if (or (ok? r) (>= n net-attempts))
+        r
+        (do (when-let [ms (nth net-backoff-ms (dec n) nil)] (Thread/sleep ms))
+            (recur (inc n)))))))
 ;; Progress / informational lines (fetching, using-cache, skipping, added-natives)
 ;; print only when JOLT_DEBUG is set — otherwise a routine run (e.g. a ys-generated
 ;; program pulling a native-declaring lib) barfs them on every invocation. Genuine
@@ -180,16 +206,19 @@
       ;; the reader to the repository and the pin instead of to the fetch. (The
       ;; v0.7.7 release failed this way against a tag two weeks old.) Same
       ;; distinction the Maven path makes below, and for the same reason.
-      (let [{:keys [exit out err]} (sh-out* (str "git ls-remote " (pr-str url) " "
-                                                 (pr-str (str "refs/tags/" tag)) " "
-                                                 (pr-str (str "refs/tags/" tag "^{}"))))]
+      (let [{:keys [exit out err]}
+            (with-net-retries #(zero? (:exit %))
+              #(sh-out* (str "git ls-remote " (pr-str url) " "
+                             (pr-str (str "refs/tags/" tag)) " "
+                             (pr-str (str "refs/tags/" tag "^{}")))))]
         (when-not (zero? exit)
           (throw (ex-info (str "git dep: could not list " url " (git ls-remote exited "
-                               exit (when-not (str/blank? err)
-                                      (str ": " (first (str/split-lines err))))
+                               exit " after " net-attempts " attempts"
+                               (when-not (str/blank? err)
+                                 (str ": " (first (str/split-lines err))))
                                ")")
                           {:type :jolt.deps/git-ls-remote-failed
-                           :url url :tag tag :exit exit :err err})))
+                           :url url :tag tag :exit exit :err err :attempts net-attempts})))
         (let [lines (str/split-lines (or out ""))
               parse (fn [suffix]
                       (some (fn [l] (let [[sha ref] (str/split l #"\s+")]
@@ -262,13 +291,18 @@
         fail (fn [msg data] (scrub) (throw (ex-info msg (merge {:url url :sha sha} data))))]
     (info "fetching " url " @ " (subs sha 0 (min 12 (count sha))))
     (sh (str "mkdir -p " (pr-str repo-dir)))
-    (when-not (zero? (sh (str "git clone --quiet " (pr-str url) " " (pr-str stage))))
-      (fail (str "git clone failed: " url) nil))
+    ;; the clone talks to the remote, so it gets the same bounded retry the tag
+    ;; listing does — scrubbing first, since a failed clone leaves a partial
+    ;; staging dir that the next attempt would refuse to clone into.
+    (when-not (zero? (with-net-retries zero? (fn [] (scrub) (sh (str "git clone --quiet " (pr-str url) " " (pr-str stage))))))
+      (fail (str "git clone failed after " net-attempts " attempts: " url) nil))
+    ;; local, so no retry: the objects are already in the staging clone.
     (when-not (zero? (sh (str "git -C " (pr-str stage) " checkout --quiet " (pr-str sha))))
       (fail (str "git checkout failed: " sha " in " url) nil))
-    ;; submodules are pinned in the checkout; pull them if the dep uses any.
-    (when-not (zero? (sh (str "git -C " (pr-str stage) " submodule update --init --recursive --quiet")))
-      (fail (str "git submodule update failed for " url) nil))
+    ;; submodules are pinned in the checkout; pull them if the dep uses any. This
+    ;; one fetches too, and is idempotent, so it retries in place.
+    (when-not (zero? (with-net-retries zero? #(sh (str "git -C " (pr-str stage) " submodule update --init --recursive --quiet"))))
+      (fail (str "git submodule update failed after " net-attempts " attempts for " url) nil))
     (sh (str "touch " (pr-str (str stage "/.jolt-git-ok"))))
     (if (checkout-complete? dir)
       (do (scrub) dir)                    ; another process published it first

--- a/jolt-core/jolt/nrepl.clj
+++ b/jolt-core/jolt/nrepl.clj
@@ -69,7 +69,7 @@
     ;; fixed/variadic boundary; a fixed-arity binding silently corrupts the
     ;; stack-passed argument on Apple arm64. POSIX only — Windows controls
     ;; inheritance with HANDLE_FLAG_INHERIT, not FD_CLOEXEC.
-    (ffi/defcfn c-fcntl-set "fcntl" [:int :int :varargs :int] :int)))
+    (ffi/defcfn c-fcntl     "fcntl" [:int :int :varargs :int] :int)))
 
 (def ^:private AF-INET 2)
 (def ^:private SOCK-STREAM 1)
@@ -116,7 +116,7 @@
   F_SETFD is 2 and FD_CLOEXEC is 1 on both macOS and Linux."
   [fd]
   (when-not windows?
-    (try (c-fcntl-set fd 2 1) (catch Throwable _ nil)))
+    (try (c-fcntl fd 2 1) (catch Throwable _ nil)))
   fd)
 
 (defn- listen-socket [port]


### PR DESCRIPTION
Two follow-ups from the v0.7.7 release failure.

## Bounded retry on the git network steps

`git ls-remote`, `clone` and `submodule update` talk to a remote, and a remote
fails transiently more often than not — a reset, a rate limit, a DNS blip. The
v0.7.7 release died on exactly one such flake, and #595 only made it *legible*;
it still failed. Now it retries.

The HTTPS fetch has worked this way for a while (`jolt/mvn_http.clj`: 3 attempts,
`[200 600]` backoff, `:retryable` classification). `with-net-retries` is the
git-side equivalent with the same cap and the same short backoff, for the reason
that file already gives — this sits in front of a developer waiting on a build,
and the failures it covers clear in well under a second, so a long backoff would
trade a rare recovery for a guaranteed stall on the genuinely-unreachable case.

What does **not** retry: `git checkout` and the publish rename. Both are local —
the objects are already in the staging clone — so retrying would only hide a real
failure. A failed clone scrubs its staging directory before the next attempt,
since a partial one is not something the next `git clone` will write into.

The error now says how many attempts were made:

```
git dep: could not list <url> (git ls-remote exited 128 after 3 attempts: ...)
```

**Tests** (`make depssmoke`, offline): a `git` shim ahead of the real one on PATH
fails the first `ls-remote` the way a reset does, then gets out of the way — the
dep resolves only if the failure was retried, and a counter file makes the retry
observable rather than inferred (an unretried run leaves it at 1). A second case
pins the cap: a shim that always fails must report after exactly 3 attempts, not
spin. Both fail on `main`.

## The nREPL close-on-exec check (jolt-hgcq)

#596 set close-on-exec on the listen socket, verified by hand. Nothing checked
it, so a future edit to `listen-socket` could drop it with every gate green — and
that failure surfaces much later as a port that outlived its server, which nobody
attributes to the right change.

The CLI smoke now asks the descriptor itself, `fcntl(F_GETFD) & FD_CLOEXEC`, on
an ephemeral port — no subprocess and no fixed port number. It asserts the
**property**, not one mechanism: macOS reaches it through the `fcntl` in
`close-on-exec!`, Linux through `SOCK_CLOEXEC` on `socket()` as well, so each
platform checks the path it actually relies on. I confirmed it is not vacuous by
removing the `close-on-exec!` call and watching it go red. Windows has no
`FD_CLOEXEC`, so there it asserts nothing rather than the wrong thing.

Also: the `fcntl` binding was named `c-fcntl-set` while being used for both
`F_SETFD` and `F_GETFD`. It is just `fcntl` — the cmd decides — so it is named
that now.

## Verification

`make test` green (65 ci targets). deps smoke 104 passed / 0 failed (was 100),
cli smoke 135 / 0.