### PR TITLE
Resolve a chunk's leaf once per block, not once per element

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 JOLT-TARGETS-NEEDING-DEPS := \
   aotcacheperf aotcachesmoke aotfingerprint asynctimer buildlibsmoke buildsmoke \
   aotcachepathsmoke compilepathsmoke contagion corpus cts dcerefs depssmoke depsunit devboot \
-  readscaling vecscaling pipescaling chunkscaling printscaling ioscaling hotscaling \
+  readscaling vecscaling pipescaling chunkscaling printscaling ioscaling hotscaling seqscaling \
   devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform grenadine \
   gateboot gatebootsmoke gosm httpsfetch infer inline inline-body irvalidate \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
@@ -116,7 +116,7 @@ install: build
 # naming the covered tree is written ONLY on a complete pass. `make gate-status`
 # answers "is this working tree gated?" — which is not something to remember.
 
-CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling ioscaling hotscaling depssmoke depscpcache depsunit \
+CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling ioscaling hotscaling seqscaling depssmoke depscpcache depsunit \
   smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
@@ -395,6 +395,13 @@ chunkscaling: testbin
 # pr-str/str/prn of any collection, record, or sorted coll.
 printscaling: testbin
 	@JOLT_NO_USER_DEPS=1 target/release/jolt run test/print_scaling_test.clj
+
+# Chunk-preserving map/filter must actually PAY: per-element cost over a
+# chunkable source (vector) has to beat the same over a list. They were equal —
+# chunking bought nothing — until cseq-chunked/vec->seq stopped re-deriving each
+# element's leaf. Shape, not an absolute ceiling.
+seqscaling: testbin
+	@JOLT_NO_USER_DEPS=1 target/release/jolt run test/seq_scaling_test.clj
 
 # Draining *in* / with-in-str by lines or forms costs O(input), not
 # O(input x items): the IReader buffer atoms re-copied (and read re-parsed) the

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -47,11 +47,35 @@
 ;; the already-coerced after-chunk seq (cseq | jolt-nil | a jolt-lazyseq), held in
 ;; crest for chunk-rest/chunk-next and forced lazily by the tail thunk at the chunk
 ;; boundary so a chunked map over an infinite chunked source stays productive.
