### PR TITLE
jolt.ffi: public thread-correct errno accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`jolt.ffi/errno` and `errno-message`: a public, thread-correct errno.**
+  errno is a per-thread slot behind a libc function (`__error` on macOS,
+  `__errno_location` on Linux, `_errno` on Windows); the accessor reads the
+  calling thread's slot, so it is right under threads and under fibers
+  (whose syscall and read share a carrier thread). `jolt.io-poller` now
+  reads through it instead of binding the platform pair privately —
+  downstream FFI code no longer has to rediscover that dance. Read it
+  immediately after the failing call; the docstring says why.
+
 - **`jolt.fibers`: the fiber primitive as a public API**, side by side with
   core.async. `spawn` runs a body on the carrier pool and returns the fiber
   handle; `join` waits for its value (parking on a fiber, blocking on a

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -883,6 +883,23 @@ else
   fails=$((fails + 1))
 fi
 
+# jolt.ffi errno — the public thread-correct errno accessor (per-platform
+# thread-local slot; ENOENT/EBADF after failing syscalls, from threads and
+# fibers). Self-checks, one marker; same capture rules as the socket gate.
+errno_out="$($jolt run test/chez/jolt-ffi-errno-test.clj 2>&1)"
+if printf '%s' "$errno_out" | grep -q 'JOLT-FFI-ERRNO-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.ffi errno"
+  if printf '%s\n' "$errno_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$errno_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$errno_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$errno_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # jolt.fibers — the public lower-level fiber API (spawn/join/monitor!, states,
 # knobs) over the carrier pool. Self-checks, one marker; same capture rules as
 # the socket gate above.

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -72,3 +72,39 @@
                (list 'jolt.ffi/__ccallable f argtypes rettype :collect-safe)
                (list 'jolt.ffi/__ccallable f argtypes rettype))]
     (list 'jolt.ffi/register-export name addr)))
+
+;; -- errno --------------------------------------------------------------------
+;; errno is a PER-THREAD slot behind a libc function on every platform jolt
+;; runs on: __error on macOS, __errno_location on Linux, _errno on Windows
+;; (ucrt). Each returns the calling thread's &errno, so reading through it is
+;; correct under threads — and under fibers, whose syscall and errno read both
+;; run on the fiber's carrier thread. A global cell would be wrong the moment
+;; two threads made syscalls. The foreign-procedure form is created lazily on
+;; first call, so declaring all three is safe; errno calls the live one.
+;;
+;; Read it IMMEDIATELY after the failing call: anything that can enter the
+;; runtime between the call and the read — an allocation, a park, another FFI
+;; call — may make a syscall of its own and overwrite the slot.
+(defcfn c-errno-location "__errno_location" [] :pointer)
+(defcfn c-error-location "__error" [] :pointer)
+(defcfn c-errno-msvc "_errno" [] :pointer)
+(defcfn c-strerror "strerror" [:int] :string)
+
+(def ^:private errno-loc
+  (case (System/getProperty "os.name")
+    "Mac OS X" c-error-location
+    "Windows"  c-errno-msvc
+    c-errno-location))
+
+(defn errno
+  "The calling thread's errno, read through the platform's thread-local
+  accessor. Read it immediately after the failing foreign call — any
+  intervening call into the runtime can overwrite the slot."
+  []
+  (jolt.ffi/read (errno-loc) :int 0))
+
+(defn errno-message
+  "strerror's description of errno code e; with no argument, of the current
+  errno."
+  ([] (errno-message (errno)))
+  ([e] (c-strerror e)))

--- a/stdlib/jolt/io_poller.clj
+++ b/stdlib/jolt/io_poller.clj
@@ -68,11 +68,6 @@
 
 ;; -- syscalls -----------------------------------------------------------------
 (ffi/defcfn c-fcntl "fcntl" [:int :int :varargs :int] :int)
-;; macOS exposes the errno slot via __error, Linux via __errno_location. The
-;; foreign-procedure form is created lazily on first call (emit-ffi-fn), so
-;; declaring both is safe; errno picks the live one per platform.
-(ffi/defcfn c-errno-loc "__errno_location" [] :pointer)
-(ffi/defcfn c-error-loc "__error" [] :pointer)
 (ffi/defcfn c-close "close" [:int] :int)
 (ffi/defcfn c-pipe "pipe" [:pointer] :int)
 (ffi/defcfn c-write "write" [:int :pointer :size_t] :ssize_t)
@@ -88,7 +83,7 @@
 (ffi/defcfn c-epoll-wait "epoll_wait" [:int :pointer :int :int] :int :blocking)
 
 ;; -- fd helpers (the socket layer's syscall surface) ---------------------------
-(defn errno [] (ffi/read (if macos? (c-error-loc) (c-errno-loc)) :int 0))
+(defn errno [] (ffi/errno))
 (defn eagain? [] (= EAGAIN (errno)))
 (defn eintr? [] (= EINTR (errno)))
 (defn connect-pending? [e] (or (= EINPROGRESS e) (= EALREADY e)))

--- a/test/chez/jolt-ffi-errno-test.clj
+++ b/test/chez/jolt-ffi-errno-test.clj
@@ -1,0 +1,57 @@
+;; jolt.ffi errno gate (epic jolt-of08.2) — the public thread-correct errno
+;; accessor. errno is a per-thread slot behind a libc function (__error on
+;; macOS, __errno_location on Linux), so reading it from the calling thread is
+;; the only correct way; a global would be wrong under threads.
+;; Run: bin/jolt run test/chez/jolt-ffi-errno-test.clj (smoke.sh greps for
+;; "JOLT-FFI-ERRNO-TEST OK").
+(ns jolt-ffi-errno-test)
+
+(require '[jolt.ffi :as ffi])
+(require '[jolt.fibers :as fib])
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; ENOENT is 2 and EBADF is 9 on every platform jolt runs on.
+(ffi/defcfn c-access "access" [:string :int] :int)
+(ffi/defcfn c-close "close" [:int] :int)
+
+;; a failing syscall sets the calling thread's errno; read it immediately
+(let [r (c-access "/definitely/not/here/jolt-errno-gate" 0)]
+  (check-eq "access on a missing path fails" r -1)
+  (check-eq "errno after ENOENT" (ffi/errno) 2))
+
+(let [r (c-close -1)]
+  (check-eq "close(-1) fails" r -1)
+  (check-eq "errno after EBADF" (ffi/errno) 9))
+
+;; another thread's failing call reads through ITS slot, not this thread's
+(check-eq "a thread reads its own errno"
+          @(future (c-access "/also/not/here/jolt-errno-gate" 0) (ffi/errno))
+          2)
+
+;; and on a fiber the carrier thread's slot answers (no park between the call
+;; and the read)
+(check-eq "errno on a fiber"
+          (fib/join (fib/spawn (fn [] (c-close -1) (ffi/errno))))
+          9)
+
+;; errno-message renders a code, and the 0-arity renders the current errno
+(check-eq "errno-message is a string" (string? (ffi/errno-message 2)) true)
+(check-eq "errno-message is non-empty" (pos? (count (ffi/errno-message 2))) true)
+(let [_ (c-close -1)]
+  (check-eq "0-arity errno-message reads the current errno"
+            (ffi/errno-message)
+            (ffi/errno-message 9)))
+
+(if (empty? @failures)
+  (println "JOLT-FFI-ERRNO-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "JOLT-FFI-ERRNO-TEST FAILED:" (count @failures))))


### PR DESCRIPTION
jolt-of08.2 (downstream report epic). errno is a per-thread slot behind a libc function (__error on macOS, __errno_location on Linux, _errno on Windows ucrt); jolt.ffi/errno reads the calling thread's slot through the platform's accessor, so it is right under threads and under fibers. errno-message renders a code via strerror. jolt.io-poller now reads through the public accessor instead of binding the platform pair privately — the exact dance ring-chez-adapter had to reinvent.

Gate: test/chez/jolt-ffi-errno-test.clj — ENOENT/EBADF after failing syscalls from the main thread, a spawned thread, and a fiber — wired into smoke.sh. Full make test green locally.