### PR TITLE
resolve answers only for classes the host models

### DIFF
--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -2291,7 +2291,17 @@
            (and (or (string=? nm cn) (string=? nm (hsc-last-segment cn)))
                 root)))))
 (define (rsv-class-for-name nm)
-  (cond ((hc-fq-class-name? nm) (jolt-class-for nm))
+  ;; only classes the host actually MODELS answer — the class graph, a
+  ;; statics/ctor registration, or a deftype. The syntactic dotted-name shape
+  ;; is deliberately not enough: resolve is how tooling feature-detects a class
+  ;; (compliment gates its JDK9 module scanner on resolving
+  ;; java.lang.module.ModuleFinder), and a token for a class jolt cannot back
+  ;; sends such code down paths that then die on the missing pieces. A symbol
+  ;; in code keeps the syntactic model (hc-resolve-global); resolve answers
+  ;; the narrower "does this class exist here".
+  (cond ((and (hc-fq-class-name? nm)
+              (or (jch-known? nm) (host-class-registered? nm)))
+         (jolt-class-for nm))
         ((and (fx>? (string-length nm) 0) (char-upper-case? (string-ref nm 0)))
          (cond ((host-class-has-statics? nm) (jolt-class-for nm))
                ((chez-deftype-simple->tag nm) => jolt-class-for)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -372,6 +372,11 @@
   {:suite "ns" :expr "(nil? (resolve 'NoSuchClassXyz))" :expected "true"}
   {:suite "ns" :expr "(do (def rzc-alias String) (var? (resolve 'rzc-alias)))" :expected "true"}
   {:suite "ns" :expr "(do (deftype RzResT [a]) (class? (resolve 'RzResT)))" :expected "true"}
+  ;; resolve answers only for classes the host MODELS: tooling feature-detects
+  ;; by resolving a class name (compliment's JDK9 gate), so an unmodeled dotted
+  ;; name is nil here where the symbol itself still evaluates syntactically.
+  {:suite "ns" :expr "(nil? (resolve 'java.lang.module.ModuleFinder))" :expected "true"}
+  {:suite "ns" :expr "(nil? (ns-resolve *ns* 'no.such.ClassXyz))" :expected "true"}
   ;; reader conditionals match :bb (ahead of :clj, like babashka); clause order
   ;; still wins when :clj is listed first.
   {:suite "reader-features" :expr "#?(:bb :bb-branch :clj :clj-branch)" :expected ":bb-branch"}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -232,6 +232,12 @@
    :jvm "throws: No reader function for tag foo/bar"
    :jolt "#foo/bar 5 (a tagged literal)"
    :note "The default data-reader tags rather than throwing, like #= reads as data. clojure.edn still throws on an unknown tag."}
+  ;; resolve of a class name jolt does not model answers nil, not a throw.
+  {:category :host-model
+   :behavior "(resolve 'java.lang.module.ModuleFinder)"
+   :jvm "throws ClassNotFoundException"
+   :jolt "nil"
+   :note "resolve answers the narrower \"does this class exist here\" for feature detection (compliment gates its JDK9 scanner on it); a class the host models resolves to the class. The bare symbol still evaluates through the syntactic class model."}
   ;; reader conditionals match :bb, ahead of :clj when the clause is listed first.
   {:category :reader-model
    :behavior "#?(:bb 1 :clj 2)"


### PR DESCRIPTION
The v0.7.10 fleet's nrepl job caught a real #608 regression: resolve's no-var fallback accepted any dotted capitalized name (the syntactic class shape), so it returned a class token for classes jolt cannot back. compliment gates its JDK9 module scanner on (resolve-class ns 'java.lang.module.ModuleFinder) — truthy sent it into Files.walk/Collectors machinery that died with Unknown class Collectors, killing completion wholesale (every candidate set empty, 7 suite failures).

The dotted fallback now requires the class graph or a host registration, like the bare-symbol arm always did. Modeled classes keep resolving ((= (resolve 'java.util.Map) java.util.Map) still holds); unmodeled ones answer nil, which is the feature-detection answer tools want (the JVM throws ClassNotFoundException there — documented in known-divergences). Bare symbols in code keep the syntactic class model.

nrepl suite against a release binary with this fix: 63 tests, 132 assertions, 0 failures (was 7). Full make test green, cts matches baseline.