### PR TITLE
Parse repo text files the same on CRLF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+host/chez/stdlib-fasl-manifest.txt text eol=lf

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -284,11 +284,18 @@
           (else (read-file-string path)))))
 
 (define (bld-string-lines s)
+  ;; a line drops its trailing \r: a CRLF checkout (Windows git autocrlf) must
+  ;; parse identically to an LF one — the stdlib-fasl manifest read through
+  ;; here failed set-equality on Windows with every name carrying \r.
   (let ((n (string-length s)))
+    (define (slice start end)
+      (let ((end (if (and (> end start) (char=? (string-ref s (- end 1)) #\return))
+                     (- end 1) end)))
+        (substring s start end)))
     (let loop ((i 0) (start 0) (acc '()))
-      (cond ((>= i n) (reverse (if (> i start) (cons (substring s start i) acc) acc)))
+      (cond ((>= i n) (reverse (if (> i start) (cons (slice start i) acc) acc)))
             ((char=? (string-ref s i) #\newline)
-             (loop (+ i 1) (+ i 1) (cons (substring s start i) acc)))
+             (loop (+ i 1) (+ i 1) (cons (slice start i) acc)))
             (else (loop (+ i 1) start acc))))))
 
 (define (bld-file-lines path) (bld-string-lines (bld-source-string path)))

--- a/host/chez/stdlib-fasl-smoke.sh
+++ b/host/chez/stdlib-fasl-smoke.sh
@@ -78,8 +78,8 @@ else
   fails=$((fails+1))
 fi
 
-# (e) the manifest lists clojure.test
-if grep -q '^clojure.test$' host/chez/stdlib-fasl-manifest.txt; then
+# (e) the manifest lists clojure.test (\r?: a CRLF checkout must still match)
+if grep -q $'^clojure.test\r\{0,1\}$' host/chez/stdlib-fasl-manifest.txt; then
   echo "PASS: (e) manifest lists clojure.test"; pass=$((pass+1))
 else
   echo "FAIL: (e) manifest does not list clojure.test"; fails=$((fails+1))

--- a/host/chez/stdlib-fasl-smoke.sh
+++ b/host/chez/stdlib-fasl-smoke.sh
@@ -78,8 +78,8 @@ else
   fails=$((fails+1))
 fi
 
-# (e) the manifest lists clojure.test (\r?: a CRLF checkout must still match)
-if grep -q $'^clojure.test\r\{0,1\}$' host/chez/stdlib-fasl-manifest.txt; then
+# (e) the manifest lists clojure.test (tr -d: a CRLF checkout must still match)
+if tr -d '\r' < host/chez/stdlib-fasl-manifest.txt | grep -qx 'clojure.test'; then
   echo "PASS: (e) manifest lists clojure.test"; pass=$((pass+1))
 else
   echo "FAIL: (e) manifest does not list clojure.test"; fails=$((fails+1))


### PR DESCRIPTION
The v0.7.10 Windows release build failed the stdlib-fasl drift gate: git autocrlf gives the manifest CRLF line endings on the Windows runner, and bld-string-lines split on newline alone — every parsed name carried a trailing \r, so set equality failed while printing two identical 62-name sets. (First Windows exposure of the gate; CI runs Linux/macOS.)

Lines now drop a trailing \r at the split point, which fixes every bld-file-lines consumer at once; the stdlib-fasl smoke's manifest grep tolerates a \r; and .gitattributes pins the manifest to LF regardless. Verified locally by converting the manifest to CRLF and running the stdlib-fasl gate red-before/green-after, and again on LF.

Release v0.7.10 is parked as a draft on the failed run; the tag gets re-cut on this fix.