### PR TITLE
jolt.scheme: (scheme ...) macro for inline Scheme

### DIFF
--- a/stdlib/jolt/scheme.clj
+++ b/stdlib/jolt/scheme.clj
@@ -41,3 +41,59 @@
   (defsfn fx+ \"fx+\") then (fx+ 1 2). Resolution happens at load time."
   [name scheme-name]
   (list 'def name (list 'jolt.scheme/proc scheme-name)))
+
+;; --- (scheme ...): inline Scheme, do-shaped ----------------------------------
+;; The body is READ BY JOLT (the two syntaxes share the s-expression family),
+;; so Scheme spellings jolt's reader rejects are written in jolt spellings and
+;; rendered across: true/false -> #t/#f, \\A -> #\\A, [1 2 3] -> the datum
+;; vector #(1 2 3), nil -> jolt-nil (the runtime's nil value, a bound host
+;; global). Strings, numbers, and ratios print compatibly. Keywords, maps, and
+;; sets have no Scheme reading and are refused at macroexpansion. Reader sugar
+;; that expands to clojure.core calls (@x, syntax-quote) lands as unbound
+;; Scheme names — write (unquote ...) longhand or avoid it.
+
+(def ^:private scheme-char-names
+  {\newline "#\\newline" \space "#\\space" \tab "#\\tab"
+   \return "#\\return" \backspace "#\\backspace" \formfeed "#\\page"})
+
+(defn- form->scheme
+  "Render a jolt-read form as Scheme source text. quoted? tracks whether f
+  sits inside (quote ...)/(quasiquote ...) — it decides only how a VECTOR
+  renders: #(...) is a datum, not an expression, in R6RS, so an expression
+  position gets (quote #(...)) and a datum position the bare literal.
+  (unquote ...) under quasiquote re-enters expression position."
+  ([f] (form->scheme f false))
+  ([f quoted?]
+   (cond
+     (true? f)    "#t"
+     (false? f)   "#f"
+     (nil? f)     "jolt-nil"
+     (symbol? f)  (str f)
+     (string? f)  (pr-str f)
+     (char? f)    (or (get scheme-char-names f) (str "#\\" f))
+     (number? f)  (pr-str f)
+     (vector? f)  (let [datum (str "#(" (apply str (interpose " " (map (fn [x] (form->scheme x true)) f))) ")")]
+                    (if quoted? datum (str "(quote " datum ")")))
+     (seq? f)
+     (let [head (first f)]
+       (cond
+         (and (not quoted?) (= 2 (count f)) (or (= head 'quote) (= head 'quasiquote)))
+         (str "(" head " " (form->scheme (second f) true) ")")
+         (and quoted? (= 2 (count f)) (or (= head 'unquote) (= head 'unquote-splicing)))
+         (str "(" head " " (form->scheme (second f) false) ")")
+         :else
+         (str "(" (apply str (interpose " " (map (fn [x] (form->scheme x quoted?)) f))) ")")))
+     :else (throw (ex-info (str "form has no Scheme rendering: " (pr-str f)
+                                (when (keyword? f) " (keywords are not Scheme syntax)"))
+                           {:form f})))))
+
+(defmacro scheme
+  "Inline Scheme. The body forms are rendered to Scheme source at
+  macroexpansion (see the spellings note above) and evaluated with the host's
+  eval — multiple forms behave like (begin ...), so a define splices into the
+  interaction environment and the LAST form's value is returned, as with do.
+  Values cross on this namespace's raw contract."
+  [& forms]
+  (if (empty? forms)
+    nil
+    (list 'jolt.scheme/eval-string (form->scheme (cons 'begin forms)))))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1708,4 +1708,19 @@
   ;; Appending past the declared cap grows the buffer — a jolt superset (the JVM
   ;; ChunkBuffer throws); portable rows are in the corpus ("chunk-builder API").
   {:suite "chunk-builder overflow" :expr "(let [b (chunk-buffer 2)] (dotimes [i 5] (chunk-append b i)) (let [c (chunk b)] [(count c) (nth c 4)]))" :expected "[5 4]"}
+
+  ;; (scheme ...) — inline Scheme, do-shaped: jolt READS the body (so booleans,
+  ;; chars, and vectors are written in jolt spellings and rendered to Scheme),
+  ;; multiple forms behave like (begin ...) with define splicing, and the last
+  ;; form's value returns on jolt.scheme's raw crossing contract.
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (+ 1 2)))" :expected "3"}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme 1 2 3))" :expected "3"}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (define sm-probe-x 40) (fx+ sm-probe-x 2)))" :expected "42"}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (if true (string-length \"abc\") 0)))" :expected "3"}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (if false 1 (char->integer \\A))))" :expected "65"}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (vector-length [1 2 3])))" :expected "3"}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (symbol->string (car '(alpha beta)))))" :expected "\"alpha\""}
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (jolt.scheme/scheme (let loop ((i 0) (acc 0)) (if (fx=? i 5) acc (loop (fx+ i 1) (fx+ acc i))))))" :expected "10"}
+  ;; a keyword has no Scheme reading — macroexpansion refuses it
+  {:suite "scheme-macro" :expr "(do (require 'jolt.scheme) (try (eval '(jolt.scheme/scheme (list :kw))) :no-throw (catch Exception e :threw)))" :expected ":threw"}
 ]


### PR DESCRIPTION
Inline Scheme, do-shaped: the body is written as Scheme but read by jolt (the two syntaxes share the s-expression family), rendered to Scheme source at macroexpansion, and evaluated through the existing eval-string seam. Multiple forms wrap in (begin ...) so define splices and the last form's value returns.

The renderer owns the spellings jolt's reader owns: true/false -> #t/#f, chars -> #\x with the named set, [1 2 3] -> the datum vector (quoted in expression position — R6RS vector literals are not self-evaluating, which the unit rows caught), nil -> jolt-nil. Keywords, maps, and sets have no Scheme reading and are refused at macroexpansion. Values cross on the namespace's raw contract.

    (scheme (define x 40) (fx+ x 2))                    ; => 42
    (scheme (let loop ((i 0) (acc 0))
              (if (fx=? i 5) acc (loop (fx+ i 1) (fx+ acc i)))))  ; => 10

Nine unit.edn rows pin the semantics. Site docs for jolt.scheme get the macro section when this ships in a release.