### PR TITLE
Cache resolved dependency roots per project (.jolt/cpcache)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ install: build
 # naming the covered tree is written ONLY on a complete pass. `make gate-status`
 # answers "is this working tree gated?" — which is not something to remember.
 
-CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling depssmoke depsunit \
+CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling depssmoke depscpcache depsunit \
   smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi stdlibfasl \
   transient stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
@@ -377,6 +377,12 @@ readscaling: testbin
 # fixture projects in test/chez/deps-alias/. Offline.
 depssmoke: testbin
 	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/deps-alias-smoke.sh
+
+# The resolved-roots cache (.jolt/cpcache): a warm run reuses a project's final
+# dependency resolution instead of re-expanding the graph. Offline throwaway
+# project in a temp dir; gates the cache key, invalidation, and dev posture.
+depscpcache: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/deps-cpcache-smoke.sh
 
 # Shared Grenadine dependency-expansion integration tests: exclusions, version
 # selection, orphan cutting, and the Maven version comparator, driven through

--- a/host/chez/deps-cpcache-smoke.sh
+++ b/host/chez/deps-cpcache-smoke.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# deps-cpcache-smoke.sh — the resolved-roots cache (.jolt/cpcache).
+#
+# A warm `jolt -e nil` in a project with deps re-expands the dependency graph
+# (POM parsing, version selection, gitlib probing) on every run. R2 of the
+# startup plan caches the FINAL resolution under the project's .jolt/ dir,
+# keyed on a content hash of the inputs — the project deps.edn bytes, the user
+# deps.edn (or an explicit absent/skipped marker), JOLT_NO_USER_DEPS, the ACTIVE
+# alias set, the runtime version, and every :local/root dep's deps.edn bytes —
+# so a warm run skips the expansion. This gates that cache through the real CLI
+# over a throwaway OFFLINE project (a :local/root lib + :paths; no network):
+#   1. first run misses, second run hits;
+#   2. touching the PROJECT deps.edn content -> miss, then hit again;
+#   3. editing the LOCAL DEP's deps.edn -> miss (the :local/root fold-in works);
+#   4. an alias flag selects a different key (miss); the no-alias entry still hits;
+#   5. deleting a cached-referenced path -> re-expansion (miss), never an error.
+# Also asserts the dev bin/jolt (JOLT_AOT_CACHE=0) never caches — same gate as
+# the AOT namespace cache, so source-mode dev shows neither line.
+#
+# JOLT_BIN overrides the binary under test (defaults to bin/jolt source mode);
+# the gate runs it through target/release/jolt (make testbin).
+set -u
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+JOLT="${JOLT_BIN:-bin/jolt}"
+pass=0; fail=0
+# Hermetic: never read the developer's real ~/.clojure/deps.edn, and leave the
+# binary's cache gate at its default (ON) regardless of the dev environment.
+export JOLT_NO_USER_DEPS=1
+unset JOLT_AOT_CACHE
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+hit()  { printf '%s' "$1" | grep -q '\[jolt.deps\] cpcache hit'; }
+miss() { printf '%s' "$1" | grep -q '\[jolt.deps\] cpcache miss'; }
+nocp() { ! printf '%s' "$1" | grep -q '\[jolt.deps\] cpcache'; }
+
+# label, then a yes/no word
+yn() { if [ "$2" = "yes" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "  FAIL: $1" >&2; fi; }
+
+# throwaway project: an app that depends on a tiny local lib. Fully offline.
+mkdir -p "$tmp/proj/src/app" "$tmp/proj/dev" "$tmp/lib/src/libx"
+cat > "$tmp/proj/deps.edn" <<'EOF'
+{:paths ["src"]
+ :aliases {:dbg {}}
+ :deps {local/lib {:local/root "../lib"}}}
+EOF
+cat > "$tmp/proj/src/app/core.clj" <<'EOF'
+(ns app.core (:require [libx.core :as l]))
+(defn -main [& _] (println "app+lib" l/x))
+EOF
+cat > "$tmp/proj/dev/extra.clj" <<'EOF'
+(ns extra)
+EOF
+cat > "$tmp/lib/deps.edn" <<'EOF'
+{:paths ["src"]}
+EOF
+cat > "$tmp/lib/src/libx/core.clj" <<'EOF'
+(ns libx.core)
+(def x 42)
+EOF
+
+run() { JOLT_PWD="$tmp/proj" JOLT_QUIET=1 JOLT_DEBUG=1 "$JOLT" "$@" 2>&1; }
+
+# 1. first run misses, second run hits, and a cached run still loads the lib.
+out1="$(run -e nil)"; out2="$(run -e nil)"
+yn "1: first run is a miss" "$(miss "$out1" && echo yes || echo no)"
+yn "1: second run is a hit" "$(hit "$out2" && echo yes || echo no)"
+yn "1: cached run loads the lib" "$(JOLT_PWD="$tmp/proj" JOLT_QUIET=1 "$JOLT" run -m app.core 2>&1 | tail -1 | grep -q 'app+lib 42' && echo yes || echo no)"
+
+# 2. touching the PROJECT deps.edn content (add a key) -> miss, then hit again.
+printf '{:paths ["src"] :aliases {:dbg {}} :deps {local/lib {:local/root "../lib"}} :tasks {}}\n' > "$tmp/proj/deps.edn"
+out3="$(run -e nil)"; out4="$(run -e nil)"
+yn "2: project-deps edit misses" "$(miss "$out3" && echo yes || echo no)"
+yn "2: then hits again" "$(hit "$out4" && echo yes || echo no)"
+
+# 3. editing the LOCAL DEP's deps.edn -> miss (the :local/root fold-in works).
+printf '{:paths ["src"] :extra {:edit 1}}\n' > "$tmp/lib/deps.edn"
+out5="$(run -e nil)"; out6="$(run -e nil)"
+yn "3: local-dep edit misses" "$(miss "$out5" && echo yes || echo no)"
+yn "3: then hits again" "$(hit "$out6" && echo yes || echo no)"
+
+# 4. an alias flag selects a different key (miss); the no-alias entry still hits,
+#    and the aliased entry hits on its second run.
+out7="$(run -A:dbg -e nil)"; out8="$(run -e nil)"; out9="$(run -A:dbg -e nil)"
+yn "4: aliased run misses (different key)" "$(miss "$out7" && echo yes || echo no)"
+yn "4: no-alias run still hits" "$(hit "$out8" && echo yes || echo no)"
+yn "4: second aliased run hits" "$(hit "$out9" && echo yes || echo no)"
+
+# 5. deleting a cached-referenced path -> re-expansion (miss), never an error.
+#    Re-establish a clean hit, then prune the local dep's source root.
+out10="$(run -e nil)"; yn "5: baseline hit before deletion" "$(hit "$out10" && echo yes || echo no)"
+rm -rf "$tmp/lib/src"
+out11="$(run -e nil)"
+yn "5: deleted dep root -> miss" "$(miss "$out11" && echo yes || echo no)"
+yn "5: ...and no error/stacktrace" "$(printf '%s' "$out11" | grep -qi 'exception\|stacktrace\|error building' && echo no || echo yes)"
+
+# Dev posture: bin/jolt exports JOLT_AOT_CACHE=0, so the cache is OFF — neither
+# hit nor miss line appears, same gate as the AOT namespace cache. Skipped (not
+# failed) if bin/jolt can't run here.
+if "$root/bin/jolt" -e nil >/dev/null 2>&1; then
+  devout="$(JOLT_PWD="$tmp/proj" JOLT_QUIET=1 JOLT_DEBUG=1 "$root/bin/jolt" -e nil 2>&1)"
+  yn "dev: bin/jolt shows no cpcache line" "$(nocp "$devout" && echo yes || echo no)"
+else
+  echo "  (skip: bin/jolt not runnable here)" >&2
+fi
+
+echo "deps-cpcache smoke: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -928,6 +928,193 @@
         :libs libmap
         :trace (:trace expansion)})))))
 
