### PR TITLE
Register graph rows for the statics-only shims

### DIFF
--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -396,6 +396,11 @@
 (jch-register-supers! "java.lang.Object" '())
 (jch-register-supers! "java.lang.Class" '())
 (jch-register-supers! "java.lang.Throwable" '())
+;; statics-only shims (no value ever carries these tags, so the rows cannot
+;; shift protocol dispatch) — present so Class.getSuperclass answers Object
+;; as the JVM does, jolt-of08.8
+(jch-register-supers! "java.lang.Math" '())
+(jch-register-supers! "java.lang.System" '())
 (jch-register-supers! "java.lang.Byte" '("java.lang.Number"))
 (jch-register-supers! "java.lang.Short" '("java.lang.Number"))
 ;; java.lang.AutoCloseable / java.io.Closeable / java.io.Flushable — the

--- a/test/chez/class-reflect-test.clj
+++ b/test/chez/class-reflect-test.clj
@@ -56,6 +56,11 @@
 (check-eq "Throwable assignable from ex-info's class"
           (.isAssignableFrom Throwable clojure.lang.ExceptionInfo) true)
 
+;; statics-only shims sit in the graph too (jolt-of08.8): no value carries
+;; their tags, but getSuperclass must answer Object as the JVM does
+(check-eq "Math's superclass" (.getSuperclass Math) Object)
+(check-eq "System's superclass" (.getSuperclass System) Object)
+
 ;; a defrecord grafts into the graph and reflects like any modeled class
 (defrecord ReflectProbe [x])
 (check-eq "record class assignable to IPersistentMap"


### PR DESCRIPTION
jolt-of08.8, the divergence left open by #623: Math and System had no class-hierarchy row (nothing instantiates them, so nothing ever needed one), which made Class.getSuperclass answer nil where the JVM answers Object. Two rows with no supers close it; no value carries these tags, so protocol dispatch cannot shift — verified by the full suite, including the pinned corpus rows.

Two rows added to the reflect gate; statics (Math/sqrt, System/getProperty) probed unchanged.