### PR TITLE
Gate that reading a file form by form stays linear

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ endif
 JOLT-TARGETS-NEEDING-DEPS := \
   aotcacheperf aotcachesmoke aotfingerprint asynctimer buildlibsmoke buildsmoke \
   aotcachepathsmoke compilepathsmoke contagion corpus cts dcerefs depssmoke depsunit devboot \
+  readscaling \
   devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform grenadine \
   gateboot gatebootsmoke gosm httpsfetch infer inline inline-body irvalidate \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
@@ -115,7 +116,7 @@ install: build
 # naming the covered tree is written ONLY on a complete pass. `make gate-status`
 # answers "is this working tree gated?" — which is not something to remember.
 
-CI-GATES := submodules values corpus unit grenadine mvnhttp depssmoke depsunit \
+CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling depssmoke depsunit \
   smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi \
   transient stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
@@ -361,6 +362,15 @@ libconformance: testbin
 # network, no OpenSSL — runs in the default gate.
 mvnhttp:
 	@bin/jolt run test/mvn_http_test.clj
+
+# Reading a source file form by form off a java.io reader must cost time LINEAR
+# in the source. It was quadratic until v0.7.7 (37s to read clojure/core.clj,
+# against the JVM's 0.06s) and nothing caught it, because the corpus rows about
+# reading are all about the VALUES a read produces. Asserts the 1x-vs-4x ratio
+# measured inside ONE process, so it judges the shape and not the machine.
+# Takes the built binary: script mode would measure the same ratio far slower.
+readscaling: testbin
+	@JOLT_NO_USER_DEPS=1 target/release/jolt run test/read_scaling_test.clj
 
 # deps.edn alias + CLI semantics (tools.deps args-map keys, -X/-T/-Sdeps, the
 # user deps.edn chain, jar/git coordinates) through the real CLI, over local

