### PR TITLE
Fiber-parking for jolt.process subprocess pipe reads/writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Fibers R8, extended to `jolt.process`: a subprocess pipe read or write
+  parks the fiber instead of pinning its carrier.** The trick `jolt.socket`
+  already applies to sockets now applies to `proc-fd-input-port` /
+  `proc-fd-output-port` (`host/chez/java/process.ss`): the pipe fd the
+  parent retains is set `O_NONBLOCK` at creation (never poller-gated), and
+  on `EAGAIN` registers readiness with `jolt.io-poller` and parks the
+  current fiber — the carrier runs other fibers meanwhile, and blocks on a
+  private `kevent`/`epoll_wait` exactly as before when there is no fiber
+  (jolt.process's own no-poller fallback keeps working standalone). A
+  working `fcntl` binding for Apple arm64 is what makes the non-blocking fd
+  viable at all: `F_SETFL` is C-variadic, and without the
+  `(__varargs_after 2)` calling-convention marker it reports success but
+  silently never applies the flags. Closing a pipe port now also tells
+  `jolt.io-poller` to forget the fd, mirroring the socket fix below: a
+  closed fd is auto-dropped from the kernel's kqueue/epoll set, so a fiber
+  still parked on it would otherwise wait forever for an event that is
+  never coming. Gated by `test/chez/fibers-process-io-test.ss`, wired into
+  `make fibers` right after the socket half's own gate.
+
 ## [0.7.14] - 2026-08-16
 
 A collections release. The theme running through it is operations that were

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ fibers:
 	@$(CHEZ) --script test/chez/fibers-go-test.ss
 	@$(CHEZ) --script test/chez/fibers-pool-test.ss
 	@$(CHEZ) --script test/chez/fibers-io-test.ss
+	@$(CHEZ) --script test/chez/fibers-process-io-test.ss
 	@$(CHEZ) --script test/chez/fibers-sm-test.ss
 	@$(CHEZ) --script test/chez/fibers-preempt-test.ss
 	@$(CHEZ) --script test/chez/fibers-lock-test.ss

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -413,9 +413,23 @@
   (for-each sa-foreign-free (cdr m))
   (sa-foreign-free (car m)))
 
-;; binary ports over the raw pipe fds. EINTR is retried; any other read error
-;; reads as EOF (the child is gone and the pipe with it). A short write returns
-;; its count and Chez's port machinery re-calls for the rest.
+;; binary ports over the raw pipe fds. EINTR is retried; EAGAIN parks the
+;; current fiber (or blocks this thread) via jolt.io-poller when it's loaded
+;; -- symmetric on both sides below: proc-fd-input-port waits on :read,
+;; proc-fd-output-port waits on :write, over the same mk-pipe-created
+;; non-blocking fd and the same poller-wait-ready bridge. When no poller is
+;; loaded, EAGAIN clears O_NONBLOCK on this fd (fd is genuinely non-blocking
+;; now per mk-pipe above, so a no-poller EAGAIN is a live "not ready yet"
+;; signal, not a real failure) and falls through to a real blocking
+;; proc-c-read/proc-c-write from then on -- exact behavioral parity with
+;; pre-this-plan code once triggered, verified standalone: a blocked
+;; read/write genuinely waits rather than busy-looping or returning a
+;; spurious result. Any OTHER error still ends the port, but the two sides
+;; report it differently -- pre-existing asymmetry, unchanged by this: the
+;; read side reads it as EOF (0, the child is gone and the pipe with it);
+;; the write side raises (child gone, `error 'process "write to child
+;; failed"`). A short write returns its count and Chez's port machinery
+;; re-calls for the rest.
 (define proc-fd-buf-size 32768)
 (define (proc-fd-input-port fd)
   (let ((buf (sa-foreign-alloc proc-fd-buf-size)))
@@ -434,6 +448,13 @@
                  got)
                 ((= got 0) 0)
                 ((= (proc-errno) proc-EINTR) (retry))
+                ((= (proc-errno) proc-EAGAIN)
+                 (if (poller-wait-ready fd (jolt-keyword "read"))
+                     (retry)
+                     (begin
+                       (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
+                         (proc-fcntl-set fd proc-F-SETFL (fxand flags (fxnot proc-O-NONBLOCK))))
+                       (retry))))
                 (else 0))))))
       #f #f
       (lambda () (sa-foreign-free buf) (proc-c-close fd)))))
@@ -452,6 +473,13 @@
               (cond
                 ((>= wrote 0) wrote)
                 ((= (proc-errno) proc-EINTR) (retry))
+                ((= (proc-errno) proc-EAGAIN)
+                 (if (poller-wait-ready fd (jolt-keyword "write"))
+                     (retry)
+                     (begin
+                       (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
+                         (proc-fcntl-set fd proc-F-SETFL (fxand flags (fxnot proc-O-NONBLOCK))))
+                       (retry))))
                 (else (error 'process "write to child failed" fd)))))))
       #f #f
       (lambda () (sa-foreign-free buf) (proc-c-close fd)))))
