### PR TITLE
Add jolt.scheme: the Scheme escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`jolt.scheme`: the Scheme escape hatch.** Call a host Scheme procedure
+  by name (`call`, `proc`, `defsfn`) or evaluate Scheme text
+  (`eval-string`) from any jolt program. The contract is raw — numbers,
+  strings, booleans and chars are shared representations; everything else
+  crosses as whatever it is on the other side, and host values round-trip
+  opaquely. Host-specific by design, and resolution happens at run time,
+  so a tree-shaken binary reports a shaken-out binding as a catchable
+  "no top-level Scheme binding" error rather than a silent nil.
+
 - **System properties libraries actually sniff.** `os.arch` answers in the
   JVM's spelling (`aarch64`/`amd64`), `user.name` comes from the
   environment, and `os.version` reports the macOS product version

--- a/host/chez/compile-eval.ss
+++ b/host/chez/compile-eval.ss
@@ -538,3 +538,39 @@
 (def-var! "clojure.core" "eval"
   (lambda (form) (jolt-compile-eval-form form (chez-current-ns))))
 (def-var! "clojure.core" "load-string" jolt-load-string)
+
+;; --- jolt.scheme: the Scheme escape hatch (epic jolt-of08.6) ------------------
+;; stdlib/jolt/scheme.clj is a thin veneer over these two. The contract is RAW:
+;; nothing is marshaled in either direction — numbers, strings, booleans and
+;; chars are shared representations anyway; everything else crosses as whatever
+;; it is on the other side, and the docs say so. Host-specific by design.
+;;
+;; scheme-proc resolves a top-level Scheme binding at CALL time, through the
+;; adapter's global-reflection seam (sa-baked-global — portcheck pins the raw
+;; top-level-value/bound? primitives to scheme-adapter-runtime.ss). Its #f
+;; sentinel conflates "unbound" with "bound to #f", which is fine here: this
+;; fetches PROCEDURES, and a procedure is never #f. An unbound name answers a
+;; catchable ex-info rather than Chez's raw error, because "you typo'd the
+;; primitive" is the hatch's everyday failure — and in a tree-shaken binary it
+;; is also how a shaken-out primitive reports itself.
+(def-var! "jolt.host" "scheme-proc"
+  (lambda (name)
+    (let ((sym (string->symbol (jolt-need-string name))))
+      (let ((v (sa-baked-global sym)))
+        (or v
+            (jolt-throw (jolt-ex-info
+                         (string-append "no top-level Scheme binding: "
+                                        (symbol->string sym))
+                         (jolt-hash-map (jolt-keyword "name")
+                                        (symbol->string sym)))))))))
+;; scheme-eval-string reads SCHEME text with the Scheme reader (not jolt's) and
+;; evaluates every form, returning the last value; definitions persist in the
+;; interaction environment, where the runtime itself lives.
+(def-var! "jolt.host" "scheme-eval-string"
+  (lambda (s)
+    (let ((p (open-input-string (jolt-need-string s))))
+      (let loop ((last jolt-nil))
+        (let ((form (read p)))
+          (if (eof-object? form)
+              last
+              (loop (eval form))))))))

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -169,6 +169,8 @@ resolve-global
 run-expr-string
 run-interruptible
 run-main-pump
+scheme-eval-string
+scheme-proc
 scheme-version
 set-field!
 set-instant-ctor!

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -883,6 +883,22 @@ else
   fails=$((fails + 1))
 fi
 
+# jolt.scheme — the Scheme escape hatch (call/proc/eval-string/defsfn, raw
+# value contract, catchable errors). Self-checks, one marker.
+scm_out="$($jolt run test/chez/jolt-scheme-test.clj 2>&1)"
+if printf '%s' "$scm_out" | grep -q 'JOLT-SCHEME-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.scheme"
+  if printf '%s\n' "$scm_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$scm_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$scm_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$scm_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # System properties — the JVM-standard keys (os.arch in JVM spelling,
 # user.name, os.version) plus the deliberate nils. Self-checks, one marker.
 props_out="$($jolt run test/chez/sysprops-test.clj 2>&1)"

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -63,6 +63,7 @@ jolt.parser.combinators
 jolt.parser.monad
 jolt.parser.position
 jolt.process
+jolt.scheme
 jolt.socket
 jolt.time.amount
 jolt.time.base

--- a/stdlib/jolt/scheme.clj
+++ b/stdlib/jolt/scheme.clj
@@ -1,0 +1,43 @@
+;; jolt.scheme — the Scheme escape hatch. The portable interop layers (the
+;; Java-shaped shims, jolt.ffi for C, the curated jolt.host seams) cover what
+;; libraries need; this namespace is the level under them: call a host Scheme
+;; procedure by name, or evaluate Scheme text, from any jolt program.
+;;
+;; The contract is RAW — no marshaling layer. Numbers, strings, booleans and
+;; characters are the same representations on both sides and cross untouched;
+;; everything else crosses as whatever it is on the other side. A Scheme
+;; vector arriving in jolt is an opaque host value (hand it back to Scheme to
+;; use it); a jolt collection handed to Scheme is jolt's representation, not a
+;; Scheme list; nil is jolt's nil, not '() and not #f.
+;;
+;; Two caveats. Code using this namespace is HOST-SPECIFIC by design — tied to
+;; the Chez runtime and its primitives, unlike everything else in the stdlib.
+;; And names resolve at RUN time, so a tree-shaken binary only finds what the
+;; kept runtime still carries: a shaken-out binding is a catchable
+;; "no top-level Scheme binding" error, never a silent nil.
+(ns jolt.scheme)
+
+(defn proc
+  "The top-level Scheme procedure named by scheme-name (a string), as a
+  callable value. Resolved now; throws when the name is unbound."
+  [scheme-name]
+  (jolt.host/scheme-proc scheme-name))
+
+(defn call
+  "Resolve the top-level Scheme procedure named by scheme-name and apply it
+  to args. Values cross raw — see the namespace docs."
+  [scheme-name & args]
+  (apply (jolt.host/scheme-proc scheme-name) args))
+
+(defn eval-string
+  "Evaluate s as Scheme text — read with the SCHEME reader, not jolt's — and
+  return the last form's value. Definitions persist in the interaction
+  environment."
+  [s]
+  (jolt.host/scheme-eval-string s))
+
+(defmacro defsfn
+  "Def name to the top-level Scheme procedure named by scheme-name:
+  (defsfn fx+ \"fx+\") then (fx+ 1 2). Resolution happens at load time."
+  [name scheme-name]
+  (list 'def name (list 'jolt.scheme/proc scheme-name)))

--- a/test/chez/jolt-scheme-test.clj
+++ b/test/chez/jolt-scheme-test.clj
@@ -1,0 +1,66 @@
+;; jolt.scheme gate (epic jolt-of08.6) — the Scheme escape hatch: call host
+;; Scheme procedures and evaluate Scheme text from jolt, by decision (we want
+;; interop). The contract is RAW: no marshaling layer — numbers, strings,
+;; booleans and chars are shared representations; anything else crosses as
+;; whatever it is on the other side, and host values round-trip opaquely.
+;; Host-specific and non-portable by design.
+;; Run: bin/jolt run test/chez/jolt-scheme-test.clj (smoke.sh greps for
+;; "JOLT-SCHEME-TEST OK").
+(ns jolt-scheme-test)
+
+(require '[jolt.scheme :as scheme])
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; call: resolve a top-level Scheme procedure by name and apply it
+(check-eq "call +" (scheme/call "+" 1 2) 3)
+(check-eq "call string-append" (scheme/call "string-append" "a" "b") "ab")
+(check-eq "call expt" (scheme/call "expt" 2 10) 1024)
+
+;; proc: the procedure as a value, callable like any jolt fn
+(let [upcase (scheme/proc "char-upcase")]
+  (check-eq "proc is callable" (upcase \a) \A))
+(check-eq "proc composes" (map (scheme/proc "char-upcase") [\a \b]) [\A \B])
+
+;; a host value round-trips opaquely through jolt
+(let [v (scheme/call "vector" 1 2 3)]
+  (check-eq "host value answers its own predicates" (scheme/call "vector?" v) true)
+  (check-eq "host value is not fooled by jolt values" (scheme/call "vector?" [1 2 3]) false)
+  (check-eq "host value reads back" (scheme/call "vector-ref" v 0) 1))
+
+;; eval-string: Scheme text, last form's value; definitions persist
+(check-eq "eval-string" (scheme/eval-string "(let ((x 3)) (* x 14))") 42)
+(check-eq "eval-string multiple forms"
+          (scheme/eval-string "(define jolt-scheme-gate-var 7) jolt-scheme-gate-var")
+          7)
+
+;; booleans cross as booleans
+(check-eq "scheme #t is true" (scheme/call "even?" 4) true)
+(check-eq "scheme #f is false" (scheme/call "even?" 5) false)
+
+;; errors are catchable jolt-side
+(check-eq "an unbound name throws"
+          (try (scheme/call "no-such-procedure-jolt-gate" 1) :no-throw
+               (catch Exception e :threw))
+          :threw)
+(check-eq "a scheme error throws"
+          (try (scheme/call "car" 5) :no-throw
+               (catch Throwable e :threw))
+          :threw)
+
+;; defsfn sugar
+(scheme/defsfn sch-max "max")
+(check-eq "defsfn binds a callable" (sch-max 3 9 5) 9)
+
+(if (empty? @failures)
+  (println "JOLT-SCHEME-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "JOLT-SCHEME-TEST FAILED:" (count @failures))))


### PR DESCRIPTION
jolt-of08.6 (downstream report epic; decision was to expose interop rather than document the absence). Call a host Scheme procedure by name (call/proc/defsfn) or evaluate Scheme text (eval-string) from jolt.

Two host seams in compile-eval.ss: scheme-proc resolves a top-level binding at call time through the portable layer's sa-baked-global (portcheck pins raw top-level-value/bound? to the adapter — the strict lint caught my first version), answering an unbound name with a catchable ex-info, which is also how a tree-shaken binary reports a shaken-out primitive; scheme-eval-string reads with the Scheme reader and returns the last form's value.

The contract is raw: no marshaling either way. Numbers, strings, booleans and chars are shared representations; everything else crosses as-is and host values round-trip opaquely. Host-specific by design; documented as such on the site.

Gate: test/chez/jolt-scheme-test.clj (15 checks) in smoke.sh, which runs against the release binary — proving eval works in a built jolt, not only dev mode. Full make test green locally (including portcheck).