### PR TITLE
cpcache: never cache a degraded resolution, key the Maven repo location

### DIFF
--- a/host/chez/deps-cpcache-smoke.sh
+++ b/host/chez/deps-cpcache-smoke.sh
@@ -95,6 +95,54 @@ out11="$(run -e nil)"
 yn "5: deleted dep root -> miss" "$(miss "$out11" && echo yes || echo no)"
 yn "5: ...and no error/stacktrace" "$(printf '%s' "$out11" | grep -qi 'exception\|stacktrace\|error building' && echo no || echo yes)"
 
+# 6. a resolution that FAILED to materialize an artifact is never cached.
+#    A :local/root jar that cannot be extracted (corrupt zip — same machinery
+#    as a missing unzip or a full disk) must fail resolution loudly, not
+#    silently drop the root; and once the jar is fixed IN PLACE (the cache
+#    material doesn't fold jar bytes) the next run must resolve it, which it
+#    can only do if the degraded result was never written.
+if command -v python3 >/dev/null 2>&1; then
+  export JOLT_JARLIBS="$tmp/jarlibs"
+  mkdir -p "$tmp/proj2/src/app2"
+  cat > "$tmp/proj2/deps.edn" <<'EOF'
+{:paths ["src"]
+ :deps {local/jarlib {:local/root "libj.jar"}}}
+EOF
+  cat > "$tmp/proj2/src/app2/core.clj" <<'EOF'
+(ns app2.core (:require [libj.core :as j]))
+(defn -main [& _] (println "jarlib" j/y))
+EOF
+  printf 'this is not a zip file\n' > "$tmp/proj2/libj.jar"
+  run2() { JOLT_PWD="$tmp/proj2" JOLT_QUIET=1 JOLT_DEBUG=1 "$JOLT" "$@" 2>&1; }
+  out12="$(run2 -e nil)"
+  yn "6: corrupt jar fails resolution loudly" "$(printf '%s' "$out12" | grep -qi 'could not be resolved' && echo yes || echo no)"
+  python3 -c 'import zipfile,sys; z=zipfile.ZipFile(sys.argv[1],"w"); z.writestr("libj/core.clj","(ns libj.core) (def y 7)"); z.close()' "$tmp/proj2/libj.jar"
+  out13="$(JOLT_PWD="$tmp/proj2" JOLT_QUIET=1 "$JOLT" run -m app2.core 2>&1)"
+  yn "6: fixed jar resolves and loads" "$(printf '%s' "$out13" | tail -1 | grep -q 'jarlib 7' && echo yes || echo no)"
+  unset JOLT_JARLIBS
+else
+  echo "  (skip: python3 not available for case 6)" >&2
+fi
+
+# 7. the env knobs that move where Maven artifacts live select different keys:
+#    a run with JOLT_LOCAL_REPO / JOLT_MVNLIBS / GRENADINE_LOCAL_REPOSITORY set
+#    must not share the unset run's entry (its cached roots would point into
+#    the other location).
+# (direct invocations, not run(): an env prefix on a shell FUNCTION call
+# persists after the call in dash, which would contaminate later cases)
+runenv() { JOLT_PWD="$tmp/proj" JOLT_QUIET=1 JOLT_DEBUG=1 env "$@" "$JOLT" -e nil 2>&1; }
+# case 5 deleted the lib's src root, so re-establish it and a warm entry first.
+mkdir -p "$tmp/lib/src/libx"
+printf '(ns libx.core)\n(def x 42)\n' > "$tmp/lib/src/libx/core.clj"
+run -e nil >/dev/null 2>&1
+out14="$(run -e nil)"; yn "7: baseline hit" "$(hit "$out14" && echo yes || echo no)"
+out15="$(runenv JOLT_LOCAL_REPO="$tmp/alt-repo")"
+yn "7: JOLT_LOCAL_REPO change misses" "$(miss "$out15" && echo yes || echo no)"
+out16="$(runenv JOLT_MVNLIBS="$tmp/alt-mvnlibs")"
+yn "7: JOLT_MVNLIBS change misses" "$(miss "$out16" && echo yes || echo no)"
+out17="$(runenv GRENADINE_LOCAL_REPOSITORY="$tmp/alt-gren")"
+yn "7: GRENADINE_LOCAL_REPOSITORY change misses" "$(miss "$out17" && echo yes || echo no)"
+
 # Dev posture: bin/jolt exports JOLT_AOT_CACHE=0, so the cache is OFF — neither
 # hit nor miss line appears, same gate as the AOT namespace cache. Skipped (not
 # failed) if bin/jolt can't run here.

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -440,12 +440,25 @@
     (do (sh (str "touch " (pr-str (str dir "/.jolt-ok")))) dir)
     (do (warn "failed to extract " jar) nil)))
 