@@ -476,17 +504,41 @@
 ;; the pipe path — so the mask is corrected on this side, around the spawn
 ;; itself (see the call below).
 (define (proc-spawn-fd-level sh-cmd inherit-in? inherit-out? inherit-err?)
-  (define (mk-pipe)
+  ;; nonblocking-read? / nonblocking-write? -- set O_NONBLOCK unconditionally
+  ;; on the PARENT's own RETAINED end at creation (never poller-gated), so
+  ;; the retry loops below
+  ;; (proc-fd-input-port / proc-fd-output-port) can park a fiber on EAGAIN
+  ;; instead of pinning the carrier. Which end is "the parent's own" is
+  ;; per-role and asymmetric: for out-p/err-p the parent keeps the read end
+  ;; (car) and the child gets the write end (cdr) via dup2, so only
+  ;; nonblocking-read? applies; in-p is the mirror image -- the CHILD gets
+  ;; the read end (dup2'd to its own stdin) and the PARENT keeps the write
+  ;; end (cdr, feeding proc-fd-output-port), so only nonblocking-write?
+  ;; applies. Per POSIX, dup2/dup/fork-duplicated descriptors share file
+  ;; status flags -- including O_NONBLOCK -- via the shared open file
+  ;; description; only per-descriptor flags like FD_CLOEXEC are NOT shared
+  ;; (verified standalone: a dup()'d fd inherits O_NONBLOCK from the fd it
+  ;; was dup'd from). So flipping O_NONBLOCK on the end that gets dup2'd into
+  ;; the child would silently change the CHILD's own stdio behavior, not just
+  ;; the parent's -- a non-blocking in-p read end makes the child's own
+  ;; stdin reads see spurious EAGAIN; a non-blocking out-p/err-p write end
+  ;; would do the same to the child's own stdout/stderr writes. Each of the
+  ;; three pipes below only ever sets non-blocking on the end the parent
+  ;; itself retains.
+  (define (mk-pipe nonblocking-read? nonblocking-write?)
     (let ((fds (sa-foreign-alloc 8)))
       (if (= 0 (proc-c-pipe fds))
           (let ((p (cons (sa-foreign-ref 'int fds 0) (sa-foreign-ref 'int fds 4))))
-            (sa-foreign-free fds) p)
+            (sa-foreign-free fds)
+            (when nonblocking-read? (set-nonblocking! (car p)))
+            (when nonblocking-write? (set-nonblocking! (cdr p)))
+            p)
           (begin (sa-foreign-free fds)
                  (throw-jvm (quote java.io.IOException) "pipe: cannot allocate")))))
   (jolt-with-mutex proc-spawn-fd-mutex
-    (let* ((in-p  (and (not inherit-in?)  (mk-pipe)))
-           (out-p (and (not inherit-out?) (mk-pipe)))
-           (err-p (and (not inherit-err?) (mk-pipe)))
+    (let* ((in-p  (and (not inherit-in?)  (mk-pipe #f #t)))
+           (out-p (and (not inherit-out?) (mk-pipe #t #f)))
+           (err-p (and (not inherit-err?) (mk-pipe #t #f)))
            (fa (sa-foreign-alloc 128))
            (pidbuf (sa-foreign-alloc 8)))
       (proc-fa-init fa)

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -106,6 +106,21 @@
         #f
         (begin (jolt-invoke2 f fd filt-kw) #t))))
 
+;; Bridge to jolt.io-poller/forget!, same shape as poller-wait-ready above.
+;; A closed fd is auto-removed from the kernel's kqueue/epoll set, so no
+;; event is ever coming for a fiber still parked on it -- without telling
+;; the poller to drop its registration, that fiber sleeps forever, and a
+;; leaked ready=true tombstone in the poller's shared :fds table (keyed by
+;; bare fd integer, shared with jolt.socket) can then be consumed by a
+;; REUSED fd number belonging to an unrelated later socket. Mirrors
+;; jolt.socket's socket-close! (stdlib/jolt/socket.clj), which does the
+;; identical close-then-forget for the same reason. Same unbound-var guard
+;; as poller-wait-ready: when jolt.io-poller was never loaded, forget! has
+;; nothing to forget and this is a no-op.
+(define (poller-forget! fd)
+  (let ((f (var-deref "jolt.io-poller" "forget!")))
+    (unless (jolt-var-unbound? f) (jolt-invoke1 f fd))))
+
 ;; A jolt that spawns children has to be able to reap them, so SIGCHLD must not be
 ;; left at an INHERITED SIG_IGN: with that disposition the kernel reaps every child
 ;; itself and waitpid can only ever fail with ECHILD, making exit statuses
@@ -457,7 +472,7 @@
                        (retry))))
                 (else 0))))))
       #f #f
-      (lambda () (sa-foreign-free buf) (proc-c-close fd)))))
+      (lambda () (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
 (define (proc-fd-output-port fd)
   (let ((buf (sa-foreign-alloc proc-fd-buf-size)))
     (make-custom-binary-output-port
@@ -482,7 +497,7 @@
                        (retry))))
                 (else (error 'process "write to child failed" fd)))))))
       #f #f
-      (lambda () (sa-foreign-free buf) (proc-c-close fd)))))
+      (lambda () (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
 
 ;; What the API hands back for a stream that was INHERITED: the JVM's null
 ;; streams. Reads are at EOF from the start; writes are accepted and dropped.

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -458,36 +458,99 @@
 ;; the write side raises (child gone, `error 'process "write to child
 ;; failed"`). A short write returns its count and Chez's port machinery
 ;; re-calls for the rest.
+;;
+;; The `closed?` box each port allocates alongside its buf is what makes the
+;; close proc safe against a fiber PARKED in that retry loop. Close is three
+;; steps -- free buf, close fd, forget the fd -- and the third wakes any parked
+;; waiter through jolt.io-poller. That wake is ASYNCHRONOUS: jolt.host's
+;; fiber-resume -> sa-fiber-resume (host/chez/fibers.ss) only flips the fiber to
+;; 'ready and enqueues it on its carrier's run queue; the fiber's continuation
+;; runs later, on the carrier thread. Between the wake and that continuation
+;; there is a real scheduling gap, and by then buf is already free()d
+;; (sa-foreign-free is a bare foreign-free -- no pooling, no quarantine) and fd
+;; is already closed. A closed fd number is immediately eligible for reuse by
+;; ANY concurrent pipe/socket/open/accept anywhere in the process -- POSIX hands
+;; out the lowest free number, and jolt.process exists to support many
+;; concurrent spawns -- so without the flag the woken fiber's (retry) calls
+;; proc-c-read/proc-c-write with a fd that is valid again but belongs to
+;; something else entirely, handing the kernel a pointer into freed memory. That
+;; stale retry could also re-register the reused fd with jolt.io-poller,
+;; cross-talking with its new owner's registration. proc-spawn-fd-mutex does not
+;; help: it covers only the pipe()-through-posix_spawn sequence, not close and
+;; not fd allocation in general.
+;;
+;; So the close proc sets closed? FIRST, before it frees, closes, or forgets,
+;; and the retry loop tests it at the TOP of EVERY iteration -- the first one
+;; included, not just the one after a park. The ordering is what makes that test
+;; sound rather than hopeful: set-box! happens before poller-forget!, which
+;; reaches sa-fiber-resume, which takes and releases the carrier's mutex to
+;; enqueue the fiber; the carrier thread takes that SAME mutex in
+;; jolt-fiber-dequeue! before it can run the fiber at all. A release/acquire
+;; pair on one mutex, so the #t is published to the woken fiber -- it cannot
+;; observe a stale #f, and it cannot have cached the read across the park, since
+;; the park sits behind poller-wait-ready's opaque var-deref'd call. Same
+;; box/set-box!/unbox shape concurrency.ss uses for its own cross-thread flag
+;; (agents-shutdown?).
+;;
+;; Each side short-circuits the way it already reports a dead pipe: the read
+;; side returns 0 (the `(else 0)` EOF convention below), the write side raises
+;; (the `error 'process` convention below) -- with its own message, so a port
+;; closed under a parked write is not misreported as a failing child.
+;;
+;; Deliberately NOT covered: a close racing a syscall already IN FLIGHT on
+;; another thread rather than parked. That caller read fd and buf before any
+;; flag could be set, so no flag can help it; it is a pre-existing hazard of
+;; closing a port other threads are actively using, not something this adds.
+;;
+;; Also NOT covered: a fiber that has decided to call poller-wait-ready but
+;; has not yet registered when close runs -- forget! finds nothing to drop,
+;; then the fiber registers on an already-dead fd. That is a strand (a hang),
+;; not a use-after-free; closing it needs coordination on the jolt.io-poller
+;; side (a register/forget race), left out of scope here. Pre-existing,
+;; not introduced by this fix.
 (define proc-fd-buf-size 32768)
 (define (proc-fd-input-port fd)
-  (let ((buf (sa-foreign-alloc proc-fd-buf-size)))
+  (let ((buf (sa-foreign-alloc proc-fd-buf-size))
+        (closed? (box #f)))
     (make-custom-binary-input-port
       (string-append "process-fd-" (number->string fd))
       (lambda (bv start n)
         (let ((want (min n proc-fd-buf-size)))
           (let retry ()
-            (let ((got (proc-c-read fd buf want)))
-              (cond
-                ((> got 0)
-                 (let loop ((i 0))
-                   (when (< i got)
-                     (bytevector-u8-set! bv (+ start i) (sa-foreign-ref 'unsigned-8 buf i))
-                     (loop (+ i 1))))
-                 got)
-                ((= got 0) 0)
-                ((= (proc-errno) proc-EINTR) (retry))
-                ((= (proc-errno) proc-EAGAIN)
-                 (if (poller-wait-ready fd (jolt-keyword "read"))
-                     (retry)
-                     (begin
-                       (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
-                         (proc-fcntl-set fd proc-F-SETFL (fxand flags (fxnot proc-O-NONBLOCK))))
-                       (retry))))
-                (else 0))))))
+            ;; Top of EVERY iteration, first one included: a fiber woken by the
+            ;; close proc's poller-forget! resumes HERE, and buf is freed and fd
+            ;; closed (possibly reused) by then. Read as EOF without touching
+            ;; either -- same answer the (else 0) branch below would give for a
+            ;; closed fd's EBADF, reached without the syscall.
+            (if (unbox closed?)
+                0
+                (let ((got (proc-c-read fd buf want)))
+                  (cond
+                    ((> got 0)
+                     (let loop ((i 0))
+                       (when (< i got)
+                         (bytevector-u8-set! bv (+ start i) (sa-foreign-ref 'unsigned-8 buf i))
+                         (loop (+ i 1))))
+                     got)
+                    ((= got 0) 0)
+                    ((= (proc-errno) proc-EINTR) (retry))
+                    ((= (proc-errno) proc-EAGAIN)
+                     (if (poller-wait-ready fd (jolt-keyword "read"))
+                         (retry)
+                         (begin
+                           (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
+                             (proc-fcntl-set fd proc-F-SETFL (fxand flags (fxnot proc-O-NONBLOCK))))
+                           (retry))))
+                    (else 0)))))))
       #f #f
-      (lambda () (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
+      ;; closed? goes up BEFORE the free/close/forget below, so it is already #t
+      ;; on the far side of the carrier-mutex handoff every woken fiber crosses.
+      (lambda ()
+        (set-box! closed? #t)
+        (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
 (define (proc-fd-output-port fd)
-  (let ((buf (sa-foreign-alloc proc-fd-buf-size)))
+  (let ((buf (sa-foreign-alloc proc-fd-buf-size))
+        (closed? (box #f)))
     (make-custom-binary-output-port
       (string-append "process-fd-" (number->string fd))
       (lambda (bv start n)
@@ -497,20 +560,31 @@
               (sa-foreign-set! 'unsigned-8 buf i (bytevector-u8-ref bv (+ start i)))
               (loop (+ i 1))))
           (let retry ()
-            (let ((wrote (proc-c-write fd buf want)))
-              (cond
-                ((>= wrote 0) wrote)
-                ((= (proc-errno) proc-EINTR) (retry))
-                ((= (proc-errno) proc-EAGAIN)
-                 (if (poller-wait-ready fd (jolt-keyword "write"))
-                     (retry)
-                     (begin
-                       (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
-                         (proc-fcntl-set fd proc-F-SETFL (fxand flags (fxnot proc-O-NONBLOCK))))
-                       (retry))))
-                (else (error 'process "write to child failed" fd)))))))
+            ;; Top of EVERY iteration, first one included -- the read side's
+            ;; twin, and the branch a fiber woken by the close proc lands on.
+            ;; Raises rather than returning a count, matching the (else ...)
+            ;; convention below; its own message because the child is fine here,
+            ;; the port under this write is not.
+            (if (unbox closed?)
+                (error 'process "write to closed pipe" fd)
+                (let ((wrote (proc-c-write fd buf want)))
+                  (cond
+                    ((>= wrote 0) wrote)
+                    ((= (proc-errno) proc-EINTR) (retry))
+                    ((= (proc-errno) proc-EAGAIN)
+                     (if (poller-wait-ready fd (jolt-keyword "write"))
+                         (retry)
+                         (begin
+                           (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
+                             (proc-fcntl-set fd proc-F-SETFL (fxand flags (fxnot proc-O-NONBLOCK))))
+                           (retry))))
+                    (else (error 'process "write to child failed" fd))))))))
       #f #f
-      (lambda () (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
+      ;; closed? goes up BEFORE the free/close/forget below, so it is already #t
+      ;; on the far side of the carrier-mutex handoff every woken fiber crosses.
+      (lambda ()
+        (set-box! closed? #t)
+        (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
 
 ;; What the API hands back for a stream that was INHERITED: the JVM's null
 ;; streams. Reads are at EOF from the start; writes are accepted and dropped.

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -59,6 +59,53 @@
 ;; concurrency.ss uses for the SIG_BLOCK numerics.
 (define proc-SIGCHLD (if (eq? (sa-os-family) 'macos) 20 17))
 
+;; EAGAIN/EWOULDBLOCK, for the R8-style non-blocking pipe read/write retry
+;; loop (proc-fd-input-port / proc-fd-output-port below). Genuinely
+;; platform-dependent, unlike proc-EINTR -- same os-family test process.ss
+;; already uses for proc-SIGCHLD.
+(define proc-EAGAIN (if (eq? (sa-os-family) 'macos) 35 11))
+
+;; fcntl(F_GETFL)/(F_SETFL) for setting a pipe fd non-blocking, mirroring
+;; stdlib/jolt/io_poller.clj's own private c-fcntl binding
+;; (io_poller.clj:59-63,70) at the Scheme level. fcntl(2) is C-variadic;
+;; F_GETFL is called with NO variadic argument (plain 2-arg binding is
+;; correct). F_SETFL is ALWAYS called with one variadic argument (the new
+;; flags value) and REQUIRES the (__varargs_after 2) calling-convention
+;; token -- "2" is the count of fixed/named params before the first true
+;; variadic arg. Without this marker, F_SETFL on Apple arm64 returns
+;; success but silently fails to apply the flags (verified by
+;; test/chez/ffi-binding-test.ss:82-104, which proves the identical fix
+;; via the Clojure FFI :varargs marker on a real socket with F_SETFL
+;; before/after flags readback). Mirrors stdlib/jolt/ffi.clj's own
+;; :varargs marker (io_poller.clj's `(ffi/defcfn c-fcntl "fcntl"
+;; [:int :int :varargs :int] :int)`), exposed here as the raw Scheme-level
+;; jolt-foreign-proc-safe 4-arg form (rt.ss:73-88) -- a Chez/Apple-ABI
+;; feature, not a jolt invention.
+(define proc-fcntl-get (jolt-foreign-proc-safe "fcntl" '(int int) 'int))
+(define proc-fcntl-set (jolt-foreign-proc-safe (__varargs_after 2) "fcntl" '(int int int) 'int))
+(define proc-F-GETFL 3)
+(define proc-F-SETFL 4)
+(define proc-O-NONBLOCK (if (eq? (sa-os-family) 'macos) #x4 #x800))
+
+(define (set-nonblocking! fd)
+  (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
+    (proc-fcntl-set fd proc-F-SETFL (fxior flags proc-O-NONBLOCK))))
+
+;; Bridge to jolt.io-poller/wait-ready: var-deref never throws for a
+;; missing var -- jolt-var auto-vivifies a jolt-var-unbound placeholder
+;; instead (rt.ss:662-669), checkable via the record type's own
+;; predicate. So when jolt.process is used standalone, without
+;; jolt.socket/jolt.io-poller ever loaded, this returns #f and the
+;; caller falls back to a real blocking wait it implements itself (the
+;; EAGAIN branches in proc-fd-input-port/proc-fd-output-port below --
+;; a bare 0-byte return there would misread as EOF, since the pipe fd
+;; is genuinely non-blocking by then).
+(define (poller-wait-ready fd filt-kw)
+  (let ((f (var-deref "jolt.io-poller" "wait-ready")))
+    (if (jolt-var-unbound? f)
+        #f
+        (begin (jolt-invoke2 f fd filt-kw) #t))))
+
 ;; A jolt that spawns children has to be able to reap them, so SIGCHLD must not be
 ;; left at an INHERITED SIG_IGN: with that disposition the kernel reaps every child
 ;; itself and waitpid can only ever fail with ECHILD, making exit statuses

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -87,9 +87,18 @@
 (define proc-F-SETFL 4)
 (define proc-O-NONBLOCK (if (eq? (sa-os-family) 'macos) #x4 #x800))
 
+;; Deliberately unprefixed (no `proc-` prefix, unlike every other definition
+;; in this file): a bridge point meant to be reachable beyond this file, not
+;; a private proc-* helper. Don't rename it into collision with the
+;; naming-shadow hazard this file's own header documents (line ~40-42).
 (define (set-nonblocking! fd)
   (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
-    (proc-fcntl-set fd proc-F-SETFL (fxior flags proc-O-NONBLOCK))))
+    ;; A negative flags value means F_GETFL itself failed -- don't hand that
+    ;; straight to F_SETFL: (fxior -1 proc-O-NONBLOCK) is still negative, and
+    ;; the kernel would mask it down, silently leaving the fd blocking with
+    ;; no diagnostic that anything went wrong.
+    (when (>= flags 0)
+      (proc-fcntl-set fd proc-F-SETFL (fxior flags proc-O-NONBLOCK)))))
 
 ;; Bridge to jolt.io-poller/wait-ready: var-deref never throws for a
 ;; missing var -- jolt-var auto-vivifies a jolt-var-unbound placeholder
@@ -100,6 +109,9 @@
 ;; EAGAIN branches in proc-fd-input-port/proc-fd-output-port below --
 ;; a bare 0-byte return there would misread as EOF, since the pipe fd
 ;; is genuinely non-blocking by then).
+;; poller-wait-ready and poller-forget! below are ALSO deliberately
+;; unprefixed, same reason as set-nonblocking! above: bridge points, not
+;; private proc-* helpers.
 (define (poller-wait-ready fd filt-kw)
   (let ((f (var-deref "jolt.io-poller" "wait-ready")))
     (if (jolt-var-unbound? f)
@@ -401,7 +413,8 @@
 
 (define proc-spawn-fd-ok?
   (and proc-c-pipe proc-c-close proc-fa-init proc-fa-dup2 proc-fa-close
-       proc-fa-destroy proc-c-spawn proc-c-read proc-c-write #t))
+       proc-fa-destroy proc-c-spawn proc-c-read proc-c-write
+       proc-fcntl-get proc-fcntl-set proc-errno-loc #t))
 
 ;; marshal a string list into a NULL-terminated char**; returns (array . cstrs)
 ;; so the caller can free every allocation once posix_spawn has copied them.
@@ -436,8 +449,8 @@
 ;; loaded, EAGAIN clears O_NONBLOCK on this fd (fd is genuinely non-blocking
 ;; now per mk-pipe above, so a no-poller EAGAIN is a live "not ready yet"
 ;; signal, not a real failure) and falls through to a real blocking
-;; proc-c-read/proc-c-write from then on -- exact behavioral parity with
-;; pre-this-plan code once triggered, verified standalone: a blocked
+;; proc-c-read/proc-c-write from then on -- exact behavioral parity with a
+;; plain blocking fd once triggered, verified standalone: a blocked
 ;; read/write genuinely waits rather than busy-looping or returning a
 ;; spurious result. Any OTHER error still ends the port, but the two sides
 ;; report it differently -- pre-existing asymmetry, unchanged by this: the
@@ -506,10 +519,17 @@
 (define (proc-null-output-port)
   (make-custom-binary-output-port "process-null" (lambda (bv start n) n) #f #f #f))
 
-;; The pipe fds are not close-on-exec (fcntl/ioctl are variadic, which the FFI
-;; cannot call safely on arm64), so a concurrent spawn's child could inherit
-;; them and hold a read end open past this child's exit. Exclusion by mutex
-;; instead: no other fd-level spawn runs between pipe() and posix_spawn.
+;; The pipe fds are not close-on-exec: macOS has no pipe2()/O_CLOEXEC (unlike
+;; Linux), so FD_CLOEXEC can only be applied with a SEPARATE fcntl(F_SETFD)
+;; call after pipe() returns -- and that leaves a window, between pipe() and
+;; that fcntl call, where a concurrent spawn's child could still inherit the
+;; fd and hold a read end open past this child's exit. This is true even now
+;; that this file has a working arm64 fcntl binding (proc-fcntl-get/-set
+;; above, via the (__varargs_after 2) marker): a working fcntl fixes whether
+;; we CAN make the F_SETFD call safely, not the fact that pipe() and
+;; F_SETFD are still two separate syscalls with a gap between them. Exclusion
+;; by mutex instead: no other fd-level spawn runs between pipe() and
+;; posix_spawn.
 (define proc-spawn-fd-mutex (make-mutex))
 
 ;; Spawn `/bin/sh -c sh-cmd` with fd-level stdio: an inherited stream gets no

--- a/test/chez/fibers-process-io-test.ss
+++ b/test/chez/fibers-process-io-test.ss
@@ -1,0 +1,482 @@
+;; test/chez/fibers-process-io-test.ss — R8 gate, extended to jolt.process pipe
+;; I/O (Tasks 1-4 of the fiber-pipe-io-parking plan). Run:
+;; chez --script test/chez/fibers-process-io-test.ss (wired into `make fibers`
+;; immediately after fibers-io-test.ss).
+;;
+;; fibers-io-test.ss covers R8's socket half; this file covers the other half of
+;; the same trick applied to a subprocess's stdin/stdout pipes:
+;; proc-fd-input-port / proc-fd-output-port (host/chez/java/process.ss) set
+;; O_NONBLOCK unconditionally on the pipe fd the parent retains, and on EAGAIN
+;; ask jolt.io-poller to wait for readiness — parking the fiber when there is a
+;; current fiber, blocking this thread when there is not. Same user-facing
+;; jolt.process code either way. The retry loop also has a THIRD branch neither
+;; socket.clj nor fibers-io-test.ss needs: when jolt.io-poller was never
+;; required at all (jolt.process is usable standalone), EAGAIN clears
+;; O_NONBLOCK on the fd and falls through to a real blocking read/write —
+;; behaviorally identical to the pre-R8-extension code, once triggered.
+;;
+;; Gate checks, in order:
+;;   1. a fiber reading a subprocess pipe with nothing written yet PARKS, and a
+;;      sibling fiber on the SAME carrier makes progress while it waits — the
+;;      whole round in one check, same shape as fibers-io-test.ss's check 1.
+;;   2. the same code path on a plain OS thread (no current fiber) still blocks
+;;      and still works — a lower-bound elapsed-time check.
+;;   3. jolt.host/gc-full! succeeds while the poller is blocked servicing a pipe
+;;      registration (the __collect_safe property fibers-io-test.ss's check 3
+;;      asserts for sockets — this is the same poller, so this is really a
+;;      belt-and-suspenders repeat of it via a different registration path,
+;;      worth asserting explicitly since jolt.process is a distinct caller of
+;;      poller-wait-ready from jolt.socket).
+;;   4. N fibers (N picked below, see the note at its definition), each reading
+;;      its OWN subprocess's pipe, all on ONE carrier: all N park at once, then
+;;      all N complete with their own payload — real parking, not serialized
+;;      blocking.
+;;   5. jolt.process's existing higher-level API (process / sh / shell, :in /
+;;      :out piping, @proc deref) is unaffected OFF a fiber — confirms the R8
+;;      extension does not leak into or change the non-fiber path every
+;;      existing jolt.process caller (process-test.clj, babashka.process
+;;      itself) depends on.
+;;   6. the no-poller fallback: a FRESH Chez process that requires jolt.process
+;;      but never jolt.io-poller (so poller-wait-ready's var-deref finds it
+;;      genuinely unbound, not just un-invoked) still blocks correctly on a
+;;      pipe read — not a spurious short-read/EOF on the first EAGAIN, and not
+;;      a busy spin. No analog in fibers-io-test.ss: sockets always require
+;;      jolt.io-poller by construction, so this state is only reachable through
+;;      jolt.process. Runs the probe as a genuinely separate `chez --script`
+;;      subprocess (see check 6 below) — jolt-var auto-vivifies an unbound
+;;      placeholder for any never-required ns, so within ONE process there is
+;;      no way back to "genuinely never required" once checks 1-5 have required
+;;      jolt.io-poller for real parking.
+;;   7. closing a pipe-read port while a fiber is parked on it must not strand
+;;      the fiber — the CRITICAL close-races-a-parked-read regression: the fd
+;;      close proc now tells jolt.io-poller to forget the fd (mirroring
+;;      jolt.socket's socket-close!), which wakes any parked waiter instead of
+;;      leaving it waiting on an event that will never come (the kernel
+;;      auto-drops a closed fd from the kqueue/epoll set).
+;;   8. a fiber write that fills a subprocess pipe parks, and a sibling fiber
+;;      on the SAME carrier makes real progress while the write is blocked —
+;;      the write-side twin of check 1, closing the permanent-gate coverage
+;;      gap the write path (EAGAIN branch + fcntl fallback, symmetric with the
+;;      read side) had until now.
+;;
+;; Watchdog: the whole workload (all 6 checks) runs on a forked thread; this
+;; script's main thread does nothing but watch a hard-coded deadline. A wedge
+;; anywhere in the workload — including a raw blocking spawn/read call that
+;; isn't wrapped in wait-until's own per-check bound — fails the gate loudly
+;; with the phase it was in and jolt.io-poller's debug-state, instead of
+;; hanging `make fibers` silently. Same shape as test/chez/poller-registration.clj's
+;; watchdog, adapted to this file's plain Chez-thread (not Jolt Thread/System)
+;; primitives, since this is a raw gate-boot .ss script, not a .clj file run
+;; through jolt.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+;; The real loader, in cli.ss's order: loader.ss seeds its loaded-ns from the
+;; vars that exist AT LOAD TIME, so jolt.ffi's host vars (java/ffi.ss) must come
+;; AFTER it, or a (require '[jolt.ffi]) skips stdlib/jolt/ffi.clj and the
+;; defcfn macro never exists. gate-boot's image (target/dev/gate.so, when fresh)
+;; already bakes both — the delete below makes the require pull the Clojure
+;; side in that case too, so the gate behaves identically with and without the
+;; image.
+(load "host/chez/loader.ss")
+(hashtable-delete! loaded-ns "jolt.ffi")
+(set-source-roots!* '("jolt-core" "stdlib" "vendor/fs/src" "vendor/process/src" "vendor/grenadine/src"
+                      "vendor/grenadine-generated"))
+(load "host/chez/java/ffi.ss")
+
+(define total 0)
+(define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred
+    (set! fails (+ fails 1))
+    (printf "  FAIL: ~a\n" name)))
+
+(define (mono-nanos)
+  (let ((t (current-time 'time-monotonic)))
+    (+ (* 1000000000 (time-second t)) (time-nanosecond t))))
+(define (now-secs) (/ (exact->inexact (mono-nanos)) 1000000000.0))
+
+;; Bounded wait: a bug must FAIL the gate, never hang it.
+(define (wait-until pred secs what)
+  (let ((deadline (+ (now-secs) secs)))
+    (let loop ()
+      (if (pred)
+          #t
+          (if (> (now-secs) deadline)
+              (begin (set! fails (+ fails 1))
+                     (printf "  FAIL: ~a (timed out)\n" what) #f)
+              (begin (sleep (make-time 'time-duration 1000000 0)) (loop)))))))
+
+;; Compile+eval one jolt form in the "user" ns and return its value.
+(define (ev s) (jolt-compile-eval s "user"))
+(define (all-done? fs)
+  (or (null? fs) (and (eq? (jolt-fiber-state (car fs)) 'done) (all-done? (cdr fs)))))
+(define (all-parked? fs)
+  (or (null? fs) (and (eq? (jolt-fiber-state (car fs)) 'parked) (all-parked? (cdr fs)))))
+(define (spawn-n n mk)
+  (let loop ((i 0) (acc '()))
+    (if (fx<? i n)
+        (loop (fx+ i 1) (cons (mk i) acc))
+        (reverse acc))))
+
+;; Render a raised condition (or any thrown value) as a string for a diagnostic
+;; print — mirrors test/chez/op-arity-test.ss's render-condition.
+(define (render-condition e)
+  (if (condition? e)
+      (let ((p (open-output-string))) (display-condition e p) (get-output-string p))
+      (format "~s" e)))
+
+;; A plain, dependency-free substring search — used once, on check 6's captured
+;; subprocess stdout.
+(define (string-contains-substr? s sub)
+  (let ((ls (string-length s)) (lsub (string-length sub)))
+    (let loop ((i 0))
+      (cond ((> (+ i lsub) ls) #f)
+            ((string=? (substring s i (+ i lsub)) sub) #t)
+            (else (loop (+ i 1)))))))
+
+;; --- watchdog scaffolding -------------------------------------------------------
+;; progress: the phase the workload thread is currently in, for the watchdog's
+;; diagnostic print on a trip. outcome: 'running until the workload sets it to
+;; 'ok / 'failed, or (threw . <string>) if the workload itself raised.
+(define progress (box "starting"))
+(define (at! phase) (set-box! progress phase))
+(define outcome (box 'running))
+
+;; Measured real runtime (5 repeated runs, this machine): ~8.5-12.5s total —
+;; roughly 3.2s for this file's own gate-boot+loader+ffi load plus requiring
+;; jolt.process/jolt.io-poller, ~1.9s for checks 1-5 combined (real subprocess
+;; spawns, N=6 of them in check 4), and ~3.4s for check 6's nested Chez
+;; subprocess (which repeats the same gate-boot+loader+ffi+require cost, plus
+;; its own 0.3s delayed read). hang-secs is ~10x the slowest observed run —
+;; generous for a slower CI machine, still bounded: anything that reaches it
+;; is wedged, not slow.
+(define hang-secs 120.0)
+
+;; Every check-local value below is pre-declared here and filled with set!,
+;; never nested define: R6RS bodies require every internal define to precede
+;; every expression, and these checks interleave "compute a value" with
+;; "assert on it" (an ok call between two dependent state reads) by design —
+;; see check 1's "sibling made progress while parked" assertion, which must
+;; read fa's state at that exact point in the sequence, not after fa-done is
+;; also known. A single flat let keeps that interleaving exactly as written.
+(define (workload)
+ (let ((read-thunk-1 #f) (fa #f) (fb #f) (fa-parked #f) (fb-done #f) (fa-done #f)
+       (t2 #f) (r2 #f) (el2 #f)
+       (read-thunk-3 #f) (fc #f) (fc-parked #f) (w3 #f) (gc-ok #f) (fc-done #f)
+       (r4-n #f) (r4-worker #f) (f4s #f) (all-parked4 #f) (all-done4 #f)
+       (r5-sh-out #f) (r5-in #f) (r5-pipe #f) (r5-deref-exit #f)
+       (repo-dir #f) (no-poller-script #f) (no-poller-path #f) (chez-bin #f)
+       (np-out #f) (np-err #f) (np-exit #f)
+       (read-thunk-7 #f) (f7 #f) (f7-parked #f) (f7-unparked #f) (f7-result #f)
+       (r8-payload-len #f) (write-thunk-8 #f) (f8w #f) (f8sib #f)
+       (f8w-parked #f) (f8sib-done #f) (r8-total #f) (f8w-done #f))
+  (at! "requiring jolt.process + jolt.io-poller")
+  (ev "(require 'jolt.process)")
+  ;; Checks 1-5 need REAL parking, which needs jolt.io-poller genuinely
+  ;; required (poller-wait-ready's var-deref returns unbound, and the
+  ;; no-poller fallback fires, until this happens) — mirrors
+  ;; fibers-io-test.ss's own explicit require.
+  (ev "(require 'jolt.io-poller)")
+
+  ;; One carrier, started as a real carrier thread — the R8 wake path (poller ->
+  ;; sa-fiber-resume -> carrier run queue) needs it live. Never reset mid-file.
+  (jolt-fiber-carrier-count-set! 1)
+  (jolt-fiber-pool-reset!)
+  (jolt-fiber-ensure-carrier!)
+
+  (printf "== fibers-process-io: transparent jolt.process pipe parking on a fiber ==\n")
+
+  ;; --- 1. a fiber read on a subprocess pipe parks; a sibling progresses ------
+  (at! "1. park+sibling-progress")
+  (printf "\n== 1. a fiber read on a subprocess pipe parks; a sibling on the same carrier runs ==\n")
+  (ev "(def p1 (jolt.process/process [\"sh\" \"-c\" \"sleep 0.2; printf x\"]))")
+  (ev "(def p1-out (:out p1))")
+  (set! read-thunk-1
+    (ev "(fn [] (let [b (byte-array 64) n (.read p1-out b 0 64)] (String. b 0 n \"UTF-8\")))"))
+  (set! fa (sa-fiber-spawn read-thunk-1))
+  (set! fb (sa-fiber-spawn (lambda () 4242)))
+  (ok "1. the two fibers share one carrier" (eq? (jolt-fiber-carrier fa) (jolt-fiber-carrier fb)))
+  (set! fa-parked
+    (wait-until (lambda () (eq? (jolt-fiber-state fa) 'parked)) 15.0 "1. the pipe-read fiber parked"))
+  (ok "1. the pipe read parked the fiber (no data written yet)" fa-parked)
+  (set! fb-done
+    (wait-until (lambda () (eq? (jolt-fiber-state fb) 'done)) 15.0 "1. the sibling completed"))
+  (ok "1. the sibling fiber on the SAME carrier made progress while the read was parked"
+      (and fb-done (eq? (jolt-fiber-state fa) 'parked)))
+  (ok "1. the sibling ran to completion" (eqv? (jolt-fiber-result fb) 4242))
+  (set! fa-done
+    (wait-until (lambda () (eq? (jolt-fiber-state fa) 'done)) 15.0 "1. the read resumed"))
+  (ok "1. the parked read resumed with the child's data"
+      (and fa-done (string=? (jolt-fiber-result fa) "x")))
+  (ev "(deref p1 5000 :reap-timeout)")
+
+  ;; --- 2. the same code path on a plain OS thread blocks and works ----------
+  (at! "2. thread-mode")
+  (printf "\n== 2. the thread path still blocks and still works ==\n")
+  (ev "(def p2 (jolt.process/process [\"sh\" \"-c\" \"sleep 0.3; printf threaded\"]))")
+  (set! t2 (mono-nanos))
+  (set! r2
+    (ev "(let [b (byte-array 64) n (.read (:out p2) b 0 64)] (String. b 0 n \"UTF-8\"))"))
+  (set! el2 (/ (exact->inexact (- (mono-nanos) t2)) 1000000.0))
+  (ok "2. the thread-mode read returned the delayed data" (string=? r2 "threaded"))
+  ;; floor, relative to the in-run child delay: a read that returned without
+  ;; waiting for the data would clock in well under this (a spin, or a wrong
+  ;; EAGAIN-as-EOF); a slow machine only makes the wait longer
+  (ok "2. it actually waited for the child (>= half the 300 ms delay)"
+      (> el2 150.0))
+  (printf "   thread-path read took ~,1f ms for a 300 ms delayed write\n" el2)
+  (ev "(deref p2 5000 :reap-timeout)")
+
+  ;; --- 3. jolt.host/gc-full! succeeds while the poller is blocked -----------
+  (at! "3. gc-full! mid poller-blocked wait")
+  (printf "\n== 3. jolt.host/gc-full! succeeds while the poller is blocked servicing a pipe registration ==\n")
+  (ev "(def p3 (jolt.process/process [\"sh\" \"-c\" \"sleep 0.3; printf z\"]))")
+  (ev "(def p3-out (:out p3))")
+  (set! read-thunk-3
+    (ev "(fn [] (let [b (byte-array 64) n (.read p3-out b 0 64)] (String. b 0 n \"UTF-8\")))"))
+  (set! fc (sa-fiber-spawn read-thunk-3))
+  (set! fc-parked
+    (wait-until (lambda () (eq? (jolt-fiber-state fc) 'parked)) 15.0 "3. the pipe-read fiber parked"))
+  (ok "3. the pipe-read fiber parked" fc-parked)
+  ;; the poller entered its blocking wait (jolt.io-poller/waits increments each
+  ;; round, immediately before kevent/epoll_wait) — so gc-full! below races a
+  ;; thread that is (about to be / already) inside the blocking foreign call
+  (set! w3
+    (wait-until (lambda () (> (ev "@jolt.io-poller/waits") 0)) 15.0 "3. the poller entered its wait"))
+  (ok "3. the poller entered its blocking wait" w3)
+  (sleep (make-time 'time-duration 50000000 0))  ; let it settle into the wait
+  (set! gc-ok
+    (guard (e (#t (printf "  FAIL detail: gc-full! raised ~a\n" (render-condition e)) #f))
+      (ev "(jolt.host/gc-full!)")
+      #t))
+  (ok "3. jolt.host/gc-full! succeeded while the poller was blocked (a pipe registration mid-flight)"
+      gc-ok)
+  (ok "3. the parked fiber survived the collection" (eq? (jolt-fiber-state fc) 'parked))
+  (set! fc-done
+    (wait-until (lambda () (eq? (jolt-fiber-state fc) 'done)) 15.0 "3. the read resumed after gc-full!"))
+  (ok "3. the fiber completed after gc-full! with the correct payload"
+      (and fc-done (string=? (jolt-fiber-result fc) "z")))
+  (ev "(deref p3 5000 :reap-timeout)")
+
+  ;; --- 4. N fibers, one carrier: all park at once, all round-trip -----------
+  (at! "4. N processes one carrier")
+  (printf "\n== 4. N fibers, one carrier, each reading its own subprocess pipe, all round-trip ==\n")
+  ;; N in the 4-8 range: 6 was tuned against this gate's own measured runtime
+  ;; (profiled per-check: N=6 here added well under a second on top of the
+  ;; fixed gate-boot/require/nested-chez costs that dominate this file's total
+  ;; runtime) — real subprocess spawn (posix_spawn + two pipes each) is
+  ;; materially heavier than fibers-io-test.ss's check 4 (8 in-process
+  ;; socketpairs), so this check does not default to 8.
+  (set! r4-n 6)
+  (ev (string-append
+       "(def p4-procs (mapv (fn [i] (jolt.process/process [\"sh\" \"-c\" (str \"sleep 0.3; printf m\" i)])) (range "
+       (number->string r4-n) ")))"))
+  (ev "(def p4-outs (mapv :out p4-procs))")
+  (set! r4-worker
+    (ev "(fn [i] (let [s (nth p4-outs i) b (byte-array 64) n (.read s b 0 64)] (String. b 0 n \"UTF-8\")))"))
+  (set! f4s (spawn-n r4-n (lambda (i) (sa-fiber-spawn (lambda () (r4-worker i))))))
+  ;; serialized blocking could never get here: with the carrier pinned by one
+  ;; blocking read, at most ONE fiber is 'parked at a time and the rest sit
+  ;; 'ready behind it. All N 'parked at one instant proves real parking.
+  (set! all-parked4
+    (wait-until (lambda () (all-parked? f4s)) 20.0 "4. all N fibers parked on their pipe reads"))
+  (ok "4. all N fibers parked simultaneously on one carrier (real parking, not serialized blocking)"
+      all-parked4)
+  (set! all-done4
+    (wait-until (lambda () (all-done? f4s)) 20.0 "4. all N round trips completed"))
+  (ok "4. all N round trips completed" all-done4)
+  ;; A fiber that never resumed has #f for a result, and string=? on it RAISES —
+  ;; guard on all-done4 like the other result reads, matching
+  ;; fibers-io-test.ss's own check 4 hardening.
+  (ok "4. every fiber got its own payload"
+      (and all-done4
+           (let loop ((i 0))
+             (or (fx=? i r4-n)
+                 (let ((r (jolt-fiber-result (list-ref f4s i))))
+                   (and (string? r)
+                        (string=? r (string-append "m" (number->string i)))
+                        (loop (fx+ i 1))))))))
+  (ev "(doseq [p p4-procs] (deref p 5000 :reap-timeout))")
+
+  ;; --- 5. existing jolt.process API is unaffected off-fiber ------------------
+  (at! "5. existing API off-fiber")
+  (printf "\n== 5. existing jolt.process API (process/sh/shell, :in/:out piping, deref) is unaffected off-fiber ==\n")
+  ;; Every call in this section runs directly on this (workload) thread — a
+  ;; plain OS thread with no current fiber, never inside sa-fiber-spawn — the
+  ;; same off-fiber path process-test.clj exercises.
+  (set! r5-sh-out (ev "(:out (jolt.process/sh [\"echo\" \"hi-check5\"]))"))
+  (ok "5. sh captures stdout, off-fiber" (string=? r5-sh-out "hi-check5\n"))
+  (set! r5-in (ev "(:out (jolt.process/sh [\"cat\"] {:in \"check5-in\"}))"))
+  (ok "5. :in piping still works, off-fiber" (string=? r5-in "check5-in"))
+  (set! r5-pipe (ev "(-> (jolt.process/process [\"echo\" \"check5-pipe\"]) (jolt.process/process [\"cat\"]) :out slurp)"))
+  (ok "5. :out piping between two processes still works, off-fiber" (string=? r5-pipe "check5-pipe\n"))
+  (set! r5-deref-exit (ev "(:exit @(jolt.process/process [\"true\"]))"))
+  (ok "5. @proc deref still returns the exit code, off-fiber" (eqv? r5-deref-exit 0))
+  (ok "5. shell (stdio-inherit, throw-on-failure) still runs without raising, off-fiber"
+      (guard (e (#t (printf "  FAIL detail: shell raised ~a\n" (render-condition e)) #f))
+        (ev "(jolt.process/shell \"true\")")
+        #t))
+
+  ;; --- 6. the no-poller fallback path -----------------------------------------
+  (at! "6. no-poller fallback (nested chez subprocess)")
+  (printf "\n== 6. the no-poller fallback: jolt.process usable standalone, jolt.io-poller never required ==\n")
+  ;; This process already required jolt.io-poller for checks 1-5 (jolt-var
+  ;; auto-vivifies an unbound placeholder for a never-required ns, so once a
+  ;; require has happened for real there is no way back within this process).
+  ;; So this check runs the probe in a genuinely fresh `chez --script`
+  ;; subprocess that requires jolt.process and nothing else, and reports its
+  ;; own verdict on stdout.
+  (set! repo-dir (current-directory))
+  (set! no-poller-script (string-append
+    "(import (chezscheme))\n"
+    "(load \"host/chez/gate-boot.ss\")\n"
+    "(load \"host/chez/loader.ss\")\n"
+    "(hashtable-delete! loaded-ns \"jolt.ffi\")\n"
+    "(set-source-roots!* '(\"jolt-core\" \"stdlib\" \"vendor/fs/src\" \"vendor/process/src\" \"vendor/grenadine/src\"\n"
+    "                      \"vendor/grenadine-generated\"))\n"
+    "(load \"host/chez/java/ffi.ss\")\n"
+    "(define (ev s) (jolt-compile-eval s \"user\"))\n"
+    "(define (mono-nanos) (let ((t (current-time 'time-monotonic))) (+ (* 1000000000 (time-second t)) (time-nanosecond t))))\n"
+    "(define (now-secs) (/ (exact->inexact (mono-nanos)) 1000000000.0))\n"
+    "(define (wait-until pred secs)\n"
+    "  (let ((deadline (+ (now-secs) secs)))\n"
+    "    (let loop ()\n"
+    "      (cond ((pred) #t)\n"
+    "            ((> (now-secs) deadline) #f)\n"
+    "            (else (sleep (make-time 'time-duration 1000000 0)) (loop))))))\n"
+    ;; deliberately never requires jolt.io-poller
+    "(ev \"(require 'jolt.process)\")\n"
+    "(jolt-fiber-carrier-count-set! 1)\n"
+    "(jolt-fiber-pool-reset!)\n"
+    "(jolt-fiber-ensure-carrier!)\n"
+    "(ev \"(def np-proc (jolt.process/process [\\\"sh\\\" \\\"-c\\\" \\\"sleep 0.3; printf npo\\\"]))\")\n"
+    "(ev \"(def np-out (:out np-proc))\")\n"
+    "(define read-thunk (ev \"(fn [] (let [b (byte-array 64) n (.read np-out b 0 64)] (String. b 0 n \\\"UTF-8\\\")))\"))\n"
+    "(define t0 (mono-nanos))\n"
+    "(define f (sa-fiber-spawn read-thunk))\n"
+    "(define done (wait-until (lambda () (eq? (jolt-fiber-state f) 'done)) 15.0))\n"
+    "(define el (/ (exact->inexact (- (mono-nanos) t0)) 1000000.0))\n"
+    "(define r (jolt-fiber-result f))\n"
+    "(if (and done (string? r) (string=? r \"npo\") (> el 150.0))\n"
+    "    (begin (printf \"NO-POLLER-PROBE OK elapsed=~,1fms\\n\" el) (exit 0))\n"
+    "    (begin (printf \"NO-POLLER-PROBE FAIL done=~a result=~a elapsed=~,1fms\\n\" done r el) (exit 1)))\n"))
+  (set! no-poller-path
+    (string-append "/tmp/jolt-fibers-process-io-no-poller-probe-" (number->string (get-process-id)) ".ss"))
+  (let ((p (open-output-file no-poller-path 'replace)))
+    (display no-poller-script p)
+    (close-output-port p))
+  (set! chez-bin (or (getenv "JOLT_CHEZ") "chez"))
+  (ev (string-append
+       "(def np-result (jolt.process/sh [\"" chez-bin "\" \"--script\" \"" no-poller-path "\"]"
+       " {:out :string :err :string :dir \"" repo-dir "\"}))"))
+  (set! np-out (ev "(:out np-result)"))
+  (set! np-err (ev "(:err np-result)"))
+  (set! np-exit (ev "(:exit np-result)"))
+  (ok "6. the no-poller subprocess exited 0"
+      (eqv? np-exit 0))
+  (ok "6. the no-poller subprocess reported a genuine blocking read (correct payload, waited for it)"
+      (and (string? np-out) (string-contains-substr? np-out "NO-POLLER-PROBE OK")))
+  (unless (and (eqv? np-exit 0) (string? np-out) (string-contains-substr? np-out "NO-POLLER-PROBE OK"))
+    (printf "  no-poller subprocess stdout: ~a\n" np-out)
+    (printf "  no-poller subprocess stderr: ~a\n" np-err))
+  (guard (e (#t #f)) (delete-file no-poller-path))
+
+  ;; --- 7. closing a port while parked on its read must not strand the fiber -
+  (at! "7. close-while-parked (no strand)")
+  (printf "\n== 7. closing a pipe-read port while a fiber is parked on it must not strand it ==\n")
+  ;; sleep long enough that nothing is ever written before we close — the
+  ;; fiber must park on a genuinely empty pipe, not race a real payload
+  (ev "(def p7 (jolt.process/process [\"sh\" \"-c\" \"sleep 5\"]))")
+  (ev "(def p7-out (:out p7))")
+  (set! read-thunk-7
+    (ev "(fn [] (let [b (byte-array 64) n (.read p7-out b 0 64)] (String. b 0 (max 0 n) \"UTF-8\")))"))
+  (set! f7 (sa-fiber-spawn read-thunk-7))
+  (set! f7-parked
+    (wait-until (lambda () (eq? (jolt-fiber-state f7) 'parked)) 15.0 "7. the pipe-read fiber parked"))
+  (ok "7. the read parked (nothing written yet)" f7-parked)
+  ;; close from the workload thread while the fiber is still parked — this is
+  ;; the exact race Fix 1 closes: the close proc now forgets the fd with
+  ;; jolt.io-poller, waking the parked waiter instead of leaving it waiting on
+  ;; an event the kernel will never deliver for an already-closed fd.
+  (ev "(.close p7-out)")
+  (set! f7-unparked
+    (wait-until (lambda () (not (eq? (jolt-fiber-state f7) 'parked))) 5.0
+                "7. the parked read left 'parked after the port closed (did not strand)"))
+  (ok "7. closing the port unparked the fiber within the bound" f7-unparked)
+  (set! f7-result
+    (wait-until (lambda () (eq? (jolt-fiber-state f7) 'done)) 5.0 "7. the unparked read finished"))
+  (ok "7. the fiber finished cleanly (closed-fd read reads as EOF, not a hang or a crash)"
+      (and f7-result (string? (jolt-fiber-result f7))))
+  (ev "(jolt.process/destroy p7)")
+  (ev "(deref p7 5000 :reap-timeout)")
+
+  ;; --- 8. a fiber write that fills a subprocess pipe parks; a sibling runs --
+  (at! "8. write-park+sibling-progress")
+  (printf "\n== 8. a fiber write that fills a subprocess pipe parks; a sibling on the same carrier runs ==\n")
+  ;; 2MB -- comfortably over any platform's actual pipe-buffer size (commonly
+  ;; 16-64KB), not a hardcoded assumption of what that size is
+  (set! r8-payload-len (* 2 1024 1024))
+  (ev "(def p8 (jolt.process/process [\"cat\"]))")
+  (ev "(def p8-in (:in p8))")
+  (ev "(def p8-out (:out p8))")
+  (ev (string-append "(def p8-payload (byte-array " (number->string r8-payload-len) "))"))
+  (set! write-thunk-8
+    (ev "(fn [] (.write p8-in p8-payload 0 (alength p8-payload)) (.flush p8-in) (.close p8-in) (alength p8-payload))"))
+  (set! f8w (sa-fiber-spawn write-thunk-8))
+  (set! f8sib (sa-fiber-spawn (lambda () 8181)))
+  (ok "8. the two fibers share one carrier" (eq? (jolt-fiber-carrier f8w) (jolt-fiber-carrier f8sib)))
+  (set! f8w-parked
+    (wait-until (lambda () (eq? (jolt-fiber-state f8w) 'parked)) 15.0
+                "8. the pipe-write fiber parked (the pipe filled)"))
+  (ok "8. the oversized write parked the fiber once the pipe filled" f8w-parked)
+  (set! f8sib-done
+    (wait-until (lambda () (eq? (jolt-fiber-state f8sib) 'done)) 15.0 "8. the sibling completed"))
+  (ok "8. the sibling fiber on the SAME carrier made real progress while the write was parked"
+      (and f8sib-done (eq? (jolt-fiber-state f8w) 'parked)))
+  (ok "8. the sibling ran to completion" (eqv? (jolt-fiber-result f8sib) 8181))
+  ;; drain cat's echoed stdout on this (plain OS thread) workload thread to
+  ;; release the backpressure chain: cat is blocked writing its own stdout
+  ;; before it reads more stdin, so nothing unparks the write until this reads
+  (set! r8-total
+    (ev (string-append
+         "(let [b (byte-array 65536)]"
+         " (loop [total 0]"
+         "   (let [n (.read p8-out b 0 65536)]"
+         "     (if (< n 0) total (recur (+ total n))))))")))
+  (set! f8w-done
+    (wait-until (lambda () (eq? (jolt-fiber-state f8w) 'done)) 15.0 "8. the parked write resumed"))
+  (ok "8. the parked write resumed and reported the full payload length written"
+      (and f8w-done (eqv? (jolt-fiber-result f8w) r8-payload-len)))
+  (ok "8. the drain side received the full payload byte-for-byte" (eqv? r8-total r8-payload-len))
+  (ev "(deref p8 5000 :reap-timeout)")
+
+  (printf "\nfibers-process-io: ~a checks, ~a failures\n" total fails)
+  (set-box! outcome (if (zero? fails) 'ok 'failed))))
+
+(fork-thread
+  (lambda ()
+    (guard (e (#t (set-box! outcome (cons 'threw (render-condition e)))))
+      (workload))))
+
+;; The main thread from here on is only the deadline. Every exit goes through it,
+;; matching test/chez/poller-registration.clj's watchdog shape: the workload runs
+;; entirely on a spawned thread, and the one thread that cannot itself be what
+;; wedges is the one doing nothing but watching the clock.
+(let ((deadline (+ (now-secs) hang-secs)))
+  (let loop ()
+    (sleep (make-time 'time-duration 25000000 0))
+    (let ((o (unbox outcome)))
+      (cond
+        ((eq? o 'ok) (exit 0))
+        ((eq? o 'failed) (exit 1))
+        ((and (pair? o) (eq? (car o) 'threw))
+         (printf "FIBERS-PROCESS-IO THREW: ~a\n" (cdr o))
+         (exit 1))
+        ((> (now-secs) deadline)
+         (printf "FIBERS-PROCESS-IO HUNG after ~a s, last phase: ~a\n" hang-secs (unbox progress))
+         (guard (e (#t (printf "  (debug-state unavailable: ~a)\n" (render-condition e))))
+           (printf "  jolt.io-poller debug-state: ~a\n" (ev "(pr-str (jolt.io-poller/debug-state))")))
+         (exit 1))
+        (else (loop))))))

--- a/test/chez/fibers-process-io-test.ss
+++ b/test/chez/fibers-process-io-test.ss
@@ -1,5 +1,5 @@
-;; test/chez/fibers-process-io-test.ss — R8 gate, extended to jolt.process pipe
-;; I/O (Tasks 1-4 of the fiber-pipe-io-parking plan). Run:
+;; test/chez/fibers-process-io-test.ss — R8 gate, extended to jolt.process
+;; subprocess pipe I/O. Run:
 ;; chez --script test/chez/fibers-process-io-test.ss (wired into `make fibers`
 ;; immediately after fibers-io-test.ss).
 ;;
@@ -164,7 +164,7 @@
 (define (workload)
  (let ((read-thunk-1 #f) (fa #f) (fb #f) (fa-parked #f) (fb-done #f) (fa-done #f)
        (t2 #f) (r2 #f) (el2 #f)
-       (read-thunk-3 #f) (fc #f) (fc-parked #f) (w3 #f) (gc-ok #f) (fc-done #f)
+       (read-thunk-3 #f) (fc #f) (fc-parked #f) (waits-before-3 #f) (w3 #f) (gc-ok #f) (fc-done #f)
        (r4-n #f) (r4-worker #f) (f4s #f) (all-parked4 #f) (all-done4 #f)
        (r5-sh-out #f) (r5-in #f) (r5-pipe #f) (r5-deref-exit #f)
        (repo-dir #f) (no-poller-script #f) (no-poller-path #f) (chez-bin #f)
@@ -236,6 +236,12 @@
   (ev "(def p3-out (:out p3))")
   (set! read-thunk-3
     (ev "(fn [] (let [b (byte-array 64) n (.read p3-out b 0 64)] (String. b 0 n \"UTF-8\")))"))
+  ;; snapshot BEFORE spawning fc: jolt.io-poller/waits is a GLOBAL monotonic
+  ;; counter, already nonzero from check 1's own registration by the time we
+  ;; get here, so "> 0" alone would pass instantly without ever proving THIS
+  ;; check's own registration made the poller wait. Comparing against this
+  ;; snapshot instead requires an actual increase after fc parks.
+  (set! waits-before-3 (ev "@jolt.io-poller/waits"))
   (set! fc (sa-fiber-spawn read-thunk-3))
   (set! fc-parked
     (wait-until (lambda () (eq? (jolt-fiber-state fc) 'parked)) 15.0 "3. the pipe-read fiber parked"))
@@ -244,8 +250,9 @@
   ;; round, immediately before kevent/epoll_wait) — so gc-full! below races a
   ;; thread that is (about to be / already) inside the blocking foreign call
   (set! w3
-    (wait-until (lambda () (> (ev "@jolt.io-poller/waits") 0)) 15.0 "3. the poller entered its wait"))
-  (ok "3. the poller entered its blocking wait" w3)
+    (wait-until (lambda () (> (ev "@jolt.io-poller/waits") waits-before-3)) 15.0
+                "3. the poller entered its wait"))
+  (ok "3. the poller entered its blocking wait for THIS check's own registration (counter increased)" w3)
   (sleep (make-time 'time-duration 50000000 0))  ; let it settle into the wait
   (set! gc-ok
     (guard (e (#t (printf "  FAIL detail: gc-full! raised ~a\n" (render-condition e)) #f))

--- a/test/chez/fibers-process-io-test.ss
+++ b/test/chez/fibers-process-io-test.ss
@@ -58,6 +58,13 @@
 ;;      the write-side twin of check 1, closing the permanent-gate coverage
 ;;      gap the write path (EAGAIN branch + fcntl fallback, symmetric with the
 ;;      read side) had until now.
+;;   9. closing a pipe-WRITE port while a fiber is parked on it makes the woken
+;;      fiber take the port's closed? short-circuit, rather than re-running
+;;      proc-c-write against a fd the close proc has already closed (and that
+;;      the kernel may already have reassigned to an unrelated
+;;      pipe/socket/open) with a buf it has already free()d. Check 7's twin one
+;;      level deeper: check 7 asserts the woken fiber is not STRANDED, this one
+;;      asserts WHICH path it takes once woken.
 ;;
 ;; Watchdog: the whole workload (all 6 checks) runs on a forked thread; this
 ;; script's main thread does nothing but watch a hard-coded deadline. A wedge
@@ -127,8 +134,8 @@
       (let ((p (open-output-string))) (display-condition e p) (get-output-string p))
       (format "~s" e)))
 
-;; A plain, dependency-free substring search — used once, on check 6's captured
-;; subprocess stdout.
+;; A plain, dependency-free substring search — used on check 6's captured
+;; subprocess stdout and, since check 9, on captured condition messages too.
 (define (string-contains-substr? s sub)
   (let ((ls (string-length s)) (lsub (string-length sub)))
     (let loop ((i 0))
@@ -171,7 +178,9 @@
        (np-out #f) (np-err #f) (np-exit #f)
        (read-thunk-7 #f) (f7 #f) (f7-parked #f) (f7-unparked #f) (f7-result #f)
        (r8-payload-len #f) (write-thunk-8 #f) (f8w #f) (f8sib #f)
-       (f8w-parked #f) (f8sib-done #f) (r8-total #f) (f8w-done #f))
+       (f8w-parked #f) (f8sib-done #f) (r8-total #f) (f8w-done #f)
+       (r9-payload-len #f) (write-thunk-9 #f) (f9 #f) (f9-parked #f)
+       (f9-done #f) (f9-result #f))
   (at! "requiring jolt.process + jolt.io-poller")
   (ev "(require 'jolt.process)")
   ;; Checks 1-5 need REAL parking, which needs jolt.io-poller genuinely
@@ -416,6 +425,14 @@
     (wait-until (lambda () (eq? (jolt-fiber-state f7) 'done)) 5.0 "7. the unparked read finished"))
   (ok "7. the fiber finished cleanly (closed-fd read reads as EOF, not a hang or a crash)"
       (and f7-result (string? (jolt-fiber-result f7))))
+  ;; Pin the read side's closed-case convention: EOF, i.e. an empty payload.
+  ;; Note this cannot tell the two ways of GETTING there apart, and no
+  ;; value-based assertion can: the read side's closed? short-circuit and its
+  ;; "any other errno -> 0" branch both answer 0/EOF by construction, so they
+  ;; are indistinguishable to a caller. Check 9 asserts the shared mechanism on
+  ;; the write side, where the two paths raise distinguishable conditions.
+  (ok "7. the closed-port read reported EOF (empty payload), not partial or garbage data"
+      (and f7-result (equal? "" (jolt-fiber-result f7))))
   (ev "(jolt.process/destroy p7)")
   (ev "(deref p7 5000 :reap-timeout)")
 
@@ -458,6 +475,54 @@
       (and f8w-done (eqv? (jolt-fiber-result f8w) r8-payload-len)))
   (ok "8. the drain side received the full payload byte-for-byte" (eqv? r8-total r8-payload-len))
   (ev "(deref p8 5000 :reap-timeout)")
+
+  ;; --- 9. a close under a PARKED write short-circuits on the closed? flag ---
+  (at! "9. close-while-parked-write (closed short-circuit)")
+  (printf "\n== 9. closing a pipe-write port while a fiber is parked on it takes the closed short-circuit ==\n")
+  ;; Check 8's fill-the-pipe setup, minus the drain: cat's own stdout is never
+  ;; read here, so cat stops consuming stdin and the write stays parked until
+  ;; the close below wakes it. What this adds over check 7 is WHICH path the
+  ;; woken fiber then takes, and the two candidates are told apart by the
+  ;; condition each raises:
+  ;;   "write to closed pipe"  -- the closed? test at the top of the retry loop
+  ;;       fired and proc-c-write was never called. The fix's own path.
+  ;;   "write to child failed" -- the retry re-ran proc-c-write against a fd the
+  ;;       close proc had already closed (and that the kernel is free to hand
+  ;;       straight to an unrelated pipe/socket/open, since POSIX reuses the
+  ;;       lowest free number) passing a buf the close proc had already
+  ;;       free()d. That is the use-after-free the flag exists to prevent, and
+  ;;       it is exactly what this check observes when the flag is removed.
+  ;; So this is a direct assertion on the mechanism, not on "nothing crashed" —
+  ;; and it needs no timing race to be deterministic, because the fiber cannot
+  ;; run at all until the close proc has already set the flag and woken it.
+  (set! r9-payload-len (* 2 1024 1024))
+  (ev "(def p9 (jolt.process/process [\"cat\"]))")
+  (ev "(def p9-in (:in p9))")
+  (ev (string-append "(def p9-payload (byte-array " (number->string r9-payload-len) "))"))
+  (set! write-thunk-9
+    (ev "(fn [] (.write p9-in p9-payload 0 (alength p9-payload)) (.flush p9-in) :never-raised)"))
+  ;; guard inside the fiber thunk so the raise becomes this fiber's RESULT: an
+  ;; unguarded raise ends the fiber through jolt-fiber-dead! instead, and the
+  ;; message is the whole point of the check.
+  (set! f9 (sa-fiber-spawn (lambda () (guard (e (#t (render-condition e))) (write-thunk-9)))))
+  (set! f9-parked
+    (wait-until (lambda () (eq? (jolt-fiber-state f9) 'parked)) 15.0
+                "9. the pipe-write fiber parked (the pipe filled)"))
+  (ok "9. the oversized write parked the fiber once the pipe filled" f9-parked)
+  (ev "(.close p9-in)")
+  (set! f9-done
+    (wait-until (lambda () (eq? (jolt-fiber-state f9) 'done)) 10.0
+                "9. the parked write left 'parked after the port closed"))
+  (ok "9. closing the port unparked the parked write within the bound" f9-done)
+  (set! f9-result (and f9-done (jolt-fiber-result f9)))
+  (ok "9. the woken retry took the CLOSED short-circuit (proc-c-write never re-ran on the closed fd)"
+      (and (string? f9-result) (string-contains-substr? f9-result "write to closed pipe")))
+  (ok "9. and did NOT reach the real-write error path (no syscall on the freed buf / closed fd)"
+      (and (string? f9-result) (not (string-contains-substr? f9-result "write to child failed"))))
+  (unless (and (string? f9-result) (string-contains-substr? f9-result "write to closed pipe"))
+    (printf "  check 9 fiber result: ~s\n" f9-result))
+  (ev "(jolt.process/destroy p9)")
+  (ev "(deref p9 5000 :reap-timeout)")
 
   (printf "\nfibers-process-io: ~a checks, ~a failures\n" total fails)
   (set-box! outcome (if (zero? fails) 'ok 'failed))))


### PR DESCRIPTION
Closes #641.

## Summary

Extends Fibers R8 ("a socket read parks the fiber instead of pinning its
carrier") to `jolt.process` subprocess pipe reads and writes. Today a
blocked pipe read/write pins the whole fiber carrier instead of parking;
with more concurrent pipe-I/O `go`-blocks than `*fiber-carrier-count*`, the
excess ones silently starve forever. See #641 for the full problem
statement and rationale.

## What changed

Entirely at the Scheme/FFI layer in `host/chez/java/process.ss` — mirrors
the existing `jolt.socket` pattern, no changes to `jolt.io-poller`,
`jolt.socket`, or `jolt.process`'s public Clojure API:

- Non-blocking pipe fds at creation, role-aware (only the end the parent
  retains — `O_NONBLOCK` is shared via `dup2`'s open-file-description, so a
  role-blind version would make the *child's* own stdio non-blocking too).
- A working `fcntl` binding for Apple arm64: `F_SETFL` is C-variadic, and
  without the `(__varargs_after 2)` calling-convention marker it reports
  success but silently never applies the flags.
- On `EAGAIN`, park via a small bridge into the already fd-generic
  `jolt.io-poller/wait-ready`; a real blocking fallback (not a busy-loop)
  when no poller is loaded, so `jolt.process` used standalone pays zero
  behavior change.
- `forget!` the fd from the poller on close, matching `jolt.socket`'s own
  close-then-forget order — otherwise a close racing a parked read/write
  strands the fiber permanently, and a leaked tombstone in the poller's
  shared fd-keyed table can be consumed by a later, unrelated socket
  assigned the same reused fd number.
- A per-port `closed?` flag, set synchronously by the close proc before it
  frees/closes/forgets, checked at the top of every retry — the
  `forget!` wakeup is asynchronous, so without this a woken fiber's retry
  could execute a real syscall against an already-freed buffer and a
  possibly-reused fd.

## Testing

New permanent gate, `test/chez/fibers-process-io-test.ss` (36 checks),
wired into `make fibers` right after the socket half's own gate. Covers:
real parking under contention (read and write sides, each with a sibling
fiber proven to make progress while the first stays parked), thread-mode
(off-fiber) behavior, a full GC succeeding mid poller-wait, N fibers on one
carrier each reading a separate subprocess pipe, the existing
`jolt.process` API unaffected off-fiber, the no-poller fallback, and two
close-safety regressions (a close racing a parked read must not strand the
fiber; a close racing a parked write must take the closed short-circuit,
not re-run the syscall against freed memory — this one is a deterministic
mechanism-proof test, not dependent on winning a real fd-reuse timing race).

`make fibers`: all 12 gates green. `bin/jolt run test/chez/process-test.clj`
and the `process-suite` conformance harness both confirmed unaffected.

## Scope

Process pipes only, not general file-descriptor/file-offload support — R8's
own changelog deferred that explicitly, and it's out of scope here too.
