### PR TITLE
Release fleet: glimmer-gtk checkout and library row

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,9 @@ jobs:
             apt: ''
           - repo: router
             apt: ''
-          - repo: glimmer             # GTK4 widget tree; the suite is headless
+          - repo: glimmer             # reactive core; the suite is headless
+            apt: libgtk-4-1
+          - repo: glimmer-gtk         # its GTK4 backend
             apt: libgtk-4-1
           - repo: glimmer-gl          # + GL geometry/matrix
             apt: libgtk-4-1 libgl1
@@ -483,6 +485,10 @@ jobs:
         with:
           repository: jolt-lang/glimmer
           path: glimmer
+      - uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/glimmer-gtk
+          path: glimmer-gtk
       - uses: actions/checkout@v5
         with:
           repository: jolt-lang/glimmer-gl


### PR DESCRIPTION
The v0.7.10 release's examples job failed a second way once the manifest row landed: glimmer-app, glimmer-gl-app and fps-demo declare jolt-lang/glimmer-gtk as a workspace sibling ({:local/root "../../glimmer-gtk"} — the same provisional pattern as glimmer/glimmer-gl, and the direct local root shadows glimmer-gl's git pin), and the workflow doesn't check that repo out. Adds the checkout next to its siblings and a glimmer-gtk row to the library matrix (suite verified locally on a 0.7.10-shaped binary: 6 tests, 24 assertions, headless, needs libgtk-4-1 like glimmer).