+;; --- resolved-roots cache (.jolt/cpcache) -----------------------------------
+;; tools.deps calls this .cpcache: the resolved classpath keyed on a content
+;; hash of the inputs, so a warm run skips dep-graph expansion (POM parsing,
+;; version selection, gitlib probing) entirely. The key folds in everything the
+;; expansion reads, so changing any of it misses automatically:
+;;   - the project deps.edn bytes
+;;   - the user deps.edn bytes, or an explicit "absent/skipped" marker
+;;     (JOLT_NO_USER_DEPS / :repro?)
+;;   - the active alias set (-M:alias must not share a no-alias entry)
+;;   - the runtime version (the same source the AOT cache keys on)
+;;   - every :local/root dep's deps.edn bytes (editing a local dep invalidates)
+;; Gated the same way the AOT namespace cache is: JOLT_AOT_CACHE. The dev
+;; bin/jolt exports JOLT_AOT_CACHE=0, so source-mode dev never caches — a
+;; volatile compiler re-expands every run, same posture as a fasl cache would
+;; take. No gate (e.g. a non-binary running with the cache explicitly off) means
+;; we cannot safely tell one runtime from another, so the cache stays off.
+;;
+;; The cache sits AFTER fetch/resolution: a miss runs the full resolve-deps
+;; (which fetches missing deps over the network) and then writes; a hit never
+;; touches the network. On a hit every cached path is checked to still exist on
+;; disk — a pruned gitlib checkout or a deleted jar/extraction is a miss, not an
+;; error. A corrupt or unreadable cache file is a miss too, never an error.
+
+(defn- cpcache-enabled?
+  "Same posture as the AOT namespace cache: ON by default, OFF under
+  JOLT_AOT_CACHE=0/false/no/off (which the dev bin/jolt sets). Reachable from
+  Clojure because the host already reads it, so no new host seam is needed."
+  []
+  (let [e (getenv "JOLT_AOT_CACHE")]
+    (if (and (string? e) (pos? (count e)))
+      (not (#{"0" "false" "no" "off"} (str/lower-case e)))
+      true)))
+
+(defn- slurp-quiet
+  "slurp that returns nil for a missing file instead of throwing, for the cache
+  key (a deleted local deps.edn folds in as empty, which still moves the key)."
+  [p]
+  (when (file-exists? p) (slurp p)))
+
+(defn- cpcache-file-key
+  "Filename-safe key for the cache entry: jolt's own hash of the material. The
+  hash only NAMES the file — a collision cannot serve a wrong entry, because
+  cpcache-hit? requires the stored material to equal the current one exactly.
+  That equality is also what makes the key content-exact (a same-length edit
+  moves it), the trap a sampled or truncated hash walks into. No subprocess, no
+  temp file: an earlier draft shelled to shasum, which minimal Linux images may
+  not carry and which costs a spawn on the path this cache exists to shave."
+  [material]
+  (str "k" (bit-and (hash material) 0x7fffffff)))
+
+(defn- local-deps-edn-paths
+  "The deps.edn files of every :local/root coordinate reachable from `deps`
+  (absolutized against base-dir), transitively. Each local dep's own :local/root
+  deps are followed so a whole local subgraph folds into the cache key; a jar or
+  missing deps.edn contributes nothing. The walk is bounded by the set of dirs
+  visited, so a local cycle terminates."
+  [deps base-dir]
+  (letfn [(locals-in [m dir]
+            (when-let [ds (:deps m)]
+              (keep (fn [[_ spec]]
+                      (when-let [r (:local/root spec)]
+                        (abspath dir r)))
+                    ds)))
+          (walk [queue seen acc]
+            (lazy-seq
+              (if-let [dir (first queue)]
+                (if (contains? seen dir)
+                  (walk (rest queue) seen acc)
+                  (let [seen (conj seen dir)
+                        dep-edn (str dir "/deps.edn")
+                        ;; a local dep without a deps.edn (bare source dir, a jar)
+                        ;; contributes nothing to the key — its roots are its own.
+                        m (read-edn dep-edn)
+                        acc (if m (conj acc dep-edn) acc)
+                        next (or (locals-in m dir) [])]
+                    (walk (concat (rest queue) next) seen acc)))
+                acc)))]
+    (vec (walk (locals-in {:deps deps} base-dir) #{} []))))
+
+(defn- cpcache-material
+  "Everything the expansion reads, as one string — the cache entry stores this
+  verbatim and a hit requires exact equality against it. project-edn-bytes is
+  the project deps.edn as a string (already read by the caller); user-edn-bytes
+  is the user deps.edn as a string, or a fixed marker when it is skipped
+  (JOLT_NO_USER_DEPS / :repro?) or absent. alias-kws is the active alias set.
+  Each :local/root dep's deps.edn CONTENT is folded in — its length alone once
+  was, and a same-length edit (one version digit for another) then kept serving
+  the stale entry."
+  [project-edn-bytes user-edn-bytes alias-kws local-dep-edns runtime-version]
+  (str (count project-edn-bytes) ":" project-edn-bytes
+       "|" (count user-edn-bytes) ":" user-edn-bytes
+       "|" (pr-str (vec (sort alias-kws)))
+       "|" runtime-version
+       ;; the environment-dependent artifact roots resolution materializes into:
+       ;; a run pointed at a different gitlibs/jarlibs (JOLT_GITLIBS — the
+       ;; deps-alias smoke's retry scenarios do exactly this) or a different
+       ;; HOME (the ~/.m2 and ~/.jolt defaults) must not share an entry whose
+       ;; cached roots point into the old location.
+       "|" (gitlibs-dir)
+       "|" (or (getenv "JOLT_JARLIBS") "")
+       "|" (or (getenv "HOME") "")
+       "|" (str/join "|" (for [p (sort local-dep-edns)]
+                           (let [b (or (slurp-quiet p) "")]
+                             (str p "=" (count b) ":" b))))))
+(defn- cpcache-dir
+  "The project-local cache dir, under the project's .jolt/ state dir."
+  [project-dir]
+  (str project-dir "/.jolt/cpcache"))
+
+(defn- cached-paths
+  "Every filesystem path a cached resolution depends on at run time — the roots
+  that were resolved, plus the source-tree roots a :local/root dep (or the
+  project itself) declared. A missing one means the cache is stale: a pruned
+  gitlib checkout, a deleted jar, or a removed local dep dir."
+  [resolved]
+  (let [roots (:roots resolved)
+        project-roots (:project-roots resolved)
+        ;; natives are on-disk extractions too — a pruned one must miss, not
+        ;; hand the runtime a dangling dylib path.
+        natives (:natives resolved)]
+    (vec (distinct (concat roots project-roots natives)))))
+
+(defn- cpcache-hit?
+  "Read and validate the cache file named by `k`: returns the cached value when
+  the file parses, its stored :material EQUALS `material` (the hash in the
+  filename only names the entry — equality is what rules a collision out), and
+  every cached path still exists. A corrupt/unreadable file is a miss, never an
+  error."
+  [project-dir k material]
+  (let [f (str (cpcache-dir project-dir) "/" k ".edn")]
+    (when (file-exists? f)
+      (when-let [cached (try (edn/read-string (slurp f))
+                             (catch :default _ nil))]
+        (when (= (:material cached) material)
+          (if (every? file-exists? (cached-paths (:value cached)))
+            (:value cached)
+            (do (info "cpcache miss (a cached path no longer exists)")
+                (sh (str "rm -f " (pr-str f)))    ; stale — don't re-strike
+                nil)))))))
+
+(defn- cpcache-write!
+  "Write `resolved` to the cache atomically (temp + rename), so a reader never
+  sees a half-written file. A write failure (read-only dir, full disk) is a
+  quiet miss: the cache is best-effort, the resolution already succeeded."
+  [project-dir k material resolved]
+  (let [dir (cpcache-dir project-dir)
+        f (str dir "/" k ".edn")
+        stage (str f ".part-" (System/currentTimeMillis) "-" (rand-int 100000))]
+    (sh (str "mkdir -p " (pr-str dir)))
+    (try
+      (spit stage (pr-str {:material material :value resolved}))
+      ;; rename is atomic on POSIX; mv across the same dir never copies.
+      (when-not (zero? (sh (str "mv " (pr-str stage) " " (pr-str f))))
+        (sh (str "rm -f " (pr-str stage))))
+      (catch :default _
+         (sh (str "rm -f " (pr-str stage)))))))
+
+(declare user-deps-path)   ; defined below with the deps.edn readers
+
+(defn- resolve-deps-cached
+  "resolve-deps wrapped in the .jolt/cpcache cache. On a hit the cached result
+  (the resolve-deps return map) is returned without expanding the graph or
+  touching the network; on a miss the full expansion runs (which fetches missing
+  deps) and the result is written. The cache is OFF when JOLT_AOT_CACHE is off
+  (the dev bin/jolt posture) or when trace? is set — a trace is a one-off query
+  (-Stree/-Strace), not the resolution a run reuses, so it never caches and a
+  cached run never serves one. Emits the JOLT_DEBUG-gated hit/miss lines."
+  [project-dir deps alias-kws repro? opts]
+  (if (and (cpcache-enabled?) (not (:trace? opts)))
+    (let [proj-bytes (or (slurp-quiet (str project-dir "/deps.edn")) "")
+          skip-user? (or repro? (getenv "JOLT_NO_USER_DEPS"))
+          user-path (user-deps-path)
+          user-bytes (if skip-user?
+                        "::no-user-deps::"
+                        (or (slurp-quiet user-path) "::absent::"))
+          runtime-version (jolt.host/jolt-version)
+          local-edns (local-deps-edn-paths deps project-dir)
+          material (cpcache-material proj-bytes user-bytes alias-kws local-edns runtime-version)
+          k (cpcache-file-key material)]
+      (if-let [cached (cpcache-hit? project-dir k material)]
+        (do (info "cpcache hit") cached)
+        (let [r (resolve-deps deps project-dir opts)]
+          (info "cpcache miss")
+          (cpcache-write! project-dir k material r)
+          r)))
+    (resolve-deps deps project-dir opts)))
+
 ;; --- dependency tree --------------------------------------------------------
 ;; The trace is a flat log of expansion decisions in traversal order; the tree is
 ;; that log re-hung on the paths the nodes were reached by. Rendering follows
@@ -1068,21 +1255,21 @@
          all-deps (merge (or (:replace-deps argmap) (:deps argmap)
                              (if tool? {} (:deps edn)))
                          (:extra-deps argmap))
-         ;; :cp (the CLI's -Scp) supplies the roots outright, so the dependency
-         ;; graph is never expanded and nothing is fetched. The deps.edn chain is
-         ;; still read and the aliases still combine — that is only file reads,
-         ;; and an alias's :main-opts / :exec-fn and the project's :tasks come
-         ;; from there. tools.deps' --skip-cp draws the line in the same place:
-         ;; the merged edn and argmap, without calc-basis.
-         {dep-roots :roots dep-natives :natives prep-libs :prep dep-trace :trace}
-         (when-not cp
-           (binding [*mvn-local-repo* (when-let [r (:mvn/local-repo edn)]
-                                        (abspath project-dir r))
-                     *mvn-repos* (mvn-repo-urls edn)]
-             (resolve-deps all-deps project-dir
-                           {:override-deps (:override-deps argmap)
-                            :default-deps (:default-deps argmap)
-                            :trace? trace?})))
+          ;; :cp (the CLI's -Scp) supplies the roots outright, so the dependency
+          ;; graph is never expanded and nothing is fetched. The deps.edn chain is
+          ;; still read and the aliases still combine — that is only file reads,
+          ;; and an alias's :main-opts / :exec-fn and the project's :tasks come
+          ;; from there. tools.deps' --skip-cp draws the line in the same place:
+          ;; the merged edn and argmap, without calc-basis.
+          {dep-roots :roots dep-natives :natives prep-libs :prep dep-trace :trace}
+          (when-not cp
+            (binding [*mvn-local-repo* (when-let [r (:mvn/local-repo edn)]
+                                         (abspath project-dir r))
+                      *mvn-repos* (mvn-repo-urls edn)]
+              (resolve-deps-cached project-dir all-deps alias-kws repro?
+                                   {:override-deps (:override-deps argmap)
+                                    :default-deps (:default-deps argmap)
+                                    :trace? trace?})))
          _ (when (seq prep-libs)
              (warn "deps declare :deps/prep-lib steps jolt does not run "
                    "(their compiled/generated assets will be missing): "


### PR DESCRIPTION
A warm run in a project re-expanded the dependency graph (POM parsing, version selection, gitlib probing) on every invocation — ~0.23s for a two-dep project. tools.deps caches this as .cpcache; jolt now does the same under the project's .jolt/ dir.

Correctness model: the entry stores its key material verbatim and a hit requires exact equality, so the filename hash only names the entry — a collision is a miss, never a wrong classpath. The material folds in the project and user deps.edn bytes (or explicit skip/absent markers), the active alias set, the runtime version, every :local/root dep's deps.edn content (transitively — content, not length, so a same-length edit invalidates), and the environment-dependent artifact roots (JOLT_GITLIBS / JOLT_JARLIBS / HOME) — the deps-alias retry scenarios caught that a run pointed at a different gitlibs must not share an entry. Hits validate every cached root still exists (a pruned gitlib re-expands, never errors); corrupt files and failed writes are quiet misses; writes are temp+rename. Gated by JOLT_AOT_CACHE like the namespace cache (dev source mode never caches); -Stree / -Strace / -Scp never touch it.

New depscpcache smoke (in the ci list, offline via a :local/root project): hit/miss, project-edit and local-dep-edit invalidation, alias keying, stale-path re-expansion, dev posture.

Measured warm against the 0.7.9 baseline (with the stdlib-fasl round merged): project -e nil 0.38s -> 0.14s, project run -m 1.7s -> 0.17s. Full make test green (68 ci targets).