### PR TITLE
Embed per-namespace stdlib fasls in the release binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ install: build
 # answers "is this working tree gated?" — which is not something to remember.
 
 CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling depssmoke depsunit \
-  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi \
+  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi stdlibfasl \
   transient stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform traceemit traceeval degradedbacktrace \
@@ -406,6 +406,14 @@ jolt: selfhost jolt-release jolt-debug
 # Self-build smoke: the distributed jolt compiles an app with Chez + cc removed.
 joltsmoke:
 	@sh host/chez/jolt-selfbuild-smoke.sh
+
+# The embedded per-namespace stdlib fasls (R1): assert that a built jolt serves
+# clojure.test (and jolt.time) from the compiled fasl blob rather than
+# recompiling from source, that the aot-info line fires (non-vacuous), and that a
+# real deftest + LocalDate expression run through the binary. Depends on
+# jolt-release having run.
+stdlibfasl: testbin
+	@sh host/chez/stdlib-fasl-smoke.sh
 
 # SCI conformance: load borkdude/sci's source through jolt (floor-gated).
 sci:

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -366,22 +366,6 @@
       ldr-install-roots)
     (reverse out)))
 
-;; Emit one ns's own forms to its .scm under the build dir. The emit machinery
-;; captures the ns in isolation under its own ei-fresh-unit!, so the fasl holds
-;; ONLY that ns's forms (loader.ss:~432 nested-load bug discipline).
-(define (jb-emit-stdlib-scm! name abs scm)
-  (let ((src (ldr-read-source abs)) (outp (open-output-file scm 'replace)))
-    (put-string outp (string-append "\n;; --- AOT stdlib " name " ---\n"))
-    (parameterize ((rdr-source-file abs))
-      (put-string outp "(jolt-ns-load-vars-push!)\n")
-      (for-each (lambda (s) (put-string outp s) (put-string outp "\n"))
-                (bld-ns-prelude name src))
-      (for-each (lambda (s) (put-string outp s) (put-string outp "\n"))
-                (bld-emit-ns name src))
-      (put-string outp "(jolt-ns-load-vars-pop!)\n"))
-    (put-string outp (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n"))
-    (close-port outp)))
-
 ;; ONE batch compile of every emitted stdlib .scm, in a FRESH Chez that has the
 ;; SAME runtime preamble loaded as build-jolt's own header. The emitted Scheme
 ;; references runtime MACROS — jolt-n-, jolt-n+, jolt-n*, jolt-n-div, jolt-n-min
@@ -437,31 +421,51 @@
       (close-port p))
     (bld-system (string-append bld-chez " --script '" cs "'"))))
 
-;; Emit the per-ns Scheme with the same dynamic-wind profile as jb-emit-cli-ns.
-(define (jb-emit-stdlib-ns! name abs scm)
-  (dynamic-wind
-    (lambda ()
-      (ei-fresh-unit!)
-      ((var-deref "jolt.backend-scheme" "set-prelude-mode!") #t)
-      (set-optimize! #t) (set-release! #t)
-      ((var-deref "jolt.backend-scheme" "set-var-cache!") #t))
-    (lambda () (jb-emit-stdlib-scm! name abs scm))
-    (lambda ()
-      (set-optimize! #f) (set-release! #f)
-      ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
-      (ei-clear-cached!))))
+;; Capture one ns's emitted Scheme to its .scm. aot-capture-load evaluates the
+;; FILE through the normal load loop while teeing the per-form Scheme — the SAME
+;; path the on-disk AOT cache (aot-compile-and-cache) and clojure.core/compile
+;; (cpath-compile-load) use — so the captured string INCLUDES the ns form's
+;; requires. bld-emit-ns (whole-program APP emission) drops requires, since in an
+;; app image every dep is already present; an on-demand fasl is different —
+;; requiring jolt.fs loads its fasl but babashka.fs never arrives, leaving every
+;; proxied var unbound. aot-capture-load evals the file directly (re-evaluation
+;; at build time is fine; defonce guards hold), tees ONLY this file's forms
+;; (loader.ss:438 nested-capture discipline keeps a nested require out of this
+;; capture), and runs under the process's own compile settings — no
+;; prelude-mode/optimize/release/var-cache dynamic-wind, matching what the
+;; binary's own cache-miss path would produce at runtime. A capture returning a
+;; non-string or empty string is a BUILD FAILURE (reported), not a skip —
+;; matching cpath-compile-load's guard. A load EXCEPTION is a skip.
+(define (jb-capture-stdlib-scm! name abs scm)
+  (let ((captured-or-skip
+          (guard (e (else
+                      (let ((msg (guard (_ (#t "(unprintable)"))
+                                  (let ((m ((var-deref "jolt.host" "condition-message") e)))
+                                    (and (string? m) m)))))
+                        (display (string-append "build-jolt: stdlib-fasl FAILED " name ": " msg "\n")
+                                 (current-error-port))
+                        (cons 'skip (string-append "load failed: " msg)))))
+            (cons 'ok (aot-capture-load abs (ldr-read-source abs))))))
+    (cond
+      ((eq? (car captured-or-skip) 'skip) (cons 'skip (cdr captured-or-skip)))
+      ((or (not (string? (cdr captured-or-skip)))
+           (fx=? (string-length (cdr captured-or-skip)) 0))
+       ;; empty capture for a real ns is a build failure — escapes this function
+       ;; (no guard here) so it aborts the build rather than silently skipping.
+       (error 'build-jolt
+         (string-append "stdlib-fasl capture produced no code for " name)))
+      (else
+       (let ((outp (open-output-file scm 'replace)))
+         (put-string outp (cdr captured-or-skip))
+         (close-port outp))
+       'ok))))
 
-;; Load+emit+compile every candidate ns to its own fasl. Returns two values: the
-;; list of (name . fasl-path) that compiled OK (in load order), and the list of
-;; (name . reason) that were skipped. A ns that fails to LOAD standalone (needs an
-;; optional library, or its top level wedges the build) is skipped with a reason,
-;; NOT silently dropped — it lands in the manifest. A ns that LOADS but fails to
-;; EMIT (bld-emit-ns is strict) is a build failure, same as an app build.
+;; Capture (aot-capture-load) every candidate ns to its own fasl, then ONE batch
+;; compile. Returns two values: (name . so) that captured OK (in load order) and
+;; (name . reason) that were skipped. A manifest-declared skip is never
+;; load-attempted. A load exception is a skip with a reason; an empty capture is
+;; a build failure (see jb-capture-stdlib-scm!).
 (define (jb-compile-stdlib-fasls!)
-  ;; Manifest-declared skips are EXCLUDED from the batch compile: a skip whose
-  ;; emitted .scm Chez rejects (jolt.io-poller, whose foreign-procedure form
-  ;; renders an empty () arg list) would otherwise kill the single batch
-  ;; bld-system. Their verified reason is carried straight through.
   (define-values (man-embed man-skips) (jb-read-stdlib-manifest))
   (bld-system (string-append "mkdir -p '" jb-stdlib-dir "'"))
   (let ((order '()) (to-compile '()) (skips (reverse man-skips)))
@@ -474,25 +478,20 @@
                  (so (string-append jb-stdlib-dir "/" san ".so")))
             (if (assoc name skips)
                 ;; manifest-declared skip — already in skips with its verified
-                ;; reason; do not load-attempt (a load failure here would
-                ;; duplicate the ns in skips and never reach the batch compile).
-                ;; jb-emit-stdlib-fasls! prints all skips once at the end.
+                ;; reason; do not load-attempt. jb-emit-stdlib-fasls! prints
+                ;; all skips once at the end.
                 (if #f #f)
-                (guard (e (else
-                            (let ((msg (guard (_ (#t "(unprintable)"))
-                                        (let ((m ((var-deref "jolt.host" "condition-message") e)))
-                                          (and (string? m) m)))))
-                              (display (string-append "build-jolt: stdlib-fasl FAILED " name ": " msg "\n")
-                                       (current-error-port))
-                              (set! skips (cons (cons name (string-append "load failed: " msg)) skips)))))
-                  (load-namespace name)
-                  (jb-emit-stdlib-ns! name abs scm)
-                  (set! order (cons (cons name so) order))
-                  (set! to-compile (cons (cons scm so) to-compile))))))
+                (let ((r (jb-capture-stdlib-scm! name abs scm)))
+                  (cond
+                    ((eq? r 'ok)
+                     (set! order (cons (cons name so) order))
+                     (set! to-compile (cons (cons scm so) to-compile)))
+                    ((pair? r)
+                     (set! skips (cons (cons name (cdr r)) skips))))))))
         (jb-stdlib-candidates))
       (set-ns-loaded-hook! (lambda (name file) #f)))
     ;; ONE batch compile with the runtime preamble loaded (see jb-compile-stdlib-sos!).
-    ;; A failure here is a BUILD FAILURE — emitted Scheme must compile once the
+    ;; A failure here is a BUILD FAILURE — captured Scheme must compile once the
     ;; macro environment is present.
     (jb-compile-stdlib-sos! (reverse to-compile))
     (values (reverse order) (reverse skips))))

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -181,6 +181,7 @@
     ;; JOLT_TRACE at RUNTIME (the env is unset at heap-build), before any app ns
     ;; compiles, so a `-M:run` traces the app's own code.
     (jolt-trace-init-from-env!)
+    (jolt-stdlib-fasls-attach! '" (jb-stdlib-index-str) ")
     ;; shared dispatch (cli-core.ss, inlined via the runtime manifest): the -e
     ;; arm, end-of-options, and uncaught reporting are the same code the script
     ;; driver runs — the launcher once carried a stale fork of the -e arm.
@@ -249,6 +250,328 @@
           ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
           (ei-clear-cached!))))))
 
+;; --- AOT the install-owned stdlib namespaces as embedded fasls --------------
+;; install-owned source (jolt-core/, stdlib/, ...) is excluded from the on-disk AOT
+;; cache (aot-load-or-compile's `(not (ldr-install-file? file))` guard), so every
+;; `(require 'clojure.test)` recompiled ~671 lines from source on EACH process
+;; start. Instead: load each remaining install-owned namespace HERE, emit its
+;; Scheme, compile it to a fasl in a FRESH Chez with the release profile, and bake
+;; the bytes into flat.ss as `(register-embedded-fasl! "<ns>" <bytevector>)`. At
+;; require time the loader finds the embedded fasl for an install-owned ns and
+;; loads it via load-compiled-from-port instead of recompiling.
+
+(define jb-stdlib-manifest-path "host/chez/stdlib-fasl-manifest.txt")
+
+;; Shared profile boolean renderer (also used by the flat.ss compile step below).
+;; Defined here, before jb-compile-stdlib-so!, because the stdlib fasl compile
+;; runs during flat.ss emission — earlier than the step-2 compile block that
+;; once held the only definition.
+(define jb-bool (lambda (b) (if b "#t" "#f")))
+
+;; Filled by jb-emit-stdlib-fasls! during flat.ss emission: the single blob path
+;; (xxd'd into the binary as jolt_stdlib_fasls in step 3) and the (ns offset
+;; length) index (baked into flat.ss via the launcher's jolt-stdlib-fasls-attach!
+;; call). #f / () until then.
+(define jb-stdlib-blob-path #f)
+(define jb-stdlib-index '())
+
+;; Render jb-stdlib-index as a Scheme source list for the launcher's attach call:
+;; (("clojure.test" 0 123456) ...). This literal is the only thing baked into
+;; flat.ss for the stdlib fasls — small, regardless of how big the blob is.
+(define (jb-stdlib-index-str)
+  (string-append "("
+    (apply string-append
+      (map (lambda (e)
+             (string-append "(" (ei-str-lit (car e)) " "
+                            (number->string (cadr e)) " "
+                            (number->string (caddr e)) ")"))
+           jb-stdlib-index))
+    ")"))
+
+;; Parse the manifest into (values embedded-names skip-alist). Skip lines look
+;; like "skip <ns> — <reason>"; the alist entry is (ns . reason). The reason is
+;; what jb-compile-stdlib-fasls! reports and the manifest author verified, and
+;; the ns drives compile EXCLUSION: a skip is not even load-attempted, so a ns
+;; whose emitted .scm Chez rejects cannot kill the batch compile.
+(define (jb-read-stdlib-manifest)
+  (let loop ((lines (bld-file-lines jb-stdlib-manifest-path))
+             (names '()) (skips '()))
+    (if (null? lines)
+        (values (reverse names) (reverse skips))
+        (let* ((ln (car lines)) (n (string-length ln)))
+          (cond
+            ((or (string=? ln "") (char=? (string-ref ln 0) #\#))
+             (loop (cdr lines) names skips))
+            ((and (>= n 5) (string=? (substring ln 0 5) "skip "))
+             (let* ((rest (substring ln 5 n)) (di (jb-str-index rest " — ")))
+               (loop (cdr lines) names
+                     (cons (if di
+                               (cons (substring rest 0 di)
+                                     (substring rest (+ di 3) (string-length rest)))
+                               (cons rest ""))
+                           skips))))
+            (else (loop (cdr lines) (cons ln names) skips)))))))
+
+(define (jb-stdlib-manifest-check! discovered)
+  (define-values (man-names man-skips) (jb-read-stdlib-manifest))
+  (let ((man-keys (sort string<? (append man-names (map car man-skips))))
+        (disc-keys (sort string<? discovered)))
+    (unless (and (= (length man-keys) (length disc-keys))
+                 (equal? man-keys disc-keys))
+      (error 'build-jolt
+        (string-append
+          "stdlib-fasl manifest drift — discovered set does not match "
+          jb-stdlib-manifest-path "\n"
+          "  discovered (" (number->string (length disc-keys)) "): "
+          (apply string-append (map (lambda (n) (string-append n " ")) disc-keys)) "\n"
+          "  manifest   (" (number->string (length man-keys)) "): "
+          (apply string-append (map (lambda (n) (string-append n " ")) man-keys)) "\n"
+          "  Edit the manifest to match the discovered set.")))))
+
+(define (jb-strip-source-ext rel)
+  (let loop ((es ldr-source-exts))
+    (and (pair? es)
+         (let* ((suf (car es)) (m (string-length suf)) (n (string-length rel)))
+           (if (and (>= n m) (string=? (substring rel (- n m) n) suf))
+               (substring rel 0 (- n m))
+               (loop (cdr es)))))))
+
+;; Discover every install-owned source ns in first-root-wins order, dropping ones
+;; already loaded (image + CLI closure). Returns ((name . abspath) ...) in walk
+;; order. Same walk + ldr-source-path? + first-root-wins discipline as
+;; jb-emit-source-embeds.
+(define (jb-stdlib-candidates)
+  (let ((seen (make-hashtable string-hash string=?)) (out '()))
+    (for-each
+      (lambda (root)
+        (for-each
+          (lambda (rp)
+            (let* ((rel (car rp)) (abs (cdr rp)) (core (jb-strip-source-ext rel)))
+              (when (and core (ldr-source-path? rel) (not (hashtable-ref seen core #f)))
+                (hashtable-set! seen core #t)
+                (let ((ns (jb-ns-from-rel core)))
+                  ;; A file under clojure/core/ named 10-seq.clj derives the ns
+                  ;; name clojure.core.10-seq, but that is a clojure.core OVERLAY
+                  ;; SHARD (its ns form is (ns clojure.core)), not a standalone
+                  ;; namespace: load-namespace would fail to find it (ns-name->rel
+                  ;; munges the dash to an underscore) and there is nothing to
+                  ;; AOT — it is already in the image as part of clojure.core.
+                  ;; Drop a candidate whose derived name does not round-trip to a
+                  ;; findable source file.
+                  (unless (or (hashtable-ref loaded-ns ns #f)
+                              (member ns '("jolt.main" "jolt.deps"))
+                              (not (find-ns-file ns)))
+                    (set! out (cons (cons ns abs) out)))))))
+          (bld-walk-files root "" '())))
+      ldr-install-roots)
+    (reverse out)))
+
+;; Emit one ns's own forms to its .scm under the build dir. The emit machinery
+;; captures the ns in isolation under its own ei-fresh-unit!, so the fasl holds
+;; ONLY that ns's forms (loader.ss:~432 nested-load bug discipline).
+(define (jb-emit-stdlib-scm! name abs scm)
+  (let ((src (ldr-read-source abs)) (outp (open-output-file scm 'replace)))
+    (put-string outp (string-append "\n;; --- AOT stdlib " name " ---\n"))
+    (parameterize ((rdr-source-file abs))
+      (put-string outp "(jolt-ns-load-vars-push!)\n")
+      (for-each (lambda (s) (put-string outp s) (put-string outp "\n"))
+                (bld-ns-prelude name src))
+      (for-each (lambda (s) (put-string outp s) (put-string outp "\n"))
+                (bld-emit-ns name src))
+      (put-string outp "(jolt-ns-load-vars-pop!)\n"))
+    (put-string outp (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n"))
+    (close-port outp)))
+
+;; ONE batch compile of every emitted stdlib .scm, in a FRESH Chez that has the
+;; SAME runtime preamble loaded as build-jolt's own header. The emitted Scheme
+;; references runtime MACROS — jolt-n-, jolt-n+, jolt-n*, jolt-n-div, jolt-n-min
+;; are define-syntax in seq.ss — which a bare (import (chezscheme)) leaves as
+;; top-level variable references, so a fasl compiled that way throws "variable
+;; jolt-n- is not bound" the moment a loaded namespace does arithmetic. Loading
+;; the preamble (rt.ss loads seq.ss) gives compile-file the macro environment
+;; the Scheme was produced under. The on-disk AOT cache never hits this because
+;; loader.ss compiles emitted Scheme IN-PROCESS (sa-compile-file) with the
+;; runtime already loaded.
+;;
+;; PAIRS is a list of (scm . so) in load order. The script loads the preamble,
+;; THEN the xpatch (cross only — the runtime must load as host-executed code
+;; first, the xpatch then retargets compile-file's code generation for the
+;; .scm files), sets the per-profile flags mirrored from the flat.ss compile
+;; step, and compile-file's every .scm -> .so. A compile failure here is a BUILD
+;; FAILURE (not a skip): with the macro environment present there is no
+;; legitimate reason emitted Scheme should fail to compile.
+(define (jb-compile-stdlib-sos! pairs)
+  (let ((cs (string-append jb-stdlib-dir "/compile-all.ss")))
+    (let ((p (open-output-file cs 'replace)))
+      (put-string p
+        (string-append
+          "(import (chezscheme))\n"
+          ;; runtime preamble — mirror build-jolt.ss's own header (lines 27-43)
+          ;; exactly, so the macro environment matches what emitted the Scheme.
+          "(load \"host/chez/scheme-adapter-runtime.ss\")\n"
+          "(load \"host/chez/rt.ss\")\n"
+          "(set-chez-ns! \"clojure.core\")\n"
+          "(load \"host/chez/seed/prelude.ss\")\n"
+          "(load \"host/chez/post-prelude.ss\")\n"
+          "(set-chez-ns! \"user\")\n"
+          "(load \"host/chez/host-contract.ss\")\n"
+          "(load \"host/chez/seed/image.ss\")\n"
+          "(load \"host/chez/compile-eval.ss\")\n"
+          "(load \"host/chez/cli-core.ss\")\n"
+          "(load \"host/chez/png.ss\")\n"
+          "(load \"host/chez/loader.ss\")\n"
+          "(load \"host/chez/java/ffi.ss\")\n"
+          (if (bld-cross?) (string-append "(load " (ei-str-lit (bld-xpatch)) ")\n") "")
+          ;; per-profile flags, mirrored from the flat.ss compile step.
+          "(optimize-level " (if jb-release? "2" "0") ")\n"
+          "(generate-inspector-information " (jb-bool (not jb-release?)) ")\n"
+          "(generate-procedure-source-information " (jb-bool (not jb-release?)) ")\n"
+          "(debug-on-exception " (jb-bool (not jb-release?)) ")\n"
+          "(fasl-compressed " (jb-bool jb-release?) ")\n"
+          (apply string-append
+            (map (lambda (sp)
+                   (string-append "(compile-file "
+                     (ei-str-lit (car sp)) " "
+                     (ei-str-lit (cdr sp)) ")\n"))
+                 pairs))))
+      (close-port p))
+    (bld-system (string-append bld-chez " --script '" cs "'"))))
+
+;; Emit the per-ns Scheme with the same dynamic-wind profile as jb-emit-cli-ns.
+(define (jb-emit-stdlib-ns! name abs scm)
+  (dynamic-wind
+    (lambda ()
+      (ei-fresh-unit!)
+      ((var-deref "jolt.backend-scheme" "set-prelude-mode!") #t)
+      (set-optimize! #t) (set-release! #t)
+      ((var-deref "jolt.backend-scheme" "set-var-cache!") #t))
+    (lambda () (jb-emit-stdlib-scm! name abs scm))
+    (lambda ()
+      (set-optimize! #f) (set-release! #f)
+      ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
+      (ei-clear-cached!))))
+
+;; Load+emit+compile every candidate ns to its own fasl. Returns two values: the
+;; list of (name . fasl-path) that compiled OK (in load order), and the list of
+;; (name . reason) that were skipped. A ns that fails to LOAD standalone (needs an
+;; optional library, or its top level wedges the build) is skipped with a reason,
+;; NOT silently dropped — it lands in the manifest. A ns that LOADS but fails to
+;; EMIT (bld-emit-ns is strict) is a build failure, same as an app build.
+(define (jb-compile-stdlib-fasls!)
+  ;; Manifest-declared skips are EXCLUDED from the batch compile: a skip whose
+  ;; emitted .scm Chez rejects (jolt.io-poller, whose foreign-procedure form
+  ;; renders an empty () arg list) would otherwise kill the single batch
+  ;; bld-system. Their verified reason is carried straight through.
+  (define-values (man-embed man-skips) (jb-read-stdlib-manifest))
+  (bld-system (string-append "mkdir -p '" jb-stdlib-dir "'"))
+  (let ((order '()) (to-compile '()) (skips (reverse man-skips)))
+    (parameterize ((ldr-source-only? #t))
+      (set-ns-loaded-hook! (lambda (name file) #f))
+      (for-each
+        (lambda (nf)
+          (let* ((name (car nf)) (abs (cdr nf)) (san (jb-sanitize name))
+                 (scm (string-append jb-stdlib-dir "/" san ".scm"))
+                 (so (string-append jb-stdlib-dir "/" san ".so")))
+            (if (assoc name skips)
+                ;; manifest-declared skip — already in skips with its verified
+                ;; reason; do not load-attempt (a load failure here would
+                ;; duplicate the ns in skips and never reach the batch compile).
+                ;; jb-emit-stdlib-fasls! prints all skips once at the end.
+                (if #f #f)
+                (guard (e (else
+                            (let ((msg (guard (_ (#t "(unprintable)"))
+                                        (let ((m ((var-deref "jolt.host" "condition-message") e)))
+                                          (and (string? m) m)))))
+                              (display (string-append "build-jolt: stdlib-fasl FAILED " name ": " msg "\n")
+                                       (current-error-port))
+                              (set! skips (cons (cons name (string-append "load failed: " msg)) skips)))))
+                  (load-namespace name)
+                  (jb-emit-stdlib-ns! name abs scm)
+                  (set! order (cons (cons name so) order))
+                  (set! to-compile (cons (cons scm so) to-compile))))))
+        (jb-stdlib-candidates))
+      (set-ns-loaded-hook! (lambda (name file) #f)))
+    ;; ONE batch compile with the runtime preamble loaded (see jb-compile-stdlib-sos!).
+    ;; A failure here is a BUILD FAILURE — emitted Scheme must compile once the
+    ;; macro environment is present.
+    (jb-compile-stdlib-sos! (reverse to-compile))
+    (values (reverse order) (reverse skips))))
+
+;; Compile the stdlib fasls (jb-compile-stdlib-fasls!, unchanged), concatenate
+;; them into ONE blob file, and record an index of (ns offset length) into
+;; jb-stdlib-index. The blob is xxd'd into the binary as the C array
+;; jolt_stdlib_fasls (step 3, below); the index — small — is the ONLY thing baked
+;; into flat.ss for the stdlib, via the launcher's jolt-stdlib-fasls-attach! call.
+;; Putting the multi-MB fasl bytes into flat.ss as boot-image literals regresses
+;; startup (the hard floor), and ei-bytes-lit corrupts them anyway — it round-
+;; trips through utf8->string, which arbitrary binary does not survive. Runs the
+;; manifest drift check. Called inside the flat.ss emit block, before the
+;; launcher (which renders jb-stdlib-index) and before step 3 (which xxd's the
+;; blob).
+(define (jb-emit-stdlib-fasls! out)
+  (define-values (embedded skips) (jb-compile-stdlib-fasls!))
+  (jb-stdlib-manifest-check! (append (map car embedded) (map car skips)))
+  (set! jb-stdlib-blob-path (string-append jb-build "/stdlib_fasls.blob"))
+  (let ((outp (open-file-output-port jb-stdlib-blob-path (file-options no-fail) (buffer-mode block)))
+        (index '())
+        (total 0))
+    (for-each
+      (lambda (nf)
+        (let* ((name (car nf)) (bv (read-file-bytes (cdr nf))) (len (bytevector-length bv)))
+          (put-bytevector outp bv)
+          (set! index (cons (list name total len) index))
+          (set! total (+ total len))))
+      embedded)
+    ;; Empty blob (every candidate skipped): keep the C array non-degenerate so
+    ;; the symbol is well-defined and the link is unconditional. The index stays
+    ;; empty, so nothing derefs it — behavior is exactly today's source path.
+    (when (fx=? total 0)
+      (put-bytevector outp (bytevector 0)))
+    (close-port outp)
+    (set! jb-stdlib-index (reverse index)))
+  (put-string out "\n;; === embedded stdlib fasls (per-namespace, in one C-array blob) ===\n")
+  (for-each
+    (lambda (s)
+      (display (string-append "build-jolt: stdlib-fasl skip " (car s) " — " (cdr s) "\n")))
+    skips))
+
+(define jb-stdlib-dir (string-append jb-build "/stdlib"))
+
+;; index of needle in s, or #f
+(define (jb-str-index s needle)
+  (let ((n (string-length s)) (m (string-length needle)))
+    (let loop ((i 0))
+      (cond ((> (+ i m) n) #f)
+            ((string=? (substring s i (+ i m)) needle) i)
+            (else (loop (+ i 1)))))))
+
+(define (jb-demunge-seg s)
+  (list->string (map (lambda (c) (if (char=? c #\_) #\- c)) (string->list s))))
+
+;; Inverse of ns-name->rel for a root-relative path WITH its extension stripped:
+;; split on '/' and '.', unmunge each segment '_'->'-', join with '.'.
+;; "jolt/backend_scheme" -> "jolt.backend-scheme".
+(define (jb-ns-from-rel core)
+  (let loop ((cs (string->list core)) (seg '()) (segs '()))
+    (cond
+      ((null? cs)
+       (let ((all (reverse (cons (list->string (reverse seg)) segs))))
+         (let join ((xs all) (acc ""))
+           (if (null? xs)
+               acc
+               (let ((piece (jb-demunge-seg (car xs))))
+                 (join (cdr xs)
+                       (if (string=? acc "") piece (string-append acc "." piece))))))))
+      ((or (char=? (car cs) #\/ ) (char=? (car cs) #\.))
+       (loop (cdr cs) '() (cons (list->string (reverse seg)) segs)))
+      (else (loop (cdr cs) (cons (car cs) seg) segs)))))
+
+;; Filesystem-safe form of an ns name for per-ns .scm/.so under the build dir.
+(define (jb-sanitize name)
+  (list->string
+    (map (lambda (c) (cond ((char=? c #\.) #\_) ((char=? c #\/) #\_) (else c)))
+         (string->list name))))
+
 (display "build-jolt: emitting flat source\n")
 (let ((out (open-output-file jb-flat-ss 'replace)))
   ;; Bake the version FIRST: rt.ss's jolt-version-string probes this binding via
@@ -302,6 +625,11 @@
   ;; ~380ms analyze/emit cost on EVERY process start.
   (put-string out "\n;; === AOT jolt.main + jolt.deps (emitted Scheme) ===\n")
   (jb-emit-cli-ns out)
+  ;; Embedded stdlib fasls: load+emit+compile each remaining install-owned ns and
+  ;; bake its fasl as register-embedded-fasl!, so a require loads compiled code
+  ;; instead of recompiling from source. MUST run before flat.ss is written (it
+  ;; emits into out) and before the fingerprint step (bytes are part of the hash).
+  (jb-emit-stdlib-fasls! out)
   (put-string out "\n;; === jolt launcher ===\n")
   (jb-emit-launcher out)
   (close-port out))
@@ -335,7 +663,6 @@
 ;; jolt building (non-eval) apps, where no Chez is available.
 (define jb-flat-so (string-append jb-build "/flat.so"))
 (define jb-boot (string-append jb-build "/jolt.boot"))
-(define jb-bool (lambda (b) (if b "#t" "#f")))
 (display (string-append "build-jolt: compiling (" jb-profile " profile)\n"))
 (let ((cs (string-append jb-build "/compile.ss")))
   (let ((p (open-output-file cs 'replace)))
@@ -379,6 +706,13 @@
 (jb-c-array (string-append (bld-csv-dir) "/scheme.h") (string-append jb-build "/schemeh_data.h") "jolt_scheme_h")
 (jb-c-array (string-append (bld-csv-dir) "/libkernel.a") (string-append jb-build "/libkernel_data.h") "jolt_libkernel_a")
 (jb-c-array "host/chez/stub/launcher.c" (string-append jb-build "/launcherc_data.h") "jolt_launcher_c")
+;; The embedded stdlib fasl blob (one concatenated .so per install-owned ns).
+;; jb-emit-stdlib-fasls! wrote it during flat.ss emission; it is absent only when
+;; that step never ran, which never happens in a real build. A 1-byte placeholder
+;; keeps the symbol non-degenerate when every candidate was skipped (empty index,
+;; so nothing derefs it).
+(when (and jb-stdlib-blob-path (file-exists? jb-stdlib-blob-path))
+  (jb-c-array jb-stdlib-blob-path (string-append jb-build "/stdlib_fasls_data.h") "jolt_stdlib_fasls"))
 
 (define jb-main-c (string-append jb-build "/main.c"))
 (let ((mc (open-output-file jb-main-c 'replace)))
@@ -392,6 +726,7 @@
       "#include \"schemeh_data.h\"\n"
       "#include \"libkernel_data.h\"\n"
       "#include \"launcherc_data.h\"\n"
+      "#include \"stdlib_fasls_data.h\"\n"
       "int main(int argc, char *argv[]) {\n"
       "  Sscheme_init(0);\n"
       "  Sregister_boot_file_bytes(\"jolt\", jolt_boot, jolt_boot_len);\n"

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -67,6 +67,55 @@
   (let ((v (hashtable-ref embedded-resources name #f)))
     (and (bytevector? v) v)))
 
+;; Embedded compiled fasls for install-owned stdlib namespaces. build-jolt bakes
+;; one fasl per namespace into the binary so a require loads the compiled code
+;; instead of recompiling from source on every process start. Same seam and
+;; locking discipline as register-embedded-resource! (written only at heap-build
+;; time, single-threaded before scheme-start; read at runtime by single-key
+;; hashtable-ref, safe on strong-general hashtables). Keyed by ns name, not path.
+;;
+;; Two ways in. register-embedded-fasl! is the explicit registry: tests and other
+;; embedders can hand a bytevector directly. The built binary does NOT bake the
+;; (multi-MB) fasl bytes as boot-image literals — that regresses startup, since a
+;; flat.ss literal re-materializes at every Sbuild_heap. Instead build-jolt xxd's
+;; one concatenated blob into the linked binary as the C array jolt_stdlib_fasls
+;; (-rdynamic exports it) and records an index of (ns offset length) triples; the
+;; launcher calls jolt-stdlib-fasls-attach! with that index before any require.
+;; jolt-embedded-fasl then memcpy's the slice out of the C array on demand — once
+;; per ns per process, never cached.
+(define embedded-fasls (make-hashtable string-hash string=?))
+(define (register-embedded-fasl! name bv) (hashtable-set! embedded-fasls name bv))
+;; ns-name -> (offset . length) into the linked jolt_stdlib_fasls C array.
+;; Populated once by the launcher's jolt-stdlib-fasls-attach!; empty in every
+;; path that carries no such array (dev bin/jolt, devcache, app binaries).
+(define embedded-fasl-index (make-hashtable string-hash string=?))
+(define (jolt-stdlib-fasls-attach! index)
+  (for-each (lambda (entry)
+              (hashtable-set! embedded-fasl-index (car entry)
+                              (cons (cadr entry) (caddr entry))))
+            index))
+;; memcpy `length` bytes at `offset` out of the jolt_stdlib_fasls C array into a
+;; fresh bytevector. #f when the symbol is absent (dev/devcache/apps carry no such
+;; array) or the fetch raises, so the caller falls back to today's source path.
+;; sa-foreign-entry-address (foreign-entry) returns an integer address, so
+;; base+offset is plain arithmetic. Same memcpy pattern as the launcher's
+;; jolt-materialize-bundles!.
+(define (jolt-stdlib-fasl-fetch offset length)
+  (guard (e (else #f))
+    (sa-load-shared-object #f)
+    (let* ((base (sa-foreign-entry-address "jolt_stdlib_fasls"))
+           (bv (make-bytevector length))
+           (memcpy (sa-foreign-procedure "memcpy" (u8* uptr uptr) void*)))
+      (memcpy bv (+ base offset) length)
+      bv)))
+(define (jolt-embedded-fasl name)
+  (let ((v (hashtable-ref embedded-fasls name #f)))
+    (cond
+      ((bytevector? v) v)
+      (else
+       (let ((ol (hashtable-ref embedded-fasl-index name #f)))
+         (and ol (jolt-stdlib-fasl-fetch (car ol) (cdr ol))))))))
+
 ;; --- with-port: open a port, do work, close on success or throw ----------------
 (define (with-port port proc)
   (guard (e (#t (guard (_ (#t #f)) (close-port port)) (raise e)))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -921,34 +921,73 @@
                   (delete-file scm #f))
                 (aot-compile-and-cache name file src own)))
       (load so))))
-;; Dispatch for load-namespace*: cache hit (load .so) / miss (compile+cache) /
-;; bypass (plain load). `file` is the resolved on-disk path. force? (:reload) and
-;; ldr-reload-all? bypass entirely — live editing must win over a stale cache.
+;; Load an embedded compiled fasl for `name` if one was baked into this binary.
+;; The release jolt embeds one fasl per install-owned stdlib namespace so a
+;; require never recompiles from source on process start. The embedded bytes
+;; are produced by the same runtime that consumes them (build-jolt compiles them
+;; in a fresh Chez over this same runtime image), so there is no fingerprint
+;; check here — unlike the on-disk AOT cache, an embedded fasl cannot be stale
+;; relative to the binary it ships in. A guard falls back to the caller's source
+;; path: the bytes are baked (never truncated by a killed write), but a guard
+;; beats a dead binary. Returns #t when the embedded fasl was loaded, else #f.
+ (define (jolt-load-embedded-fasl! name)
+   (and (not (ldr-source-only?))
+        (let ((bv (jolt-embedded-fasl name)))
+          (and bv
+               (begin
+                 (aot-info (string-append "embedded " name))
+                 ;; Make success explicit: load-compiled-from-port returns the
+                 ;; fasl's LAST expression value, which can be #f for a ns whose
+                 ;; final form evaluates to nil/false. A #f read as "failed" so
+                 ;; the caller reloaded the namespace from source ON TOP of the
+                 ;; already-loaded fasl — the override-replay bug class at
+                 ;; loader.ss:~432. #t is the real success signal.
+                 (guard (e (else #f))
+                   (load-compiled-from-port (open-bytevector-input-port bv))
+                   #t))))))
+
+;; Dispatch for load-namespace*: embedded fasl (install-owned ns in a built
+;; binary) / cache hit (load .so) / miss (compile+cache) / bypass (plain load).
+;; `file` is the resolved on-disk path. force? (:reload) and ldr-reload-all?
+;; bypass the cache and the embedded branch alike — live editing must win over
+;; either a stale cache or a stale embedded fasl. ldr-source-only? is honored so
+;; the build driver (jb-emit-cli-ns) keeps loading source to emit it.
 (define (aot-load-or-compile name file force?)
-  (if (and (aot-cache-enabled?) (not force?) (not (ldr-reload-all?))
-           (not (ldr-install-file? file))
-           ;; no fingerprint = we can't tell this runtime from another one, so
-           ;; there is no key that would be safe to reuse.
-           (aot-runtime-fingerprint))
-      ;; the deps and reads this ns's own load records belong to IT, not to
-      ;; whoever is requiring it — bind fresh sinks so a nested load can't append
-      ;; to the enclosing one. A hit binds #f on both: the fasl it loads re-runs
-      ;; the requires and re-does the reads, and those are already described by
-      ;; this namespace's own sidecars.
-      (let* ((src (ldr-read-source file))
-             (own (aot-cache-key src))
-             (obase (aot-base-for-own name own))
-             (base (aot-base-full name own
-                                  (aot-read-dep-list (aot-dep-sidecar obase))
-                                  (aot-read-dep-list (aot-res-sidecar obase))))
-             (so (string-append base ".so")))
-        (if (file-exists? so)
-            (begin (aot-info (string-append "hit " name))
-                   (parameterize ((aot-dep-sink #f) (io-file-read-sink #f))
-                     (aot-safe-load-or-recompile name file src own base)))
-            (begin (aot-info (string-append "miss " name))
-                   (aot-compile-and-cache name file src own))))
-      (parameterize ((aot-dep-sink #f) (io-file-read-sink #f)) (load-jolt-file file))))
+  (cond
+    ;; install-owned + an embedded fasl baked in: load the compiled code.
+    ;; Sinks are #f like a cache hit: the fasl re-runs its own requires and
+    ;; reads, which the bytes already describe, so there is nothing to capture.
+    ((and (not force?) (not (ldr-reload-all?))
+          (ldr-install-file? file)
+          (jolt-embedded-fasl name))
+     (parameterize ((aot-dep-sink #f) (io-file-read-sink #f))
+       (unless (jolt-load-embedded-fasl! name)
+         ;; embedded fasl registered but failed to load: fall back to source.
+         (load-jolt-file file))))
+    ((and (aot-cache-enabled?) (not force?) (not (ldr-reload-all?))
+          (not (ldr-install-file? file))
+          ;; no fingerprint = we can't tell this runtime from another one, so
+          ;; there is no key that would be safe to reuse.
+          (aot-runtime-fingerprint))
+     ;; the deps and reads this ns's own load records belong to IT, not to
+     ;; whoever is requiring it — bind fresh sinks so a nested load can't append
+     ;; to the enclosing one. A hit binds #f on both: the fasl it loads re-runs
+     ;; the requires and re-does the reads, and those are already described by
+     ;; this namespace's own sidecars.
+     (let* ((src (ldr-read-source file))
+            (own (aot-cache-key src))
+            (obase (aot-base-for-own name own))
+            (base (aot-base-full name own
+                                 (aot-read-dep-list (aot-dep-sidecar obase))
+                                 (aot-read-dep-list (aot-res-sidecar obase))))
+            (so (string-append base ".so")))
+       (if (file-exists? so)
+           (begin (aot-info (string-append "hit " name))
+                  (parameterize ((aot-dep-sink #f) (io-file-read-sink #f))
+                    (aot-safe-load-or-recompile name file src own base)))
+           (begin (aot-info (string-append "miss " name))
+                  (aot-compile-and-cache name file src own)))))
+    (else (parameterize ((aot-dep-sink #f) (io-file-read-sink #f)) (load-jolt-file file)))))
 
 ;; Mark a namespace as loaded in both the host hashtable and the *loaded-libs* ref.
 (define (ldr-mark-loaded! name)

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -1,0 +1,77 @@
+# stdlib-fasl-manifest.txt — embedded stdlib fasl embedding policy.
+#
+# Each install-owned stdlib namespace that is NOT already in the runtime image
+# or the CLI closure is compiled to a fasl and concatenated into one blob
+# (jolt_stdlib_fasls) linked into the binary; a require then loads the compiled
+# code instead of recompiling from source on every process start.
+#
+# One ns name per line to EMBED. A ns that cannot be compiled standalone (an
+# optional native library it needs at load time, a top level that spawns a
+# thread or blocks the build) is recorded here instead:
+#
+#   skip <ns> — <verified reason>
+#
+# build-jolt fails on drift between this manifest and the discovered set, so the
+# two can never silently diverge. clojure.test MUST be in the embedded set.
+babashka.fs
+babashka.process
+babashka.process.pprint
+clojure.core.async
+clojure.core.async.lab
+clojure.core.protocols
+clojure.data
+clojure.datafy
+clojure.instant
+clojure.java.browse
+clojure.java.javadoc
+clojure.java.shell
+clojure.main
+clojure.sci.host-stubs
+clojure.sci.io-stubs
+clojure.sci.lang-stubs
+clojure.stacktrace
+clojure.test
+clojure.zip
+clojurestar.deps
+grenadine.basis
+grenadine.coordinate
+grenadine.core
+grenadine.gitlibs
+grenadine.graph
+grenadine.lock
+grenadine.repo
+grenadine.runtime
+grenadine.source
+jolt.fs
+jolt.image
+jolt.infix
+jolt.infix.core
+jolt.infix.grammar
+jolt.infix.math
+jolt.infix.math.bit-shuffling
+jolt.infix.math.constants
+jolt.infix.math.core
+jolt.infix.math.trig
+jolt.nrepl
+jolt.parser
+jolt.parser.basic
+jolt.parser.collections
+jolt.parser.combinators
+jolt.parser.monad
+jolt.parser.position
+jolt.process
+jolt.socket
+jolt.time.amount
+jolt.time.base
+jolt.time.enums
+jolt.time.impl
+jolt.time.instant
+jolt.time.local
+jolt.time.temporal
+jolt.time.util
+jolt.time.year
+jolt.util
+skip jolt.io-poller — emitted .scm contains an empty () arg list in a foreign-procedure form that Chez rejects at compile-file time; loads fine from source at runtime
+skip glojure.deps — requires glojure/deps/host.{jolt,clj,cljc} which is absent from the install roots at build time
+skip grenadine.host.glojure — top level references an unqualified `strings` symbol that does not resolve in the build image
+skip grenadine.cli — requires grenadine/build_info.{jolt,clj,cljc} (generated at release packaging), absent in a dev build

--- a/host/chez/stdlib-fasl-smoke.sh
+++ b/host/chez/stdlib-fasl-smoke.sh
@@ -85,6 +85,29 @@ else
   echo "FAIL: (e) manifest does not list clojure.test"; fails=$((fails+1))
 fi
 
+# (f) a dep NOT in the eager CLI image arrives via its OWN fasl, not source.
+# jolt.fs proxies babashka.fs; nothing in the CLI image requires either, so if
+# the fasl dropped the ns form's require (the bld-emit-ns regression this gates),
+# babashka.fs never loads and every proxied var is unbound. This slipped past
+# (a)-(d) because clojure.test/jolt.time deps happen to sit in the image.
+debug_f="$(JOLT_DEBUG=1 "$jolt" -e "(require '[jolt.fs :as fs])" 2>&1)"
+out_f="$("$jolt" -e '(require (quote [jolt.fs :as fs])) (println "SMOKE_FS" (str (fs/absolute? "/x")))' 2>&1)"
+if printf '%s\n' "$debug_f" | grep -q '\[jolt.aot\] embedded jolt.fs' \
+   && printf '%s\n' "$debug_f" | grep -q '\[jolt.aot\] embedded babashka.fs'; then
+  echo "PASS: (f1) JOLT_DEBUG shows both embedded jolt.fs and babashka.fs"; pass=$((pass+1))
+else
+  echo "FAIL: (f1) dep did not arrive via its own fasl"
+  printf '%s\n' "$debug_f" | grep '\[jolt.aot\]' | head
+  fails=$((fails+1))
+fi
+if printf '%s' "$out_f" | grep -q 'SMOKE_FS true'; then
+  echo "PASS: (f2) fs/absolute? runs (babashka.fs loaded via fasl)"; pass=$((pass+1))
+else
+  echo "FAIL: (f2) fs/absolute? did not run (babashka.fs unbound?)"
+  printf '%s\n' "$out_f" | tail -5
+  fails=$((fails+1))
+fi
+
 echo
 echo "stdlib-fasl smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]

--- a/host/chez/stdlib-fasl-smoke.sh
+++ b/host/chez/stdlib-fasl-smoke.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# stdlib-fasl smoke (R1): the embedded per-namespace stdlib fasls actually take.
+#
+# A built jolt compiles each install-owned stdlib namespace to a fasl at build
+# time, concatenates them into one C-array blob (jolt_stdlib_fasls, xxd'd into
+# the binary), and records an index the launcher hands to
+# jolt-stdlib-fasls-attach!. A require then loads the compiled code via
+# load-compiled-from-port instead of recompiling from source.
+#
+# Four non-vacuous checks, all against target/release/jolt:
+#   (a) JOLT_TRACE_LOAD=1 on (require 'clojure.test) emits ZERO [load-form]
+#       lines — nothing was read+compiled from source.
+#   (b) JOLT_DEBUG=1 on (require 'clojure.test) prints the "[jolt.aot] embedded
+#       clojure.test" line — the fasl path actually fired (not just that nothing
+#       loaded from source).
+#   (c) a real deftest runs and reports its pass summary through the binary.
+#   (d) jolt.time.temporal + jolt.time.local replay their __register-* seams from
+#       the fasl: a LocalDate equality/compare/str expression gives the expected
+#       output.
+#   (e) the manifest lists clojure.test (cheap grep — guards a pin that would
+#       otherwise silently drop it).
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+
+jolt="target/release/jolt"
+fails=0
+pass=0
+
+if [ ! -x "$jolt" ]; then
+  echo "FAIL: $jolt not built — run 'make jolt-release' first" >&2
+  exit 1
+fi
+
+# (a) zero [load-form] lines for clojure.test
+n="$(JOLT_TRACE_LOAD=1 "$jolt" -e "(require 'clojure.test)" 2>&1 | grep -c '\[load-form\]' || true)"
+if [ "$n" = "0" ]; then
+  echo "PASS: (a) clojure.test loads with zero [load-form] lines"; pass=$((pass+1))
+else
+  echo "FAIL: (a) clojure.test produced $n [load-form] line(s) — not fully embedded"; fails=$((fails+1))
+fi
+
+# (b) the embedded-fasl aot-info line fires
+if JOLT_DEBUG=1 "$jolt" -e "(require 'clojure.test)" 2>&1 | grep -q '\[jolt.aot\] embedded clojure.test'; then
+  echo "PASS: (b) JOLT_DEBUG prints the embedded clojure.test aot-info line"; pass=$((pass+1))
+else
+  echo "FAIL: (b) no embedded clojure.test aot-info line — fasl path did not fire"; fails=$((fails+1))
+fi
+
+# (c) a real deftest runs and reports its pass summary
+out_c="$("$jolt" -e '
+(require (quote clojure.test))
+(clojure.test/deftest t (clojure.test/is (= 1 1)) (clojure.test/is (= (+ 1 1) 2)))
+(let [r (clojure.test/run-tests)]
+  (println "SMOKE_SUMMARY test=" (:test r) "pass=" (:pass r) "fail=" (:fail r) "error=" (:error r)))' 2>&1)"
+if printf '%s' "$out_c" | grep -q 'SMOKE_SUMMARY test= 1 pass= 2 fail= 0 error= 0'; then
+  echo "PASS: (c) deftest runs and reports pass summary"; pass=$((pass+1))
+else
+  echo "FAIL: (c) deftest summary missing/wrong"
+  printf '%s\n' "$out_c" | tail -5
+  fails=$((fails+1))
+fi
+
+# (d) jolt.time.temporal + jolt.time.local replay their __register-* seams from
+# the fasl: LocalDate equality, compare, and str.
+out_d="$("$jolt" -e '
+(require (quote jolt.time.temporal))
+(require (quote jolt.time.local))
+(let [a (jolt.time.local/local-date 0)
+      b (jolt.time.local/local-date 0)
+      c (jolt.time.local/local-date 1)]
+  (println "SMOKE_DATE eq=" (= a b) "cmp=" (compare a c) "str=" (str a)))' 2>&1)"
+if printf '%s' "$out_d" | grep -q 'SMOKE_DATE eq= true cmp= -1 str= 1970-01-01'; then
+  echo "PASS: (d) LocalDate eq/compare/str replay from the fasl"; pass=$((pass+1))
+else
+  echo "FAIL: (d) LocalDate expression did not give expected output"
+  printf '%s\n' "$out_d" | tail -5
+  fails=$((fails+1))
+fi
+
+# (e) the manifest lists clojure.test
+if grep -q '^clojure.test$' host/chez/stdlib-fasl-manifest.txt; then
+  echo "PASS: (e) manifest lists clojure.test"; pass=$((pass+1))
+else
+  echo "FAIL: (e) manifest does not list clojure.test"; fails=$((fails+1))
+fi
+
+echo
+echo "stdlib-fasl smoke: $pass passed, $fails failed"
+[ "$fails" -eq 0 ]


### PR DESCRIPTION
Install-owned namespaces are excluded from the on-disk AOT cache, so every (require 'clojure.test) recompiled 671 lines from source on each process start (+0.35s), and the stdlib jolt.time base namespaces cost +1.3s in any project using the time library.

build-jolt now captures each remaining install-owned namespace via aot-capture-load — the same artifact the runtime cache produces, requires included — and batch-compiles the .scm files in a fresh Chez that loads the runtime preamble first (the emitted code references runtime macros like jolt-n-; a bare-Chez compile emits unbound-variable references that only fail at run time). The fasls are concatenated into one blob linked into the binary as a C array; flat.ss carries only an (ns offset length) index, and the loader memcpy's a slice out on first require via load-compiled-from-port. Boot-image literals would re-materialize at every Sbuild_heap and regress the startup floor.

stdlib-fasl-manifest.txt pins the embedded set (60 namespaces; drift fails the build) with verified-reason skips. The stdlibfasl smoke gate (in the ci list) asserts: zero source load-forms for clojure.test, the embedded-fasl debug line actually fires, a real deftest passes through the binary, jolt.time LocalDate semantics replay from the fasl, and the dep-chain case that slipped through an earlier iteration — requiring jolt.fs must fasl-load babashka.fs too.

Measured warm (M-series mac, 3 runs each): clojure.test / jolt.nrepl / jolt.time.temporal requires 0.49 / 0.33 / 1.35s -> 0.12s (the floor); a honeysql+time project run 1.7s -> 0.38s. Floor and RSS unchanged; binary +1.0MB. Full make test green (67 ci targets).