### PR TITLE
Do not lose a registration when the poller's wait fails

### DIFF
--- a/stdlib/jolt/io_poller.clj
+++ b/stdlib/jolt/io_poller.clj
@@ -235,6 +235,17 @@
       (loop [] (when-not (neg? (c-read r b 64)) (recur)))
       (finally (ffi/free b)))))
 
+;; Put a drained-but-unapplied add set back into :pending, unioning per fd with
+;; whatever landed while the round was in flight. Under pm, like every other write
+;; to the table. No pipe byte is needed: the caller is the poller itself, and the
+;; next thing a round does is drain :pending, so the retry is already scheduled.
+(defn- requeue-adds! [adds]
+  (when (seq adds)
+    (locking pm
+      (swap! state update :pending
+             (fn [p] (reduce (fn [m [fd filts]] (update m fd (fnil into #{}) filts))
+                             (or p {}) adds))))))
+
 ;; One loop iteration of the poller thread. Under pm, drains the pending
 ;; registrations; builds a kevent changelist (or epoll_ctl calls) carrying those
 ;; ADDs and last round's DELETEs, then blocks in the ONE collect-safe wait with
@@ -288,7 +299,26 @@
           (try
             (let [n (if macos? (c-kevent kq (or chbuf ffi/null) nch evbuf 256 ffi/null)
                                 (c-epoll-wait kq evbuf 256 -1))]
-              (if (neg? n) []
+              (if (neg? n)
+                  ;; The wait FAILED, and :pending was drained and cleared under pm
+                  ;; before the call — so without this the registrations that were in
+                  ;; this round's changelist are gone. Nothing else remembers them:
+                  ;; the waiter is parked in :fds, its fd is no longer pending, and
+                  ;; there is no retry. Put them back so the next round applies them.
+                  ;;
+                  ;; Safe whether or not the kernel got them. On kqueue the changelist
+                  ;; rides with the failing call, so it may or may not have been
+                  ;; applied; a repeat EV_ADD for the same (ident, filter) just
+                  ;; updates the existing registration. On epoll the ctls already ran
+                  ;; as their own syscalls before the wait, so the re-add is redundant
+                  ;; and harmless — DEL-then-ADD is what that path does anyway, and
+                  ;; epoll is level-triggered, so a readiness spanning the gap is
+                  ;; reported as soon as the ADD lands.
+                  ;;
+                  ;; This does not introduce a spin: the loop already returned [] and
+                  ;; came straight back round on this path. What changes is that it no
+                  ;; longer forgets what it was told to register on the way.
+                  (do (requeue-adds! adds) [])
                   ;; An EV_ERROR entry is a changelist entry the kernel REFUSED (an
                   ;; EV_DELETE for an fd that is closed or was never registered with
                   ;; that filter), not a readiness report. It used to be counted and
@@ -330,12 +360,22 @@
 
 (defn- poller-loop [kq]
   (loop [to-delete #{}]
-    (let [fds (poller-round kq to-delete)]
-      (if (seq fds)
-        (let [[woken new-del] (process-events! fds)]
+    (let [evs (poller-round kq to-delete)]
+      (if (seq evs)
+        (let [[woken new-del] (process-events! evs)]
           (doseq [f woken] (jolt.host/fiber-resume f))
           (recur new-del))
-        (recur #{})))))
+        ;; Empty means the wait FAILED, or every entry it reported was an EV_ERROR
+        ;; that got filtered out. (A pipe-only wake does not come here — the pipe is
+        ;; a reported event, so process-events! handles it above and correctly drops
+        ;; these deletes, which that round's changelist did apply.) On the failing
+        ;; path the changelist may never have reached the kernel, so carry the
+        ;; deletes rather than dropping them. Dropping left retired registrations
+        ;; in the kernel set: level-triggered, they fire on every subsequent round,
+        ;; and each phantom marks its fd ready and clears whatever waiters the fd has
+        ;; by then. Re-issuing a delete that DID land is harmless — it reports
+        ;; ENOENT, which is counted and dropped as an EV_ERROR entry.
+        (recur to-delete)))))
 
 ;; The fd's story ends with its socket. Drop the table entry and any pending
 ;; registration, and wake anything still parked on it: the kernel auto-removes


### PR DESCRIPTION
Follow-up to #653. That one fixed a real bug but explicitly did **not** explain the failure that started the investigation, because the fd-keyed defect cannot fire in a read-only test on distinct fds. This is the hole that can.

## The defect

`poller-round` drains `:pending` and clears it under `pm` **before** the `kevent`/`epoll_wait` that is supposed to apply it:

```clojure
(let [adds (locking pm
             (let [a (:pending @state)]
               (swap! state assoc :pending {})     ; cleared here
               a))]
  ...
  (let [n (... (c-kevent kq chbuf nch evbuf 256 ffi/null))]   ; applied here
    (if (neg? n) []                                          ; ...or not
        ...)))
```

If the call fails, those registrations are gone. The waiter is still parked in `:fds`, its fd is no longer in `:pending`, nothing holds a retry, and no event can ever arrive for it. `poller-loop` dropped the round's carried deletes on the same path (`(recur #{})`), leaving retired registrations in the kernel set — level-triggered, so they fire on every later round, and each phantom marks its fd ready and clears whatever waiters that fd has by then.

Put plainly: the module destroyed the record of what to register before knowing the registration had happened.

## The fix

The failing path now puts the drained set back — unioned per fd with anything that landed while the round was in flight — and carries the deletes forward instead of discarding them.

Both halves are safe whichever way the kernel went, which is what makes this a fix rather than a guess about kqueue semantics:

- a repeat `EV_ADD` for the same (ident, filter) **updates** the existing kqueue registration rather than duplicating it
- on epoll the ctls already ran as their own syscalls before the wait, so the re-add is redundant, and DEL-then-ADD is what that path does anyway
- a re-issued delete that *did* land reports `ENOENT`, which is counted and dropped as an `EV_ERROR` entry (#653)
- no pipe byte is needed for the requeue: the caller is the poller itself, and the next thing a round does is drain `:pending`

Not a new spin risk either — the loop already returned an empty event list on this path and came straight back round. What changes is that it no longer forgets what it was told to register on the way through.

## How it was found

Model-checking the protocol restricted to the shape the failing stress case actually runs — one filter, one fd per fiber — where #653's (fd, filter) fix cannot apply. A lost wakeup was still reachable, and the path went through this branch:

```
st(K=0, P=0, W=1, R=0, Pipe=0, D=0)
```

parked, unregistered, nothing pending, no tombstone to consume, no pipe byte outstanding. With the drain made durable the same search finds no reachable lost state and cannot reach that counterexample.

## What this does not claim

**Whether this caused the observed `POLLER-REGISTRATION LOST 1 of 8 in round 29` is unproven.** It requires the wait to have failed in that run, and that is exactly the evidence `smoke.sh` was discarding until #653. Worth noting the case's own comment already lists *"or add failed silently"* among the classifications it expects `debug-state` to distinguish — the author anticipated this shape.

I am landing it because it is a real hole either way, not because round 29 is explained. If it recurs, `POLLER-DEBUG` now survives and reports per filter, so the next occurrence should say which stage and which direction.

## Gates

`poller-registration` 320/320, and 25/25 under full CPU load on 10 cores. io-thread fibers gate PASS, cli smoke 146/146, full gate green (81 ci targets, 3 test targets).

No functional test for the failure path itself: triggering it needs `kevent` to fail, which has no injection seam here. Adding one is a reasonable follow-up if you want the branch covered rather than argued.