--- a/test/read_scaling_test.clj
+++ b/test/read_scaling_test.clj
@@ -1,0 +1,80 @@
+;; Reading a source file form by form off a host reader must cost time LINEAR in
+;; the source, not quadratic.
+;;
+;; It was quadratic until v0.7.7: every (read rdr) drained the whole remaining
+;; reader, parsed one form, and pushed the tail back, so a caller walking a file
+;; paid a full copy of the rest of it per FORM. Reading clojure/core.clj (263KB,
+;; 697 forms) took 37s against the JVM's 0.06s. Nothing noticed for a long time
+;; because the loop was unreachable — (read opts stream) did not exist, so it
+;; threw on the first call instead of running.
+;;
+;; What this asserts is the SHAPE, measured in one run: quadrupling the input
+;; must not quadruple the cost per form. A ratio near 4 is linear; a quadratic
+;; implementation lands near 16. Nothing here is an absolute time, so it does not
+;; care how fast the machine is, and it does not compare against a calibration
+;; constant that could drift — the two numbers come from the same process,
+;; microseconds apart, and only their ratio is judged. (Gate timing lesson: an
+;; absolute ns ceiling and a cross-run ratio both flake on CI; a property
+;; measured within one run does not.)
+;;
+;; The behavioural half of this — that a read advances the reader correctly, that
+;; the unconsumed tail survives, that each form carries its own line — is in the
+;; corpus under "interop / read over a host reader". This file is only about cost.
+
+(ns read-scaling-test)
+
+(def ^:private form-text "(def some-name-here [1 2 3 :a :b \"str\"])\n")
+
+(defn- source [n] (apply str (repeat n form-text)))
+
+(defn- read-all
+  "Read every form off a PushbackReader over s, the way a file walker does."
+  [s]
+  (let [r (java.io.PushbackReader. (java.io.StringReader. s))]
+    (count (take-while #(not= :eof %) (repeatedly #(read {:eof :eof} r))))))
+
+(defn- timed
+  "[elapsed-ms result] — the count comes back with the time so verifying what was
+  read costs no extra pass."
+  [f]
+  (let [t (System/currentTimeMillis)
+        v (f)]
+    [(- (System/currentTimeMillis) t) v]))
+
+;; n1 is big enough that the measurement sits well above timer noise (~40ms here)
+;; and small enough that a REGRESSED implementation still finishes and fails
+;; rather than hanging — a gate that hangs reports nothing.
+(def ^:private n1 8000)
+(def ^:private factor 4)
+
+;; Linear measures ~4.0 and quadratic ~16, so the line goes between them. 8 is
+;; twice the linear cost — room for a slow or loaded machine, while still an
+;; enormous distance from quadratic.
+(def ^:private max-ratio 8.0)
+
+(defn -main [& _]
+  (let [s1 (source n1)
+        s4 (source (* factor n1))
+        _ (read-all s1)                 ; warm: keep one-time costs out of the ratio
+        [t1 c1] (timed #(read-all s1))
+        [t4 c4] (timed #(read-all s4))]
+    ;; a ratio over the wrong number of forms would be meaningless, so check the
+    ;; reads did what they claim before judging what they cost
+    (when (or (not= c1 n1) (not= c4 (* factor n1)))
+      (println (str "FAIL read-scaling: read the wrong number of forms — "
+                    c1 " (want " n1 ") and " c4 " (want " (* factor n1) ")"))
+      (System/exit 1))
+    (let [t1 (max 1 t1)
+          ratio (double (/ t4 t1))]
+      (println (format "read-scaling: %d forms %dms, %d forms %dms, ratio %.2f (linear ~%.1f, quadratic ~%.1f, ceiling %.1f)"
+                       n1 t1 (* factor n1) t4 ratio
+                       (double factor) (double (* factor factor)) max-ratio))
+      (if (> ratio max-ratio)
+        (do (println (str "FAIL read-scaling: reading scaled worse than linearly in the source size. "
+                          "A read off a host reader is walking the whole remaining input again per form "
+                          "(host-reader-read-form / host-reader-string-cursor in host/chez/java/io.ss, "
+                          "or the position cursor in rdr-line-col-at no longer being reused)."))
+            (System/exit 1))
+        (println "read-scaling: passed")))))
+
+(-main)


### PR DESCRIPTION
Reading a source file off a `java.io` reader was quadratic until v0.7.7: every
`read` drained the whole remaining reader, parsed one form and pushed the tail
back, so walking a file cost a copy of the rest of it **per form** — 37s for
`clojure/core.clj` against the JVM's 0.06s.

Nothing caught it, and — the reason for this PR — nothing would catch it coming
back. The corpus rows added alongside the fix are all about the **values** a read
produces: forms in order, the unconsumed tail surviving, each form carrying its
own line. Two of them happen to fail on the old implementation, but only because
draining had a visible side effect on line numbers. Reintroduce the quadratic a
different way — break the position cursor's reuse in `rdr-line-col-at`, say — and
every one of them still passes.

## What it asserts

The **shape**, measured inside one process: read N forms and 4N forms, take the
ratio. Linear measures ~4, quadratic ~16; the ceiling is 8.

```
read-scaling: 8000 forms 46ms, 32000 forms 179ms, ratio 3.89
              (linear ~4.0, quadratic ~16.0, ceiling 8.0)
```

No absolute time and no comparison against a stored number, so it does not care
how fast the machine is or how loaded CI is — both figures come from the same
process microseconds apart, and only their ratio is judged. That is deliberate:
an absolute ceiling and a cross-run ratio have each flaked here before.

## That it actually fails

Checked against a deliberately broken build — `host-reader-string-cursor` forced
to decline, which routes every read down the pre-0.7.7 drain path:

```
read-scaling: 8000 forms 1709ms, 32000 forms 39274ms, ratio 22.98
FAIL read-scaling: reading scaled worse than linearly in the source size.
```

It takes 85s to fail. That is what the sizes are chosen for: big enough that the
passing measurement sits well clear of timer noise, small enough that a regressed
build still **finishes and reports** instead of hanging — a gate that hangs tells
you nothing.

Passing costs ~230ms, and measured 3.87 / 3.89 / 3.98 across runs.

Wired in as `make readscaling`, in `CI-GATES` (66 targets now). `make test` green.