### PR TITLE
Make the subprocess pipe fiber-parking actually engage (jolt-641)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `EAGAIN` registers readiness with `jolt.io-poller` and parks the
   current fiber — the carrier runs other fibers meanwhile, and blocks on a
   private `kevent`/`epoll_wait` exactly as before when there is no fiber
-  (jolt.process's own no-poller fallback keeps working standalone). A
-  working `fcntl` binding for Apple arm64 is what makes the non-blocking fd
-  viable at all: `F_SETFL` is C-variadic, and without the
-  `(__varargs_after 2)` calling-convention marker it reports success but
-  silently never applies the flags. Closing a pipe port now also tells
+  (jolt.process's own no-poller fallback keeps working standalone). A fiber
+  that is about to park autoloads `jolt.io-poller` if nothing else has
+  required it, which is what makes this reach the programs that motivated
+  it: `jolt.socket` was the only namespace in the tree that pulls the
+  poller in, so a build-tool wrapper or shell pipeline driving subprocesses
+  from `go` blocks without ever opening a socket would otherwise have found
+  the poller absent and taken the blocking fallback — pinning its carrier,
+  the exact starvation this removes. A plain thread does not autoload it and
+  keeps the cheaper blocking read. A working `fcntl` binding for Apple arm64
+  is what makes the non-blocking fd viable at all: `F_SETFL` is C-variadic,
+  and without the `(__varargs_after 2)` calling-convention marker it reports
+  success but silently never applies the flags. Missing `fcntl` or `errno`
+  bindings cost only the parking, not the `posix_spawn` path itself, whose
+  fallback to Chez's `fork` leaves `SIGINT` ignored in the child. Closing a
+  pipe port now also tells
   `jolt.io-poller` to forget the fd, mirroring the socket fix below: a
   closed fd is auto-dropped from the kernel's kqueue/epoll set, so a fiber
   still parked on it would otherwise wait forever for an event that is

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -87,18 +87,27 @@
 (define proc-F-SETFL 4)
 (define proc-O-NONBLOCK (if (eq? (sa-os-family) 'macos) #x4 #x800))
 
-;; Deliberately unprefixed (no `proc-` prefix, unlike every other definition
-;; in this file): a bridge point meant to be reachable beyond this file, not
-;; a private proc-* helper. Don't rename it into collision with the
-;; naming-shadow hazard this file's own header documents (line ~40-42).
-(define (set-nonblocking! fd)
-  (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
-    ;; A negative flags value means F_GETFL itself failed -- don't hand that
-    ;; straight to F_SETFL: (fxior -1 proc-O-NONBLOCK) is still negative, and
-    ;; the kernel would mask it down, silently leaving the fd blocking with
-    ;; no diagnostic that anything went wrong.
-    (when (>= flags 0)
-      (proc-fcntl-set fd proc-F-SETFL (fxior flags proc-O-NONBLOCK)))))
+;; Nothing here happens without a working fcntl and a readable errno: a pipe
+;; set non-blocking whose EAGAIN cannot be recognised reads as EOF instead
+;; (the (else 0) branch in proc-fd-input-port), which is worse than a blocking
+;; pipe. So the whole R8 extension is gated on the three bindings, and the
+;; degradation when one is missing is "no parking" — the pipes stay blocking
+;; and EAGAIN never arrives. Deliberately NOT folded into
+;; proc-spawn-fd-ok?: that gate decides posix_spawn vs Chez's fork, and the
+;; fork path leaves SIGINT at SIG_IGN in the child (see the comment above
+;; proc-spawn-fd-mutex). Correct child signal dispositions are not worth
+;; trading for O_NONBLOCK.
+(define proc-nonblock-ok? (and proc-fcntl-get proc-fcntl-set proc-errno-loc #t))
+
+(define (proc-set-nonblocking! fd)
+  (when proc-nonblock-ok?
+    (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
+      ;; A negative flags value means F_GETFL itself failed -- don't hand that
+      ;; straight to F_SETFL: (fxior -1 proc-O-NONBLOCK) is still negative, and
+      ;; the kernel would mask it down, silently leaving the fd blocking with
+      ;; no diagnostic that anything went wrong.
+      (when (>= flags 0)
+        (proc-fcntl-set fd proc-F-SETFL (fxior flags proc-O-NONBLOCK))))))
 
 ;; Bridge to jolt.io-poller/wait-ready: var-deref never throws for a
 ;; missing var -- jolt-var auto-vivifies a jolt-var-unbound placeholder
@@ -109,16 +118,13 @@
 ;; EAGAIN branches in proc-fd-input-port/proc-fd-output-port below --
 ;; a bare 0-byte return there would misread as EOF, since the pipe fd
 ;; is genuinely non-blocking by then).
-;; poller-wait-ready and poller-forget! below are ALSO deliberately
-;; unprefixed, same reason as set-nonblocking! above: bridge points, not
-;; private proc-* helpers.
-(define (poller-wait-ready fd filt-kw)
+(define (proc-poller-wait-ready fd filt-kw)
   (let ((f (var-deref "jolt.io-poller" "wait-ready")))
     (if (jolt-var-unbound? f)
         #f
         (begin (jolt-invoke2 f fd filt-kw) #t))))
 
-;; Bridge to jolt.io-poller/forget!, same shape as poller-wait-ready above.
+;; Bridge to jolt.io-poller/forget!, same shape as proc-poller-wait-ready above.
 ;; A closed fd is auto-removed from the kernel's kqueue/epoll set, so no
 ;; event is ever coming for a fiber still parked on it -- without telling
 ;; the poller to drop its registration, that fiber sleeps forever, and a
@@ -127,9 +133,9 @@
 ;; REUSED fd number belonging to an unrelated later socket. Mirrors
 ;; jolt.socket's socket-close! (stdlib/jolt/socket.clj), which does the
 ;; identical close-then-forget for the same reason. Same unbound-var guard
-;; as poller-wait-ready: when jolt.io-poller was never loaded, forget! has
+;; as proc-poller-wait-ready: when jolt.io-poller was never loaded, forget! has
 ;; nothing to forget and this is a no-op.
-(define (poller-forget! fd)
+(define (proc-poller-forget! fd)
   (let ((f (var-deref "jolt.io-poller" "forget!")))
     (unless (jolt-var-unbound? f) (jolt-invoke1 f fd))))
 
@@ -411,10 +417,13 @@
 (define proc-c-read  (jolt-foreign-proc-blocking "read"  '(int void* size_t) 'ssize_t))
 (define proc-c-write (jolt-foreign-proc-blocking "write" '(int void* size_t) 'ssize_t))
 
+;; What posix_spawn-with-pipes needs, and nothing more. The R8 fiber-parking
+;; extension's own bindings (fcntl, errno) are gated separately by
+;; proc-nonblock-ok? above: losing parking is a performance story, losing this
+;; path means falling back to Chez's fork with SIGINT ignored in the child.
 (define proc-spawn-fd-ok?
   (and proc-c-pipe proc-c-close proc-fa-init proc-fa-dup2 proc-fa-close
-       proc-fa-destroy proc-c-spawn proc-c-read proc-c-write
-       proc-fcntl-get proc-fcntl-set proc-errno-loc #t))
+       proc-fa-destroy proc-c-spawn proc-c-read proc-c-write #t))
 
 ;; marshal a string list into a NULL-terminated char**; returns (array . cstrs)
 ;; so the caller can free every allocation once posix_spawn has copied them.
@@ -445,7 +454,7 @@
 ;; current fiber (or blocks this thread) via jolt.io-poller when it's loaded
 ;; -- symmetric on both sides below: proc-fd-input-port waits on :read,
 ;; proc-fd-output-port waits on :write, over the same mk-pipe-created
-;; non-blocking fd and the same poller-wait-ready bridge. When no poller is
+;; non-blocking fd and the same proc-poller-wait-ready bridge. When no poller is
 ;; loaded, EAGAIN clears O_NONBLOCK on this fd (fd is genuinely non-blocking
 ;; now per mk-pipe above, so a no-poller EAGAIN is a live "not ready yet"
 ;; signal, not a real failure) and falls through to a real blocking
@@ -482,13 +491,13 @@
 ;; So the close proc sets closed? FIRST, before it frees, closes, or forgets,
 ;; and the retry loop tests it at the TOP of EVERY iteration -- the first one
 ;; included, not just the one after a park. The ordering is what makes that test
-;; sound rather than hopeful: set-box! happens before poller-forget!, which
+;; sound rather than hopeful: set-box! happens before proc-poller-forget!, which
 ;; reaches sa-fiber-resume, which takes and releases the carrier's mutex to
 ;; enqueue the fiber; the carrier thread takes that SAME mutex in
 ;; jolt-fiber-dequeue! before it can run the fiber at all. A release/acquire
 ;; pair on one mutex, so the #t is published to the woken fiber -- it cannot
 ;; observe a stale #f, and it cannot have cached the read across the park, since
-;; the park sits behind poller-wait-ready's opaque var-deref'd call. Same
+;; the park sits behind proc-poller-wait-ready's opaque var-deref'd call. Same
 ;; box/set-box!/unbox shape concurrency.ss uses for its own cross-thread flag
 ;; (agents-shutdown?).
 ;;
@@ -502,7 +511,7 @@
 ;; flag could be set, so no flag can help it; it is a pre-existing hazard of
 ;; closing a port other threads are actively using, not something this adds.
 ;;
-;; Also NOT covered: a fiber that has decided to call poller-wait-ready but
+;; Also NOT covered: a fiber that has decided to call proc-poller-wait-ready but
 ;; has not yet registered when close runs -- forget! finds nothing to drop,
 ;; then the fiber registers on an already-dead fd. That is a strand (a hang),
 ;; not a use-after-free; closing it needs coordination on the jolt.io-poller
@@ -518,7 +527,7 @@
         (let ((want (min n proc-fd-buf-size)))
           (let retry ()
             ;; Top of EVERY iteration, first one included: a fiber woken by the
-            ;; close proc's poller-forget! resumes HERE, and buf is freed and fd
+            ;; close proc's proc-poller-forget! resumes HERE, and buf is freed and fd
             ;; closed (possibly reused) by then. Read as EOF without touching
             ;; either -- same answer the (else 0) branch below would give for a
             ;; closed fd's EBADF, reached without the syscall.
@@ -535,7 +544,7 @@
                     ((= got 0) 0)
                     ((= (proc-errno) proc-EINTR) (retry))
                     ((= (proc-errno) proc-EAGAIN)
-                     (if (poller-wait-ready fd (jolt-keyword "read"))
+                     (if (proc-poller-wait-ready fd (jolt-keyword "read"))
                          (retry)
                          (begin
                            (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
@@ -547,7 +556,7 @@
       ;; on the far side of the carrier-mutex handoff every woken fiber crosses.
       (lambda ()
         (set-box! closed? #t)
-        (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
+        (sa-foreign-free buf) (proc-c-close fd) (proc-poller-forget! fd)))))
 (define (proc-fd-output-port fd)
   (let ((buf (sa-foreign-alloc proc-fd-buf-size))
         (closed? (box #f)))
@@ -572,7 +581,7 @@
                     ((>= wrote 0) wrote)
                     ((= (proc-errno) proc-EINTR) (retry))
                     ((= (proc-errno) proc-EAGAIN)
-                     (if (poller-wait-ready fd (jolt-keyword "write"))
+                     (if (proc-poller-wait-ready fd (jolt-keyword "write"))
                          (retry)
                          (begin
                            (let ((flags (proc-fcntl-get fd proc-F-GETFL)))
@@ -584,7 +593,7 @@
       ;; on the far side of the carrier-mutex handoff every woken fiber crosses.
       (lambda ()
         (set-box! closed? #t)
-        (sa-foreign-free buf) (proc-c-close fd) (poller-forget! fd)))))
+        (sa-foreign-free buf) (proc-c-close fd) (proc-poller-forget! fd)))))
 
 ;; What the API hands back for a stream that was INHERITED: the JVM's null
 ;; streams. Reads are at EOF from the start; writes are accepted and dropped.
@@ -639,8 +648,8 @@
       (if (= 0 (proc-c-pipe fds))
           (let ((p (cons (sa-foreign-ref 'int fds 0) (sa-foreign-ref 'int fds 4))))
             (sa-foreign-free fds)
-            (when nonblocking-read? (set-nonblocking! (car p)))
-            (when nonblocking-write? (set-nonblocking! (cdr p)))
+            (when nonblocking-read? (proc-set-nonblocking! (car p)))
+            (when nonblocking-write? (proc-set-nonblocking! (cdr p)))
             p)
           (begin (sa-foreign-free fds)
                  (throw-jvm (quote java.io.IOException) "pipe: cannot allocate")))))

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -109,17 +109,58 @@
       (when (>= flags 0)
         (proc-fcntl-set fd proc-F-SETFL (fxior flags proc-O-NONBLOCK))))))
 
+;; jolt.socket is the only thing in the tree that requires jolt.io-poller, so a
+;; program that drives subprocesses from fibers without ever touching a socket
+;; — a build-tool wrapper, a shell pipeline — would find wait-ready unbound and
+;; take the blocking fallback below, pinning its carrier: exactly the starvation
+;; this whole file's R8 extension exists to remove. Autoload the poller instead,
+;; at the one moment it is known to be needed, and only when there IS a fiber to
+;; park: a plain thread keeps the cheaper blocking read rather than paying a
+;; private kqueue/epoll per wait.
+;;
+;; Safe from inside a port read even though a load can park and can race another
+;; thread's: loader.ss's claim protocol owns both cases (ldr-begin-load! steps
+;; 2-3), and leaning on it rather than on a latch of our own is what makes the
+;; CONCURRENT case come out right. Two fibers on two carriers reach their first
+;; EAGAIN at once routinely -- it is the ordinary shape of "read several
+;; subprocesses from go blocks", the thing this whole extension is for. A
+;; boolean "already tried" latch set before the load would let the second fiber
+;; skip straight past it, find the var still unbound because the first is only
+;; part way through, and take the blocking fallback -- clearing O_NONBLOCK on
+;; its own fd for good, so that one port never parks again for the life of the
+;; process. Calling load-namespace instead makes the second fiber WAIT on the
+;; first's claim (fiber-aware, via jolt-lock-parked, so it parks rather than
+;; pinning), then find a fully built namespace. Already-loaded is a hashtable
+;; lookup, and we only get here when the var is unbound anyway.
+;;
+;; The one thing the loader cannot decide for us is a load that FAILS
+;; (jolt.io-poller off the source roots in a trimmed install): the loader rolls
+;; its own mark back on a throw, deliberately, so a retry can work. Nothing
+;; about the next EAGAIN will have changed, though, so record the failure here
+;; and stop asking.
+(define proc-poller-load-failed #f)
+(define (proc-poller-autoload!)
+  (unless proc-poller-load-failed
+    (guard (e (#t (set! proc-poller-load-failed #t) #f))
+      (load-namespace "jolt.io-poller"))))
+
 ;; Bridge to jolt.io-poller/wait-ready: var-deref never throws for a
 ;; missing var -- jolt-var auto-vivifies a jolt-var-unbound placeholder
 ;; instead (rt.ss:662-669), checkable via the record type's own
-;; predicate. So when jolt.process is used standalone, without
-;; jolt.socket/jolt.io-poller ever loaded, this returns #f and the
-;; caller falls back to a real blocking wait it implements itself (the
-;; EAGAIN branches in proc-fd-input-port/proc-fd-output-port below --
-;; a bare 0-byte return there would misread as EOF, since the pipe fd
-;; is genuinely non-blocking by then).
+;; predicate. Off a fiber an unbound var stays unbound (see
+;; proc-poller-autoload! above for why the load is fiber-only) and this
+;; returns #f, so the caller falls back to a real blocking wait it
+;; implements itself (the EAGAIN branches in
+;; proc-fd-input-port/proc-fd-output-port below -- a bare 0-byte return
+;; there would misread as EOF, since the pipe fd is genuinely
+;; non-blocking by then). On a fiber the same #f is only reachable when
+;; the autoload itself failed.
 (define (proc-poller-wait-ready fd filt-kw)
-  (let ((f (var-deref "jolt.io-poller" "wait-ready")))
+  (let* ((f0 (var-deref "jolt.io-poller" "wait-ready"))
+         (f (if (and (jolt-var-unbound? f0) (jolt-current-fiber))
+                (begin (proc-poller-autoload!)
+                       (var-deref "jolt.io-poller" "wait-ready"))
+                f0)))
     (if (jolt-var-unbound? f)
         #f
         (begin (jolt-invoke2 f fd filt-kw) #t))))
@@ -133,8 +174,8 @@
 ;; REUSED fd number belonging to an unrelated later socket. Mirrors
 ;; jolt.socket's socket-close! (stdlib/jolt/socket.clj), which does the
 ;; identical close-then-forget for the same reason. Same unbound-var guard
-;; as proc-poller-wait-ready: when jolt.io-poller was never loaded, forget! has
-;; nothing to forget and this is a no-op.
+;; as proc-poller-wait-ready, and no autoload: a poller that was never loaded
+;; holds no registration for this fd, so there is nothing to forget.
 (define (proc-poller-forget! fd)
   (let ((f (var-deref "jolt.io-poller" "forget!")))
     (unless (jolt-var-unbound? f) (jolt-invoke1 f fd))))
@@ -653,47 +694,63 @@
             p)
           (begin (sa-foreign-free fds)
                  (throw-jvm (quote java.io.IOException) "pipe: cannot allocate")))))
-  (jolt-with-mutex proc-spawn-fd-mutex
-    (let* ((in-p  (and (not inherit-in?)  (mk-pipe #f #t)))
-           (out-p (and (not inherit-out?) (mk-pipe #t #f)))
-           (err-p (and (not inherit-err?) (mk-pipe #t #f)))
-           (fa (sa-foreign-alloc 128))
-           (pidbuf (sa-foreign-alloc 8)))
-      (proc-fa-init fa)
-      (when in-p  (proc-fa-dup2 fa (car in-p) 0)
-                  (proc-fa-close fa (car in-p)) (proc-fa-close fa (cdr in-p)))
-      (when out-p (proc-fa-dup2 fa (cdr out-p) 1)
-                  (proc-fa-close fa (cdr out-p)) (proc-fa-close fa (car out-p)))
-      (when err-p (proc-fa-dup2 fa (cdr err-p) 2)
-                  (proc-fa-close fa (cdr err-p)) (proc-fa-close fa (car err-p)))
-      (let* ((argv (proc-marshal-argv (list "/bin/sh" "-c" sh-cmd)))
-             (envp (proc-marshal-argv
-                    (map (lambda (p) (string-append (car p) "=" (cdr p)))
-                         (all-env-pairs))))
-             ;; attrp is NULL, so the child inherits this thread's signal mask —
-             ;; which must carry none of jolt's own blocking (concurrency.ss).
-             (rc (jolt-with-empty-sigmask
-                   (lambda () (proc-c-spawn pidbuf "/bin/sh" fa 0 (car argv) (car envp)))))
-             (pid (sa-foreign-ref 'int pidbuf 0)))
-        (proc-fa-destroy fa)
-        (sa-foreign-free fa) (sa-foreign-free pidbuf)
-        (proc-free-argv argv) (proc-free-argv envp)
-        ;; parent side: the child's pipe ends close unconditionally; on a failed
-        ;; spawn the parent ends close too, before the throw.
-        (when in-p  (proc-c-close (car in-p)))
-        (when out-p (proc-c-close (cdr out-p)))
-        (when err-p (proc-c-close (cdr err-p)))
-        (if (= rc 0)
-            (values (and in-p  (proc-fd-output-port (cdr in-p)))
-                    (and out-p (proc-fd-input-port (car out-p)))
-                    (and err-p (proc-fd-input-port (car err-p)))
-                    pid)
-            (begin
-              (when in-p  (proc-c-close (cdr in-p)))
-              (when out-p (proc-c-close (car out-p)))
-              (when err-p (proc-c-close (car err-p)))
-              (throw-jvm (quote java.io.IOException)
-                (string-append "posix_spawn failed (errno " (number->string rc) ")"))))))))
+  ;; spawn-locked hands back RAW FDS and the ports are built after it returns,
+  ;; not inside. proc-fd-input-port / proc-fd-output-port can park now (an EAGAIN on
+  ;; a fiber waits on jolt.io-poller, and the first such wait may autoload it),
+  ;; and a park inside a jolt-with-mutex region is the deadlock shape
+  ;; test/parkcheck refuses outright -- host/chez/locks.ss. Only their
+  ;; read!/write! callbacks can actually reach a park, and those run when
+  ;; someone reads the port rather than here, so nothing was wrong before; but
+  ;; the lock has no reason to span the construction either, and its own
+  ;; contract is pipe() through posix_spawn and nothing else. Narrowing it makes
+  ;; the call graph say what is true instead of asking for an exemption.
+  (define (spawn-locked)
+    (jolt-with-mutex proc-spawn-fd-mutex
+      (let* ((in-p  (and (not inherit-in?)  (mk-pipe #f #t)))
+             (out-p (and (not inherit-out?) (mk-pipe #t #f)))
+             (err-p (and (not inherit-err?) (mk-pipe #t #f)))
+             (fa (sa-foreign-alloc 128))
+             (pidbuf (sa-foreign-alloc 8)))
+        (proc-fa-init fa)
+        (when in-p  (proc-fa-dup2 fa (car in-p) 0)
+                    (proc-fa-close fa (car in-p)) (proc-fa-close fa (cdr in-p)))
+        (when out-p (proc-fa-dup2 fa (cdr out-p) 1)
+                    (proc-fa-close fa (cdr out-p)) (proc-fa-close fa (car out-p)))
+        (when err-p (proc-fa-dup2 fa (cdr err-p) 2)
+                    (proc-fa-close fa (cdr err-p)) (proc-fa-close fa (car err-p)))
+        (let* ((argv (proc-marshal-argv (list "/bin/sh" "-c" sh-cmd)))
+               (envp (proc-marshal-argv
+                      (map (lambda (p) (string-append (car p) "=" (cdr p)))
+                           (all-env-pairs))))
+               ;; attrp is NULL, so the child inherits this thread's signal mask —
+               ;; which must carry none of jolt's own blocking (concurrency.ss).
+               (rc (jolt-with-empty-sigmask
+                     (lambda () (proc-c-spawn pidbuf "/bin/sh" fa 0 (car argv) (car envp)))))
+               (pid (sa-foreign-ref 'int pidbuf 0)))
+          (proc-fa-destroy fa)
+          (sa-foreign-free fa) (sa-foreign-free pidbuf)
+          (proc-free-argv argv) (proc-free-argv envp)
+          ;; parent side: the child's pipe ends close unconditionally; on a failed
+          ;; spawn the parent ends close too, before the throw.
+          (when in-p  (proc-c-close (car in-p)))
+          (when out-p (proc-c-close (cdr out-p)))
+          (when err-p (proc-c-close (cdr err-p)))
+          (if (= rc 0)
+              (vector (and in-p  (cdr in-p))
+                      (and out-p (car out-p))
+                      (and err-p (car err-p))
+                      pid)
+              (begin
+                (when in-p  (proc-c-close (cdr in-p)))
+                (when out-p (proc-c-close (car out-p)))
+                (when err-p (proc-c-close (car err-p)))
+                (throw-jvm (quote java.io.IOException)
+                  (string-append "posix_spawn failed (errno " (number->string rc) ")"))))))))
+  (let ((fds (spawn-locked)))
+    (values (let ((fd (vector-ref fds 0))) (and fd (proc-fd-output-port fd)))
+            (let ((fd (vector-ref fds 1))) (and fd (proc-fd-input-port fd)))
+            (let ((fd (vector-ref fds 2))) (and fd (proc-fd-input-port fd)))
+            (vector-ref fds 3))))
 
 ;; --- java.lang.Process -------------------------------------------------------
 ;; state: #(stdin-os stdout-is stderr-is pid exit-box cmd mutex stdout-port

--- a/stdlib/clojure/core/async.clj
+++ b/stdlib/clojure/core/async.clj
@@ -503,10 +503,11 @@
 ;;
 ;; What a fiber does NOT get is an OS thread of its own, so a body that blocks
 ;; SOMEWHERE THE RUNTIME DOES NOT KNOW ABOUT pins its carrier for the duration.
-;; Channel ops park, and so does jolt.socket (R8: an EAGAIN registers with the
-;; io-poller and parks). Thread/sleep, a blocking read on a raw fd, and an FFI
-;; call that blocks do not — they hold the carrier's OS thread. Use thread for
-;; those; that is what it is for.
+;; Channel ops park, and so do jolt.socket's reads and writes and jolt.process's
+;; subprocess pipe reads and writes (R8: an EAGAIN registers with the io-poller
+;; and parks). Thread/sleep, a blocking read on a raw fd you opened yourself, and
+;; an FFI call that blocks do not — they hold the carrier's OS thread. Use thread
+;; for those; that is what it is for.
 (defn thread-call
   "Executes f elsewhere, returning a channel that receives f's result then closes.
   workload says what f does and picks the carrier: :io runs f on a fiber

--- a/stdlib/jolt/fibers.clj
+++ b/stdlib/jolt/fibers.clj
@@ -10,7 +10,8 @@
 ;;   - a fiber is bound to its carrier (an OS thread of the pool) for life;
 ;;     a blocking foreign call or Thread/sleep in a body pins that carrier
 ;;     and strands the fibers queued behind it. Park-capable waits — channel
-;;     ops, deref, jolt.socket IO — are the ones to use inside a body.
+;;     ops, deref, jolt.socket IO, jolt.process subprocess pipe IO — are the
+;;     ones to use inside a body.
 ;;   - spawn conveys the caller's dynamic bindings; *txn* never conveys (a
 ;;     child cannot join the parent's STM transaction).
 ;;   - a body that throws kills its fiber: join rethrows the original error,

--- a/test/chez/fibers-process-io-test.ss
+++ b/test/chez/fibers-process-io-test.ss
@@ -10,10 +10,13 @@
 ;; ask jolt.io-poller to wait for readiness — parking the fiber when there is a
 ;; current fiber, blocking this thread when there is not. Same user-facing
 ;; jolt.process code either way. The retry loop also has a THIRD branch neither
-;; socket.clj nor fibers-io-test.ss needs: when jolt.io-poller was never
-;; required at all (jolt.process is usable standalone), EAGAIN clears
-;; O_NONBLOCK on the fd and falls through to a real blocking read/write —
-;; behaviorally identical to the pre-R8-extension code, once triggered.
+;; socket.clj nor fibers-io-test.ss needs: off a fiber, when jolt.io-poller was
+;; never required at all (jolt.process is usable standalone, and jolt.socket is
+;; the only ns in the tree that requires the poller), EAGAIN clears O_NONBLOCK
+;; on the fd and falls through to a real blocking read/write — behaviorally
+;; identical to the pre-R8-extension code, once triggered. ON a fiber that same
+;; state autoloads the poller instead, since falling back there is precisely the
+;; carrier-pinning this file exists to rule out.
 ;;
 ;; Gate checks, in order:
 ;;   1. a fiber reading a subprocess pipe with nothing written yet PARKS, and a
@@ -26,7 +29,7 @@
 ;;      asserts for sockets — this is the same poller, so this is really a
 ;;      belt-and-suspenders repeat of it via a different registration path,
 ;;      worth asserting explicitly since jolt.process is a distinct caller of
-;;      poller-wait-ready from jolt.socket).
+;;      proc-poller-wait-ready from jolt.socket).
 ;;   4. N fibers (N picked below, see the note at its definition), each reading
 ;;      its OWN subprocess's pipe, all on ONE carrier: all N park at once, then
 ;;      all N complete with their own payload — real parking, not serialized
@@ -36,11 +39,16 @@
 ;;      extension does not leak into or change the non-fiber path every
 ;;      existing jolt.process caller (process-test.clj, babashka.process
 ;;      itself) depends on.
-;;   6. the no-poller fallback: a FRESH Chez process that requires jolt.process
-;;      but never jolt.io-poller (so poller-wait-ready's var-deref finds it
-;;      genuinely unbound, not just un-invoked) still blocks correctly on a
-;;      pipe read — not a spurious short-read/EOF on the first EAGAIN, and not
-;;      a busy spin. No analog in fibers-io-test.ss: sockets always require
+;;   6. a FRESH Chez process that requires jolt.process but never
+;;      jolt.io-poller (so proc-poller-wait-ready's var-deref finds it genuinely
+;;      unbound, not just un-invoked) gets BOTH halves of the choice right: off a
+;;      fiber it blocks correctly and leaves the poller unloaded — not a spurious
+;;      short-read/EOF on the first EAGAIN, not a busy spin, and not a private
+;;      kqueue per wait either; on a fiber it autoloads the poller and genuinely
+;;      parks, with a sibling on the same carrier proving it. That fiber half is
+;;      the one that reproduces jolt-641 in full if the autoload is removed, and
+;;      it is the shape of every subprocess-driving fiber program that never
+;;      opens a socket. No analog in fibers-io-test.ss: sockets always require
 ;;      jolt.io-poller by construction, so this state is only reachable through
 ;;      jolt.process. Runs the probe as a genuinely separate `chez --script`
 ;;      subprocess (see check 6 below) — jolt-var auto-vivifies an unbound
@@ -66,7 +74,7 @@
 ;;      level deeper: check 7 asserts the woken fiber is not STRANDED, this one
 ;;      asserts WHICH path it takes once woken.
 ;;
-;; Watchdog: the whole workload (all 6 checks) runs on a forked thread; this
+;; Watchdog: the whole workload (all 9 checks) runs on a forked thread; this
 ;; script's main thread does nothing but watch a hard-coded deadline. A wedge
 ;; anywhere in the workload — including a raw blocking spawn/read call that
 ;; isn't wrapped in wait-until's own per-check bound — fails the gate loudly
@@ -154,9 +162,11 @@
 ;; Measured real runtime (5 repeated runs, this machine): ~8.5-12.5s total —
 ;; roughly 3.2s for this file's own gate-boot+loader+ffi load plus requiring
 ;; jolt.process/jolt.io-poller, ~1.9s for checks 1-5 combined (real subprocess
-;; spawns, N=6 of them in check 4), and ~3.4s for check 6's nested Chez
+;; spawns, N=6 of them in check 4), and ~5.5s for check 6's nested Chez
 ;; subprocess (which repeats the same gate-boot+loader+ffi+require cost, plus
-;; its own 0.3s delayed read). hang-secs is ~10x the slowest observed run —
+;; the 0.3s delayed read of its thread half and the 2s one of its fiber half —
+;; long enough that the fiber is provably still parked when the sibling's own
+;; progress is read). hang-secs is ~10x the slowest observed run —
 ;; generous for a slower CI machine, still bounded: anything that reaches it
 ;; is wedged, not slow.
 (define hang-secs 120.0)
@@ -335,15 +345,28 @@
         (ev "(jolt.process/shell \"true\")")
         #t))
 
-  ;; --- 6. the no-poller fallback path -----------------------------------------
-  (at! "6. no-poller fallback (nested chez subprocess)")
-  (printf "\n== 6. the no-poller fallback: jolt.process usable standalone, jolt.io-poller never required ==\n")
+  ;; --- 6. jolt.io-poller reachability, with nobody having required it --------
+  (at! "6. poller autoload + off-fiber fallback (nested chez subprocess)")
+  (printf "\n== 6. jolt.process standalone: a fiber autoloads jolt.io-poller, a thread keeps the blocking fallback ==\n")
   ;; This process already required jolt.io-poller for checks 1-5 (jolt-var
   ;; auto-vivifies an unbound placeholder for a never-required ns, so once a
   ;; require has happened for real there is no way back within this process).
   ;; So this check runs the probe in a genuinely fresh `chez --script`
   ;; subprocess that requires jolt.process and nothing else, and reports its
   ;; own verdict on stdout.
+  ;;
+  ;; The probe covers both halves of proc-poller-wait-ready's choice, in the
+  ;; one order that can observe them: OFF a fiber first, where the poller must
+  ;; stay unloaded and the read must fall back to a real blocking read; then ON
+  ;; a fiber, where the poller must autoload and the read must genuinely park.
+  ;; Reversed, the fiber half would leave the poller loaded and the thread half
+  ;; could no longer tell "did not autoload" from "someone else had".
+  ;;
+  ;; jolt.socket is the only ns in the tree that requires jolt.io-poller, so
+  ;; this is the shape every subprocess-driving fiber program that never opens
+  ;; a socket is in — a build-tool wrapper, a shell pipeline. Without the
+  ;; autoload the fiber half here pins its carrier and jolt-641 reproduces in
+  ;; full on top of everything else in this file.
   (set! repo-dir (current-directory))
   (set! no-poller-script (string-append
     "(import (chezscheme))\n"
@@ -362,22 +385,52 @@
     "      (cond ((pred) #t)\n"
     "            ((> (now-secs) deadline) #f)\n"
     "            (else (sleep (make-time 'time-duration 1000000 0)) (loop))))))\n"
+    "(define (poller-loaded?) (not (jolt-var-unbound? (var-deref \"jolt.io-poller\" \"wait-ready\"))))\n"
     ;; deliberately never requires jolt.io-poller
     "(ev \"(require 'jolt.process)\")\n"
-    "(jolt-fiber-carrier-count-set! 1)\n"
+    "(define pre (poller-loaded?))\n"
+    ;; -- off a fiber: the blocking fallback, and no autoload --
+    "(ev \"(def np1 (jolt.process/process [\\\"sh\\\" \\\"-c\\\" \\\"sleep 0.3; printf npo\\\"]))\")\n"
+    "(define t1 (mono-nanos))\n"
+    "(define r1 (ev \"(let [b (byte-array 64) n (.read (:out np1) b 0 64)] (String. b 0 n \\\"UTF-8\\\"))\"))\n"
+    "(define el1 (/ (exact->inexact (- (mono-nanos) t1)) 1000000.0))\n"
+    "(define mid (poller-loaded?))\n"
+    ;; -- on a fiber: the autoload, and real parking with a sibling progressing --
+    ;; TWO carriers and TWO readers, not one of each, because the concurrent
+    ;; autoload is the case with a wrong answer available: both readers reach
+    ;; their first EAGAIN at once, and a "have we tried yet" latch in
+    ;; proc-poller-autoload! would let the second one past it while the first is
+    ;; still loading, so the second finds the var unbound, takes the blocking
+    ;; fallback, and clears O_NONBLOCK on its own fd for good. That shows up
+    ;; here as ONE of the two readers stuck 'running instead of 'parked, which
+    ;; is exactly what parked2 catches. Two carriers is also the smallest pool
+    ;; that can host both readers at once, which is what makes them race at all.
+    "(jolt-fiber-carrier-count-set! 2)\n"
     "(jolt-fiber-pool-reset!)\n"
     "(jolt-fiber-ensure-carrier!)\n"
-    "(ev \"(def np-proc (jolt.process/process [\\\"sh\\\" \\\"-c\\\" \\\"sleep 0.3; printf npo\\\"]))\")\n"
-    "(ev \"(def np-out (:out np-proc))\")\n"
-    "(define read-thunk (ev \"(fn [] (let [b (byte-array 64) n (.read np-out b 0 64)] (String. b 0 n \\\"UTF-8\\\")))\"))\n"
-    "(define t0 (mono-nanos))\n"
-    "(define f (sa-fiber-spawn read-thunk))\n"
-    "(define done (wait-until (lambda () (eq? (jolt-fiber-state f) 'done)) 15.0))\n"
-    "(define el (/ (exact->inexact (- (mono-nanos) t0)) 1000000.0))\n"
-    "(define r (jolt-fiber-result f))\n"
-    "(if (and done (string? r) (string=? r \"npo\") (> el 150.0))\n"
-    "    (begin (printf \"NO-POLLER-PROBE OK elapsed=~,1fms\\n\" el) (exit 0))\n"
-    "    (begin (printf \"NO-POLLER-PROBE FAIL done=~a result=~a elapsed=~,1fms\\n\" done r el) (exit 1)))\n"))
+    "(ev \"(def np2s (mapv (fn [i] (jolt.process/process [\\\"sh\\\" \\\"-c\\\" \\\"sleep 2; printf npf\\\"])) (range 2)))\")\n"
+    "(ev \"(def np2-outs (mapv :out np2s))\")\n"
+    "(define read-thunk (ev \"(fn [i] (let [s (nth np2-outs i) b (byte-array 64) n (.read s b 0 64)] (String. b 0 n \\\"UTF-8\\\")))\"))\n"
+    "(define fs (list (sa-fiber-spawn (lambda () (read-thunk 0)))\n"
+    "                 (sa-fiber-spawn (lambda () (read-thunk 1)))))\n"
+    "(define (all-state? st) (lambda () (andmap (lambda (f) (eq? (jolt-fiber-state f) st)) fs)))\n"
+    "(define parked2 (wait-until (all-state? 'parked) 8.0))\n"
+    ;; a third body on a pool both of whose carriers are hosting a pipe read
+    "(define sib (sa-fiber-spawn (lambda () 606)))\n"
+    "(define sib-ran (and (wait-until (lambda () (eq? (jolt-fiber-state sib) 'done)) 5.0)\n"
+    "                     ((all-state? 'parked))))\n"
+    "(define post (poller-loaded?))\n"
+    "(define done2 (wait-until (all-state? 'done) 15.0))\n"
+    "(define r2 (map jolt-fiber-result fs))\n"
+    "(if (and (not pre) (string? r1) (string=? r1 \"npo\") (> el1 150.0) (not mid)\n"
+    "         parked2 sib-ran post done2 (equal? r2 (list \"npf\" \"npf\")))\n"
+    "    (begin (printf \"NO-POLLER-PROBE OK thread-read=~,1fms\\n\" el1) (exit 0))\n"
+    "    (begin (printf (string-append \"NO-POLLER-PROBE FAIL pre=~a r1=~a el1=~,1fms mid=~a\"\n"
+    "                                  \" parked2=~a sib-ran=~a post=~a done2=~a r2=~s\"\n"
+    "                                  \" states=~a\\n\")\n"
+    "                   pre r1 el1 mid parked2 sib-ran post done2 r2\n"
+    "                   (map jolt-fiber-state fs))\n"
+    "           (exit 1)))\n"))
   (set! no-poller-path
     (string-append "/tmp/jolt-fibers-process-io-no-poller-probe-" (number->string (get-process-id)) ".ss"))
   (let ((p (open-output-file no-poller-path 'replace)))
@@ -390,13 +443,13 @@
   (set! np-out (ev "(:out np-result)"))
   (set! np-err (ev "(:err np-result)"))
   (set! np-exit (ev "(:exit np-result)"))
-  (ok "6. the no-poller subprocess exited 0"
+  (ok "6. the standalone-jolt.process subprocess exited 0"
       (eqv? np-exit 0))
-  (ok "6. the no-poller subprocess reported a genuine blocking read (correct payload, waited for it)"
+  (ok "6. off a fiber it fell back to a real blocking read and left jolt.io-poller unloaded; on a fiber it autoloaded the poller and genuinely parked"
       (and (string? np-out) (string-contains-substr? np-out "NO-POLLER-PROBE OK")))
   (unless (and (eqv? np-exit 0) (string? np-out) (string-contains-substr? np-out "NO-POLLER-PROBE OK"))
-    (printf "  no-poller subprocess stdout: ~a\n" np-out)
-    (printf "  no-poller subprocess stderr: ~a\n" np-err))
+    (printf "  standalone subprocess stdout: ~a\n" np-out)
+    (printf "  standalone subprocess stderr: ~a\n" np-err))
   (guard (e (#t #f)) (delete-file no-poller-path))
 
   ;; --- 7. closing a port while parked on its read must not strand the fiber -


### PR DESCRIPTION
Follow-up to #642, which extended Fibers R8 to `jolt.process` subprocess pipes. The machinery there is right, but it does not engage in the case #641 describes, and this finishes it. Also carries two smaller cleanups from reviewing that PR.

## The poller was not reachable

`proc-poller-wait-ready` only used `jolt.io-poller` if something else had already loaded it, and `jolt.socket` is the only namespace in the tree that requires it. So a program that drives subprocesses from fibers and never opens a socket, which is two of the three cases #641 names (a build-tool wrapper, a shell pipeline), found `wait-ready` unbound, took the blocking fallback, cleared `O_NONBLOCK`, and starved exactly as before.

Verified on the merged branch, two carriers with both hosting a subprocess pipe read and a third fiber body spawned after them:

```
poller loaded by this program's requires? false
sibling result: nil after 1509 ms
VERDICT: STARVED — every carrier pinned by a pipe read
```

and on this branch, same program:

```
poller loaded by this program's requires? false
sibling result: :sibling-ran after 1 ms
VERDICT: the pipe reads parked — a further body ran on a full carrier pool
```

`proc-poller-wait-ready` now loads the poller itself, at the one moment it is known to be needed and only when there is a current fiber to park. A plain thread keeps the blocking fallback rather than paying a private `kqueue` per wait, which is the cheaper answer for it anyway and leaves every existing off-fiber `jolt.process` caller on exactly the path it was on.

The load leans on `loader.ss`'s claim protocol rather than on a latch of its own, and that turned out to be the part that matters. Two fibers on two carriers reach their first `EAGAIN` at once routinely, and my first attempt used a boolean "already tried" latch set before the load. The second fiber skipped straight past it, found the var still unbound because the first was only part way through, and cleared `O_NONBLOCK` on its own fd for good, so that port never parked again. One of the two readers sat `:running` while the other sat `:parked`. Calling `load-namespace` instead makes the second fiber wait on the first's claim, fiber-aware so it parks rather than pinning, and then find a fully built namespace. A load that fails is recorded and not retried, since the loader deliberately rolls its own mark back and nothing about the next `EAGAIN` will have changed.

Narrowing `proc-spawn-fd-level`'s lock falls out of this. The port constructors can now reach a park and were being called inside the `proc-spawn-fd-mutex` region, which `make parkcheck` refuses outright. Only their `read!`/`write!` callbacks can actually park and those run when someone reads the port, so nothing was wrong, but the lock's own contract is `pipe()` through `posix_spawn` and nothing else. It hands back raw fds now and the ports are built after it returns.

## The gate check that should have caught it

Check 6 required `jolt.io-poller` explicitly for checks 1-5, and its standalone probe only asserted that a read eventually returned the right bytes, which the fallback also does. It now covers both halves of the choice, in the one order that can observe them: off a fiber the poller must stay unloaded and the read must really block, then on a fiber it must autoload and both readers must park with a third body proving the carriers are free. Two carriers and two readers rather than one of each, because the concurrent autoload is the case with a wrong answer available.

Both failure modes were confirmed to fail the check. Without the autoload at all: `parked2=#f sib-ran=#f post=#f`. With the latch instead of the claim protocol: `parked2=#f sib-ran=#f post=#t states=(done done)`.

## Two cleanups

`proc-spawn-fd-ok?` had grown `proc-fcntl-get`, `proc-fcntl-set` and `proc-errno-loc`, so a machine where any of the three fails to resolve stops using `posix_spawn` altogether and falls back to Chez's fork. The comment above `proc-spawn-fd-mutex` explains why that is the fallback and not the default: it leaves `SIGINT` at `SIG_IGN` in the child. Correct child signal dispositions are not worth trading for the ability to set `O_NONBLOCK`, so the parking bindings get their own gate and the degradation when they are missing is that pipes stay blocking.

`set-nonblocking!`, `poller-wait-ready` and `poller-forget!` were left unprefixed as bridge points reachable beyond the file, but nothing outside `process.ss` references any of them, and the file's own header documents why an unprefixed top-level define here is a hazard: the file is `load`-ed at top level, so a second define of the same name silently wins. That is why `proc-libc-signal` exists. They carry the prefix now.

## Testing

`make fibers` all 12 gates green, `fibers-process-io` 36 checks / 0 failures. `make parkcheck`, `make lockcheck`, `make gosm`, `make asynctimer` green. `bin/jolt run test/chez/process-test.clj` and `host/chez/process-suite.sh` (the vendored babashka.process upstream suite) both clean. `make test` in progress; I will note the result here.

The CHANGELOG entry for #642 is still unreleased, so it is amended in place rather than given a second bullet.
