### PR TITLE
Profile standalone binary startup stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,17 @@ out — keeping everything, and reporting which library is responsible — when 
 code resolves vars by name at runtime (`eval`/`resolve`/`ns-resolve`/…). See
 [deps.edn internals](https://jolt-lang.github.io/docs/tools-deps.html) and [RFC 0007](https://jolt-lang.github.io/docs/rfc/0007-compilation-modes-and-binary-output.html).
 
+Built executables contain an optional startup profiler. Set
+`JOLT_STARTUP_PROFILE=1` when launching one to write per-stage wall time,
+process CPU time, collection counts, reclaimed bytes, and current heap size to
+standard error. Markers cover the native boot loader, Jolt runtime files, each
+application namespace, and `-main`; normal launches leave the profiler disabled
+and silent.
+
+```bash
+JOLT_STARTUP_PROFILE=1 ./myapp arg1 arg2
+```
+
 This needs Chez's kernel development files (`libkernel.a`, `scheme.h`) and a C
 compiler. They come with a from-source Chez install; a distro `chezscheme`
 package ships only the runtime, so `build` won't link a binary there.

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -63,6 +63,22 @@ if [ "$got" != "$want" ]; then
   exit 1
 fi
 
+# Startup profiling is one opt-in switch on the same binary. The ordinary run
+# above is exact-output proof that it stays silent by default; an enabled run
+# spans the native heap loader, app namespace initialization, and -main.
+profiled="$(cd / && JOLT_STARTUP_PROFILE=1 "$out" alpha bb ccc 2>&1)"
+for marker in \
+  'jolt startup: [profile] native Sbuild_heap' \
+  'jolt startup: [profile] scheme namespace app.core' \
+  'jolt startup: [profile] scheme entry -main'
+do
+  if ! printf '%s\n' "$profiled" | grep -Fq "$marker"; then
+    echo "  FAIL: startup profile missing marker: $marker"
+    echo "--- got ----"; echo "$profiled"
+    exit 1
+  fi
+done
+
 # --- release now defaults to direct-linking + whole-program inference ------------
 # A plain `jolt build` (release, no flags) must direct-link app->app calls (the
 # throughput lever the perf audit identified) AND run wp-infer — both were opt-in

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -219,6 +219,64 @@
     ;; editor (ncurses + terminfo), threads, dlopen, libuuid, and clock_gettime.
     (else "-llz4 -lz -lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt")))
 
