### PR TITLE
Minimal Class reflection over the modeled hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Minimal Class reflection.** `.getSuperclass`, `.getInterfaces`,
+  `.isAssignableFrom`, and `.isInterface` answer from the one modeled class
+  graph — so the exception chain walks to `Object`, an interface's
+  superclass is nil, and a defrecord reflects like any modeled class. A dot
+  form on a class token whose static member doesn't exist now falls back to
+  the `java.lang.Class` instance methods on the class object, the way JVM
+  Clojure resolves `(.getName String)` — which also makes
+  `(.isAssignableFrom Object …)` reachable. `getSuperclass` on a
+  statics-only shim (`Math`) answers nil where the JVM answers `Object`;
+  tracked.
+
 - **`jolt.ffi/errno` and `errno-message`: a public, thread-correct errno.**
   errno is a per-thread slot behind a libc function (`__error` on macOS,
   `__errno_location` on Linux, `_errno` on Windows); the accessor reads the

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -616,6 +616,26 @@
 (def-var! "jolt.host" "register-class-supers!"
   (lambda (name supers) (jch-register-supers! name (seq->list supers)) jolt-nil))
 
+;; the ONE superclass edge for Class.getSuperclass: the first direct super that
+;; is not an interface, else java.lang.Object for a known concrete class. #f for
+;; Object itself, for interfaces (the JVM's null), and for names the graph does
+;; not model — the caller decides what unknown means (the reflection surface
+;; answers nil there, a recorded divergence for statics-only shims like Math).
+(define (jch-superclass name)
+  (cond
+    ((string=? name "java.lang.Object") #f)
+    ((jch-interface? name) #f)
+    ((not (jch-known? name)) #f)
+    (else
+     ;; prefer a concrete super over Object wherever it sits in the row —
+     ;; a row may list Object ahead of an abstract base.
+     (let loop ((ss (jch-direct-supers name)))
+       (cond ((null? ss) "java.lang.Object")
+             ((or (jch-interface? (car ss))
+                  (string=? (car ss) "java.lang.Object"))
+              (loop (cdr ss)))
+             (else (car ss)))))))
+
 ;; transitive ancestry rooted at Object for a concrete class; an interface's chain
 ;; has no Object (its getSuperclass is null). '() for Object itself.
 (define (jch-ancestors-rooted name)

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1580,6 +1580,27 @@
         ;; Class.isInstance(o) == (instance? class o); core.logic's deftype .equals
         ;; uses (.. this getClass (isInstance o)).
         (cons "isInstance" (lambda (self o) (if (instance-check self o) #t #f)))
+        ;; --- reflection over the jch graph (epic jolt-of08.3) -----------------
+        ;; getSuperclass: the graph's class edge — nil for Object, for an
+        ;; interface (the JVM's null), and for a name the graph does not model
+        ;; (statics-only shims like Math; recorded divergence).
+        (cons "getSuperclass" (lambda (self)
+                                (let ((s (jch-superclass (jclass-name self))))
+                                  (if s (jolt-class-for s) jolt-nil))))
+        ;; getInterfaces: the DIRECT super-interfaces, as a seqable of Class
+        ;; values (the JVM's Class[] surfaces to Clojure as a seq anyway).
+        (cons "getInterfaces" (lambda (self)
+                                (list->cseq
+                                 (map jolt-class-for
+                                      (filter jch-interface?
+                                              (jch-direct-supers (jclass-name self)))))))
+        (cons "isInterface" (lambda (self) (if (jch-interface? (jclass-name self)) #t #f)))
+        ;; isAssignableFrom: the graph's isa?, JVM argument order — self is the
+        ;; wanted supertype. class-key so a deftype ctor or a name string on
+        ;; either side answers too.
+        (cons "isAssignableFrom" (lambda (self other)
+                                   (let ((ka (class-key self)) (kb (class-key other)))
+                                     (if (and ka kb (jch-isa? kb ka)) #t #f))))
         (cons "getConstructors" (lambda (self) (class-constructors self)))
         (cons "getDeclaredConstructors" (lambda (self) (class-constructors self)))
         (cons "getClass" (lambda (self) (make-class-obj "java.lang.Class")))))

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -389,6 +389,20 @@
         (string-append "No such var: " class "/" member)
         (unknown-class-message class))))
 
+;; JVM Clojure resolves (.getName String) — an instance member on a class
+;; token — as a call on the java.lang.Class OBJECT when the class has no such
+;; static. Mirror it: a static-member miss consults the Class instance table
+;; (the "class" tag) and applies the method to the interned class object. Only
+;; the miss paths reach here, so a real static always wins; the unknown-class
+;; arm additionally requires jch-known?, so a typo'd class name still reports
+;; Unknown class instead of answering reflection calls. jolt-class-for is
+;; defined in host-static-classes.ss (loads after us) — resolved at call time.
+(define (class-instance-fallback class member)
+  (let ((h (hashtable-ref host-methods-tbl "class" #f)))
+    (and h
+         (let ((m (hashtable-ref h member #f)))
+           (and m (lambda args (apply m (jolt-class-for class) args)))))))
+
 (define (host-static-ref class member)
   (let ((cell (mutable-static-cell class member #f)))
     (if cell
@@ -396,12 +410,15 @@
         (let ((h (lookup-class class-statics-tbl class)))
           (if h
               (let ((v (hashtable-ref h member #f)))
-                (if v v (throw-jvm (quote IllegalArgumentException) (string-append "No matching field or method: " class "/" member))))
+                (or v
+                    (class-instance-fallback class member)
+                    (throw-jvm (quote IllegalArgumentException) (string-append "No matching field or method: " class "/" member))))
               ;; class miss — autoload a provider (the java.time base, or a
               ;; first-party library that installs the class) and retry once
               (if (or (jt-try-autoload! class) (lib-try-autoload! class))
                   (host-static-ref class member)
-                  (throw-jvm (quote IllegalArgumentException) (static-miss-message class member))))))))
+                  (or (and (jch-known? class) (class-instance-fallback class member))
+                      (throw-jvm (quote IllegalArgumentException) (static-miss-message class member)))))))))
 
 (define (host-static-call class member . args)
   (apply (host-static-ref class member) args))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -883,6 +883,23 @@ else
   fails=$((fails + 1))
 fi
 
+# Class reflection — getSuperclass/getInterfaces/isAssignableFrom/isInterface
+# over the jch graph, and the static-miss fallback to Class instance methods
+# (JVM Clojure's (.getName String) shape). Self-checks, one marker.
+refl_out="$($jolt run test/chez/class-reflect-test.clj 2>&1)"
+if printf '%s' "$refl_out" | grep -q 'CLASS-REFLECT-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: class reflection"
+  if printf '%s\n' "$refl_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$refl_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$refl_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$refl_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # jolt.ffi errno — the public thread-correct errno accessor (per-platform
 # thread-local slot; ENOENT/EBADF after failing syscalls, from threads and
 # fibers). Self-checks, one marker; same capture rules as the socket gate.

--- a/test/chez/class-reflect-test.clj
+++ b/test/chez/class-reflect-test.clj
@@ -1,0 +1,68 @@
+;; Class reflection gate (epic jolt-of08.3) — the minimal reflective surface
+;; over the modeled class hierarchy: getSuperclass / getInterfaces /
+;; isAssignableFrom / isInterface, and java.lang.Object as a real token.
+;; Everything answers from the ONE jch graph (class-hierarchy.ss), so a class
+;; a library grafts on is reflectable with no core change.
+;; Run: bin/jolt run test/chez/class-reflect-test.clj (smoke.sh greps for
+;; "CLASS-REFLECT-TEST OK").
+(ns class-reflect-test)
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; java.lang.Object is a real token
+(check-eq "Object resolves to a Class" (class Object) java.lang.Class)
+(check-eq "Object names itself" (.getName Object) "java.lang.Object")
+(check-eq "isa? reaches Object" (isa? String Object) true)
+
+;; getSuperclass walks the class (not interface) edge of the graph
+(check-eq "String's superclass" (.getSuperclass String) Object)
+(check-eq "Object has no superclass" (.getSuperclass Object) nil)
+(check-eq "an interface has no superclass" (.getSuperclass clojure.lang.ISeq) nil)
+(check-eq "exception chain: Arithmetic -> Runtime"
+          (.getSuperclass ArithmeticException) RuntimeException)
+(check-eq "exception chain: Runtime -> Exception"
+          (.getSuperclass RuntimeException) Exception)
+(check-eq "exception chain: Exception -> Throwable"
+          (.getSuperclass Exception) Throwable)
+(check-eq "exception chain: Throwable -> Object"
+          (.getSuperclass Throwable) Object)
+(check-eq "a concrete collection's superclass is the abstract base"
+          (.getSuperclass clojure.lang.PersistentVector) clojure.lang.APersistentVector)
+
+;; getInterfaces: the direct super-interfaces (order is the graph's; compare as a set)
+(check-eq "String's direct interfaces"
+          (set (map #(.getName %) (.getInterfaces String)))
+          #{"java.lang.CharSequence" "java.lang.Comparable"})
+(check-eq "Object has no interfaces" (seq (.getInterfaces Object)) nil)
+
+;; isInterface
+(check-eq "String is not an interface" (.isInterface String) false)
+(check-eq "List is an interface" (.isInterface java.util.List) true)
+(check-eq "ISeq is an interface" (.isInterface clojure.lang.ISeq) true)
+
+;; isAssignableFrom: the graph's isa?, argument order as the JVM has it
+(check-eq "Object assignable from String" (.isAssignableFrom Object String) true)
+(check-eq "String not assignable from Object" (.isAssignableFrom String Object) false)
+(check-eq "CharSequence assignable from String" (.isAssignableFrom CharSequence String) true)
+(check-eq "reflexive" (.isAssignableFrom String String) true)
+(check-eq "Throwable assignable from ex-info's class"
+          (.isAssignableFrom Throwable clojure.lang.ExceptionInfo) true)
+
+;; a defrecord grafts into the graph and reflects like any modeled class
+(defrecord ReflectProbe [x])
+(check-eq "record class assignable to IPersistentMap"
+          (.isAssignableFrom clojure.lang.IPersistentMap ReflectProbe) true)
+(check-eq "record class assignable to Object" (.isAssignableFrom Object ReflectProbe) true)
+
+(if (empty? @failures)
+  (println "CLASS-REFLECT-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "CLASS-REFLECT-TEST FAILED:" (count @failures))))


### PR DESCRIPTION
jolt-of08.3 (downstream report epic). getSuperclass, getInterfaces, isAssignableFrom and isInterface answer from the jch graph: the superclass edge is the first non-interface direct super (Object for a known concrete class), interfaces and Object have a nil superclass, getInterfaces is the direct super-interfaces as a seqable of Class values.

A dot form on a class token whose static member doesn't exist falls back to the java.lang.Class instance methods applied to the interned class object — how JVM Clojure resolves (.getName String). The unknown-class arm requires jch-known?, so a typo'd class name still reports Unknown class rather than answering reflection calls; verified the statics, member-miss, typo'd-class and var-miss paths all still report as before.

getSuperclass on a statics-only shim (Math) answers nil where the JVM answers Object — jolt-of08.8 tracks registering graph rows for those.

Gate: test/chez/class-reflect-test.clj (23 checks) in smoke.sh. Full make test green locally.