### PR TITLE
Do the resolver's filesystem work with filesystem calls, not a shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,21 @@ uniform per-call overhead. Those are here too.
 
 ### Fixed
 
+- **The dependency resolver does its filesystem work on Windows.** Every
+  `mkdir -p`, `mv`, `rm`, `touch`, `test -nt` and `find` in `jolt.deps` went
+  through `jolt.host/sh`, which is `cmd.exe` on Windows: `mkdir` there has no
+  `-p` and takes a list of paths, so every run created a directory literally
+  named `-p` in the working directory, and mv/rm/touch/test/find are not
+  commands at all. Running `jolt` in any directory left that `-p` behind plus a
+  `.jolt/cpcache` full of `.part-` files the failed `mv` never published, and
+  the classpath cache could never hit, so a warm run re-resolved from scratch
+  and dropped one more file. Maven jar extraction and git checkout publishing
+  failed the same way. All of it is filesystem calls now (new `jolt.host`
+  seams: `mkdirs!`, `rename-file!`, `delete-file!`, `delete-tree!`,
+  `file-mtime`, `list-dir`, `symlink?`), the captured-output temp files follow
+  `%TEMP%` where there is no `/tmp`, and the `shelloutcheck` gate holds the
+  line: only `git` and `unzip`, which are real external programs, may reach the
+  shell.
 - **`jolt build` finds host classes a dependency provides.** The
   require-graph scan never looked at class references inside the closure, so a
   program using a lib-provided host class (`java.util.Locale`,

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscali
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform traceemit traceeval degradedbacktrace \
-  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck irvalidate devbootsmoke \
+  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck shelloutcheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
   certify gambitcheck gambitgencheck gambitboot grenadinecheck fibers gosm asynctimer threadsafety
@@ -757,6 +757,15 @@ lockcheck:
 # halves cannot be removed independently.
 parkcheck:
 	@sh host/chez/park-lock-check.sh
+
+# jolt.host/sh is Chez's `system`, which is cmd.exe on Windows: `mkdir -p a/b`
+# there creates a directory named `-p`, and mv/rm/touch/test/find are not
+# commands at all. So the resolver does its filesystem work through filesystem
+# calls, and the shell is left for git and unzip, which are real programs. The
+# two spellings look alike in the source, so the rule is checked rather than
+# remembered.
+shelloutcheck:
+	@sh host/chez/shellout-check.sh
 
 # Makefile dependency selection: explicit Chez overrides must bypass local
 # Makes provisioning so release jobs retain their chosen compiler and libc.

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -2022,7 +2022,6 @@
 (def-var! "jolt.host" "add-shutdown-hook" jolt-add-shutdown-hook)
 (def-var! "jolt.host" "block-sigint" (lambda () (jolt-set-sigint-blocked #t)))
 (def-var! "jolt.host" "park-until-interrupt" jolt-park-until-interrupt)
-(def-var! "jolt.host" "delete-file" delete-file)
 
 ;; reference types report their JVM classes and answer the IDeref/IRef taxonomy
 ;; ((class (agent 1)) is clojure.lang.Agent; derefables are IDeref; the mutable

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -34,7 +34,8 @@ cpu-nanos
 current-memory-bytes
 current-fiber
 deftype-ctor-class
-delete-file
+delete-file!
+delete-tree!
 directory?
 enable-trace!
 entry-at
@@ -57,6 +58,7 @@ fiber-to-scheduler!
 fiber-yield
 fiber?
 file-exists?
+file-mtime
 find-var
 form-bigdec-source
 form-bigdec-value-source
@@ -134,6 +136,7 @@ jolt-class-for
 jolt-version
 jrec-method?
 late-bind?
+list-dir
 list?
 load-namespace
 locale-name
@@ -142,6 +145,7 @@ make-interrupt
 make-thread-local
 map-entry
 maximum-memory-bytes
+mkdirs!
 monitor-enter
 monitor-exit
 mono-nanos
@@ -165,6 +169,7 @@ register-class-supers!
 register-extension!
 register-extension-point!
 register-source!
+rename-file!
 resolvable-names
 resolve-class-hint
 resolve-global
@@ -186,6 +191,7 @@ source-roots
 stash-inline!
 static-member
 stop-main-pump
+symlink?
 table?
 tagged-table
 thread-id

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -1920,6 +1920,63 @@
 (def-var! "jolt.host" "directory?" (lambda (p) (if (file-directory? p) #t #f)))
 (def-var! "jolt.host" "getenv" (lambda (n) (let ((v (getenv n))) (if v v jolt-nil))))
 
+;; --- filesystem primitives (jolt.host) --------------------------------------
+;; jolt.deps did its filesystem work by shelling out: `mkdir -p`, `mv`, `rm -f`,
+;; `rm -rf`, `test -nt`, `find`. jolt-sh is Chez's `system`, which on Windows
+;; runs the string through cmd.exe, where none of those mean what they mean on
+;; POSIX — cmd's `mkdir` has no `-p` and takes a list of paths, so `mkdir -p
+;; a/b` silently creates a directory literally NAMED `-p` alongside a/b, and
+;; mv/rm/test/find are not commands at all. That left every Windows run
+;; littering the project with a `-p` dir and `.part-` files the failed `mv`
+;; never published, and the classpath cache never hit. Same failure the AOT
+;; cache hit (aot-mkdir-p above); these are the native equivalents, so the
+;; resolver never spawns a shell for something the filesystem API does. Only
+;; git and unzip stay subprocesses — those are real external programs.
+;;
+;; A Windows path can arrive with backslashes (a %TEMP%- or %HOME%-derived one
+;; does), and the separator-splitting walks below know only "/" — which Windows
+;; accepts everywhere anyway. POSIX keeps the path verbatim: there a backslash
+;; is an ordinary character in a filename, not a separator.
+(define (host-fs-path p)
+  (if (eq? (sa-os-family) 'windows)
+      (list->string (map (lambda (c) (if (char=? c #\\) #\/ c)) (string->list p)))
+      p))
+(def-var! "jolt.host" "mkdirs!"
+  (lambda (p) (if (mkdirs! (host-fs-path p)) #t #f)))
+;; `rm -f`: an absent path is success, not failure.
+(def-var! "jolt.host" "delete-file!"
+  (lambda (p)
+    (let ((p (host-fs-path p)))
+      (if (file-exists? p) (if (delete-path! p) #t #f) #t))))
+;; `rm -rf`, reusing the AOT cache's pruner (which does not follow symlinks).
+(def-var! "jolt.host" "delete-tree!"
+  (lambda (p)
+    (let ((p (host-fs-path p)))
+      (aot-delete-tree p)
+      (if (file-exists? p) #f #t))))
+;; `mv` within one filesystem: rename(2), which is the atomicity the publish
+;; steps (a staged cache entry, a staged git checkout) depend on.
+(def-var! "jolt.host" "rename-file!"
+  (lambda (from to)
+    (guard (e (#t #f)) (rename-file (host-fs-path from) (host-fs-path to)) #t)))
+;; last-modified in epoch milliseconds, 0 when absent — what `test -nt` compared.
+(def-var! "jolt.host" "file-mtime"
+  (lambda (p)
+    (let ((p (host-fs-path p)))
+      (if (file-exists? p) (sa-file-mtime-ms p) 0))))
+;; directory entries (names only), nil when p is not a directory — the pieces a
+;; `find` walk is built from on the Clojure side.
+(def-var! "jolt.host" "list-dir"
+  (lambda (p)
+    (let ((p (host-fs-path p)))
+      (if (file-directory? p)
+          (guard (e (#t jolt-nil)) (list->cseq (directory-list p)))
+          jolt-nil))))
+;; …and whether it is a symlink, so that walk can decline to follow one, as
+;; `find` does by default.
+(def-var! "jolt.host" "symlink?"
+  (lambda (p) (if (file-symbolic-link? (host-fs-path p)) #t #f)))
+
 ;; jolt version string — one source (jolt-version-string, rt.ss): the baked
 ;; release tag in a binary, $JOLT_VERSION under bin/jolt, else "dev".
 (def-var! "jolt.host" "jolt-version" (lambda () (jolt-version-string)))

--- a/host/chez/shellout-check.sh
+++ b/host/chez/shellout-check.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# shellout-check.sh — jolt-core may hand the shell external programs, not
+# filesystem operations.
+#
+# WHY THIS GATE EXISTS. jolt.host/sh is Chez's `system`: on Windows that runs
+# the command string through cmd.exe, which shares almost nothing with a POSIX
+# shell. `mkdir -p a/b` there does not create a/b's parents — cmd's mkdir has no
+# options and takes a LIST of paths, so it creates a directory literally named
+# `-p` and reports nothing wrong. mv, rm, touch, test and find are not commands
+# at all. So a resolver written in shell commands does not fail on Windows, it
+# half-works: jolt v0.7.14 littered every project it ran in with a `-p`
+# directory and a growing pile of `.part-` files that the failed `mv` never
+# published, and its classpath cache could never hit.
+#
+# The fix was to do the filesystem work through filesystem calls (jolt.host
+# mkdirs!/rename-file!/delete-file!/delete-tree!/file-mtime/list-dir), leaving
+# the shell for the two things that really are external programs: git and unzip.
+# That distinction is invisible in the source — a `(sh (str "rm -f " …))` reads
+# exactly like a `(sh (str "git clone " …))` — so it is checked here rather than
+# left to whoever adds the next one to remember which host they are on.
+#
+# The scan covers jolt-core/, which is the dependency resolver and the CLI: the
+# code that runs on a user's machine before anything of theirs does. stdlib/ is
+# deliberately out of scope — clojure.java.browse opening a URL through xdg-open
+# IS a platform-specific program, and says so.
+#
+#   sh host/chez/shellout-check.sh
+set -eu
+cd "$(dirname "$0")/../.."
+
+# The external programs jolt is allowed to run. Both are real dependencies with
+# no in-process equivalent (jolt has neither a git client nor an inflater).
+ALLOWED='git|unzip'
+
+fail=0
+
+# Every (sh …) / (sh-out* …) call site, reduced to the first word of the command
+# it runs. A site whose command does not begin with a string literal — the one
+# in sh-out* itself, which redirects a command it was handed — has no head to
+# check and is skipped by the pattern.
+bad=$(grep -rnoE '\((sh|sh-out\*)[[:space:]]+(\(str[[:space:]]+)?"[^" ]*' jolt-core/ \
+      | grep -vE "\"($ALLOWED)\$" || true)
+if [ -n "$bad" ]; then
+  echo "shellout-check: these run something other than $ALLOWED through the shell." >&2
+  echo "shellout-check: filesystem work goes through the jolt.host seams instead." >&2
+  echo "$bad" >&2
+  fail=1
+fi
+
+# A command that discards its output by redirecting to /dev/null is POSIX-only
+# the same way: cmd.exe reads that as a path and fails the whole redirect, which
+# takes the command with it. sh-out* captures through a temp file, which works
+# everywhere and is what the callers that need silence use.
+devnull=$(grep -rnE '\((sh|sh-out\*)[[:space:]]' jolt-core/ | grep '/dev/null' || true)
+if [ -n "$devnull" ]; then
+  echo "shellout-check: /dev/null is not a path on every host jolt runs on." >&2
+  echo "$devnull" >&2
+  fail=1
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+echo "shellout-check: jolt-core shells out to $ALLOWED only"

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -35,28 +35,57 @@
 (defn- getenv [n] (let [v (jolt.host/getenv n)] (when-not (str/blank? v) v)))
 (defn- file-exists? [p] (jolt.host/file-exists? p))
 (defn- sh [cmd] (jolt.host/sh cmd))           ; exit code, inherits stdout/stderr
+
+;; The filesystem seams. These used to be shell commands (`mkdir -p`, `mv`,
+;; `rm -f`, `rm -rf`, `test -nt`, `find`), which is a POSIX assumption jolt.host/sh
+;; does not carry: on Windows it runs the string through cmd.exe, where `mkdir -p
+;; a/b` creates a directory named `-p` and the rest are not commands at all. Every
+;; one of these is now a filesystem call, so the only subprocesses left in this
+;; namespace are the two real external programs, git and unzip.
+(defn- mkdirs! [p] (jolt.host/mkdirs! p))     ; mkdir -p; true if p ends up a dir
+(defn- rm-f [p] (jolt.host/delete-file! p))   ; absent is success
+(defn- rm-rf [p] (jolt.host/delete-tree! p))
+(defn- mv! [from to] (jolt.host/rename-file! from to))
+(defn- file-mtime [p] (jolt.host/file-mtime p))   ; epoch ms, 0 when absent
+(defn- touch! [p] (spit p ""))                ; the markers are all empty files
+
+(defn- find-file
+  "Walk `dir` for the first entry whose NAME satisfies `pred`, returning its
+  full path, or nil. Every name at a level is checked before any subdirectory
+  below it is descended into, and a symlinked directory is not followed — as
+  the `find … -print -quit` this replaces did not."
+  [dir pred]
+  (let [full #(str dir "/" %)]
+    (when-let [entries (seq (jolt.host/list-dir dir))]
+      (or (some #(when (pred %) (full %)) entries)
+          (some #(let [p (full %)]
+                   (when (and (jolt.host/directory? p) (not (jolt.host/symlink? p)))
+                     (find-file p pred)))
+                entries)))))
+
+(defn- tmp-dir
+  "A directory for scratch files. /tmp is not universal — Windows has no such
+  path, and %TEMP% is where a temporary file goes there."
+  []
+  (let [d (or (getenv "TMPDIR") (getenv "TEMP") (getenv "TMP") "/tmp")]
+    (str/replace d #"[/\\]+$" "")))
+
 (defn- sh-out*
   "Run a shell command, capturing stdout and stderr separately:
   {:exit n :out s :err s}. Captures through temp files (jolt.host/sh inherits
-  stdio). Use this wherever \"the command failed\" and \"the command ran and
-  found nothing\" are different answers to the caller — sh-out below collapses
-  them, which is only right when they mean the same thing."
+  stdio), which is also how a command's output gets discarded portably — there
+  is no /dev/null to redirect to everywhere jolt runs."
   [cmd]
   (let [stamp (str (System/currentTimeMillis) "-" (rand-int 100000))
-        out-f (str "/tmp/jolt-deps-" stamp ".out")
-        err-f (str "/tmp/jolt-deps-" stamp ".err")
+        out-f (str (tmp-dir) "/jolt-deps-" stamp ".out")
+        err-f (str (tmp-dir) "/jolt-deps-" stamp ".err")
         code (sh (str cmd " > " (pr-str out-f) " 2> " (pr-str err-f)))
         read-f (fn [p] (when (file-exists? p) (str/trim (slurp p))))
         r {:exit code :out (read-f out-f) :err (read-f err-f)}]
-    (sh (str "rm -f " (pr-str out-f) " " (pr-str err-f)))
+    (rm-f out-f)
+    (rm-f err-f)
     r))
 
-(defn- sh-out
-  "Run a shell command, returning its trimmed stdout, or nil on a non-zero
-  exit — for callers to which a failure and an empty result mean the same."
-  [cmd]
-  (let [{:keys [exit out]} (sh-out* cmd)]
-    (when (zero? exit) out)))
 (defn- warn [& xs] (binding [*out* *err*] (println (str "[jolt.deps] " (apply str xs)))))
 
 ;; --- retrying the network steps ---------------------------------------------
@@ -229,7 +258,7 @@
               commit (or peeled obj)
               obj (when (and peeled obj (not= peeled obj)) obj)]
           (when commit
-            (sh (str "mkdir -p " (pr-str (str (gitlibs-dir) "/tags/" (sanitize url)))))
+            (mkdirs! (str (gitlibs-dir) "/tags/" (sanitize url)))
             (spit cache (str commit " " (or obj "-")))
             [commit obj]))))))
 
@@ -287,10 +316,10 @@
   [url sha repo-dir]
   (let [dir (str repo-dir "/" sha)
         stage (str repo-dir "/.part-" sha "-" (System/currentTimeMillis) "-" (rand-int 100000))
-        scrub #(sh (str "rm -rf " (pr-str stage)))
+        scrub #(rm-rf stage)
         fail (fn [msg data] (scrub) (throw (ex-info msg (merge {:url url :sha sha} data))))]
     (info "fetching " url " @ " (subs sha 0 (min 12 (count sha))))
-    (sh (str "mkdir -p " (pr-str repo-dir)))
+    (mkdirs! repo-dir)
     ;; the clone talks to the remote, so it gets the same bounded retry the tag
     ;; listing does — scrubbing first, since a failed clone leaves a partial
     ;; staging dir that the next attempt would refuse to clone into.
@@ -303,13 +332,13 @@
     ;; one fetches too, and is idempotent, so it retries in place.
     (when-not (zero? (with-net-retries zero? #(sh (str "git -C " (pr-str stage) " submodule update --init --recursive --quiet"))))
       (fail (str "git submodule update failed after " net-attempts " attempts for " url) nil))
-    (sh (str "touch " (pr-str (str stage "/.jolt-git-ok"))))
+    (touch! (str stage "/.jolt-git-ok"))
     (if (checkout-complete? dir)
       (do (scrub) dir)                    ; another process published it first
       (do
         ;; clears the incomplete remains of an interrupted in-place clone
-        (sh (str "rm -rf " (pr-str dir)))
-        (when-not (zero? (sh (str "mv " (pr-str stage) " " (pr-str dir))))
+        (rm-rf dir)
+        (when-not (mv! stage dir)
           (fail (str "git checkout could not be moved into the cache: " dir) {:dir dir}))
         dir))))
 
@@ -390,8 +419,7 @@
   (if (file-exists? target)
     target
     (do
-      (sh (str "mkdir -p "
-               (pr-str (subs target 0 (str/last-index-of target "/")))))
+      (mkdirs! (subs target 0 (str/last-index-of target "/")))
       (loop [repos *mvn-repos*]
         (when-let [repo (first repos)]
           (if (http/fetch (str repo "/" relative) target)
@@ -415,16 +443,16 @@
 (defn- cache-fresh?
   "Is the extraction at `dir` still valid for `jar`? The `.jolt-ok` marker is
   written after a successful unzip; it is stale once the jar is rebuilt/refetched
-  (a SNAPSHOT, or the same coord re-installed into ~/.m2). A POSIX `test -nt`
-  re-extracts when the jar is newer than the marker. The legacy JOLT_MVNLIBS
-  layout keeps no jar, so its extraction is the only copy — trust it. A jar that
-  has since vanished (m2 pruned) also leaves the extraction as the last good copy."
+  (a SNAPSHOT, or the same coord re-installed into ~/.m2), so a jar whose mtime
+  is later than the marker's re-extracts. The legacy JOLT_MVNLIBS layout keeps
+  no jar, so its extraction is the only copy — trust it. A jar that has since
+  vanished (m2 pruned) also leaves the extraction as the last good copy."
   [dir jar legacy]
   (let [ok (str dir "/.jolt-ok")]
     (and (file-exists? ok)
          (or legacy
              (not (file-exists? jar))
-             (not (zero? (sh (str "test " (pr-str jar) " -nt " (pr-str ok)))))))))
+             (<= (file-mtime jar) (file-mtime ok))))))
 
 (defn- extract-jar!
   "Unzip `jar` into `dir` (overwriting), marking `.jolt-ok` only on success so a
@@ -434,10 +462,10 @@
   skip). The jar may live inside `dir` (the legacy JOLT_MVNLIBS layout), so `dir`
   is not wiped."
   [jar dir]
-  (sh (str "mkdir -p " (pr-str dir)))
-  (sh (str "rm -f " (pr-str (str dir "/.jolt-ok"))))
+  (mkdirs! dir)
+  (rm-f (str dir "/.jolt-ok"))
   (if (zero? (sh (str "unzip -o -q " (pr-str jar) " -d " (pr-str dir))))
-    (do (sh (str "touch " (pr-str (str dir "/.jolt-ok")))) dir)
+    (do (touch! (str dir "/.jolt-ok")) dir)
     (do (warn "failed to extract " jar) nil)))
 
 (defn- extract-or-note!
@@ -493,14 +521,14 @@
                         (str/join ", " *mvn-repos*) ")")))
                 nil)
             (let [repo (first repos)
-                  _ (sh (str "mkdir -p " (pr-str (if legacy dir (str (m2-repo-dir) "/" vdir-rel)))))
+                  _ (mkdirs! (if legacy dir (str (m2-repo-dir) "/" vdir-rel)))
                   r (http/fetch* (str repo "/" vdir-rel "/" jar-name) jar)]
               (if (= :ok (:outcome r))
                 (do (info "fetching " coord " " version)
                     (let [d (extract-or-note! jar dir coord version)]
                       ;; legacy layout never keeps the jar; the m2 layout does —
                       ;; that IS the sharing.
-                      (when legacy (sh (str "rm -f " (pr-str jar))))
+                      (when legacy (rm-f jar))
                       d))
                 (recur (rest repos)
                        (if (= :not-found (:outcome r))
@@ -573,8 +601,7 @@
   it contributes nothing to run and its transitive deps are the cljs/JVM toolchain,
   so the walk skips it rather than dragging in that whole subtree."
   [root]
-  (zero? (sh (str "find " (pr-str root)
-                  " \\( -name '*.clj' -o -name '*.cljc' \\) -print -quit 2>/dev/null | grep -q ."))))
+  (boolean (find-file root #(or (str/ends-with? % ".clj") (str/ends-with? % ".cljc")))))
 
 ;; --- coordinate skips + normalization ----------------------------------------
 ;; jolt IS Clojure, so org.clojure/clojure is intrinsic; jolt has no
@@ -795,8 +822,8 @@
           (let [dir (jar-extraction-dir path)]
             (if (or (cache-fresh? dir path false)
                     (extract-or-note! path dir lib path))
-              (let [pom (sh-out (str "find " (pr-str dir) "/META-INF -name pom.xml -print -quit 2>/dev/null"))]
-                {:root dir :manifest :mvn :pom (when (and pom (not (str/blank? pom))) pom)})
+              (let [pom (find-file (str dir "/META-INF") #(= % "pom.xml"))]
+                {:root dir :manifest :mvn :pom pom})
               {:root nil :manifest :none}))
           (manifest-info path))))))
 
@@ -827,8 +854,11 @@
    (:mvn/version x)
    (:mvn/version y)))
 
+;; sh-out* rather than sh: this asks a question whose "no" arrives as both a
+;; non-zero exit and a message on stderr, and the 2>/dev/null that used to
+;; silence it is a POSIX path, not a portable way to discard output.
 (defn- git-ancestor? [dir a b]
-  (zero? (sh (str "git -C " (pr-str dir) " merge-base --is-ancestor " a " " b " 2>/dev/null"))))
+  (zero? (:exit (sh-out* (str "git -C " (pr-str dir) " merge-base --is-ancestor " a " " b)))))
 
 (defmethod ext/compare-versions [:git :git] [lib x y]
   (let [xi (git-info lib x) yi (git-info lib y)
@@ -1089,7 +1119,7 @@
             (if (every? file-exists? (cached-paths (:value cached)))
               (:value cached)
               (do (info "cpcache miss (a cached path no longer exists)")
-                  (sh (str "rm -f " (pr-str f)))    ; stale — don't re-strike
+                  (rm-f f)                         ; stale — don't re-strike
                   nil)))))
       (catch :default _ nil))))
 
@@ -1101,14 +1131,14 @@
   (let [dir (cpcache-dir project-dir)
         f (str dir "/" k ".edn")
         stage (str f ".part-" (System/currentTimeMillis) "-" (rand-int 100000))]
-    (sh (str "mkdir -p " (pr-str dir)))
+    (mkdirs! dir)
     (try
       (spit stage (pr-str {:material material :value resolved}))
-      ;; rename is atomic on POSIX; mv across the same dir never copies.
-      (when-not (zero? (sh (str "mv " (pr-str stage) " " (pr-str f))))
-        (sh (str "rm -f " (pr-str stage))))
+      ;; rename within one directory is atomic and never copies.
+      (when-not (mv! stage f)
+        (rm-f stage))
       (catch :default _
-         (sh (str "rm -f " (pr-str stage)))))))
+         (rm-f stage)))))
 
 (declare user-deps-path)   ; defined below with the deps.edn readers
 

--- a/jolt-core/jolt/nrepl.clj
+++ b/jolt-core/jolt/nrepl.clj
@@ -437,5 +437,8 @@
       (fn stop []
         (when (compare-and-set! stopped false true)
           (c-close fd)
-          (jolt.host/delete-file ".nrepl-port"))
+          ;; delete-file!, not the raw Chez delete-file this used to call: that
+          ;; one RAISES when the file is already gone, so a stop after someone
+          ;; cleaned the port file up threw out of the shutdown path.
+          (jolt.host/delete-file! ".nrepl-port"))
         nil))))


### PR DESCRIPTION
Reported from a Windows machine: running `jolt` in a directory printed four errors and then started the repl anyway.

```
PS D:\data\notes-by-date> jolt
A subdirectory or file -p already exists.
Error occurred while processing: -p.
A subdirectory or file ./.jolt/cpcache already exists.
Error occurred while processing: ./.jolt/cpcache.
'mv' is not recognized as an internal or external command,
operable program or batch file.
'rm' is not recognized as an internal or external command,
operable program or batch file.
;; jolt v0.7.14 repl
```

It also left behind a directory literally named `-p` and a `.jolt/cpcache` full of files named `kNNNNN.edn.part-NNNNN`.

## What was happening

`jolt.deps` did all of its filesystem work by shelling out: `mkdir -p`, `mv`, `rm -f`, `rm -rf`, `touch`, `test -nt`, `find`. `jolt.host/sh` is Chez's `system`, which on Windows runs the command string through `cmd.exe`, and cmd shares almost none of that vocabulary. Its `mkdir` takes no options and accepts a list of paths, so `mkdir -p ./.jolt/cpcache` creates a directory named `-p` alongside the real one and reports nothing wrong. `mv`, `rm`, `touch`, `test` and `find` are not commands there at all.

So the classpath cache staged its entry with `spit`, failed to rename it, failed to clean up the staging file, and left one more `.part-` file on disk every run while never hitting the cache. The same pattern broke Maven jar extraction and git checkout publishing, and `sh-out*` captured stdout through `/tmp`, which does not exist on Windows either, so the `git ls-remote` behind `:git/tag` resolution was running with a redirect that could not open.

The loader hit exactly this once before and fixed it locally with `aot-mkdir-p` (there is a comment about it at `host/chez/loader.ss:840`). The resolver never got the same treatment because `jolt.host` exposed no filesystem seams beyond `file-exists?` and `directory?`.

## What this does

Seven new `jolt.host` seams over filesystem primitives the runtime already had: `mkdirs!`, `rename-file!`, `delete-file!`, `delete-tree!`, `file-mtime`, `list-dir`, `symlink?`. Every shellout in `jolt.deps` that was really a filesystem operation now uses them, the two `find` invocations became a `find-file` walk in Clojure that checks names level by level and declines to follow symlinked directories the way `find` does, `test -nt` became an mtime comparison, and scratch files follow `%TEMP%` where there is no `/tmp`. What still goes through the shell is `git` and `unzip`, which are real external programs with no in-process substitute here.

`jolt.host/delete-file` is removed. It was raw Chez `delete-file`, which raises when the path is already gone, and its one caller was the nrepl server deleting `.nrepl-port` on shutdown. That now uses `delete-file!`, where an absent file is success, so a stop after someone removed the port file no longer throws out of the shutdown path.

Nothing in the source distinguishes running a program from doing filesystem work, so `shelloutcheck` is a new CI gate that does: it reduces every `(sh …)` and `(sh-out* …)` site in `jolt-core/` to the first word of its command and fails on anything that is not git or unzip, and separately fails on a `/dev/null` redirect. Mutation-tested in both directions.

## Verification

`make test` passes end to end (81 CI targets, 3 test targets), which includes `depssmoke` (104), `depscpcache` (20) and `depsunit` (39).

The interesting paths were also driven by hand on macOS against a throwaway project, since the gates are offline: a cold resolve writes the cache entry and a warm one hits it with no `.part-` litter; deleting a resolved root produces the stale-entry miss and removes the file; a Maven dep fetches, extracts, and re-uses its extraction on the next run; a git dep clones through the staging directory and is published by rename with its `.jolt-git-ok` marker; and a `:local/root` pointing at a jar finds `META-INF/maven/org.clojure/tools.namespace/pom.xml` three levels down and resolves that pom's children.

I do not have a Windows machine to confirm the original report is gone. Everything here is the mechanism behind it, but a check on Windows before this ships would be worth it.