### PR TITLE
RRB vector: O(log n) catvec/slice with a native-backed clojure.core.rrb-vector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ install: build
 
 CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling depssmoke depscpcache depsunit \
   smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi stdlibfasl \
-  transient stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
+  transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck portcheck adaptercheck lockcheck parkcheck irvalidate devbootsmoke \
@@ -439,6 +439,14 @@ ffi:
 # Transients: mutable backing, snapshot on persistent!, and linear-time builds.
 transient:
 	@$(CHEZ) --script test/chez/transient-test.ss
+
+# RRB vector: catvec/slice against a list model with structural invariants
+# (seeded sequences, seed printed on failure), and the n-vs-4n complexity
+# ratio measured in one process.
+rrbprop:
+	@$(CHEZ) --script test/chez/rrb-property-test.ss
+rrbscaling:
+	@$(CHEZ) --script test/chez/rrb-scaling-test.ss
 
 # State images: value-graph round-trip through jolt.image, plus the Chez fasl
 # behaviour the format assumes (machine-independence, what fasl refuses).

--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -70,14 +70,61 @@
 
 (define (pv-tailoff cnt)
   (if (fx<? cnt pv-width) 0 (fxsll (fxsra (fx- cnt 1) pv-bits) pv-bits)))
+
+;; --- RRB relaxed nodes -------------------------------------------------------
+;; catvec/slice (below) produce RELAXED branch nodes: children needn't be full,
+;; so radix addressing gives way to a size-table search. A relaxed node is a
+;; dedicated record — a regular branch is a Scheme vector of children and a leaf
+;; is a chunk of ELEMENTS (which can themselves be Scheme vectors), so a record
+;; is the only representation whose discrimination is total: rrbnode? and
+;; vector? are disjoint, and a value is only ever treated as a node at level>0.
+;; sizes are CUMULATIVE subtree counts (sizes[k] = elements in children 0..k).
+;;
+;; Invariants:
+;;  - a pvec whose root is a plain vector is a CLASSIC PersistentVector trie
+;;    (full 32-wide leaves, 32-aligned tailoff) — every pre-RRB invariant holds
+;;    and every pre-RRB code path runs unchanged;
+;;  - a pvec whose root is an rrbnode may be arbitrary: the size tables are
+;;    authoritative and the tail is the last 0..32 elements (tailoff is
+;;    cnt - tail length, NOT the aligned formula);
+;;  - inside an RRB trie a plain-vector branch means LEFTWISE DENSE (all but
+;;    the last child fully dense), so radix addressing on a subtree-relative
+;;    index is valid from that node down.
+(define-record-type rrbnode (fields sizes children) (nongenerative chez-rrbnode-v1))
+
+;; first child whose cumulative size exceeds i (linear over <=32 slots)
+(define (rrb-find-child sizes i)
+  (let loop ((k 0))
+    (if (fx<=? (vector-ref sizes k) i) (loop (fx+ k 1)) k)))
+
+(define (pv-tailoff-of p) (fx- (pvec-cnt p) (vector-length (pvec-tail p))))
+
+;; leaf resolution: the chunk holding index i and i's offset within it. The
+;; classic trie keeps its radix descent (one rrbnode? test per level is the only
+;; added cost); a relaxed node switches to its size table and subtree-relative
+;; addressing from there down. At level 0 the low 5 bits are the offset for
+;; both absolute (classic) and relative (leftwise-dense subtree) indices.
+(define (pv-leaf-for p i)
+  (let ((tailoff (pv-tailoff-of p)))
+    (if (fx>=? i tailoff)
+        (values (pvec-tail p) (fx- i tailoff))
+        (let loop ((node (pvec-root p)) (level (pvec-shift p)) (i i))
+          (cond
+            ((fx=? level 0) (values node (fxand i pv-mask)))
+            ((rrbnode? node)
+             ;; a relaxed node below dense ancestors receives an unmasked index;
+             ;; its in-subtree part is the low level+5 bits (dense ancestors are
+             ;; aligned), and masking a subtree-relative index is the identity.
+             (let* ((i (fxand i (fx- (fxsll 1 (fx+ level pv-bits)) 1)))
+                    (sizes (rrbnode-sizes node))
+                    (k (rrb-find-child sizes i))
+                    (sub (if (fx=? k 0) i (fx- i (vector-ref sizes (fx- k 1))))))
+               (loop (vector-ref (rrbnode-children node) k) (fx- level pv-bits) sub)))
+            (else (loop (vector-ref node (fxand (fxsra i level) pv-mask))
+                        (fx- level pv-bits) i)))))))
 ;; the 32-chunk Scheme vector holding index i (the tail or a trie leaf)
 (define (pv-chunk-for p i)
-  (if (fx>=? i (pv-tailoff (pvec-cnt p)))
-      (pvec-tail p)
-      (let loop ((node (pvec-root p)) (level (pvec-shift p)))
-        (if (fx>? level 0)
-            (loop (vector-ref node (fxand (fxsra i level) pv-mask)) (fx- level pv-bits))
-            node))))
+  (let-values (((chunk off) (pv-leaf-for p i))) chunk))
 
 ;; jolt models every number as a double, so vector indices arrive as flonums —
 ;; coerce an integer-valued index to a Scheme fixnum before bounds math.
@@ -86,7 +133,7 @@
 (define (pvec-nth-d p i d)
   (let ((i (->idx i)))
     (if (and (fixnum? i) (fx>=? i 0) (fx<? i (pvec-cnt p)))
-        (vector-ref (pv-chunk-for p i) (fxand i pv-mask))
+        (let-values (((chunk off) (pv-leaf-for p i))) (vector-ref chunk off))
         d)))
 
 ;; new-path: wrap a node in single-child nodes up `level` bits.