+;; A standalone chunk holds at most 32 elements, so a pvec built from one keeps
+;; every element in its TAIL vector (tailoff 0) and never in the trie. Resolve
+;; that vector ONCE per chunk and read elements out of it directly: pvec-nth-d
+;; re-derives the leaf on every call — bounds checks, an index coercion, a
+;; tailoff computation and a multiple-value return — which measures 13.1ns
+;; against a raw vector-ref's 1.9ns (Chez 10.4.1, 32-element chunk). It runs once
+;; per element of every chunked map/filter result, so it was most of what the
+;; chunked path cost over the per-element path it was supposed to beat.
+;;
+;; The cell's fields are unchanged (chunk/i/rest), so chunk-first / chunk-rest /
+;; chunked-seq? see exactly what they saw before. A chunk whose elements are not
+;; tail-resident — which the callers here never build, but the shape does not
+;; forbid — keeps the general path.
 (define (cseq-chunked chunk i rest)
+  (if (fx=? (pv-tailoff-of chunk) 0)
+      (cseq-chunked/tail chunk (pvec-tail chunk) (pvec-count chunk) i rest)
+      (cseq-chunked/gen chunk i rest)))
+(define (cseq-chunked/tail chunk tv n i rest)
+  (make-cseq (vector-ref tv i)
+             (lambda () (let ((i1 (fx+ i 1)))
+                          (if (fx<? i1 n)
+                              (cseq-chunked/tail chunk tv n i1 rest)
+                              (jolt-seq rest))))
+             #f #f chunk i rest #f))
+(define (cseq-chunked/gen chunk i rest)
   (make-cseq (pvec-nth-d chunk i jolt-nil)
              (lambda () (let ((i1 (fx+ i 1)))
                           (if (fx<? i1 (pvec-count chunk))
-                              (cseq-chunked chunk i1 rest)
+                              (cseq-chunked/gen chunk i1 rest)
                               (jolt-seq rest))))
               #f #f chunk i rest #f))
 (define (seq-first s) (cseq-head s))
@@ -140,9 +164,29 @@
   (if (and (pair? xs) (null? (cdr xs)) (lazy-rest? (car xs)))
       (lazy-rest-seq (car xs))
       (list->cseq xs)))
-(define (vec->seq v i)                 ; chunked index seq over a persistent vector
-  (if (fx>=? i (pvec-count v)) jolt-nil
-      (cseq-vec (pvec-nth-d v i jolt-nil) (lambda () (vec->seq v (fx+ i 1))) v i)))
+;; chunked index seq over a persistent vector. Walking one element at a time
+;; through pvec-nth-d re-descends the trie per element (a full descent once the
+;; vector outgrows its tail); the leaf holding index i also holds the next 31, so
+;; resolve it once and index it directly until the block is exhausted, then
+;; resolve the next. Same cells and same fields as before — cvec/ci still carry
+;; the backing vector and absolute index, so chunk-first/chunk-rest/reduce are
+;; unaffected — only the element read changes.
+(define (vec->seq v i)
+  (let ((n (pvec-count v)))
+    (if (fx>=? i n)
+        jolt-nil
+        (let-values (((leaf off) (pv-leaf-for v i)))
+          (vec->seq/leaf v n leaf off i)))))
+;; leaf: the block holding element i, off: i's offset within it. Advancing stays
+;; in this leaf while the offset is in range, so the descent is paid once per 32.
+(define (vec->seq/leaf v n leaf off i)
+  (cseq-vec (vector-ref leaf off)
+            (lambda ()
+              (let ((i1 (fx+ i 1)) (off1 (fx+ off 1)))
+                (cond ((fx>=? i1 n) jolt-nil)
+                      ((fx<? off1 (vector-length leaf)) (vec->seq/leaf v n leaf off1 i1))
+                      (else (vec->seq v i1)))))
+            v i))
 (define (str->seq s i)
   (if (fx>=? i (string-length s)) jolt-nil
       (cseq-lazy (string-ref s i) (lambda () (str->seq s (fx+ i 1))))))

--- a/test/seq_scaling_test.clj
+++ b/test/seq_scaling_test.clj
@@ -1,0 +1,94 @@
+;; Seq-tier shape gates.
+;;
+;; jolt's map/filter/remove are chunk-preserving: a chunked source has the whole
+;; 32-element chunk realized at once and the result is itself chunked. The point
+;; of doing that is that walking a CHUNKABLE source (vector, range) should cost
+;; less per element than walking an unchunkable one (a list) — the chunk is
+;; resolved once and its elements read straight out of it.
+;;
+;; That was not true. cseq-chunked re-derived the element's leaf through
+;; pvec-nth-d on every element, and vec->seq re-descended the trie per element.
+;; Over a 100k vector that cost 107.4 ns/elem against 79.7 for the same map over
+;; a LIST — so chunking was worse than not chunking. Resolving the leaf once per
+;; 32-block took the vector row to 61.9, i.e. below the list row where it
+;; belongs. (The JVM's equivalents are 16.7 and 49.2 over 32 elements.)
+;;
+;; So the gate is a SHAPE, judged in one process: per-element cost over a vector
+;; must come in under the same over a list. It walks with COUNT rather than
+;; doall — doall retains n cells per repetition, so the two arms end up compared
+;; under different GC pressure and the ratio wanders across runs. An implementation that stops
+;; consuming chunks, or that goes back to re-deriving the leaf per element, makes
+;; the two equal again and fails here. Absolute ns ceilings are deliberately NOT
+;; asserted — they flake across machines and CI (see the readscaling family).
+
+(ns seq-scaling-test)
+
+;; LARGE, and that matters: a vector of 32 keeps every element in its tail array,
+;; so pvec-nth-d never descends the trie and the defect is invisible — the same
+;; probe at n=32 showed 93.8 ns/elem both before and after the fix. The descent
+;; only bites once the vector outgrows its tail, where the fix measured
+;; 107.4 -> 61.9 ns/elem. Before it, map over a 100k VECTOR (107.4) was slower
+;; than over a 100k LIST (79.7): chunking was not merely failing to pay, it was
+;; costing more than walking cons cells.
+(def ^:private n 100000)
+(def ^:private reps 5)
+
+(defn- timed [f]
+  (let [t (System/nanoTime)]
+    (f)
+    (- (System/nanoTime) t)))
+
+(defn- best-of [k f]
+  (f)                                    ; warm before the first sample
+  (reduce min (map (fn [_] (timed f)) (range k))))
+
+(def ^:private failures (atom 0))
+
+(defn- judge [label t-chunkable t-plain ceiling detail]
+  (let [ratio (double (/ t-chunkable (max 1 t-plain)))]
+    (println (format "seq %-22s chunkable %5dms vs plain %5dms, ratio %5.2f (ceiling %.2f)"
+                     label (quot t-chunkable 1000000) (quot t-plain 1000000) ratio ceiling))
+    (when (> ratio ceiling)
+      (println (str "FAIL seq " label ": " detail))
+      (swap! failures inc))))
+
+(defn -main [& _]
+  (let [v (vec (range n))
+        l (apply list (range n))]
+    ;; the two sources must agree on values, or the ratio compares nothing
+    (when-not (and (= (seq v) (seq l))
+                   (= (map inc v) (map inc l))
+                   (= (filter odd? v) (filter odd? l))
+                   (= (count (chunk-first (seq v))) 32)
+                   (chunked-seq? (seq v))
+                   (not (chunked-seq? (seq l))))
+      (println "FAIL seq-scaling: vector and list sources disagree, or the vector source is not chunked")
+      (System/exit 1))
+
+    ;; NOT gated: (seq v) against (seq l). A list IS already a seq, so that side
+    ;; allocates nothing while the vector side must build cells — the comparison
+    ;; measures construction against no construction, not chunking. map/filter
+    ;; below are the fair test: both sides build a fresh cell per element, so the
+    ;; only difference left is whether the source's chunk is exploited.
+
+    ;; the chunk-preserving transforms
+    (judge "map" (best-of 5 #(dotimes [_ reps] (count (map inc v))))
+                 (best-of 5 #(dotimes [_ reps] (count (map inc l))))
+           1.0
+           "chunked map costs as much per element as unchunked map — either map stopped taking the na-chunked-seq? branch, or cseq-chunked is re-deriving the element's leaf per element (host/chez/seq.ss)")
+
+    ;; Coarser than the map section: filter reads 0.84 with the defect present
+    ;; and 0.68 without it, so it passes either way and is a "does this still
+    ;; consume chunks at all" check. MAP is the section that red-proofs the leaf
+    ;; resolution — it goes above 1.00 the moment the per-element descent returns.
+    (judge "filter" (best-of 5 #(dotimes [_ reps] (count (filter odd? v))))
+                    (best-of 5 #(dotimes [_ reps] (count (filter odd? l))))
+           1.0
+           "chunked filter costs as much per element as unchunked filter (host/chez/seq.ss)")
+
+    (if (pos? @failures)
+      (do (println (str "seq-scaling: " @failures " section(s) failed"))
+          (System/exit 1))
+      (println "seq-scaling: passed"))))
+
+(-main)


### PR DESCRIPTION
First increment of epic jolt-r8tz (seq tier).

## What was wrong

jolt's map/filter/remove **already** consume chunks — `map-seq` has an
`na-chunked-seq?` branch, and realization on `(first (map f a-100-vector))` is 32
on both runtimes. The chunking simply wasn't paying for itself: `cseq-chunked`
read every element through `pvec-nth-d`, and `vec->seq` re-descended the trie per
element.

Over a 100k vector that cost **107.4 ns/elem against 79.7** for the same map over
a **list** — chunking was worse than not chunking.

## Fix

A standalone chunk is ≤32 elements and therefore entirely tail-resident, and the
leaf holding element *i* also holds the next 31. Resolve it once per block and
index it directly. `pvec-nth-d` measures 13.1ns against a raw `vector-ref`'s
1.9ns (Chez 10.4.1).

| 100k elements | before | after |
|---|---|---|
| `map inc` over a vector | 107.4 ns/elem | **61.9** (1.73x) |
| `count` of a vector seq | 59.5 | **30.8** (1.93x) |
| `map inc` over a list (untouched) | 79.7 | 81.1 |

The vector row now sits below the list row, which is the property that was
inverted.

## Gate

New `seqscaling`, in CI-GATES. Shape, not an absolute ceiling: per-element cost
over a chunkable source must beat the same over a list.

Two things the gate's design had to get right, both learned the hard way here:

- **n=100000, not 32.** At 32 the whole vector lives in its tail, so there is no
  descent to skip and the defect is invisible — 93.8 ns/elem before *and* after.
  My first version of this gate used 32 and was vacuous.
- **`count`, not `doall`.** `doall` retains n cells per repetition, so the two
  arms get compared under different GC pressure and the ratio wanders.

Red-proofed by reverting only `seq.ss` (with a forced rebuild — `make testbin`
reported "up to date" and quietly measured the fixed binary the first time):
the map section goes above its ceiling. The filter section passes either way
(0.84 → 0.68) and is documented as a coarse still-chunking check, not the sharp
one.

## Correctness

Cell shape and fields unchanged, so chunk-first / chunk-rest / chunked-seq? /
reduce see what they saw before. Verified across trie depths (32 / 100 / 5000
elements), subvec, chunk boundaries, and reverse.

Gates: unit, corpus (0 new divergences), values, selfhost, smoke, shakesmoke,
portcheck, chunkscaling, readscaling, vecscaling, seqscaling.

Still ~3.7x off the JVM on this path (61.9 vs 16.7 at 32 elements); the residual
is bead jolt-r8tz.3.