+(defn- extract-or-note!
+  "extract-jar! that records a failed extraction as an unresolvable artifact.
+  The jar is on disk but its source cannot be materialized (unzip missing, disk
+  full) — a failure to OBTAIN the artifact, not a skip. Left silent, the
+  resolution completes without the dep's root and the cpcache persists the
+  degraded roots until the project's .jolt is deleted by hand."
+  [jar dir coord version]
+  (or (extract-jar! jar dir)
+      (do (note-unresolvable! coord version
+                              (str jar " could not be extracted (is unzip installed?)"))
+          nil)))
+
 (defn- ensure-maven
   "Ensure coord@version's JAR is in the local Maven repository (reusing one the
   JVM toolchain already fetched; downloading from Clojars then Central when
   absent) and extract its source beside it. Re-extracts when the jar is newer
-  than the last extraction. Returns the extraction dir, or nil if no repo has the
-  artifact / extraction failed (a non-fatal skip)."
+  than the last extraction. Returns the extraction dir, or nil after recording
+  the artifact as unresolvable (absent from every repo, fetch failures, or a
+  failed extraction) — the expansion reports every one and aborts at its end."
   [coord version]
   (let [group (mvn-group coord) artifact (name coord)
         vdir-rel (str (str/replace group "." "/") "/" artifact "/" version)
@@ -461,7 +474,7 @@
       dir
       (if (and (not legacy) (file-exists? jar))
         (do (info "using " jar-name " from the local Maven repository")
-            (extract-jar! jar dir))
+            (extract-or-note! jar dir coord version))
         ;; ERRORS carries the repos that failed for a reason OTHER than "no such
         ;; artifact". Every repo answering 404 is a real "not found" and says so;
         ;; a reset or a 503 is not, and reporting it as absent sent people
@@ -484,7 +497,7 @@
                   r (http/fetch* (str repo "/" vdir-rel "/" jar-name) jar)]
               (if (= :ok (:outcome r))
                 (do (info "fetching " coord " " version)
-                    (let [d (extract-jar! jar dir)]
+                    (let [d (extract-or-note! jar dir coord version)]
                       ;; legacy layout never keeps the jar; the m2 layout does —
                       ;; that IS the sharing.
                       (when legacy (sh (str "rm -f " (pr-str jar))))
@@ -781,7 +794,7 @@
           ;; jar is newer than the extraction, like a Maven jar.
           (let [dir (jar-extraction-dir path)]
             (if (or (cache-fresh? dir path false)
-                    (extract-jar! path dir))
+                    (extract-or-note! path dir lib path))
               (let [pom (sh-out (str "find " (pr-str dir) "/META-INF -name pom.xml -print -quit 2>/dev/null"))]
                 {:root dir :manifest :mvn :pom (when (and pom (not (str/blank? pom))) pom)})
               {:root nil :manifest :none}))
@@ -1023,11 +1036,16 @@
        "|" runtime-version
        ;; the environment-dependent artifact roots resolution materializes into:
        ;; a run pointed at a different gitlibs/jarlibs (JOLT_GITLIBS — the
-       ;; deps-alias smoke's retry scenarios do exactly this) or a different
-       ;; HOME (the ~/.m2 and ~/.jolt defaults) must not share an entry whose
-       ;; cached roots point into the old location.
+       ;; deps-alias smoke's retry scenarios do exactly this), a different
+       ;; HOME (the ~/.m2 and ~/.jolt defaults), or a moved Maven repo
+       ;; (JOLT_MVNLIBS / JOLT_LOCAL_REPO / GRENADINE_LOCAL_REPOSITORY) must
+       ;; not share an entry whose cached roots point into the old location —
+       ;; the old paths usually still exist, so validation alone won't miss.
        "|" (gitlibs-dir)
        "|" (or (getenv "JOLT_JARLIBS") "")
+       "|" (or (getenv "JOLT_MVNLIBS") "")
+       "|" (or (getenv "JOLT_LOCAL_REPO") "")
+       "|" (or (getenv "GRENADINE_LOCAL_REPOSITORY") "")
        "|" (or (getenv "HOME") "")
        "|" (str/join "|" (for [p (sort local-dep-edns)]
                            (let [b (or (slurp-quiet p) "")]


### PR DESCRIPTION
Closes jolt-mczj (the v0.7.10-hunt cpcache bug).

The incident: a container without unzip resolved a project, every Maven extraction failed with only a warning, and the degraded roots (missing orchard entirely) were written to .jolt/cpcache — and then served on every later run even after the environment was fixed, until .jolt was deleted by hand. The cross-machine-hit theory in the bead doesn't hold (a hit requires exact material equality, and HOME is folded in); the caching of a silently degraded resolution does.

Two changes:
- a failed extraction now collects into the same 'artifacts could not be resolved' report as a fetch failure and aborts resolution (it is a failure to obtain the artifact, per the module's own contract), so nothing degraded is ever cached. Applies to Maven jars and :local/root jars alike.
- the key folds JOLT_MVNLIBS / JOLT_LOCAL_REPO / GRENADINE_LOCAL_REPOSITORY: they move where extractions live, and since the old location usually still exists, the cached-path validation can't catch the switch.

The cpcache smoke grows 5 cases: a corrupt local jar fails loudly and is resolvable after fixing the jar in place (red pre-fix: the broken result was cached and hit), and each env knob selects a different key (red pre-fix: hit). 20/20 green; depssmoke/depsunit/grenadine/mvnhttp green; full make test green.