### PR TITLE
System properties: fill the keys libraries sniff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **System properties libraries actually sniff.** `os.arch` answers in the
+  JVM's spelling (`aarch64`/`amd64`), `user.name` comes from the
+  environment, and `os.version` reports the macOS product version
+  (`sw_vers`, what the JVM says there) or the kernel release on Linux —
+  each also present in `(System/getProperties)`. `java.version` stays nil
+  deliberately: jolt has no JDK to report, and claiming one would activate
+  JVM-only code paths in libraries that parse it.
+
 - **Minimal Class reflection.** `.getSuperclass`, `.getInterfaces`,
   `.isAssignableFrom`, and `.isInterface` answer from the one modeled class
   graph — so the exception chain walks to `Object`, an interface's

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -750,6 +750,44 @@
     ((macos) "Mac OS X")
     ((windows) "Windows")
     (else "Linux")))
+;; os.arch in the JVM's spelling — libraries parse these exact strings
+;; (aarch64/amd64), not Chez's. An unrecognized arch answers the host tag,
+;; which is at least truthful.
+(define sys-os-arch
+  (case (sa-arch)
+    ((arm64) "aarch64")
+    ((x86-64) "amd64")
+    ((i386) "x86")
+    (else (sa-host-tag))))
+;; user.name: the login name from the environment, as the JVM reports it.
+(define (sys-user-name)
+  (or (getenv "USER") (getenv "LOGNAME") (getenv "USERNAME") jolt-nil))
+;; os.version, computed once on first read: the macOS PRODUCT version
+;; (sw_vers, what the JVM reports there — the kernel release is the wrong
+;; number for "which macOS is this"), the kernel release elsewhere. Windows
+;; has neither command: nil. A failed probe caches "" so it is not retried.
+(define sys-os-version-cache #f)
+(define (sys-os-version-probe cmd)
+  (guard (e (#t #f))
+    (call-with-values
+      (lambda () (sa-run-process cmd (native-transcoder)))
+      (lambda (stdin stdout stderr pid)
+        (let ((s (get-line stdout)))
+          (close-port stdin) (close-port stdout) (close-port stderr)
+          (and (string? s) (> (string-length s) 0) s))))))
+(define (sys-os-version)
+  (cond
+    (sys-os-version-cache
+     (if (string=? sys-os-version-cache "") jolt-nil sys-os-version-cache))
+    ((eq? (sa-os-family) 'windows) jolt-nil)
+    (else
+     (let ((v (or (if (eq? (sa-os-family) 'macos)
+                      (sys-os-version-probe "sw_vers -productVersion")
+                      #f)
+                  (sys-os-version-probe "uname -r")
+                  "")))
+       (set! sys-os-version-cache v)
+       (if (string=? v "") jolt-nil v)))))
 ;; runtime-settable system properties (System/setProperty). A set value wins over
 ;; the built-in defaults below; clearProperty removes it.
 ;; Written at RUN time (System/setProperty) from whatever thread calls it, so the
@@ -791,6 +829,9 @@
          (set-val (hashtable-ref sys-prop-table k #f)))
     (cond (set-val set-val)
           ((string=? k "os.name") sys-os-name)
+          ((string=? k "os.arch") sys-os-arch)
+          ((string=? k "os.version") (sys-os-version))
+          ((string=? k "user.name") (sys-user-name))
           ((string=? k "jolt.version") (jolt-version-string))
           ((string=? k "line.separator") "\n")
           ((string=? k "file.separator") "/")
@@ -805,11 +846,18 @@
           ((pair? dflt) (car dflt))
           (else jolt-nil))))
 (define (sys-properties-map)
-  (let ((base (jolt-hash-map "os.name" sys-os-name "line.separator" "\n" "file.separator" "/"
+  (let ((base (jolt-hash-map "os.name" sys-os-name "os.arch" sys-os-arch
+                             "line.separator" "\n" "file.separator" "/"
                              "path.separator" ":" "java.class.path" (sys-class-path)
                              "jolt.version" (jolt-version-string)
                              "user.dir" (jolt-user-dir) "user.home" (or (getenv "HOME") "")
                              "java.io.tmpdir" (or (getenv "TMPDIR") "/tmp"))))
+    ;; keys whose value can be absent join only when they answer — a JVM
+    ;; Properties never holds a nil value
+    (let ((v (sys-os-version)))
+      (unless (jolt-nil? v) (set! base (jolt-assoc base "os.version" v))))
+    (let ((v (sys-user-name)))
+      (unless (jolt-nil? v) (set! base (jolt-assoc base "user.name" v))))
     (for-each
       (lambda (kv)
         (set! base (jolt-assoc base (car kv) (cdr kv))))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -883,6 +883,22 @@ else
   fails=$((fails + 1))
 fi
 
+# System properties — the JVM-standard keys (os.arch in JVM spelling,
+# user.name, os.version) plus the deliberate nils. Self-checks, one marker.
+props_out="$($jolt run test/chez/sysprops-test.clj 2>&1)"
+if printf '%s' "$props_out" | grep -q 'SYSPROPS-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: system properties"
+  if printf '%s\n' "$props_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$props_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$props_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$props_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # Class reflection — getSuperclass/getInterfaces/isAssignableFrom/isInterface
 # over the jch graph, and the static-miss fallback to Class instance methods
 # (JVM Clojure's (.getName String) shape). Self-checks, one marker.

--- a/test/chez/sysprops-test.clj
+++ b/test/chez/sysprops-test.clj
@@ -1,0 +1,60 @@
+;; System-properties gate (epic jolt-of08.4) — the JVM-standard keys a library
+;; can reasonably sniff. os.arch answers in the JVM's spelling (aarch64/amd64),
+;; user.name from the environment, os.version from the kernel. java.version
+;; stays nil deliberately (jolt has no JDK to report — known divergence);
+;; unknown keys answer nil exactly as the JVM's do.
+;; Run: bin/jolt run test/chez/sysprops-test.clj (smoke.sh greps for
+;; "SYSPROPS-TEST OK").
+(ns sysprops-test)
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; os.arch: the JVM's spelling for the machine we are on
+(check-eq "os.arch is the JVM spelling"
+          (contains? #{"aarch64" "amd64"} (System/getProperty "os.arch"))
+          true)
+
+;; user.name: the login name, as the JVM reports
+(check-eq "user.name matches the environment"
+          (System/getProperty "user.name")
+          (or (System/getenv "USER") (System/getenv "LOGNAME") (System/getenv "USERNAME")))
+
+;; os.version: non-empty version string (Windows has no uname/sw_vers — nil there)
+(check-eq "os.version is non-empty"
+          (if (= "Windows" (System/getProperty "os.name"))
+            true
+            (pos? (count (or (System/getProperty "os.version") ""))))
+          true)
+
+;; the properties map carries the same keys with the same values
+(let [m (System/getProperties)]
+  (check-eq "getProperties has os.arch" (get m "os.arch") (System/getProperty "os.arch"))
+  (check-eq "getProperties has user.name" (get m "user.name") (System/getProperty "user.name"))
+  (check-eq "getProperties has os.version" (get m "os.version") (System/getProperty "os.version")))
+
+;; a set property still wins over the built-in answer, and clearing restores it
+(let [orig (System/getProperty "os.arch")]
+  (System/setProperty "os.arch" "vax")
+  (check-eq "setProperty wins over the builtin" (System/getProperty "os.arch") "vax")
+  (System/clearProperty "os.arch")
+  (check-eq "clearProperty restores the builtin" (System/getProperty "os.arch") orig))
+
+;; deliberate nils stay nil (documented divergence, not an accident)
+(check-eq "java.version is nil" (System/getProperty "java.version") nil)
+(check-eq "an unknown key is nil" (System/getProperty "no.such.property") nil)
+(check-eq "an unknown key takes the default"
+          (System/getProperty "no.such.property" "fallback")
+          "fallback")
+
+(if (empty? @failures)
+  (println "SYSPROPS-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "SYSPROPS-TEST FAILED:" (count @failures))))


### PR DESCRIPTION
jolt-of08.4 (downstream report epic). os.arch answers in the JVM's spelling (aarch64/amd64, from sa-arch), user.name comes from the environment, os.version reports the macOS product version (sw_vers, what the JVM says there) or the kernel release on Linux, cached on first read. All three join getProperties when they answer — a JVM Properties never holds nil. java.version stays nil deliberately: jolt has no JDK to report, and claiming one would flip JVM-only code paths in libraries that parse it (branch on jolt.version or a :jolt reader conditional instead; documented on the site).

Gate: test/chez/sysprops-test.clj in smoke.sh (Windows-tolerant os.version row). Full make test green locally.