### PR TITLE
AOT the CLI closure in the dev boot cache

### DIFF
--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -34,7 +34,7 @@
 (load "host/chez/seed/image.ss")
 (load "host/chez/compile-eval.ss")
 ;; cli-core.ss is inlined into the emitted image below, but it also has to be
-;; loaded HERE: it defines jolt.host/run-expr-string, and jb-emit-cli-ns emits
+;; loaded HERE: it defines jolt.host/run-expr-string, and bld-emit-cli-aot emits
 ;; jolt.main in this process — an unresolved jolt.host var would emit as a class
 ;; reference and the binary's -e arm would die with "Unknown class jolt.host".
 (load "host/chez/cli-core.ss")
@@ -188,67 +188,6 @@
     (jolt-cli-run args (lambda () (jolt-materialize-bundles!) (jb-load-build-subsystem!)))
     (exit 0)))
 ")))
-
-;; --- AOT the CLI entry closure ----------------------------------------------
-;; jolt.main + jolt.deps and their on-demand Clojure require closure (clojure.string,
-;; clojure.edn, jolt.mvn-http, …) used to be baked as top-level (load-namespace …)
-;; forms. flat.so is a Chez boot file whose top-level forms re-execute at every
-;; Sbuild_heap (every process start), so those load-namespace calls re-analyzed and
-;; re-emitted the whole graph from Clojure source on EVERY invocation — ~380ms, about
-;; 70% of jolt's startup floor. Instead we emit their Scheme HERE, at build time,
-;; via the same emit-image path an app build uses, so at boot the vars are defined by
-;; running compiled Scheme (a few ms) exactly like the rest of the runtime image.
-;;
-;; The runtime + compiler image + clojure.core are already emitted above (bld-emit-
-;; runtime). We load jolt.main in THIS build process to populate the compiler's
-;; registries, capturing the on-demand load order via the loader's ns-loaded-hook —
-;; which fires only for namespaces NOT already in the image, i.e. exactly the CLI's
-;; on-demand closure. Each ns is emitted var-routed (prelude mode, direct-link OFF)
-;; so its runtime behavior is identical to the interpreted load it replaces. A form
-;; that fails to emit fails the build (bld-emit-ns is strict), same as an app build.
-;; jolt.deps's lazy in-fn (require 'clojure.data.json) is not on the load path here,
-;; so it stays load-on-demand at runtime — unchanged.
-(define (jb-emit-cli-ns out)
-  (let ((order '()))
-    (set-ns-loaded-hook! (lambda (name file) (set! order (cons (cons name file) order))))
-    (parameterize ((ldr-source-only? #t))    ; emit from source, never a compiled artifact
-      (load-namespace "jolt.main")
-      (load-namespace "jolt.deps"))
-    (set-ns-loaded-hook! (lambda (name file) #f))
-    (let ((ordered (reverse order)))   ; deps complete loading before requirers -> deps-first
-      (when (null? ordered)
-        (error 'build-jolt "no CLI namespace captured for jolt.main — is jolt-core on the source roots?"))
-      (dynamic-wind
-        (lambda ()
-          (ei-fresh-unit!)
-          ((var-deref "jolt.backend-scheme" "set-prelude-mode!") #t)
-          (set-optimize! #t)
-          (set-release! #t)
-          ((var-deref "jolt.backend-scheme" "set-var-cache!") #t))
-        (lambda ()
-          (for-each
-            (lambda (nf)
-              (let ((name (car nf)) (src (ldr-read-source (cdr nf))))
-                (put-string out (string-append "\n;; --- AOT " name " ---\n"))
-                (parameterize ((rdr-source-file (cdr nf)))
-                  (put-string out "(jolt-ns-load-vars-push!)\n")
-                  (for-each (lambda (s) (put-string out s) (put-string out "\n"))
-                            (bld-ns-prelude name src))
-                  (for-each (lambda (s) (put-string out s) (put-string out "\n"))
-                            (bld-emit-ns name src))
-                  (put-string out "(jolt-ns-load-vars-pop!)\n")
-                  ;; Record the ns as loaded so the runtime dispatch's
-                  ;; (load-namespace "jolt.main") in cli-core.ss is a no-op — the
-                  ;; defines above already installed every var. Without this the
-                  ;; loader sees an unmarked ns and recompiles it from source on the
-                  ;; first command that enters jolt.main/-main (run/build/version).
-                  (put-string out (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n")))))
-            ordered))
-        (lambda ()
-          (set-optimize! #f)
-          (set-release! #f)
-          ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
-          (ei-clear-cached!))))))
 
 ;; --- AOT the install-owned stdlib namespaces as embedded fasls --------------
 ;; install-owned source (jolt-core/, stdlib/, ...) is excluded from the on-disk AOT
@@ -619,11 +558,11 @@
   (put-string out "\n;; === embedded jolt-core + stdlib source ===\n")
   (jb-emit-source-embeds out)
   ;; AOT jolt.main + jolt.deps (and their on-demand Clojure closure) as emitted
-  ;; Scheme so CLI dispatch never recompiles them from source at startup. See
-  ;; jb-emit-cli-ns — this replaces the old (load-namespace …) calls that paid the
-  ;; ~380ms analyze/emit cost on EVERY process start.
-  (put-string out "\n;; === AOT jolt.main + jolt.deps (emitted Scheme) ===\n")
-  (jb-emit-cli-ns out)
+  ;; Scheme so CLI dispatch never recompiles them from source at startup. Shared
+  ;; with make-devboot.ss via bld-emit-cli-aot (build.ss) — one artifact shape;
+  ;; the section marker + per-ns emission live there. This replaces the old
+  ;; (load-namespace …) calls that paid the ~380ms analyze/emit cost on EVERY start.
+  (bld-emit-cli-aot out)
   ;; Embedded stdlib fasls: load+emit+compile each remaining install-owned ns and
   ;; bake its fasl as register-embedded-fasl!, so a require loads compiled code
   ;; instead of recompiling from source. MUST run before flat.ss is written (it

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -489,6 +489,71 @@
         (seq->list nsf)))
     (reverse acc)))
 
+;; --- AOT the CLI entry closure (jolt.main + jolt.deps) -----------------------
+;; jolt.main + jolt.deps and their on-demand Clojure require closure (clojure.string,
+;; clojure.edn, jolt.mvn-http, jolt.ffi, grenadine.*) must NOT be baked as top-level
+;; (load-namespace …) forms in flat.ss: flat.so is a Chez boot file whose top-level
+;; forms re-execute at every Sbuild_heap (every process start), so those load-namespace
+;; calls re-analyze and re-emit the whole graph from Clojure source on EVERY invocation
+;; — the measured ~380ms release floor, ~1.3s in the dev boot cache. Instead we emit
+;; their Scheme HERE, at image-emit time, via the same emit-image path an app build
+;; uses, so at boot the vars are defined by running compiled Scheme (a few ms) exactly
+;; like the rest of the runtime image.
+;;
+;; The runtime + compiler image + clojure.core are already emitted (bld-emit-runtime,
+;; which the caller ran before this). We load jolt.main + jolt.deps in THIS build
+;; process to populate the compiler's registries, capturing the on-demand load order
+;; via the loader's ns-loaded-hook — which fires only for namespaces NOT already in
+;; the image, i.e. exactly the CLI's on-demand closure. Each ns is emitted var-routed
+;; (prelude mode, direct-link OFF) so its runtime behavior is identical to the
+;; interpreted load it replaces. A form that fails to emit fails the build
+;; (bld-emit-ns is strict), same as an app build. jolt.deps's lazy in-fn
+;; (require 'clojure.data.json) is not on the load path here, so it stays
+;; load-on-demand at runtime — unchanged. Used by BOTH the release build
+;; (build-jolt.ss) and the dev boot cache (make-devboot.ss): one artifact shape.
+(define (bld-emit-cli-aot out)
+  (put-string out "\n;; === AOT jolt.main + jolt.deps (emitted Scheme) ===\n")
+  (let ((order '()))
+    (set-ns-loaded-hook! (lambda (name file) (set! order (cons (cons name file) order))))
+    (parameterize ((ldr-source-only? #t))    ; emit from source, never a compiled artifact
+      (load-namespace "jolt.main")
+      (load-namespace "jolt.deps"))
+    (set-ns-loaded-hook! (lambda (name file) #f))
+    (let ((ordered (reverse order)))   ; deps complete loading before requirers -> deps-first
+      (when (null? ordered)
+        (error 'bld-emit-cli-aot "no CLI namespace captured for jolt.main — is jolt-core on the source roots?"))
+      (dynamic-wind
+        (lambda ()
+          (ei-fresh-unit!)
+          ((var-deref "jolt.backend-scheme" "set-prelude-mode!") #t)
+          (set-optimize! #t)
+          (set-release! #t)
+          ((var-deref "jolt.backend-scheme" "set-var-cache!") #t))
+        (lambda ()
+          (for-each
+            (lambda (nf)
+              (let ((name (car nf)) (src (ldr-read-source (cdr nf))))
+                (put-string out (string-append "\n;; --- AOT " name " ---\n"))
+                (parameterize ((rdr-source-file (cdr nf)))
+                  (put-string out "(jolt-ns-load-vars-push!)\n")
+                  (for-each (lambda (s) (put-string out s) (put-string out "\n"))
+                            (bld-ns-prelude name src))
+                  (for-each (lambda (s) (put-string out s) (put-string out "\n"))
+                            (bld-emit-ns name src))
+                  (put-string out "(jolt-ns-load-vars-pop!)\n")
+                  ;; Record the ns as loaded so the runtime dispatch's
+                  ;; (load-namespace "jolt.main") in cli-core.ss is a no-op — the
+                  ;; defines above already installed every var. Without this the
+                  ;; loader sees an unmarked ns and recompiles it from source on the
+                  ;; first command that enters jolt.main/-main (run/build/version).
+                  (put-string out (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n")))))
+            ordered))
+        (lambda ()
+          (set-optimize! #f)
+          (set-release! #f)
+          ((var-deref "jolt.backend-scheme" "set-var-cache!") #f)
+          (ei-clear-cached!))))))
+
 ;; --- bundling: native libs + resources --------------------------------------
 ;; A jolt seq of jolt strings -> a Scheme list of Scheme strings.
 (define (bld-strs x) (map jolt-str-render-one (seq->list x)))

--- a/host/chez/make-devboot.ss
+++ b/host/chez/make-devboot.ss
@@ -104,10 +104,12 @@
                     (ei-bytes-lit (read-file-string abs)) ")\n")))))
           (bld-walk-files root "" '())))
       ldr-install-roots))
-  ;; Preload jolt.main + jolt.deps into the image.
-  (put-string out "\n;; === AOT jolt.main + jolt.deps ===\n")
-  (put-string out "(load-namespace \"jolt.main\")\n")
-  (put-string out "(load-namespace \"jolt.deps\")\n")
+  ;; AOT jolt.main + jolt.deps (and their on-demand Clojure closure) into the image
+  ;; as emitted Scheme — the SAME path build-jolt.ss uses (bld-emit-cli-aot), so the
+  ;; CLI closure is compiled here, not recompiled from source on every dev invocation.
+  ;; The old top-level (load-namespace …) forms re-executed at every Sbuild_heap and
+  ;; cost ~1.3s/invocation. bld-emit-cli-aot emits the section marker + per-ns Scheme.
+  (bld-emit-cli-aot out)
   (close-port out))
 
 ;; --- write input list (before compile, so the list is always consistent) ------

--- a/test/chez/devboot-smoke.sh
+++ b/test/chez/devboot-smoke.sh
@@ -111,6 +111,40 @@ else
 fi
 rm -rf "$projdir"
 
+# (f) guard the CLI-AOT regression. The dev boot cache must AOT the CLI closure
+# (jolt.main + jolt.deps + their on-demand Clojure requires) into flat.ss as
+# emitted Scheme, NOT as top-level (load-namespace …) forms — those re-execute at
+# every Sbuild_heap and recompile the whole CLI closure from source on every dev
+# invocation (~1.3s). The release build (build-jolt.ss) has always done this AOT;
+# make-devboot must share the same bld-emit-cli-aot path. This asserts on the
+# EMITTED flat.ss text so the tail coming back fails here without adding a full
+# ~90s `make devboot` to the ci gate.
+echo "=== (f) flat.ss CLI-AOT section ==="
+flat_ss="target/dev/flat.ss"
+if [ -f "$flat_ss" ]; then
+  # must contain the CLI-AOT section marker bld-emit-cli-aot writes.
+  if grep -q '=== AOT jolt.main + jolt.deps (emitted Scheme) ===' "$flat_ss"; then
+    echo "  PASS: CLI-AOT section marker present in flat.ss"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: CLI-AOT section marker missing from flat.ss (bld-emit-cli-aot did not run?)"
+    fails=$((fails + 1))
+  fi
+  # must NOT contain a top-level (load-namespace "jolt.main"/"jolt.deps") line.
+  # cli-core.ss's inlined copy is INDENTED (inside jolt-cli-run's body), so the
+  # column-0 anchor skips it; only a regression that re-adds the tail matches.
+  if grep -nE '^\(load-namespace "jolt\.(main|deps)"\)$' "$flat_ss" >/dev/null; then
+    echo "  FAIL: flat.ss has a top-level (load-namespace \"jolt.main\"/\"jolt.deps\") — CLI closure not AOT'd"
+    grep -nE '^\(load-namespace "jolt\.(main|deps)"\)$' "$flat_ss" | head | sed 's/^/    /'
+    fails=$((fails + 1))
+  else
+    echo "  PASS: no top-level load-namespace for the CLI closure in flat.ss"
+    pass=$((pass + 1))
+  fi
+else
+  echo "  SKIP: $flat_ss does not exist (run 'make devboot' first); CLI-AOT text assertion not run"
+fi
+
 echo ""
 echo "devboot smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
make-devboot ended flat.ss with top-level (load-namespace "jolt.main") / (load-namespace "jolt.deps"), so every dev bin/jolt invocation re-ran the compiler over the whole CLI closure — 1.34s of the 1.65s dev floor, measured by chunk-splitting flat.so and timing each section's load. build-jolt solved the identical problem for the release binary with jb-emit-cli-ns.

That emitter is now a shared build.ss helper (bld-emit-cli-aot), byte-identical for the release path, and make-devboot calls it instead of the load-namespace tail. devboot-smoke additionally asserts on the emitted flat.ss text — CLI-AOT section marker present, no top-level load-namespace tail — so the recompile can't quietly come back (a full devboot build stays out of the ci gate; the text assertion is the cheap regression tripwire).

Measured: dev bin/jolt -e nil 1.65s -> 0.25s warm, zero [load-form] lines on boot. Release path re-verified through the refactor: testbin rebuild + stdlibfasl smoke 7/7, full make test green (67 targets).