### PR TITLE
bench: vecops — vector concat and slice, the RRB axis

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -21,6 +21,7 @@ absolute reference.
 | `dispatch` | polymorphic (**megamorphic**) protocol dispatch | devirt, inline-cache | AWFY-style |
 | `mono-dispatch` | **monomorphic** protocol dispatch (devirt/inline-cache *can* fire) | devirt, inline-cache | AWFY-style |
 | `collections` | persistent map/vector churn (HAMT / 32-way tries) + map/filter/take/reduce over the built vector | persistent structures, transients | CLBG k-nucleotide-style |
+| `vecops` | vector-of-vectors: pairwise `into` concatenation, `subvec` windows + reduce, split-at/rejoin loop | vector concat + slice (the RRB axis; today linear per op on jolt, `subvec` an O(1) view on the JVM) | RRB workload |
 | `mandelbrot` | pure float compute (tight arith loops, no alloc/dispatch) | native arith, loop codegen | CLBG |
 | `arrays` | primitive `double-array` throughput (unboxed `aget`/`aset`, no boxing/collections) | unboxed primitive-array codegen (flvector read/write) | CLBG-style |
 | `mathfns` | transcendental math (`java.lang.Math` sqrt/sin/cos/log/pow/atan2 over doubles) | native `Math` op lowering (`flsqrt`/`flsin`/… vs generic host-static dispatch) | CLBG-style |

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -46,7 +46,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 seqs:20000 transducers:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 vecops:60000 seqs:20000 transducers:20000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/bench/vecops.clj
+++ b/bench/vecops.clj
@@ -1,0 +1,66 @@
+;; vecops — VECTOR CONCATENATION AND SLICING, the axis no other suite measures.
+;; collections churns one vector with conj/assoc; this suite makes vectors OUT
+;; OF vectors: pairwise `into` concatenation, `subvec` windows consumed by
+;; reduce, and a split-at-then-rejoin loop (the classic RRB workload). Today
+;; every one of these is linear per operation on jolt; when pvec grows RRB
+;; concat/slice AND core's `into`/`subvec` are wired through it (the follow-up
+;; beads to the rrb epic), these rows are where the change shows. On the JVM,
+;; `into` is linear too (core Clojure has no RRB) and `subvec` is an O(1) view
+;; that retains its parent — the ratio columns stay honest about both.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh vecops 60000
+(ns vecops)
+
+;; pairwise concat: fold k chunk-vectors into one. Linear in total elements per
+;; fold step today — quadratic overall in k; O(k log n) with RRB-backed into.
+(defn concat-chunks [k chunk]
+  (let [c (vec (range chunk))]
+    (loop [i 0 acc []]
+      (if (< i k)
+        (recur (inc i) (into acc c))
+        acc))))
+
+;; sliding windows: subvec a big vector at striding offsets, reduce each
+;; window. Measures slice construction AND read-through-a-slice.
+(defn window-sums [v win stride]
+  (let [n (count v)]
+    (loop [i 0 acc 0]
+      (if (<= (+ i win) n)
+        (recur (+ i stride)
+               (+ acc (reduce + 0 (subvec v i (+ i win)))))
+        acc))))
+
+;; split + rejoin: cut the vector at a moving point and join the halves
+;; swapped — both halves rebuilt today, structural sharing with RRB.
+(defn split-rejoin [v rounds]
+  (let [n (count v)]
+    (loop [i 0 v v]
+      (if (< i rounds)
+        (let [at (inc (mod (* (inc i) 2654435761) (dec n)))]
+          (recur (inc i) (into (subvec v at) (subvec v 0 at))))
+        (reduce + 0 v)))))
+
+(defn run [n]
+  (let [chunk 512
+        k (quot n chunk)
+        big (concat-chunks k chunk)]
+    (+ (count big)
+       (window-sums big 1024 512)
+       (split-rejoin (vec (range (quot n 4))) 48))))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 60000)]
+    (dotimes [_ 2] (run (quot n 4)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "vecops n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))


### PR DESCRIPTION
Adds the missing benchmark axis ahead of the RRB vector work: pairwise into-concatenation, subvec windows + reduce, and a split-at/rejoin loop. Baseline today (run mode, n=60000): jolt 464ms vs JVM 17ms with identical results — linear-per-op concat/slice dominates, which is what RRB plus the into/subvec wiring collapses. Wired into run.sh's suite list and the README table.