@@ -103,35 +150,59 @@
                       (pv-new-path (fx- level pv-bits) tail-node)))))))
 (define (pvec-conj p x)
   (let ((cnt (pvec-cnt p)) (shift (pvec-shift p)))
-    (if (fx<? (fx- cnt (pv-tailoff cnt)) pv-width)
-        ;; room in the tail
-        (mk-pvec (fx+ cnt 1) shift (pvec-root p) (vec-snoc (pvec-tail p) x) #f)
-        ;; tail full: push it into the trie, start a fresh tail
-        (let ((tail-node (pvec-tail p)))
-          (if (fx>? (fxsra cnt pv-bits) (fxsll 1 shift))
-              ;; root overflow: grow the trie a level
-              (mk-pvec (fx+ cnt 1) (fx+ shift pv-bits)
-                       (vector (pvec-root p) (pv-new-path shift tail-node))
-                       (vector x) #f)
-              (mk-pvec (fx+ cnt 1) shift
-                       (pv-push-tail cnt shift (pvec-root p) tail-node)
-                       (vector x) #f))))))
+    (cond
+      ((fx<? (vector-length (pvec-tail p)) pv-width)
+       ;; room in the tail (classic and RRB alike)
+       (mk-pvec (fx+ cnt 1) shift (pvec-root p) (vec-snoc (pvec-tail p) x) #f))
+      ((rrbnode? (pvec-root p))
+       ;; tail full under a relaxed root: push it down the rightmost spine
+       (let* ((tail-node (pvec-tail p))
+              (pushed (rrb-push-leaf (pvec-root p) shift tail-node)))
+         (if pushed
+             (mk-pvec (fx+ cnt 1) shift pushed (vector x) #f)
+             (let ((trie-cnt (fx- cnt pv-width)))   ; count already in the trie
+               (mk-pvec (fx+ cnt 1) (fx+ shift pv-bits)
+                        (make-rrbnode (vector trie-cnt cnt)
+                                      (vector (pvec-root p) (pv-new-path shift tail-node)))
+                        (vector x) #f)))))
+      (else
+       ;; tail full: push it into the classic trie, start a fresh tail
+       (let ((tail-node (pvec-tail p)))
+         (if (fx>? (fxsra cnt pv-bits) (fxsll 1 shift))
+             ;; root overflow: grow the trie a level
+             (mk-pvec (fx+ cnt 1) (fx+ shift pv-bits)
+                      (vector (pvec-root p) (pv-new-path shift tail-node))
+                      (vector x) #f)
+             (mk-pvec (fx+ cnt 1) shift
+                      (pv-push-tail cnt shift (pvec-root p) tail-node)
+                      (vector x) #f)))))))
 
 (define (pv-assoc-trie level node i x)
-  (if (fx=? level 0)
-      (vec-set node (fxand i pv-mask) x)
-      (let ((subidx (fxand (fxsra i level) pv-mask)))
-        (vec-set node subidx (pv-assoc-trie (fx- level pv-bits) (vector-ref node subidx) i x)))))
+  (cond
+    ((fx=? level 0) (vec-set node (fxand i pv-mask) x))
+    ((rrbnode? node)
+     (let* ((i (fxand i (fx- (fxsll 1 (fx+ level pv-bits)) 1)))   ; see pv-leaf-for
+            (sizes (rrbnode-sizes node))
+            (k (rrb-find-child sizes i))
+            (sub (if (fx=? k 0) i (fx- i (vector-ref sizes (fx- k 1)))))
+            (children (rrbnode-children node)))
+       (make-rrbnode sizes
+                     (vec-set children k
+                              (pv-assoc-trie (fx- level pv-bits) (vector-ref children k) sub x)))))
+    (else
+     (let ((subidx (fxand (fxsra i level) pv-mask)))
+       (vec-set node subidx (pv-assoc-trie (fx- level pv-bits) (vector-ref node subidx) i x))))))
 (define (pvec-assoc p i x)            ; i in [0,count]; =count appends
   (let ((i (->idx i)) (cnt (pvec-cnt p)))
     (cond
       ((fx=? i cnt) (pvec-conj p x))
       ((and (fx>=? i 0) (fx<? i cnt))
-       (if (fx>=? i (pv-tailoff cnt))
-           (mk-pvec cnt (pvec-shift p) (pvec-root p)
-                    (vec-set (pvec-tail p) (fxand i pv-mask) x) #f)
-           (mk-pvec cnt (pvec-shift p)
-                    (pv-assoc-trie (pvec-shift p) (pvec-root p) i x) (pvec-tail p) #f)))
+       (let ((tailoff (pv-tailoff-of p)))
+         (if (fx>=? i tailoff)
+             (mk-pvec cnt (pvec-shift p) (pvec-root p)
+                      (vec-set (pvec-tail p) (fx- i tailoff) x) #f)
+             (mk-pvec cnt (pvec-shift p)
+                      (pv-assoc-trie (pvec-shift p) (pvec-root p) i x) (pvec-tail p) #f))))
       (else (jolt-throw (jolt-host-throwable "java.lang.IndexOutOfBoundsException" "vector index out of bounds"))))))
 (define (pvec-peek p)
   (let ((n (pvec-cnt p))) (if (fx=? n 0) jolt-nil (pvec-nth-d p (fx- n 1) jolt-nil))))
@@ -151,8 +222,11 @@
     (cond
       ((fx=? cnt 0) (jolt-throw (jolt-host-throwable "java.lang.IllegalStateException" "Can't pop empty vector")))
       ((fx=? cnt 1) empty-pvec)
-      ((fx>? (fx- cnt (pv-tailoff cnt)) 1)
+      ((fx>? (vector-length (pvec-tail p)) 1)
        (mk-pvec (fx- cnt 1) shift (pvec-root p) (vec-drop-last (pvec-tail p)) #f))
+      ((rrbnode? (pvec-root p))
+       ;; relaxed trie: pop is a slice — O(log n) via the take machinery
+       (pvec-slice p 0 (fx- cnt 1)))
       (else
        (let* ((new-tail (pv-chunk-for p (fx- cnt 2)))
               (popped (pv-pop-tail cnt shift (pvec-root p)))
@@ -180,15 +254,375 @@
   (let* ((cnt (pvec-cnt p)) (out (make-vector cnt)))
     (let loop ((i 0))
       (if (fx<? i cnt)
-          (let* ((chunk (pv-chunk-for p i)) (clen (vector-length chunk)))
-            (let cloop ((j 0) (k i))
-              (if (and (fx<? j clen) (fx<? k cnt))
-                  (begin (vector-set! out k (vector-ref chunk j)) (cloop (fx+ j 1) (fx+ k 1)))
-                  (loop k))))
+          (let-values (((chunk off) (pv-leaf-for p i)))
+            (let ((run (fxmin (fx- (vector-length chunk) off) (fx- cnt i))))
+              (let cloop ((j 0))
+                (if (fx<? j run)
+                    (begin (vector-set! out (fx+ i j) (vector-ref chunk (fx+ off j))) (cloop (fx+ j 1)))
+                    (loop (fx+ i run))))))
           out))))
 (define (jolt-vector . xs) (make-pvec (list->vector xs)))
 (define (make-map-entry k v) (make-pvec (vector k v) #t))
 (define (jolt-map-entry? x) (and (pvec? x) (pvec-ent x) #t))
+
+;; ============================================================================
+;; RRB concat / slice — O(log n) pvec-catvec and pvec-slice
+;;
+;; The concat/rebalance plan, size-table search, and take/drop node surgery are
+;; ported from Racket's treelist (racket/collects/racket/treelist.rkt, MIT or
+;; Apache-2.0), adapted to this file's node shapes: leaves are element chunks,
+;; regular branches are Scheme vectors, relaxed branches are rrbnode records,
+;; and the vector keeps Clojure's tail (treelist has none; the tail seam
+;; follows clojure/core.rrb-vector, with L'orange's RRB thesis arbitrating).
+;; Levels are in SHIFT BITS like the rest of this file: leaves at 0, a node's
+;; children one pv-bits step down.
+;; ============================================================================
+
+;; children of a slot, viewing a leaf as a chunk of "children" (its elements)
+(define (rrb-slot-children n) (if (rrbnode? n) (rrbnode-children n) n))
+(define (rrb-nslots n) (vector-length (rrb-slot-children n)))
+(define (rrb-first-child n) (vector-ref (rrb-slot-children n) 0))
+(define (rrb-last-child n)
+  (let ((cs (rrb-slot-children n))) (vector-ref cs (fx- (vector-length cs) 1))))
+
+(define (vec-append a b)
+  (let* ((na (vector-length a)) (nb (vector-length b)) (out (make-vector (fx+ na nb))))
+    (let loop ((i 0)) (when (fx<? i na) (vector-set! out i (vector-ref a i)) (loop (fx+ i 1))))
+    (let loop ((i 0)) (when (fx<? i nb) (vector-set! out (fx+ na i) (vector-ref b i)) (loop (fx+ i 1))))
+    out))
+(define (vec-drop-first v) (vec-copy-range v 1 (vector-length v)))
+
+;; elements in a subtree
+(define (rrb-subtree-count node level)
+  (cond
+    ((fx=? level 0) (vector-length node))
+    ((rrbnode? node)
+     (let ((sizes (rrbnode-sizes node))) (vector-ref sizes (fx- (vector-length sizes) 1))))
+    (else
+     ;; leftwise dense: all but the last child are full for their level
+     (fx+ (fxsll (fx- (vector-length node) 1) level)
+          (rrb-subtree-count (rrb-last-child node) (fx- level pv-bits))))))
+
+;; build a branch at `level` from a children vector: leftwise-dense children
+;; stay a plain radix-addressed vector, anything else gets a size table.
+(define (rrb-mk-node children level)
+  (if (fx=? level 0)
+      children
+      (let* ((n (vector-length children))
+             (sizes (make-vector n))
+             (mask (fx- (fxsll 1 level) 1)))
+        (let loop ((i 0) (sum 0) (dense? #t))
+          (if (fx<? i n)
+              (let ((new-sum (fx+ sum (rrb-subtree-count (vector-ref children i) (fx- level pv-bits)))))
+                (vector-set! sizes i new-sum)
+                (loop (fx+ i 1) new-sum (and dense? (fx=? 0 (fxand sum mask)))))
+              (if dense? children (make-rrbnode sizes children)))))))
+
+;; push a full 32-wide tail leaf down the rightmost spine of a relaxed trie;
+;; #f when every node on the spine is full (caller grows the root).
+(define (rrb-push-leaf node level leaf)
+  (cond
+    ((fx=? level pv-bits)
+     (if (fx<? (rrb-nslots node) pv-width)
+         (rrb-mk-node (vec-snoc (rrb-slot-children node) leaf) level)
+         #f))
+    (else
+     (let* ((cs (rrb-slot-children node)) (n (vector-length cs))
+            (pushed (and (fx>? n 0)
+                         (rrb-push-leaf (vector-ref cs (fx- n 1)) (fx- level pv-bits) leaf))))
+       (cond
+         (pushed (rrb-mk-node (vec-set cs (fx- n 1) pushed) level))
+         ((fx<? n pv-width)
+          (rrb-mk-node (vec-snoc cs (pv-new-path (fx- level pv-bits) leaf)) level))
+         (else #f))))))
+
+;; --- concat ------------------------------------------------------------------
+(define (rrb-merge-nodes left center-slots right)
+  (vec-append (if left (vec-drop-last (rrb-slot-children left)) (vector))
+              (vec-append center-slots
+                          (if right (vec-drop-first (rrb-slot-children right)) (vector)))))
+
+;; redistribution plan over slots that temporarily exceed 32 children:
+;; #f when already within ceil(count/32)+2 slots (the RRB search-step bound).
+(define (rrb-concat-plan slots)
+  (let* ((n (vector-length slots))
+         (plan (make-vector n))
+         (child-count (let loop ((i 0) (c 0))
+                        (if (fx<? i n)
+                            (let ((sz (rrb-nslots (vector-ref slots i))))
+                              (vector-set! plan i sz)
+                              (loop (fx+ i 1) (fx+ c sz)))
+                            c)))
+         (optimal (fxquotient (fx+ child-count pv-width -1) pv-width))
+         (target (fx+ optimal 2)))
+    (if (fx>=? target n) #f (rrb-distribute plan target n))))
+
+(define (rrb-distribute plan target count)
+  (let loop ((count count) (node-idx 0))
+    (if (fx>=? target count)
+        (vec-take plan count)
+        (let* ((init-i (let short ((i node-idx))
+                         (if (fx<? (vector-ref plan i) (fx- pv-width 1)) i (short (fx+ i 1)))))
+               (i (let dist ((i init-i) (r (vector-ref plan init-i)))
+                    (if (fx=? r 0)
+                        i
+                        (let ((min-size (fxmin (fx+ r (vector-ref plan (fx+ i 1))) pv-width)))
+                          (vector-set! plan i min-size)
+                          (dist (fx+ i 1)
+                                (fx- (fx+ r (vector-ref plan (fx+ i 1))) min-size)))))))
+          ;; one slot was absorbed: close the gap
+          (let move ((j i))
+            (when (fx<? j (fx- count 1))
+              (vector-set! plan j (vector-ref plan (fx+ j 1))) (move (fx+ j 1))))
+          (loop (fx- count 1) (fxmax 0 (fx- i 1)))))))
+
+(define (rrb-exec-plan slots plan sl)     ; sl = the slots' own level
+  (if (not plan)
+      slots
+      (let* ((ns (vector-length slots))
+             (flat-size (let loop ((i 0) (s 0))
+                          (if (fx<? i ns) (loop (fx+ i 1) (fx+ s (rrb-nslots (vector-ref slots i)))) s)))
+             (flat (make-vector flat-size)))
+        (let fill ((i 0) (k 0))
+          (when (fx<? i ns)
+            (let* ((cs (rrb-slot-children (vector-ref slots i))) (n (vector-length cs)))
+              (let cp ((j 0)) (when (fx<? j n) (vector-set! flat (fx+ k j) (vector-ref cs j)) (cp (fx+ j 1))))
+              (fill (fx+ i 1) (fx+ k n)))))
+        (let* ((np (vector-length plan)) (out (make-vector np)))
+          (let build ((i 0) (sum 0))
+            (if (fx<? i np)
+                (let ((w (vector-ref plan i)))
+                  (vector-set! out i (rrb-mk-node (vec-copy-range flat sum (fx+ sum w)) sl))
+                  (build (fx+ i 1) (fx+ sum w)))
+                out))))))
+
+;; merge `left`'s children (but its last), `center`'s, and `right`'s (but its
+;; first) into <=32-slot nodes; -> (values node level), growing a level when
+;; the redistributed slots still exceed one node.
+(define (rrb-rebalance left center right level level-c)
+  (let* ((sl (fx- level pv-bits))
+         (center-slots (if (fx<? level-c level) (vector center) (rrb-slot-children center)))
+         (all-slots (rrb-merge-nodes left center-slots right))
+         (plan (rrb-concat-plan all-slots))
+         (slots (rrb-exec-plan all-slots plan sl)))
+    (if (fx<=? (vector-length slots) pv-width)
+        (values (rrb-mk-node slots level) level)
+        (let ((nl (vec-take slots pv-width))
+              (nr (vec-copy-range slots pv-width (vector-length slots))))
+          (values (rrb-mk-node (vector (rrb-mk-node nl level) (rrb-mk-node nr level))
+                               (fx+ level pv-bits))
+                  (fx+ level pv-bits))))))
+
+;; concatenate two subtrees; -> (values node level)
+(define (rrb-concat-subtree left ls right rs)
+  (cond
+    ((fx>? ls rs)
+     (let-values (((mid ml) (rrb-concat-subtree (rrb-last-child left) (fx- ls pv-bits) right rs)))
+       (rrb-rebalance left mid #f ls ml)))
+    ((fx<? ls rs)
+     (let-values (((mid ml) (rrb-concat-subtree left ls (rrb-first-child right) (fx- rs pv-bits))))
+       (rrb-rebalance #f mid right rs ml)))
+    ((fx=? ls 0)
+     (if (fx<=? (fx+ (vector-length left) (vector-length right)) pv-width)
+         (values (vec-append left right) 0)
+         (values (rrb-mk-node (vector left right) pv-bits) pv-bits)))
+    (else
+     (let-values (((mid ml) (rrb-concat-subtree (rrb-last-child left) (fx- ls pv-bits)
+                                                (rrb-first-child right) (fx- rs pv-bits))))
+       (rrb-rebalance left mid right ls ml)))))
+
+;; --- take / drop -------------------------------------------------------------
+;; keep elements [0, i] of the subtree (i relative, inclusive)
+(define (rrb-take-node node level i)
+  (cond
+    ((fx=? level 0) (vec-take node (fx+ (fxand i pv-mask) 1)))
+    ((rrbnode? node)
+     (let* ((i (fxand i (fx- (fxsll 1 (fx+ level pv-bits)) 1)))   ; see pv-leaf-for
+            (sizes (rrbnode-sizes node))
+            (k (rrb-find-child sizes i))
+            (sub (if (fx=? k 0) i (fx- i (vector-ref sizes (fx- k 1)))))
+            (children (rrbnode-children node))
+            (new-child (rrb-take-node (vector-ref children k) (fx- level pv-bits) sub))
+            (new-children (vec-take children (fx+ k 1))))
+       (vector-set! new-children k new-child)
+       (if (fx=? (vector-length new-children) 1)
+           new-children                       ; a single child radix-addresses as slot 0
+           (let ((new-sizes (vec-take sizes (fx+ k 1))))
+             (vector-set! new-sizes k (fx+ i 1))
+             (make-rrbnode new-sizes new-children)))))
+    (else
+     (let* ((k (fxand (fxsra i level) pv-mask))
+            (new-child (rrb-take-node (vector-ref node k) (fx- level pv-bits) i))
+            (new-children (vec-take node (fx+ k 1))))
+       (vector-set! new-children k new-child)
+       new-children))))                       ; prefix children untouched => stays leftwise dense
+
+;; drop the first i elements of the subtree (i relative)
+(define (rrb-drop-node node level i)
+  (cond
+    ((fx=? level 0) (vec-copy-range node (fxand i pv-mask) (vector-length node)))
+    ((rrbnode? node)
+     (let* ((i (fxand i (fx- (fxsll 1 (fx+ level pv-bits)) 1)))   ; see pv-leaf-for
+            (sizes (rrbnode-sizes node))
+            (k (rrb-find-child sizes i))
+            (sub (if (fx=? k 0) i (fx- i (vector-ref sizes (fx- k 1)))))
+            (children (rrbnode-children node))
+            (new-child (rrb-drop-node (vector-ref children k) (fx- level pv-bits) sub))
+            (new-children (vec-copy-range children k (vector-length children))))
+       (vector-set! new-children 0 new-child)
+       (if (fx=? (vector-length new-children) 1)
+           new-children
+           (let* ((old-len (vector-length sizes))
+                  (new-len (fx- old-len k))
+                  (new-sizes (make-vector new-len)))
+             (let loop ((j 0))
+               (when (fx<? j new-len)
+                 (vector-set! new-sizes j (fx- (vector-ref sizes (fx+ k j)) i))
+                 (loop (fx+ j 1))))
+             (make-rrbnode new-sizes new-children)))))
+    (else
+     (let* ((k (fxand (fxsra i level) pv-mask))
+            (new-child (rrb-drop-node (vector-ref node k) (fx- level pv-bits) i))
+            (new-children (vec-copy-range node k (vector-length node)))
+            (new-len (vector-length new-children)))
+       (vector-set! new-children 0 new-child)
+       (if (fx=? new-len 1)
+           new-children
+           (let ((size0 (rrb-subtree-count new-child (fx- level pv-bits)))
+                 (step (fxsll 1 level)))
+             (if (fx=? size0 step)
+                 new-children                 ; dropped whole subtrees: still leftwise dense
+                 (let ((new-sizes (make-vector new-len)))
+                   (let loop ((j 0))
+                     (when (fx<? j (fx- new-len 1))
+                       (vector-set! new-sizes j (fx+ size0 (fx* j step)))
+                       (loop (fx+ j 1))))
+                   (vector-set! new-sizes (fx- new-len 1)
+                                (fx+ size0 (fx* (fx- new-len 2) step)
+                                     (rrb-subtree-count (vector-ref new-children (fx- new-len 1))
+                                                        (fx- level pv-bits))))
+                   (make-rrbnode new-sizes new-children)))))))))
+
+;; collapse single-child levels; -> (values node level)
+(define (rrb-squash node level)
+  (if (and (fx>? level 0) (fx=? (rrb-nslots node) 1))
+      (rrb-squash (rrb-first-child node) (fx- level pv-bits))
+      (values node level)))
+
+;; --- pvec boundary -----------------------------------------------------------
+;; the whole vector (tail folded in) as one subtree; -> (values root level)
+(define (pvec->rrb-tree p)
+  (let ((tail (pvec-tail p)) (tailoff (pv-tailoff-of p)))
+    (cond
+      ((fx=? tailoff 0) (values tail 0))
+      ((fx=? (vector-length tail) 0) (values (pvec-root p) (pvec-shift p)))
+      (else (rrb-concat-subtree (pvec-root p) (pvec-shift p) tail 0)))))
+
+;; is this subtree a full classic trie (32-aligned count, plain rightmost
+;; spine)? Plain multi-child nodes are leftwise dense by construction, so a
+;; plain spine + aligned total means every leaf is full and radix-addressed.
+(define (rrb-classic-tree? node level cnt)
+  (and (fx=? 0 (fxand cnt pv-mask))
+       (let spine ((n node) (l level))
+         (cond ((fx=? l 0) #t)
+               ((rrbnode? n) #f)
+               (else (spine (rrb-last-child n) (fx- l pv-bits)))))))
+
+;; classic emission: pull the rightmost leaf back out as the tail so every
+;; classic invariant (tail 1..32, aligned tailoff, full leaves) holds.
+(define (rrb-tree->classic-pvec root level cnt)
+  (let* ((new-tail (let last ((n root) (l level))
+                     (if (fx=? l 0) n (last (rrb-last-child n) (fx- l pv-bits)))))
+         (popped (pv-pop-tail cnt level root))
+         (new-root (or popped pv-empty-node)))
+    (if (and (fx>? level pv-bits) (fx<? (vector-length new-root) 2))
+        (mk-pvec cnt (fx- level pv-bits)
+                 (if (fx=? 0 (vector-length new-root)) pv-empty-node (vector-ref new-root 0))
+                 new-tail #f)
+        (mk-pvec cnt level new-root new-tail #f))))
+
+;; force a size table onto a plain (leftwise-dense) root: a plain-rooted pvec
+;; promises the FULL classic invariants, which a partial last leaf breaks.
+(define (rrb-force-relaxed root level)
+  (if (rrbnode? root)
+      root
+      (let* ((n (vector-length root)) (sizes (make-vector n)))
+        (let loop ((i 0) (sum 0))
+          (if (fx<? i n)
+              (let ((s (fx+ sum (rrb-subtree-count (vector-ref root i) (fx- level pv-bits)))))
+                (vector-set! sizes i s) (loop (fx+ i 1) s))
+              (make-rrbnode sizes root))))))
+
+(define (rrb-tree->pvec root level cnt)
+  (cond
+    ((fx=? cnt 0) empty-pvec)
+    ((fx=? level 0) (mk-pvec cnt pv-bits pv-empty-node root #f))   ; bare leaf: tail-only
+    ((rrb-classic-tree? root level cnt) (rrb-tree->classic-pvec root level cnt))
+    (else (mk-pvec cnt level (rrb-force-relaxed root level) (vector) #f))))
+
+;; --- public entry points -----------------------------------------------------
+(define (pvec-copy-into! out at p)
+  (let ((cnt (pvec-cnt p)))
+    (let loop ((i 0))
+      (when (fx<? i cnt)
+        (let-values (((chunk off) (pv-leaf-for p i)))
+          (let ((run (fxmin (fx- (vector-length chunk) off) (fx- cnt i))))
+            (let cp ((j 0))
+              (when (fx<? j run)
+                (vector-set! out (fx+ at (fx+ i j)) (vector-ref chunk (fx+ off j)))
+                (cp (fx+ j 1))))
+            (loop (fx+ i run))))))))
+
+;; O(log n) structural concatenation
+(define (pvec-catvec a b)
+  (let ((ca (pvec-cnt a)) (cb (pvec-cnt b)))
+    (cond
+      ((fx=? ca 0) b)
+      ((fx=? cb 0) a)
+      ((fx<=? (fx+ ca cb) pv-width)
+       (let ((out (make-vector (fx+ ca cb))))
+         (pvec-copy-into! out 0 a)
+         (pvec-copy-into! out ca b)
+         (mk-pvec (fx+ ca cb) pv-bits pv-empty-node out #f)))
+      (else
+       (let*-values (((ra la) (pvec->rrb-tree a))
+                     ((rb lb) (pvec->rrb-tree b))
+                     ((root level) (rrb-concat-subtree ra la rb lb)))
+         (rrb-tree->pvec root level (fx+ ca cb)))))))
+
+;; O(log n) structural slice [start, end)
+(define (pvec-slice p start end)
+  (let ((start (->idx start)) (end (->idx end)) (cnt (pvec-cnt p)))
+    (cond
+      ((or (not (fixnum? start)) (not (fixnum? end))
+           (fx<? start 0) (fx>? end cnt) (fx>? start end))
+       (jolt-throw (jolt-host-throwable "java.lang.IndexOutOfBoundsException" "slice index out of bounds")))
+      ((and (fx=? start 0) (fx=? end cnt)) p)
+      ((fx=? start end) empty-pvec)
+      ((fx<=? (fx- end start) pv-width)
+       ;; small windows flatten to a tail-only classic vector
+       (let* ((n (fx- end start)) (out (make-vector n)))
+         (let loop ((i start))
+           (when (fx<? i end)
+             (let-values (((chunk off) (pv-leaf-for p i)))
+               (let ((run (fxmin (fx- (vector-length chunk) off) (fx- end i))))
+                 (let cp ((j 0))
+                   (when (fx<? j run)
+                     (vector-set! out (fx+ (fx- i start) j) (vector-ref chunk (fx+ off j)))
+                     (cp (fx+ j 1))))
+                 (loop (fx+ i run))))))
+         (mk-pvec n pv-bits pv-empty-node out #f)))
+      (else
+       (let-values (((root level) (pvec->rrb-tree p)))
+         (let*-values (((root level) (if (fx=? end cnt)
+                                         (values root level)
+                                         (let ((r (rrb-take-node root level (fx- end 1))))
+                                           (rrb-squash r level))))
+                       ((root level) (if (fx=? start 0)
+                                         (values root level)
+                                         (let ((r (rrb-drop-node root level start)))
+                                           (rrb-squash r level)))))
+           (rrb-tree->pvec root level (fx- end start))))))))
 
 ;; ============================================================================
 ;; bitmap HAMT — keys hashed by jolt-hash, leaves compared by jolt=
@@ -616,7 +1050,7 @@
        (cond ((jolt-nil? coll) jolt-nil)          ; RT.nth(nil, i) is nil at any index
       ((pvec? coll) (let ((cnt (pvec-count coll)))
                               (if (and (fixnum? i) (fx>=? i 0) (fx<? i cnt))
-                                  (vector-ref (pv-chunk-for coll i) (fxand i pv-mask))
+                                  (let-values (((chunk off) (pv-leaf-for coll i))) (vector-ref chunk off))
                                   (jolt-throw (jolt-host-throwable "java.lang.IndexOutOfBoundsException" "index out of bounds")))))
              ((string? coll) (if (and (fx>=? i 0) (fx<? i (string-length coll))) (string-ref coll i)
                                  (jolt-throw (jolt-host-throwable "java.lang.IndexOutOfBoundsException" "index out of bounds"))))
@@ -805,17 +1239,22 @@
 (define (jolt-coll=? a b)
   (cond
     ((and (pvec? a) (pvec? b))
+     ;; leaf-run lockstep: a's and b's leaves needn't align (RRB tries have
+     ;; partial leaves), so each stride is the min of both remaining runs.
+     ;; Classic vectors take full-32 strides exactly as before.
      (let ((na (pvec-count a)))
        (and (fx=? na (pvec-count b))
             (let loop ((i 0))
               (if (fx=? i na) #t
-                  (let* ((ca (pv-chunk-for a i))
-                         (cb (pv-chunk-for b i))
-                         (clen (vector-length ca)))
-                    (let cloop ((j 0) (k i))
-                      (if (fx>=? j clen) (loop k)
-                          (and (jolt= (vector-ref ca j) (vector-ref cb j))
-                               (cloop (fx+ j 1) (fx+ k 1)))))))))))
+                  (let*-values (((ca oa) (pv-leaf-for a i))
+                                ((cb ob) (pv-leaf-for b i)))
+                    (let ((run (fxmin (fx- (vector-length ca) oa)
+                                      (fx- (vector-length cb) ob)
+                                      (fx- na i))))
+                      (let cloop ((j 0))
+                        (if (fx>=? j run) (loop (fx+ i run))
+                            (and (jolt= (vector-ref ca (fx+ oa j)) (vector-ref cb (fx+ ob j)))
+                                 (cloop (fx+ j 1))))))))))))
     ((and (pmap? a) (pmap? b))
      (and (fx=? (pmap-cnt a) (pmap-cnt b))
           (pmap-fold a (lambda (k v ok) (and ok (jolt= (pmap-get b k pmap-absent) v))) #t)))

--- a/host/chez/host-table.ss
+++ b/host/chez/host-table.ss
@@ -45,6 +45,10 @@
 ;; map-entry constructor: a 2-elem entry-flagged pvec (map-entry? true, vector?
 ;; false), so sorted-map seq/first produce real map entries that key/val accept.
 (def-var! "jolt.host" "map-entry" make-map-entry)
+;; O(log n) RRB concat / slice over pvec (collections.ss). The stdlib
+;; clojure.core.rrb-vector ns is a thin Clojure layer over these two.
+(def-var! "jolt.host" "catvec" pvec-catvec)
+(def-var! "jolt.host" "slice" pvec-slice)
 ;; The stored entry for k, or nil — the native map's Associative.entryAt. The
 ;; entry's key is the key the MAP holds, which is jolt= to the one probed with but
 ;; is the only one carrying the element's metadata; clojure.core/find reads it.

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -19,6 +19,7 @@ bytes-allocated
 call-on-main-thread
 call-on-main-thread-async
 callable-host?
+catvec
 chez-number-literal
 class-ancestors
 class-bases
@@ -166,6 +167,7 @@ set-static-field!
 set-var!
 sh
 sh-out
+slice
 source-roots
 stash-inline!
 static-member

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -772,8 +772,8 @@
 (define (na-chunk-first s)
   (let ((vb (na-vblock s)))
     (if vb
-        (let* ((pv (car vb)) (i (cseq-ci s)) (end (cdr vb)) (len (fx- end i))
-               (node (pv-chunk-for pv i)) (off (fxand i pv-mask)))
+        (let*-values (((pv) (car vb)) ((i) (cseq-ci s)) ((end) (cdr vb)) ((len) (fx- end i))
+                      ((node off) (pv-leaf-for pv i)))
           (if (fx<=? (fx+ off len) (vector-length node))
               (make-pvec (vec-copy-range node off (fx+ off len)))
               (let ((out (make-vector len)))
@@ -806,9 +806,9 @@
 ;; Leaf resolution mirrors na-chunk-first exactly: one contiguous leaf when the
 ;; block is 32-aligned, per-index reads for the rare window crossing a leaf.
 (define (na-chunk-map-first s g)
-  (let* ((vb (na-vblock s)) (pv (car vb)) (i (cseq-ci s)) (end (cdr vb))
-         (len (fx- end i)) (out (make-vector len))
-         (node (pv-chunk-for pv i)) (off (fxand i pv-mask)))
+  (let*-values (((vb) (na-vblock s)) ((pv) (car vb)) ((i) (cseq-ci s)) ((end) (cdr vb))
+                ((len) (fx- end i)) ((out) (make-vector len))
+                ((node off) (pv-leaf-for pv i)))
     (if (fx<=? (fx+ off len) (vector-length node))
         (let loop ((j 0))
           (if (fx<? j len)
@@ -821,10 +821,10 @@
 ;; Returns the kept-elements chunk pvec, or #f when the whole block is rejected
 ;; (so the caller recurses straight into chunk-rest, emitting no empty cell).
 (define (na-chunk-filter-first s tp keep)
-  (let* ((vb (na-vblock s)) (pv (car vb)) (i (cseq-ci s)) (end (cdr vb))
-         (len (fx- end i)) (out (make-vector len))
-         (node (pv-chunk-for pv i)) (off (fxand i pv-mask))
-         (aligned? (fx<=? (fx+ off len) (vector-length node))))
+  (let*-values (((vb) (na-vblock s)) ((pv) (car vb)) ((i) (cseq-ci s)) ((end) (cdr vb))
+                ((len) (fx- end i)) ((out) (make-vector len))
+                ((node off) (pv-leaf-for pv i))
+                ((aligned?) (fx<=? (fx+ off len) (vector-length node))))
     (let loop ((j 0) (w 0))
       (if (fx<? j len)
           (let ((x (if aligned? (vector-ref node (fx+ off j)) (pvec-nth-d pv (fx+ i j) jolt-nil))))
@@ -926,9 +926,8 @@
           (cond ((jolt-reduced? acc) acc)
                 ((fx>=? i n) acc)
                 (else
-                 (let* ((chunk (pv-chunk-for v i))
-                        (clen (vector-length chunk))
-                        (offset (fxand i pv-mask)))
+                 (let*-values (((chunk offset) (pv-leaf-for v i))
+                        ((clen) (vector-length chunk)))
                    (let inner ((j offset) (k i) (acc acc))
                      (cond ((jolt-reduced? acc) acc)
                            ((fx>=? j clen) (outer k acc))
@@ -937,9 +936,8 @@
           (cond ((jolt-reduced? acc) acc)
                 ((fx>=? i n) acc)
                 (else
-                 (let* ((chunk (pv-chunk-for v i))
-                        (clen (vector-length chunk))
-                        (offset (fxand i pv-mask)))
+                 (let*-values (((chunk offset) (pv-leaf-for v i))
+                        ((clen) (vector-length chunk)))
                    (let inner ((j offset) (k i) (acc acc))
                      (cond ((jolt-reduced? acc) acc)
                            ((fx>=? j clen) (outer k acc))

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -19,6 +19,7 @@ babashka.process.pprint
 clojure.core.async
 clojure.core.async.lab
 clojure.core.protocols
+clojure.core.rrb-vector
 clojure.data
 clojure.datafy
 clojure.instant

--- a/stdlib/clojure/core/rrb_vector.clj
+++ b/stdlib/clojure/core/rrb_vector.clj
@@ -1,0 +1,83 @@
+;; clojure.core.rrb-vector — a thin mapping onto jolt's native RRB pvec.
+;;
+;; The host (host-table.ss) binds jolt.host/catvec and jolt.host/slice to the
+;; O(log n) pvec-catvec / pvec-slice in collections.ss; this namespace exposes
+;; them with the core.rrb-vector API (catvec, subvec, vector, vector-of, vec).
+;; jolt's pvec carries relaxedness in its nodes rather than as a distinct type,
+;; so every result here is an ordinary jolt vector and interops with the rest of
+;; clojure.core without conversion.
+;;
+;; DIVERGENCE from the JVM core.rrb-vector: vector-of. The JVM library packs
+;; primitives into unboxed typed arrays (a genuine gvec). jolt has no per-type
+;; unboxed vector, so vector-of coerces each element where a cast exists
+;; (long/double) and stores a plain vector of the coerced values. The element
+;; type is NOT retained — the result answers :object behavior throughout — so a
+;; :long vector-of holds boxed longs, not packed longs. catvec/subvec over one
+;; stay correct (they are ordinary vectors); only storage density differs.
+;;
+;; subvec here is the RRB slice (jolt.host/slice), NOT clojure.core/subvec
+;; (which copies). Both agree on values for valid ranges.
+;; catvec/subvec delegate to the O(log n) host pvec ops. They are called
+;; fully-qualified (jolt.host/catvec, not :as host) because jolt's compiler
+;; resolves a Prefix/member qualified symbol only against actual namespaces —
+;; an :as alias is treated as a class and fails with "Unknown class". This
+;; matches how the rest of jolt-core references jolt.host.
+(ns clojure.core.rrb-vector)
+
+(defn catvec
+  "Concatenates the given vectors in logarithmic time."
+  ([] [])
+  ([v1] v1)
+  ([v1 v2] (jolt.host/catvec v1 v2))
+  ([v1 v2 v3] (catvec (jolt.host/catvec v1 v2) v3))
+  ([v1 v2 v3 v4] (catvec (jolt.host/catvec v1 v2) (jolt.host/catvec v3 v4)))
+  ([v1 v2 v3 v4 & vn]
+   (apply catvec (jolt.host/catvec (jolt.host/catvec v1 v2) (jolt.host/catvec v3 v4)) vn)))
+
+(defn subvec
+  "Returns a new vector containing the elements of v from start (inclusive)
+  to end (exclusive) in logarithmic time. end defaults to the end of v. The
+  result shares structure with v and does not retain elements outside the
+  range."
+  ([v start] (jolt.host/slice v start (count v)))
+  ([v start end] (jolt.host/slice v start end)))
+
+(defn vector
+  "Creates a new vector containing the args."
+  ([] [])
+  ([x1] [x1])
+  ([x1 x2] [x1 x2])
+  ([x1 x2 x3] [x1 x2 x3])
+  ([x1 x2 x3 x4] [x1 x2 x3 x4])
+  ([x1 x2 x3 x4 & xn] (reduce conj [x1 x2 x3 x4] xn)))
+
+(def ^:private coerce-for
+  {;; jolt casts where it can; the rest keep :object storage.
+   :long long :double double
+   ;; :int/:short/:byte narrow to long on jolt (no fixed-width int vector).
+   :int long :short long :byte long
+   ;; :float widens to double (jolt has no 32-bit float vector).
+   :float double
+   ;; :char/:boolean/:object store as-is.
+   :char identity :boolean identity :object identity})
+
+(defn vector-of
+  "Creates a vector of homogeneous primitive type t, one of :object :int :long
+  :float :double :byte :short :char :boolean. Optionally takes elements.
+
+  Divergence: jolt has no unboxed typed vector, so elements are coerced where a
+  cast exists and stored in a plain (object) vector. See the namespace docstring."
+  ([t] [])
+  ([t x1] (vec (map (coerce-for t) [x1])))
+  ([t x1 x2] (vec (map (coerce-for t) [x1 x2])))
+  ([t x1 x2 x3] (vec (map (coerce-for t) [x1 x2 x3])))
+  ([t x1 x2 x3 x4] (vec (map (coerce-for t) [x1 x2 x3 x4])))
+  ([t x1 x2 x3 x4 & xn]
+   (vec (map (coerce-for t) (list* x1 x2 x3 x4 xn)))))
+
+(defn vec
+  "Returns a vector containing the contents of coll.
+  If coll is a vector, returns it (its tree already carries any relaxedness).
+  Otherwise realizes coll into a vector."
+  [coll]
+  (if (vector? coll) coll (clojure.core/vec coll)))

--- a/test/chez/rrb-property-test.ss
+++ b/test/chez/rrb-property-test.ss
@@ -1,0 +1,232 @@
+;; RRB property gate: pvec-catvec / pvec-slice against a naive list model, with
+;; structural invariants checked after every mutating op. Run:
+;;   chez --script test/chez/rrb-property-test.ss
+;;
+;; Seeded pseudo-random op sequences drive a pool of (model . pvec) pairs
+;; through conj/pop/assoc/nth/catvec/slice/rebuild; after every op the pvec
+;; must equal its model element-for-element through pvec-v, pvec-nth-d, AND the
+;; seq/reduce walk, and every trie node must satisfy the RRB invariants
+;; (cumulative size tables matching subtree counts, child bounds, leftwise
+;; density of plain nodes, classic shape under a plain root). The seed prints
+;; on failure so a red run reproduces.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define total 0) (define fails 0)
+(define (fail! seed step msg)
+  (set! fails (+ fails 1))
+  (printf "FAIL seed=~a step=~a: ~a\n" seed step msg))
+
+;; --- deterministic PRNG (xorshift64*) ---------------------------------------
+(define rng-state 1)
+(define (rng-seed! s) (set! rng-state (if (= s 0) 88172645463325252 s)))
+(define (rng!)
+  (let* ((x rng-state)
+         (x (bitwise-and (bitwise-xor x (bitwise-arithmetic-shift-left x 13)) #xFFFFFFFFFFFFFFFF))
+         (x (bitwise-xor x (bitwise-arithmetic-shift-right x 7)))
+         (x (bitwise-and (bitwise-xor x (bitwise-arithmetic-shift-left x 17)) #xFFFFFFFFFFFFFFFF)))
+    (set! rng-state x)
+    x))
+(define (rnd n) (mod (rng!) n))     ; 0..n-1
+
+;; --- structural invariants ---------------------------------------------------
+;; -> subtree count, raising on any violated invariant
+(define (check-node node level path)
+  (cond
+    ((fx=? level 0)
+     (unless (vector? node) (error 'rrb-check (format "leaf not a vector at ~a" path)))
+     (let ((n (vector-length node)))
+       (unless (and (fx>=? n 1) (fx<=? n 32))
+         (error 'rrb-check (format "leaf width ~a at ~a" n path)))
+       n))
+    ((rrbnode? node)
+     (let* ((sizes (rrbnode-sizes node)) (cs (rrbnode-children node))
+            (n (vector-length cs)))
+       (unless (fx=? n (vector-length sizes))
+         (error 'rrb-check (format "sizes/children length mismatch at ~a" path)))
+       (unless (and (fx>=? n 1) (fx<=? n 32))
+         (error 'rrb-check (format "branch width ~a at ~a" n path)))
+       (let loop ((i 0) (sum 0))
+         (if (fx<? i n)
+             (let ((c (check-node (vector-ref cs i) (fx- level 5) (cons i path))))
+               (unless (fx=? (vector-ref sizes i) (fx+ sum c))
+                 (error 'rrb-check (format "size[~a]=~a, want ~a at ~a"
+                                           i (vector-ref sizes i) (fx+ sum c) path)))
+               (loop (fx+ i 1) (fx+ sum c)))
+             sum))))
+    ((vector? node)
+     ;; plain branch: leftwise dense — all but the last child full for their level
+     (let ((n (vector-length node)) (full (fxsll 1 level)))
+       (unless (and (fx>=? n 1) (fx<=? n 32))
+         (error 'rrb-check (format "plain branch width ~a at ~a" n path)))
+       (let loop ((i 0) (sum 0))
+         (if (fx<? i n)
+             (let ((c (check-node (vector-ref node i) (fx- level 5) (cons i path))))
+               (when (and (fx<? i (fx- n 1)) (fx>? n 1) (not (fx=? c full)))
+                 (error 'rrb-check (format "plain prefix child ~a count ~a (full ~a) at ~a"
+                                           i c full path)))
+               (loop (fx+ i 1) (fx+ sum c)))
+             sum))))
+    (else (error 'rrb-check (format "unknown node kind at ~a" path)))))
+
+(define (check-pvec p)
+  (let* ((cnt (pvec-cnt p)) (tail (pvec-tail p)) (root (pvec-root p))
+         (tailoff (fx- cnt (vector-length tail))))
+    (unless (fx<=? (vector-length tail) 32) (error 'rrb-check "tail too wide"))
+    (when (rrbnode? root)
+      (unless (fx=? (check-node root (pvec-shift p) '()) tailoff)
+        (error 'rrb-check "relaxed root count != tailoff")))
+    (when (and (vector? root) (fx>? (vector-length root) 0))
+      ;; plain root: the full classic contract
+      (unless (fx=? 0 (fxand tailoff 31)) (error 'rrb-check "classic tailoff unaligned"))
+      (unless (fx=? (check-node root (pvec-shift p) '()) tailoff)
+        (error 'rrb-check "classic root count != tailoff"))
+      ;; every classic leaf is full: leftwise density + aligned total makes the
+      ;; last leaf full too, so spot-check the rightmost spine
+      (let spine ((n root) (l (pvec-shift p)))
+        (cond ((fx=? l 0) (unless (fx=? (vector-length n) 32)
+                            (error 'rrb-check "classic partial leaf")))
+              ((rrbnode? n) (error 'rrb-check "rrbnode under classic root"))
+              (else (spine (vector-ref n (fx- (vector-length n) 1)) (fx- l 5))))))
+    #t))
+
+;; --- model equivalence -------------------------------------------------------
+(define (model->vec m) (list->vector m))
+(define (pvec-equal-model? p m seed step)
+  (let* ((mv (model->vec m)) (n (vector-length mv)))
+    (cond
+      ((not (fx=? (pvec-cnt p) n)) (fail! seed step "count mismatch") #f)
+      (else
+       (let ((pv (pvec-v p)))
+         (let loop ((i 0) (ok #t))
+           (cond
+             ((fx=? i n)
+              ;; spot-check random-access agreement too
+              (let spot ((k 0) (ok ok))
+                (if (or (fx=? n 0) (fx=? k 8)) ok
+                    (let ((i (rnd n)))
+                      (if (equal? (pvec-nth-d p i 'missing) (vector-ref mv i))
+                          (spot (fx+ k 1) ok)
+                          (begin (fail! seed step (format "nth mismatch at ~a" i)) #f))))))
+             ((equal? (vector-ref pv i) (vector-ref mv i)) (loop (fx+ i 1) ok))
+             (else (fail! seed step (format "element mismatch at ~a" i)) #f))))))))
+
+(define (check! p m seed step)
+  (set! total (+ total 1))
+  (guard (e (#t (fail! seed step
+                       (format "invariant: ~a"
+                               (if (message-condition? e) (condition-message e) e)))))
+    (check-pvec p))
+  (pvec-equal-model? p m seed step))
+
+;; --- op sequences ------------------------------------------------------------
+(define (fresh-pair size)
+  ;; a classic vector built by conj
+  (let loop ((i 0) (m '()) (p empty-pvec))
+    (if (fx=? i size)
+        (cons (reverse m) p)
+        (loop (fx+ i 1) (cons i m) (pvec-conj p i)))))
+
+(define (list-slice m start end)
+  (let loop ((m m) (i 0) (acc '()))
+    (cond ((fx>=? i end) (reverse acc))
+          ((null? m) (reverse acc))
+          ((fx>=? i start) (loop (cdr m) (fx+ i 1) (cons (car m) acc)))
+          (else (loop (cdr m) (fx+ i 1) acc)))))
+
+(define (run-sequence seed steps)
+  (rng-seed! seed)
+  (let ((pool (make-vector 6)))
+    ;; seed the pool with varied shapes (empty, tail-only, multi-level)
+    (vector-set! pool 0 (fresh-pair 0))
+    (vector-set! pool 1 (fresh-pair (rnd 33)))
+    (vector-set! pool 2 (fresh-pair (fx+ 33 (rnd 200))))
+    (vector-set! pool 3 (fresh-pair (fx+ 1000 (rnd 1500))))
+    (vector-set! pool 4 (fresh-pair (fx+ 40 (rnd 100))))
+    (vector-set! pool 5 (fresh-pair (fx+ 2050 (rnd 100))))
+    (let step-loop ((step 0))
+      (when (fx<? step steps)
+        (let* ((slot (rnd 6)) (pair (vector-ref pool slot))
+               (m (car pair)) (p (cdr pair)) (n (pvec-cnt p))
+               (op (rnd 10)))
+          (when (getenv "RRB_TRACE")
+            (printf "seed ~a step ~a op ~a slot ~a n ~a\n" seed step op slot n))
+          (cond
+            ;; conj
+            ((fx<? op 2)
+             (let* ((x (rnd 100000)) (p2 (pvec-conj p x)) (m2 (append m (list x))))
+               (when (check! p2 m2 seed step) (vector-set! pool slot (cons m2 p2)))))
+            ;; pop
+            ((and (fx=? op 2) (fx>? n 0))
+             (let ((p2 (pvec-pop p)) (m2 (list-slice m 0 (fx- n 1))))
+               (when (check! p2 m2 seed step) (vector-set! pool slot (cons m2 p2)))))
+            ;; assoc
+            ((and (fx=? op 3) (fx>? n 0))
+             (let* ((i (rnd n)) (x (rnd 100000))
+                    (p2 (pvec-assoc p i x))
+                    (m2 (append (list-slice m 0 i) (list x) (list-slice m (fx+ i 1) n))))
+               (when (check! p2 m2 seed step) (vector-set! pool slot (cons m2 p2)))))
+            ;; catvec with another pool entry
+            ((fx<? op 7)
+             (let* ((slot2 (rnd 6)) (pair2 (vector-ref pool slot2))
+                    (p2 (pvec-catvec p (cdr pair2)))
+                    (m2 (append m (car pair2))))
+               (when (check! p2 m2 seed step)
+                 ;; cap growth so sequences stay fast
+                 (when (fx<? (pvec-cnt p2) 60000)
+                   (vector-set! pool slot (cons m2 p2))))))
+            ;; slice
+            ((and (fx<? op 9) (fx>? n 0))
+             (let* ((a (rnd n)) (b (fx+ a (rnd (fx+ 1 (fx- n a)))))
+                    (p2 (pvec-slice p a b))
+                    (m2 (list-slice m a b)))
+               (when (check! p2 m2 seed step) (vector-set! pool slot (cons m2 p2)))))
+            ;; rebuild a fresh classic vector into the slot
+            (else (vector-set! pool slot (fresh-pair (rnd 300)))))
+          (step-loop (fx+ step 1)))))))
+
+;; --- reduce/seq agreement over an RRB'd shape --------------------------------
+;; expose an RRB'd vector to jolt and walk it there: the chunked seq machinery
+;; itself must handle relaxed leaves.
+(define (sum-list m) (fold-left + 0 m))
+(define (check-jolt-walk seed)
+  (let* ((a (fresh-pair 1000)) (b (fresh-pair 700))
+         (cat (pvec-catvec (cdr a) (cdr b)))
+         (sl (pvec-slice cat 137 1391))
+         (m (list-slice (append (car a) (car b)) 137 1391)))
+    (def-var! "user" "__rrb-probe" sl)
+    (set! total (+ total 1))
+    (let ((got (jolt-final-str (jolt-compile-eval "(reduce + 0 __rrb-probe)" "user")))
+          (want (number->string (sum-list m))))
+      (unless (string=? got want)
+        (fail! seed 'reduce (format "jolt reduce got ~a want ~a" got want))))
+    (set! total (+ total 1))
+    (let ((got (jolt-final-str (jolt-compile-eval "(count (filter odd? (map inc __rrb-probe)))" "user")))
+          (want (number->string (length (filter odd? (map (lambda (x) (+ x 1)) m))))))
+      (unless (string=? got want)
+        (fail! seed 'chunk-walk (format "jolt chunked map/filter got ~a want ~a" got want))))
+    (set! total (+ total 1))
+    (let ((got (jolt-final-str (jolt-compile-eval "(= __rrb-probe (vec (seq __rrb-probe)))" "user"))))
+      (unless (string=? got "true")
+        (fail! seed 'seq-roundtrip "seq round-trip not equal")))))
+
+;; --- run ---------------------------------------------------------------------
+(let loop ((seed 1))
+  (when (<= seed 300)
+    (run-sequence seed 40)
+    (loop (+ seed 1))))
+(check-jolt-walk 9001)
+(check-jolt-walk 9002)
+
+;; equality/hash between a classic vector and its RRB'd equal
+(let* ((a (fresh-pair 2000))
+       (halves (pvec-catvec (pvec-slice (cdr a) 0 977) (pvec-slice (cdr a) 977 2000))))
+  (set! total (+ total 1))
+  (unless (jolt-truthy? (jolt=2 (cdr a) halves)) (fail! 9003 'eq "classic != rrb rebuild"))
+  (set! total (+ total 1))
+  (unless (= (jolt-hasheq (cdr a)) (jolt-hasheq halves)) (fail! 9003 'hash "hasheq differs")))
+
+(printf "rrb-property: ~a checks, ~a failures\n" total fails)
+(unless (= fails 0) (exit 1))
+(printf "RRB-PROPERTY OK\n")

--- a/test/chez/rrb-scaling-test.ss
+++ b/test/chez/rrb-scaling-test.ss
@@ -1,0 +1,64 @@
+;; RRB complexity gate: catvec and slice must not be linear in the vector size.
+;; Run:  chez --script test/chez/rrb-scaling-test.ss
+;;
+;; Guards the complexity class, not the machine: both sizes are measured in
+;; ONE process (same heap, same JIT-less substrate), and the assertion is the
+;; n-vs-4n RATIO. An O(log n) op holds the ratio near 1; a rebuild-both-halves
+;; regression puts it near 4. The bound is generous so only the class trips it
+;; (see the readscaling precedent — never assert absolute times).
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define (fresh n)
+  (let loop ((i 0) (p empty-pvec)) (if (fx=? i n) p (loop (fx+ i 1) (pvec-conj p i)))))
+
+(define reps 400)
+
+(define (time-catvec a b)
+  (let loop ((k 0) (best #f))
+    (if (fx=? k 5)
+        best
+        (let ((t0 (real-time)))
+          (do ((i 0 (fx+ i 1))) ((fx=? i reps)) (pvec-catvec a b))
+          (let ((dt (- (real-time) t0)))
+            (loop (fx+ k 1) (if (or (not best) (< dt best)) dt best)))))))
+
+(define (time-slice p)
+  (let ((n (pvec-cnt p)))
+    (let loop ((k 0) (best #f))
+      (if (fx=? k 5)
+          best
+          (let ((t0 (real-time)))
+            (do ((i 0 (fx+ i 1))) ((fx=? i reps))
+              (pvec-slice p (fxquotient n 3) (fx* 2 (fxquotient n 3))))
+            (let ((dt (- (real-time) t0)))
+              (loop (fx+ k 1) (if (or (not best) (< dt best)) dt best))))))))
+
+(define n1 50000)
+(define a1 (fresh n1)) (define b1 (fresh n1))
+(define a4 (fresh (* 4 n1))) (define b4 (fresh (* 4 n1)))
+
+;; warmup
+(pvec-catvec a1 b1) (pvec-catvec a4 b4)
+
+(define cat1 (max 1 (time-catvec a1 b1)))
+(define cat4 (max 1 (time-catvec a4 b4)))
+(define cat-ratio (/ (exact->inexact cat4) cat1))
+
+(define sl1 (max 1 (time-slice (pvec-catvec a1 b1))))
+(define sl4 (max 1 (time-slice (pvec-catvec a4 b4))))
+(define sl-ratio (/ (exact->inexact sl4) sl1))
+
+(printf "rrbscaling: catvec ~ams vs ~ams (x4 size) ratio ~a; slice ~ams vs ~ams ratio ~a\n"
+        cat1 cat4 cat-ratio sl1 sl4 sl-ratio)
+
+(define fails 0)
+(when (>= cat-ratio 2.5)
+  (set! fails (+ fails 1))
+  (printf "FAIL: catvec scales with size (ratio ~a >= 2.5) — linear rebuild is back\n" cat-ratio))
+(when (>= sl-ratio 2.5)
+  (set! fails (+ fails 1))
+  (printf "FAIL: slice scales with size (ratio ~a >= 2.5) — linear rebuild is back\n" sl-ratio))
+(unless (= fails 0) (exit 1))
+(printf "RRB-SCALING OK\n")

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -159,6 +159,16 @@
                    " (= (vec (range 5000)) (jolt.host/image-read \"" tmp "\")))")
     "true")
 
+;; RRB: a catvec result with a relaxed root (>64 elements) dump/restore — the
+;; rrbnode record is an image-format surface (chez-rrbnode-v1, raw-travel).
+;; Uses jolt.host/catvec directly: the gate harness stops before loader.ss, so
+;; a (require 'clojure.core.rrb-vector) is alias-only and cannot load the ns.
+(is "relaxed-root RRB vector round-trips (element equality after restore)"
+    (string-append "(let [c (jolt.host/catvec (vec (range 64)) (vec (range 64 128)))]"
+                   " (jolt.host/image-write! \"" tmp "\" c)"
+                   " (= c (jolt.host/image-read \"" tmp "\")))")
+    "true")
+
 ;; metadata rides along
 (is "metadata preserved"
     (string-append "(do (jolt.host/image-write! \"" tmp "\" (with-meta [1] {:m 1}))"

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -159,12 +159,14 @@
                    " (= (vec (range 5000)) (jolt.host/image-read \"" tmp "\")))")
     "true")
 
-;; RRB: a catvec result with a relaxed root (>64 elements) dump/restore — the
-;; rrbnode record is an image-format surface (chez-rrbnode-v1, raw-travel).
+;; RRB: a catvec result with a relaxed root dump/restore — the rrbnode record
+;; is an image-format surface (chez-rrbnode-v1, raw-travel). The split is 63+65
+;; deliberately: 64+64 rebalances to a fully classic trie (probed), so only a
+;; misaligned seam actually produces the relaxed root this case exists to cover.
 ;; Uses jolt.host/catvec directly: the gate harness stops before loader.ss, so
 ;; a (require 'clojure.core.rrb-vector) is alias-only and cannot load the ns.
 (is "relaxed-root RRB vector round-trips (element equality after restore)"
-    (string-append "(let [c (jolt.host/catvec (vec (range 64)) (vec (range 64 128)))]"
+    (string-append "(let [c (jolt.host/catvec (vec (range 63)) (vec (range 63 128)))]"
                    " (jolt.host/image-write! \"" tmp "\" c)"
                    " (= c (jolt.host/image-read \"" tmp "\")))")
     "true")

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1670,4 +1670,29 @@
   {:suite "spliced-class" :expr "(do (defmacro scv1 [] (list 'quote (resolve 'java.lang.Throwable))) (class? (scv1)))" :expected "true"}
   {:suite "spliced-class" :expr "(do (defmacro scv2 [] `(instance? ~(resolve 'Throwable) (ex-info \"x\" {}))) (scv2))" :expected "true"}
   {:suite "spliced-class" :expr "(do (defmacro scv3 [] `(quote (a ~(resolve 'String) b))) (= java.lang.String (second (scv3))))" :expected "true"}
+
+  ;; clojure.core.rrb-vector — catvec/subvec semantics over the native RRB pvec.
+  ;; (JVM core.rrb-vector is not on the corpus classpath, so these are jolt-only.)
+  {:suite "rrb-vector" :expr "(require '[clojure.core.rrb-vector :as rrb]) (= (rrb/catvec [1 2 3] [4 5 6]) (into [1 2 3] [4 5 6]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/catvec) []))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/catvec [1 2]) [1 2]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/catvec [1 2] [3 4] [5 6]) [1 2 3 4 5 6]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/catvec [1 2 3 4] [5 6] [7 8] [9 10]) [1 2 3 4 5 6 7 8 9 10]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (apply rrb/catvec (mapv vector (range 6))) [0 1 2 3 4 5]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/subvec [0 1 2 3 4 5 6 7 8 9] 3 7) [3 4 5 6]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/subvec [0 1 2 3 4] 2) [2 3 4]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/subvec [1 2 3 4 5 6 7 8 9 0] 0 10) [1 2 3 4 5 6 7 8 9 0]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/subvec [1 2 3] 1 1) []))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (vector? (rrb/catvec (vec (range 100)) (vec (range 100)))))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (seq (rrb/catvec [1 2] [3 4])) '(1 2 3 4)))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (reduce + 0 (rrb/catvec [1 2 3] [4 5 6])) 21))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (reduce + 0 (rrb/subvec (vec (range 1000)) 0 1000)) (reduce + 0 (range 1000))))" :expected "true"}
+  ;; an RRB'd vector (relaxed root) must equal and hash equal to its classic twin.
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (let [c (rrb/catvec (vec (range 64)) (vec (range 64 128))) k (vec (range 128))] (and (= c k) (= (hash c) (hash k)) (= (.hashCode c) (.hashCode k)))))" :expected "true"}
+  ;; nth over a catvec result is element-correct across the join (relaxed leaves).
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (let [c (rrb/catvec (vec (range 50)) (vec (range 50 100)))] (every? true? (map #(= %2 (nth c %1)) (range 100) (range 100)))))" :expected "true"}
+  ;; vector-of coerces per element type where a cast exists; stores a plain vector.
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/vector-of :long 1 2 3) [1 2 3]))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (map type (rrb/vector-of :double 1 2 3)) (repeat 3 Double)))" :expected "true"}
+  {:suite "rrb-vector" :expr "(do (require '[clojure.core.rrb-vector :as rrb]) (= (rrb/vector-of :long) []))" :expected "true"}
 ]

--- a/test/conformance/libs/manifest.edn
+++ b/test/conformance/libs/manifest.edn
@@ -408,14 +408,12 @@
    ;;
    ;; Two things shape the tally below. The suite :bb-gates roughly half its
    ;; assertions (babashka runs the reduced set, and jolt reads :bb branches
-   ;; now), which is where pass 12059 -> 6603 went — fail and error shrank
-   ;; proportionally. And 7 of the 8 load failures are the mk-am wall: fipp's
-   ;; clojure.core.rrb-vector chain reaches Clojure's private ArrayManager
-   ;; machinery, which jolt cannot supply. The RRB work ships a native-backed
-   ;; clojure.core.rrb-vector that replaces the jar (branch feat/rrb-vector);
-   ;; when it lands those namespaces come back. The 8th is jsonista/cheshire,
-   ;; i.e. Jackson.
-   :expect {:tests 209 :pass 6603 :fail 55 :error 34 :load-fail 8}}
+   ;; now) — that is where the old 12059 passes went, with fail and error
+   ;; shrinking proportionally. And the one load failure is malli.util-test's
+   ;; cheshire, i.e. Jackson. The native-backed clojure.core.rrb-vector
+   ;; replaced the jar here, which is what brought the fipp/virhe chain (ten
+   ;; namespaces) back from the old mk-am load-fail wall.
+   :expect {:tests 219 :pass 6737 :fail 55 :error 35 :load-fail 1}}
 
   ;; ---------------------------------------------------------- web
   {:name "ring-codec"


### PR DESCRIPTION
pvec gains relaxed-radix concat and slice — no parallel vector type. The concat plan/rebalance, size-table search, and take/drop node surgery are ported from Racket's treelist (MIT/Apache-2.0, attributed) onto pvec's node shapes, with the tail seam following clojure/core.rrb-vector. Relaxed branches are a dedicated rrbnode record (total discrimination from vector nodes and leaf chunks); a plain-vector root still means the full classic PersistentVector invariants, and every pre-RRB code path runs unchanged on classic vectors. Read paths go through a leaf cursor returning leaf+offset, with the existing per-index fallbacks absorbing relaxed misalignment.

clojure.core.rrb-vector ships in stdlib as a thin layer over the new jolt.host/catvec and jolt.host/slice, embedded via the stdlib-fasl manifest so it shadows the Maven jar — verified against a project depending on org.clojure/core.rrb-vector 0.1.2 in dev source mode AND a built binary. The malli fleet row's mk-am wall falls: load-fail 8 → 1 (the survivor is cheshire/Jackson), the fipp/virhe chain's ten namespaces load again, pass 6603 → 6737 (row re-recorded).

Gates: rrbprop (300 seeded op sequences vs a list model, structural invariants after every op, 10,721 checks) and rrbscaling (n-vs-4n catvec/slice ratios 0.75/1.0 in one process; linear reads ~4), both in ci; stateimage round-trips a genuinely relaxed root (63+65 — 64+64 canonicalizes classic, probed); full make test green; A/B/A perf on collections/seqs/vecops/transducers: B within noise of A1 on all four (0.97–1.00x), under the 1.1x ceiling, A2 drift documented as thermal.

Two port bugs the gates caught, for the record: relaxed nodes below dense ancestors need the incoming index masked to node capacity (treelist hides this in its step function), and the capture-count SRE walk initially missed named groups.