+;; --- optional built-binary startup profile ----------------------------------
+;; JOLT_STARTUP_PROFILE=1 reports wall time, process CPU, collections,
+;; reclaimed GC bytes, and current heap size at coarse runtime/app boundaries.
+;; The definitions use Chez primitives only, so they can run before Jolt's runtime is initialized.
+;; Calls stay in every built image but return immediately when the variable is
+;; absent; this keeps one binary usable for normal runs and startup diagnosis.
+(define (bld-emit-startup-profile-preamble out)
+  (put-string out
+    "(define jolt-startup-profile? (and (getenv \"JOLT_STARTUP_PROFILE\") #t))\n\
+(define jolt-startup-profile-start-real\n\
+  (and jolt-startup-profile? (real-time)))\n\
+(define jolt-startup-profile-last-real jolt-startup-profile-start-real)\n\
+(define jolt-startup-profile-last-cpu\n\
+  (and jolt-startup-profile? (cpu-time)))\n\
+(define jolt-startup-profile-initial-stats\n\
+  (and jolt-startup-profile? (statistics)))\n\
+(define jolt-startup-profile-last-collections\n\
+  (and jolt-startup-profile?\n\
+       (sstats-gc-count jolt-startup-profile-initial-stats)))\n\
+(define jolt-startup-profile-last-gc-bytes\n\
+  (and jolt-startup-profile?\n\
+       (sstats-gc-bytes jolt-startup-profile-initial-stats)))\n\
+(define (jolt-startup-profile-mark! label)\n\
+  (when jolt-startup-profile?\n\
+    (let* ((now-real (real-time))\n\
+           (now-cpu (cpu-time))\n\
+           (now-stats (statistics))\n\
+           (now-collections (sstats-gc-count now-stats))\n\
+           (now-gc-bytes (sstats-gc-bytes now-stats)))\n\
+      (display\n\
+        (string-append\n\
+          \"jolt startup: [profile] scheme \" label\n\
+          \"   wall \" (number->string (- now-real jolt-startup-profile-last-real)) \" ms\"\n\
+          \"   cpu \" (number->string (- now-cpu jolt-startup-profile-last-cpu)) \" ms\"\n\
+          \"   gc \" (number->string (- now-collections jolt-startup-profile-last-collections))\n\
+          \"   gc-reclaimed \" (number->string (- now-gc-bytes jolt-startup-profile-last-gc-bytes)) \" bytes\"\n\
+          \"   heap \" (number->string (current-memory-bytes)) \" bytes\"\n\
+          \"   (cumulative \" (number->string (- now-real jolt-startup-profile-start-real)) \" ms)\\n\")\n\
+        (current-error-port))\n\
+      (let ((after-stats (statistics)))\n\
+        (set! jolt-startup-profile-last-real (real-time))\n\
+        (set! jolt-startup-profile-last-cpu (cpu-time))\n\
+        (set! jolt-startup-profile-last-collections (sstats-gc-count after-stats))\n\
+        (set! jolt-startup-profile-last-gc-bytes (sstats-gc-bytes after-stats))))))\n"))
+
+(define (bld-startup-profile-form label)
+  (string-append "(jolt-startup-profile-mark! " (ei-str-lit label) ")"))
+
+(define (bld-emit-startup-profile-mark! out label)
+  (put-string out (bld-startup-profile-form label))
+  (put-string out "\n"))
+
+(define (bld-runtime-entry-label entry)
+  (cond
+    ((symbol? entry) (symbol->string entry))
+    ((bld-load-path entry) => (lambda (path) path))
+    (else entry)))
+
 ;; --- runtime manifest (mirrors host/chez/cli.ss's load order) ---------------
 ;; A line is either literal Scheme text to inline, or a tag whose emission the build
 ;; controls: 'prelude (the clojure.core blob, replaced by the shaken core under
@@ -306,16 +364,34 @@
 ;; closed AOT app that never compiles from source) omits 'image + 'compile-eval —
 ;; the analyzer/back end are dead weight in the binary (~0.8MB).
 (define (bld-emit-runtime out drop-compiler? core-strs)
+  (bld-emit-startup-profile-preamble out)
+  (bld-emit-startup-profile-mark! out "runtime begin")
   (for-each
     (lambda (entry)
-      (cond
-        ((eq? entry 'prelude)
-         (if core-strs
-             (for-each (lambda (s) (put-string out s) (put-string out "\n")) core-strs)
-             (bld-inline-line (cdr (assq 'prelude bld-tagged-loads)) out 0)))
-        ((memq entry '(image compile-eval))
-         (unless drop-compiler? (bld-inline-line (cdr (assq entry bld-tagged-loads)) out 0)))
-        (else (bld-inline-line entry out 0))))
+      (let ((emitted?
+              (cond
+                ((eq? entry 'prelude)
+                 (if core-strs
+                     (begin
+                       (for-each (lambda (s) (put-string out s) (put-string out "\n"))
+                                 core-strs)
+                       #t)
+                     (begin
+                       (bld-inline-line (cdr (assq 'prelude bld-tagged-loads)) out 0)
+                       #t)))
+                ((memq entry '(image compile-eval))
+                 (if drop-compiler?
+                     #f
+                     (begin
+                       (bld-inline-line (cdr (assq entry bld-tagged-loads)) out 0)
+                       #t)))
+                (else
+                 (bld-inline-line entry out 0)
+                 #t))))
+        (when emitted?
+          (bld-emit-startup-profile-mark!
+            out
+            (string-append "runtime " (bld-runtime-entry-label entry))))))
     bld-runtime-manifest))
 
 ;; --- app emission -----------------------------------------------------------
@@ -984,45 +1060,55 @@
                 ;; form too (no-op unless the app registered data readers).
                 (parameterize ((ei-emit-form-hook
                                 (lambda (form) (if data-readers-active (ldr-apply-readers form) form))))
-                (if tree-shake?
-                    (dce-shake
-                      (dce-blob-records "host/chez/seed/prelude.ss")
-                      (apply append
-                        (map (lambda (nf)
-                               ;; ns-prelude forms (always kept, no fqn/refs) set the
-                               ;; ns + register aliases before this ns's forms; dce
-                               ;; keeps original order.
-                               (let ((src (ldr-read-source (cdr nf))))
-                                 (jolt-enter-file! (cdr nf))   ; name the file on a failure
-                                 (parameterize ((rdr-source-file (cdr nf)))
-                                   ;; RT.load-parity bracket (dyn-binding.ss): the
-                                   ;; ns's replayed forms run under fresh
-                                   ;; *warn-on-reflection*/*assert* bindings.
-                                   (append
-                                     (list (dce-rec #t #f '() "(jolt-ns-load-vars-push!)"))
-                                     (map (lambda (s) (dce-rec #t #f '() s))
-                                          (bld-ns-prelude (car nf) src))
-                                     (ei-emit-ns-records (car nf) src)
-                                     (list (dce-rec #t #f '() "(jolt-ns-load-vars-pop!)"))))))
-                             ordered))
-                      (string-append entry-ns "/-main"))
-                    (values #f
-                            (apply append
-                              (map (lambda (nf)
-                                     (let ((src (ei-timed "emit: read source"
-                                                  (lambda () (ldr-read-source (cdr nf))))))
-                                       (jolt-enter-file! (cdr nf))   ; name the file on a failure
-                                       (parameterize ((rdr-source-file (cdr nf)))
-                                         ;; RT.load-parity bracket, matching the
-                                         ;; tree-shake path above.
-                                         (append (list "(jolt-ns-load-vars-push!)")
-                                                 (ei-timed "emit: ns-prelude"
-                                                   (lambda () (bld-ns-prelude (car nf) src)))
-                                                 (ei-timed "emit: per-ns total"
-                                                   (lambda () (bld-emit-ns (car nf) src)))
-                                                 (list "(jolt-ns-load-vars-pop!)")))))
-                                   ordered))
-                            #f))))
+                  (if tree-shake?
+                      (dce-shake
+                        (dce-blob-records "host/chez/seed/prelude.ss")
+                        (apply append
+                          (map (lambda (nf)
+                                 ;; ns-prelude forms (always kept, no fqn/refs) set the
+                                 ;; ns + register aliases before this ns's forms; dce
+                                 ;; keeps original order.
+                                 (let* ((src (ldr-read-source (cdr nf)))
+                                        (profile-form
+                                          (bld-startup-profile-form
+                                            (string-append "namespace " (car nf)))))
+                                   (jolt-enter-file! (cdr nf))   ; name the file on a failure
+                                   (parameterize ((rdr-source-file (cdr nf)))
+                                     ;; RT.load-parity bracket (dyn-binding.ss): the
+                                     ;; ns's replayed forms run under fresh
+                                     ;; *warn-on-reflection*/*assert* bindings.
+                                     (append
+                                       (list (dce-rec #t #f '() "(jolt-ns-load-vars-push!)"))
+                                       (map (lambda (s) (dce-rec #t #f '() s))
+                                            (bld-ns-prelude (car nf) src))
+                                       (ei-emit-ns-records (car nf) src)
+                                       (list
+                                         (dce-rec #t #f '() "(jolt-ns-load-vars-pop!)")
+                                         (dce-rec #t #f '() profile-form))))))
+                               ordered))
+                        (string-append entry-ns "/-main"))
+                      (values
+                        #f
+                        (apply append
+                          (map (lambda (nf)
+                                 (let ((src (ei-timed "emit: read source"
+                                              (lambda () (ldr-read-source (cdr nf))))))
+                                   (jolt-enter-file! (cdr nf))   ; name the file on a failure
+                                   (parameterize ((rdr-source-file (cdr nf)))
+                                     ;; RT.load-parity bracket, matching the
+                                     ;; tree-shake path above.
+                                     (append
+                                       (list "(jolt-ns-load-vars-push!)")
+                                       (ei-timed "emit: ns-prelude"
+                                         (lambda () (bld-ns-prelude (car nf) src)))
+                                       (ei-timed "emit: per-ns total"
+                                         (lambda () (bld-emit-ns (car nf) src)))
+                                       (list
+                                         "(jolt-ns-load-vars-pop!)"
+                                         (bld-startup-profile-form
+                                           (string-append "namespace " (car nf))))))))
+                               ordered))
+                        #f))))
               (lambda ()
                 (set-optimize! #f)
                 (set-release! #f)
@@ -1090,8 +1176,10 @@
           ;; foreign-procedure evals (a library's defcfn) and (slurp (io/resource …))
           ;; reads. So the libraries must be loaded and resources resolvable by the
           ;; time those forms run, not later in the scheme-start launcher.
+          (bld-emit-startup-profile-mark! out "app image begin")
           (put-string out "\n;; === native libraries (required) ===\n")
           (bld-emit-natives out natives 'required)
+          (bld-emit-startup-profile-mark! out "required native libraries")
           (put-string out "\n;; === embedded resources ===\n")
           (bld-emit-embeds out embed-dirs)
            (bld-emit-data-readers out)
@@ -1103,6 +1191,7 @@
                              (fold-left (lambda (s r) (string-append s (ei-str-lit r) " ")) ""
                                         (get-source-roots))
                              "))\n"))
+          (bld-emit-startup-profile-mark! out "embedded resources and source roots")
           ;; Pre-register every app namespace in ns-registry BEFORE any app form
           ;; runs, so a boot-time (require 'x) of an AOT'd namespace no-ops (the
           ;; loader's ns-registry arm) instead of hunting for absent source. Needed
@@ -1113,7 +1202,9 @@
           (put-string out "\n;; === app namespace pre-registration ===\n")
           (for-each (lambda (p) (put-string out (string-append "(intern-ns! " (ei-str-lit (car p)) ")\n")))
                     ordered)
+          (bld-emit-startup-profile-mark! out "app namespace registration")
           (put-string out "\n;; === app ===\n")
+          (bld-emit-startup-profile-mark! out "app namespaces begin")
           (for-each (lambda (s) (put-string out s) (put-string out "\n")) app-strs)
           ;; The launcher runs as Chez's scheme-start (so argv reaches -main —
           ;; top-level boot forms run during heap build, before args are set), and
@@ -1132,6 +1223,7 @@
               "        (default (* 16 1024 1024)))\n"
               "    (if trip (or (string->number trip) default) default)))\n"))
           (put-string out "(scheme-start\n  (lambda args\n")
+          (bld-emit-startup-profile-mark! out "scheme-start begin")
           ;; Shutdown hooks (`:shutdown` on a jolt.process, jolt.host/
           ;; add-shutdown-hook) run from Chez's exit-handler, which is a THREAD
           ;; parameter — so the wrapper has to be installed on the thread that
@@ -1157,6 +1249,7 @@
                              (fold-left (lambda (s r) (string-append s (ei-str-lit r) " ")) "" (bld-strs ext-roots))
                              "))\n"
                              "                  " (ldr-install-roots-str) ")))\n"))
+          (bld-emit-startup-profile-mark! out "scheme-start setup")
           (if library?
               (put-string out (bld-library-launcher-body))
               (put-string out (string-append
@@ -1181,7 +1274,10 @@
                             "        (when (and maincell (var-cell-defined? maincell))\n"
                             "          (with-exception-handler\n"
                             "            (lambda (c) (when (serious-condition? c) (jolt-capture-fault! c)) (raise-continuable c))\n"
-                            "            (lambda () (apply jolt-invoke (var-cell-root maincell) args))))))\n"
+                            "            (lambda ()\n"
+                            "              (let ((jolt-main-result (apply jolt-invoke (var-cell-root maincell) args)))\n"
+                            "                " (bld-startup-profile-form "entry -main") "\n"
+                            "                jolt-main-result))))))\n"
                             "    (exit 0)))\n")))
           (close-port out))
         (ei-mark! "write flat.ss")

--- a/host/chez/stub/launcher.c
+++ b/host/chez/stub/launcher.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -56,8 +57,37 @@ static int open_self(const char *path) { return open(path, O_RDONLY); }
 #define JOLT_MAGIC "JOLTBOOT"
 #define JOLT_MAGIC_LEN 8
 #define JOLT_TRAILER_LEN 16 /* u64 length + 8-byte magic */
+static double monotonic_ms(void) {
+#if defined(_WIN32)
+  LARGE_INTEGER frequency;
+  LARGE_INTEGER counter;
+  QueryPerformanceFrequency(&frequency);
+  QueryPerformanceCounter(&counter);
+  return (double)counter.QuadPart * 1000.0 / (double)frequency.QuadPart;
+#else
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  return (double)now.tv_sec * 1000.0 + (double)now.tv_nsec / 1000000.0;
+#endif
+}
+
+static void startup_profile_mark(int enabled, double started, double *last,
+                                 const char *label) {
+  if (enabled) {
+    double now = monotonic_ms();
+    fprintf(stderr,
+            "jolt startup: [profile] native %-22s %9.3f ms"
+            "   (cumulative %9.3f ms)\n",
+            label, now - *last, now - started);
+    *last = now;
+  }
+}
+
 
 int main(int argc, char *argv[]) {
+  int startup_profile = getenv("JOLT_STARTUP_PROFILE") != NULL;
+  double startup_started = startup_profile ? monotonic_ms() : 0.0;
+  double startup_last = startup_started;
   char path[4096];
   if (self_path(path, (uint32_t)sizeof(path)) != 0) {
     fprintf(stderr, "jolt: cannot resolve own executable path\n");
@@ -98,6 +128,8 @@ int main(int argc, char *argv[]) {
     return 1;
   }
   fclose(f);
+  startup_profile_mark(startup_profile, startup_started, &startup_last,
+                       "locate boot payload");
 
   int fd = open_self(path);
   if (fd < 0) {
@@ -106,10 +138,20 @@ int main(int argc, char *argv[]) {
   }
 
   Sscheme_init(0);
+  startup_profile_mark(startup_profile, startup_started, &startup_last,
+                       "Sscheme_init");
   /* final arg: close the fd when the boot is consumed */
   Sregister_boot_file_fd_region("jolt", fd, (iptr)boot_off, (iptr)boot_len, 1);
+  startup_profile_mark(startup_profile, startup_started, &startup_last,
+                       "register boot payload");
   Sbuild_heap(0, 0);
+  startup_profile_mark(startup_profile, startup_started, &startup_last,
+                       "Sbuild_heap");
   int status = Sscheme_start(argc, (const char **)argv);
+  startup_profile_mark(startup_profile, startup_started, &startup_last,
+                       "Sscheme_start");
   Sscheme_deinit();
+  startup_profile_mark(startup_profile, startup_started, &startup_last,
+                       "Sscheme_deinit");
   return status;
 }


### PR DESCRIPTION
Built executables now expose an opt-in JOLT_STARTUP_PROFILE trace across the native launcher, runtime files, application namespaces, and -main. Each Scheme marker reports interval wall and CPU time, collection count, reclaimed bytes, current heap size, and cumulative startup time to stderr; the normal path stays silent.

Gate both enabled marker coverage and unchanged disabled output in the standalone build smoke, and document how to profile any built executable.