### PR TITLE
examples-smoke: a row for glimmer-tui-example

### DIFF
--- a/ci/examples-smoke.sh
+++ b/ci/examples-smoke.sh
@@ -21,8 +21,8 @@
 # Build-only, and why:
 #   http-client-app  -main hits real HTTPS endpoints — a release must not depend
 #                    on third-party uptime.
-#   fps-demo, glimmer-app, glimmer-gl-app, image-dump-example   GUI/GL; no
-#                    headless test task. (image-dump-example's save/load path is
+#   fps-demo, glimmer-app, glimmer-gl-app, glimmer-tui-example,
+#   image-dump-example   GUI/GL/TUI; no headless test task. (image-dump-example's save/load path is
 #                    covered by the jolt-side stateimage gate.)
 #   hiccup/malli/markdown-app, ray-tracer*  no test task at all.
 set -eu
@@ -54,6 +54,7 @@ ray-tracer-multi rt.render      -
 fps-demo         fps-demo.core  -
 glimmer-app      app.core       -
 glimmer-gl-app   gl-demo.core   -
+glimmer-tui-example tui-demo.core -
 image-dump-example app.core     -
 EOF
 


### PR DESCRIPTION
The v0.7.10 release fleet's examples job failed on manifest drift: glimmer-tui-example is in the examples checkout with no ci/examples-smoke.sh row. Added build-only, like the other glimmer/GUI rows. Verified locally: every example builds, every test task passes, with the 0.7.10-shaped binary.