### PR TITLE
Fix three ways the poller stops reporting readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,6 +497,14 @@ jobs:
         with:
           repository: jolt-lang/glimmer-gl
           path: glimmer-gl
+      # glimmer-datastar consumes the datastar middleware the same way, as
+      # {:local/root "../../datastar"} — and the repo behind it is jolt-lang's
+      # glimmer-datastar (renamed from datastar), so the checkout path is the name
+      # the app asks for, not the repo's.
+      - uses: actions/checkout@v5
+        with:
+          repository: jolt-lang/glimmer-datastar
+          path: datastar
       - uses: actions/download-artifact@v4
         with:
           name: jolt-x86_64-linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,43 @@ uniform per-call overhead. Those are here too.
 
 ### Fixed
 
+- **Fiber I/O no longer stops for good when a registration is retired.** Three
+  holes in `jolt.io-poller`, one per platform, none of them covered by a gate.
+  On **macOS**, `poller-round` returns an empty event list for two different
+  reasons — the wait itself failed, or every entry the kernel reported was an
+  `EV_ERROR` that got filtered out — and the loop carried its pending deletes
+  forward on both. But an `EV_ERROR` *is* the kernel having processed the
+  changelist and refused an entry, so re-issuing that delete gets it refused
+  again, forever; and `kevent` returns as soon as a changelist entry errors,
+  reporting only the error and no readiness. One refused delete therefore
+  stopped every readiness report in the process and spun a core doing it, and a
+  fiber closing its own socket the moment its read returns is enough to produce
+  one (the kernel drops a closed fd from the kqueue set, so the delete already
+  scheduled for it comes back `ENOENT`). Measured: four fibers per round, each
+  closing after its read, wedged within three rounds in 10 runs out of 10, with
+  the `ev-errors` counter past 1.5 million. The two cases are now told apart —
+  `nil` for a failed wait, empty for a processed one — and only the first
+  carries its deletes.
+  On **Linux**, `epoll` keys a registration by fd and carries both directions in
+  one mask, and `EPOLL_CTL_DEL` takes no mask and removes the fd outright, so
+  retiring one direction of an fd dropped the other direction's live
+  registration — and it was no longer in `:pending`, so nothing re-added it and
+  that waiter parked forever. The same hole ran the other way: an `ADD` carrying
+  only the newly pending direction dropped the direction already registered.
+  Every round now states the whole fd — `DEL`, then `ADD` with the set of
+  directions that still have a parked waiter — instead of one direction of it.
+  On **ARM Linux**, `struct epoll_event`'s layout was hardcoded to x86_64's: the
+  kernel UAPI marks it `EPOLL_PACKED` only there (12 bytes, the `u64` data at
+  offset 4), while aarch64 aligns the `u64` naturally (16 bytes, data at offset
+  8). So the poller read every event's fd out of the padding, matched nobody,
+  and — epoll being level-triggered — was re-handed the same readiness
+  immediately, spinning at 100% of a core while reporting nothing. All fiber
+  socket I/O hung: the existing registration gate loses 8 of 8 on aarch64 and
+  passes 320 of 320 with the layout picked off `os.arch`.
+  `test/chez/poller-retirement.clj` covers the first two, red-to-green on the
+  platform each belongs to; the third is caught by the existing
+  `poller-registration` case once it can run at all.
+
 - **The dependency resolver does its filesystem work on Windows.** Every
   `mkdir -p`, `mv`, `rm`, `touch`, `test -nt` and `find` in `jolt.deps` went
   through `jolt.host/sh`, which is `cmd.exe` on Windows: `mkdir` there has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,42 +119,18 @@ uniform per-call overhead. Those are here too.
 
 ### Fixed
 
-- **Fiber I/O no longer stops for good when a registration is retired.** Three
-  holes in `jolt.io-poller`, one per platform, none of them covered by a gate.
-  On **macOS**, `poller-round` returns an empty event list for two different
-  reasons — the wait itself failed, or every entry the kernel reported was an
-  `EV_ERROR` that got filtered out — and the loop carried its pending deletes
-  forward on both. But an `EV_ERROR` *is* the kernel having processed the
-  changelist and refused an entry, so re-issuing that delete gets it refused
-  again, forever; and `kevent` returns as soon as a changelist entry errors,
-  reporting only the error and no readiness. One refused delete therefore
-  stopped every readiness report in the process and spun a core doing it, and a
-  fiber closing its own socket the moment its read returns is enough to produce
-  one (the kernel drops a closed fd from the kqueue set, so the delete already
-  scheduled for it comes back `ENOENT`). Measured: four fibers per round, each
-  closing after its read, wedged within three rounds in 10 runs out of 10, with
-  the `ev-errors` counter past 1.5 million. The two cases are now told apart —
-  `nil` for a failed wait, empty for a processed one — and only the first
-  carries its deletes.
-  On **Linux**, `epoll` keys a registration by fd and carries both directions in
-  one mask, and `EPOLL_CTL_DEL` takes no mask and removes the fd outright, so
-  retiring one direction of an fd dropped the other direction's live
-  registration — and it was no longer in `:pending`, so nothing re-added it and
-  that waiter parked forever. The same hole ran the other way: an `ADD` carrying
-  only the newly pending direction dropped the direction already registered.
-  Every round now states the whole fd — `DEL`, then `ADD` with the set of
-  directions that still have a parked waiter — instead of one direction of it.
-  On **ARM Linux**, `struct epoll_event`'s layout was hardcoded to x86_64's: the
-  kernel UAPI marks it `EPOLL_PACKED` only there (12 bytes, the `u64` data at
-  offset 4), while aarch64 aligns the `u64` naturally (16 bytes, data at offset
-  8). So the poller read every event's fd out of the padding, matched nobody,
-  and — epoll being level-triggered — was re-handed the same readiness
-  immediately, spinning at 100% of a core while reporting nothing. All fiber
-  socket I/O hung: the existing registration gate loses 8 of 8 on aarch64 and
-  passes 320 of 320 with the layout picked off `os.arch`.
-  `test/chez/poller-retirement.clj` covers the first two, red-to-green on the
-  platform each belongs to; the third is caught by the existing
-  `poller-registration` case once it can run at all.
+- **Fiber socket I/O works on ARM Linux.** `struct epoll_event`'s layout is
+  architecture-dependent — the kernel UAPI marks it `EPOLL_PACKED` only on
+  x86_64, where it is 12 bytes with the `u64` data at offset 4, while aarch64
+  aligns that `u64` naturally: 16 bytes, data at offset 8. `jolt.io-poller`
+  hardcoded the x86_64 numbers, so on aarch64 it read every event's fd out of
+  the struct padding, matched no waiter, and dropped the event — and epoll being
+  level-triggered, the same readiness was handed back immediately, so the poller
+  span at 100% of a core while reporting nothing and every fiber parked on a
+  socket hung. The layout now comes off `os.arch`; the registration gate loses 8
+  of 8 on aarch64 before and passes 320 of 320 after. No prebuilt binary ships
+  for that target, but jolt cross-builds it and it is what a source build on ARM
+  Linux produces.
 
 - **The dependency resolver does its filesystem work on Windows.** Every
   `mkdir -p`, `mv`, `rm`, `touch`, `test -nt` and `find` in `jolt.deps` went

--- a/ci/examples-smoke.sh
+++ b/ci/examples-smoke.sh
@@ -45,6 +45,7 @@ basic-example    app.core       test
 commonmark-app   app.core       test
 nrepl-example    app.core       test
 ring-app         app.core       test
+glimmer-datastar app.core       test
 hiccup-app       app.core       -
 malli-app        app.core       -
 markdown-app     app.core       -

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -553,6 +553,30 @@ else
   fails=$((fails + 1))
 fi
 
+# Retiring a registration must not cost the poller its ability to report readiness.
+# Two holes, one per platform, both invisible to the case above (which is read-only
+# on eight distinct fds, so no fd carries two filters and none closes with a delete
+# for it in flight): on kqueue a refused EV_DELETE was re-issued forever, and since
+# kevent returns as soon as a changelist entry errors and reports only the error, one
+# closed socket stopped every readiness report in the process; on epoll, which has no
+# per-direction delete, retiring one direction of an fd took the other one with it.
+pt_out="$($jolt run test/chez/poller-retirement.clj 2>&1)"
+if printf '%s' "$pt_out" | grep -q 'POLLER-RETIREMENT OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: retiring a registration cost the poller a readiness report"
+  # Same reasoning as the case above: print every POLLER line, since the
+  # POLLER-DEBUG table says which direction of which fd was left parked. NO-SHAPE
+  # is its own verdict — the round could not build the two-directions-parked state
+  # it exists to test, so a pass would have meant nothing.
+  if printf '%s' "$pt_out" | grep -q '^POLLER'; then
+    printf '%s\n' "$pt_out" | grep '^POLLER' | sed 's/^/    /'
+  else
+    printf '%s\n' "$pt_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # One monitor, contended by a real thread and by fibers at once (jolt-dfuo). This
 # case lives HERE rather than in `make fibers` because a regression wedges every
 # thread in the process, so the report has to come from outside it: the per-case

--- a/stdlib/jolt/io_poller.clj
+++ b/stdlib/jolt/io_poller.clj
@@ -107,12 +107,29 @@
 (def ^:private EPOLLOUT 0x4)
 (def ^:private EPOLL-ADD 1)
 (def ^:private EPOLL-DEL 2)
-(def ^:private EPOLL-EVENT-SIZE 12) ; struct epoll_event is EPOLL_PACKED in the kernel UAPI: u32 events @0, epoll_data_t (u64) @4
+;; struct epoll_event's layout is ARCHITECTURE-DEPENDENT. The kernel UAPI marks it
+;; EPOLL_PACKED only on x86_64 — there it is 12 bytes, u32 events @0 and the u64
+;; data @4. Everywhere else (aarch64, and every other Linux port) the u64 is
+;; naturally aligned: 16 bytes with events @0, four bytes of padding, and data @8.
+;;
+;; Hardcoding the x86_64 numbers made an aarch64 Linux poller read the fd out of the
+;; padding, so every event named an fd nobody was waiting on and was dropped —
+;; and epoll is level-triggered, so the same readiness was re-reported immediately
+;; and the loop span at 100% of a core reporting nothing. All fiber socket I/O on
+;; ARM Linux hung. Verified against the C struct on both arches rather than assumed.
+;; The 12-byte layout is the x86 family's: x86_64 because the kernel packs it
+;; there, and 32-bit x86 because a u64 aligns to 4 so no padding is needed anyway.
+;; Everything else pads. os.arch is the JVM's spelling — "amd64", "aarch64", "x86".
+(def ^:private epoll-packed?
+  (contains? #{"amd64" "x86_64" "x86" "i386" "i686"}
+             (str/lower-case (or (System/getProperty "os.arch") ""))))
+(def ^:private EPOLL-EVENT-SIZE (if epoll-packed? 12 16))
+(def ^:private EPOLL-DATA-OFFSET (if epoll-packed? 4 8))
 
 (defn- ev-fd [buf i]
   (if macos?
     (ffi/read buf :uptr (* i KEVENT-SIZE))
-    (ffi/read buf :uint (+ (* i EPOLL-EVENT-SIZE) 4))))
+    (ffi/read buf :uint (+ (* i EPOLL-EVENT-SIZE) EPOLL-DATA-OFFSET))))
 
 ;; Diagnosis counters (debug-state): kevent reports a changelist entry it could
 ;; not process — an EV_DELETE for an already-closed fd is the common one — as an
@@ -140,13 +157,28 @@
 ;; level-triggered, made it fire on every round). Read it back off the event: the
 ;; u32 at offset 8 is filter in the low half, flags in the high half (see
 ;; kevent-put!). epoll reports a mask instead, at offset 0.
-(defn- ev-filt [buf i]
+(defn- ev-filts [buf i]
   (if macos?
     (if (= (bit-and (ffi/read buf :uint (+ (* i KEVENT-SIZE) 8)) 0xffff)
            (bit-and EVFILT-WRITE 0xffff))
-      :write :read)
-    (if (pos? (bit-and (ffi/read buf :uint (* i EPOLL-EVENT-SIZE)) EPOLLOUT))
-      :write :read)))
+      [:write] [:read])
+    ;; epoll reports a MASK, and one event carries both directions whenever both are
+    ;; ready — a socket with data to read and room to write reports EPOLLIN|EPOLLOUT
+    ;; in a single event. Answering with one filter dropped the other direction's
+    ;; readiness on the floor: its waiters were not resumed, and the delete scheduled
+    ;; for the direction that WAS reported then retired the whole fd (epoll has no
+    ;; per-direction delete), so nothing was left to report it later either.
+    ;;
+    ;; EPOLLERR/EPOLLHUP arrives with neither direction bit set. Both directions have
+    ;; to hear that, or whichever one is parked sleeps through the fd's death; the
+    ;; woken fiber retries and surfaces the error through its own read/write.
+    (let [m (ffi/read buf :uint (* i EPOLL-EVENT-SIZE))
+          rd (pos? (bit-and m EPOLLIN))
+          wr (pos? (bit-and m EPOLLOUT))]
+      (cond (and rd wr) [:read :write]
+            wr [:write]
+            rd [:read]
+            :else [:read :write]))))
 
 (defn- kevent-put! [buf i fd filt flags]
   (let [o (* i KEVENT-SIZE)]
@@ -160,8 +192,8 @@
   (let [ev (ffi/alloc EPOLL-EVENT-SIZE)]
     (try
       (ffi/write ev :uint 0 (if (= filt :read) EPOLLIN EPOLLOUT))
-      (ffi/write ev :uint 4 fd)            ; epoll_data_t.fd — u64 low half
-      (ffi/write ev :uint 8 0)
+      (ffi/write ev :uint EPOLL-DATA-OFFSET fd)        ; epoll_data_t.fd — u64 low half
+      (ffi/write ev :uint (+ EPOLL-DATA-OFFSET 4) 0)
       (c-epoll-ctl ep op fd ev)
       (finally (ffi/free ev)))))
 
@@ -174,8 +206,8 @@
     (try
       (ffi/write ev :uint 0 (reduce (fn [m f] (bit-or m (if (= f :read) EPOLLIN EPOLLOUT)))
                                     0 filts))
-      (ffi/write ev :uint 4 fd)
-      (ffi/write ev :uint 8 0)
+      (ffi/write ev :uint EPOLL-DATA-OFFSET fd)
+      (ffi/write ev :uint (+ EPOLL-DATA-OFFSET 4) 0)
       (c-epoll-ctl ep op fd ev)
       (finally (ffi/free ev)))))
 
@@ -242,14 +274,31 @@
 (defn- requeue-adds! [adds]
   (when (seq adds)
     (locking pm
-      (swap! state update :pending
-             (fn [p] (reduce (fn [m [fd filts]] (update m fd (fnil into #{}) filts))
-                             (or p {}) adds))))))
+      ;; Only what is still LIVE. forget! drops an fd's :fds and :pending entries
+      ;; together when its socket closes, and it can run while the round is in
+      ;; flight — putting the drained set back verbatim would resurrect a
+      ;; registration for a closed fd, and if that number has been reused, hand it
+      ;; to whatever socket owns it now. wait-fiber writes :fds and :pending in one
+      ;; critical section, so a registration that is still wanted always has its
+      ;; :fds entry.
+      (let [live (into {} (keep (fn [[fd filts]]
+                                  (let [ks (filter #(get-in @state [:fds fd %]) filts)]
+                                    (when (seq ks) [fd (set ks)])))
+                                adds))]
+        (when (seq live)
+          (swap! state update :pending
+                 (fn [p] (reduce (fn [m [fd filts]] (update m fd (fnil into #{}) filts))
+                                 (or p {}) live))))))))
 
 ;; One loop iteration of the poller thread. Under pm, drains the pending
 ;; registrations; builds a kevent changelist (or epoll_ctl calls) carrying those
 ;; ADDs and last round's DELETEs, then blocks in the ONE collect-safe wait with
-;; that changelist applied atomically. Returns the fds whose events fired.
+;; that changelist applied atomically.
+;;
+;; Returns the [fd filt] pairs whose events fired — or NIL if the wait itself
+;; failed, which is a different thing from an empty list and poller-loop treats it
+;; as one: empty means the kernel processed the changelist and reported nothing
+;; usable, nil means it may never have seen it.
 (defn- poller-round [kq to-delete]
   ;; Read AND clear :pending in ONE critical section. As two — read, then clear —
   ;; a registration landing in between was erased without ever being applied to
@@ -257,10 +306,19 @@
   ;; waiting on it never resumed. The window is microseconds, which is why it
   ;; showed up as one fiber of eight failing to finish, once, and never again in
   ;; isolation; a stress that keeps registrations landing loses ~11% of them.
-  (let [adds (locking pm
-               (let [a (:pending @state)]
-                 (swap! state assoc :pending {})
-                 a))]
+  (let [[adds wanted]
+        (locking pm
+          (let [a (:pending @state)]
+            (swap! state assoc :pending {})
+            ;; epoll only: for every fd this round touches, the set of directions it
+            ;; still WANTS registered — those with a fiber parked on them. Read in
+            ;; the same critical section as the drain so it cannot disagree with what
+            ;; was drained. See the epoll changelist below for why a per-fd delete
+            ;; cannot be issued without also re-stating the directions that survive.
+            [a (when-not macos?
+                 (into {} (for [fd (distinct (concat (keys a) (map first to-delete)))]
+                            [fd (into #{} (keep (fn [[filt e]] (when (seq (:waiters e)) filt))
+                                                (get-in @state [:fds fd])))])))]))]
     ;; The changelist is sized to nch, not to a fixed 256. :pending holds one
     ;; entry per fd and nothing caps it, so a round that drains more than 256
     ;; registrations wrote past the end of the buffer and then told the kernel to
@@ -289,11 +347,28 @@
         ;; having to track what the kernel currently holds: the DEL of an
         ;; unregistered fd fails harmlessly, and epoll is level-triggered, so a
         ;; readiness that existed across the gap is reported as soon as the ADD lands.
-        (when (and (not macos?) (or (seq adds) (seq to-delete)))
-          (doseq [fd (distinct (map first to-delete))] (c-epoll-ctl kq EPOLL-DEL fd ffi/null))
-          (doseq [[fd filts] adds]
+        ;; epoll keys a registration by fd and carries both directions in ONE mask, so
+        ;; there is no such thing as retiring one of them: EPOLL_CTL_DEL takes no mask
+        ;; and ignores one if given (it answers ENOENT), and it removes the fd
+        ;; outright. Issuing a bare DEL to retire a fired :read therefore also
+        ;; dropped a :write registration the same fd still had a fiber parked on —
+        ;; and that direction was no longer in :pending, so nothing re-added it and
+        ;; the writer never woke. The same hole ran the other way: an ADD carrying
+        ;; only the newly pending direction dropped the direction already registered.
+        ;;
+        ;; So state the whole fd rather than one direction of it. DEL-then-ADD with
+        ;; the set of directions that still have a parked waiter says what the kernel
+        ;; should hold without tracking what it does hold; a DEL of an unregistered
+        ;; fd fails harmlessly, and epoll is level-triggered, so a readiness spanning
+        ;; the gap is reported as soon as the ADD lands. An fd with nothing left
+        ;; parked on it gets the DEL alone, which is the retirement.
+        ;;
+        ;; (kqueue needs none of this: it keys by (ident, filter), so its changelist
+        ;; above retires exactly the one registration it names.)
+        (when (and (not macos?) (seq wanted))
+          (doseq [[fd filts] wanted]
             (c-epoll-ctl kq EPOLL-DEL fd ffi/null)
-            (ep-ctl-mask! kq EPOLL-ADD fd filts)))
+            (when (seq filts) (ep-ctl-mask! kq EPOLL-ADD fd filts))))
         (swap! waits inc)
         (let [evbuf (ffi/alloc (if macos? (* 256 KEVENT-SIZE) (* 256 EPOLL-EVENT-SIZE)))]
           (try
@@ -315,10 +390,12 @@
                   ;; epoll is level-triggered, so a readiness spanning the gap is
                   ;; reported as soon as the ADD lands.
                   ;;
-                  ;; This does not introduce a spin: the loop already returned [] and
-                  ;; came straight back round on this path. What changes is that it no
-                  ;; longer forgets what it was told to register on the way.
-                  (do (requeue-adds! adds) [])
+                  ;; NIL, not an empty list, and the difference is the whole point:
+                  ;; empty means the kernel processed the changelist and reported
+                  ;; nothing usable, nil means it may never have seen it. Only the
+                  ;; second is a reason to carry the round's deletes forward, and
+                  ;; poller-loop tells them apart on exactly this.
+                  (do (requeue-adds! adds) nil)
                   ;; An EV_ERROR entry is a changelist entry the kernel REFUSED (an
                   ;; EV_DELETE for an fd that is closed or was never registered with
                   ;; that filter), not a readiness report. It used to be counted and
@@ -330,7 +407,9 @@
                     (if (< i n)
                       (if (ev-error? evbuf i)
                         (do (swap! ev-errors inc) (recur (inc i) acc))
-                        (recur (inc i) (conj acc [(ev-fd evbuf i) (ev-filt evbuf i)])))
+                        (let [fd (ev-fd evbuf i)]
+                          (recur (inc i)
+                                 (into acc (map (fn [f] [fd f]) (ev-filts evbuf i))))))
                       acc))))
             (finally (ffi/free evbuf))))
         (finally (when chbuf (ffi/free chbuf)))))))
@@ -361,21 +440,27 @@
 (defn- poller-loop [kq]
   (loop [to-delete #{}]
     (let [evs (poller-round kq to-delete)]
-      (if (seq evs)
-        (let [[woken new-del] (process-events! evs)]
-          (doseq [f woken] (jolt.host/fiber-resume f))
-          (recur new-del))
-        ;; Empty means the wait FAILED, or every entry it reported was an EV_ERROR
-        ;; that got filtered out. (A pipe-only wake does not come here — the pipe is
-        ;; a reported event, so process-events! handles it above and correctly drops
-        ;; these deletes, which that round's changelist did apply.) On the failing
-        ;; path the changelist may never have reached the kernel, so carry the
-        ;; deletes rather than dropping them. Dropping left retired registrations
-        ;; in the kernel set: level-triggered, they fire on every subsequent round,
-        ;; and each phantom marks its fd ready and clears whatever waiters the fd has
-        ;; by then. Re-issuing a delete that DID land is harmless — it reports
-        ;; ENOENT, which is counted and dropped as an EV_ERROR entry.
-        (recur to-delete)))))
+      (cond
+        ;; nil — the WAIT ITSELF failed, so the changelist may never have reached the
+        ;; kernel. Carry the deletes: dropping them would leave retired registrations
+        ;; in the set, and level-triggered they fire on every later round, each
+        ;; phantom marking its fd ready and clearing whatever waiters it has by then.
+        ;; (The adds are already back in :pending — poller-round requeued them.)
+        (nil? evs) (recur to-delete)
+        ;; Empty — the kernel DID process the changelist and every entry it reported
+        ;; was an EV_ERROR that got filtered out. An EV_ERROR is the kernel refusing a
+        ;; changelist entry, so these deletes are done: the registration they name is
+        ;; already gone (a closed fd is dropped from the kqueue set, and the delete
+        ;; the poller had scheduled for it comes back ENOENT). Carrying them forward
+        ;; re-issues a delete that will be refused again, and kevent returns as soon
+        ;; as a changelist entry errors and reports ONLY the error — so the round
+        ;; reports nothing, carries the same delete, and the poller spins without ever
+        ;; reporting readiness again. One closed socket was enough to stop all fiber
+        ;; I/O in the process. Drop them, which is what a refusal means.
+        (empty? evs) (recur #{})
+        :else (let [[woken new-del] (process-events! evs)]
+                (doseq [f woken] (jolt.host/fiber-resume f))
+                (recur new-del))))))
 
 ;; The fd's story ends with its socket. Drop the table entry and any pending
 ;; registration, and wake anything still parked on it: the kernel auto-removes
@@ -479,8 +564,8 @@
     (let [ep (c-epoll-create1 0) ev (ffi/alloc EPOLL-EVENT-SIZE)]
       (try
         (ffi/write ev :uint 0 (if (= filt :read) EPOLLIN EPOLLOUT))
-        (ffi/write ev :uint 4 fd)
-        (ffi/write ev :uint 8 0)
+        (ffi/write ev :uint EPOLL-DATA-OFFSET fd)
+        (ffi/write ev :uint (+ EPOLL-DATA-OFFSET 4) 0)
         (c-epoll-ctl ep EPOLL-ADD fd ev)
         (loop []
           (when (neg? (c-epoll-wait ep ev 1 -1)) (recur)))

--- a/test/chez/poller-retirement.clj
+++ b/test/chez/poller-retirement.clj
@@ -40,6 +40,13 @@
 
 (def rounds 12)
 (def per 4)
+;; Round B is deterministic once its shape is built — the registration either
+;; survives the other direction's retirement or it does not — so it runs twice, not
+;; once per A round. It moves 8 MB through a socket to fill the send buffer, which
+;; at jolt's stream throughput is most of a second; running it 12 times put the case
+;; at 25s locally and over the watchdog on a slower CI runner. Round A is the one
+;; that needs repeating: it is racing a close against a delete.
+(def b-rounds 2)
 (def hang-ms 60000)
 
 (def progress (atom {:round 0 :phase :starting}))
@@ -155,16 +162,21 @@
     (loop [r 0 acc 0]
       (swap! progress assoc :round r)
       (if (= r rounds)
-        (do (.close ss) {:status :ok :total acc})
+        ;; A is done; now the both-directions case, twice.
+        (loop [b 0]
+          (swap! progress assoc :round (+ rounds b))
+          (if (= b b-rounds)
+            (do (.close ss) {:status :ok :total acc})
+            (let [{:keys [shape read write fd]} (round-b ss port)]
+              (cond
+                (= shape :no-shape) (do (.close ss) {:status :no-shape :round b :got fd})
+                (not= read "x")     (do (.close ss) {:status :lost-b-read :round b :got read})
+                (not= write :wrote) (do (.close ss) {:status :lost-b-write :round b :got write})
+                :else               (recur (inc b))))))
         (let [n (round-a ss port)]
           (if (< n per)
             (do (.close ss) {:status :lost-a :missing (- per n) :round r})
-            (let [{:keys [shape read write fd]} (round-b ss port)]
-              (cond
-                (= shape :no-shape) (do (.close ss) {:status :no-shape :round r :got fd})
-                (not= read "x")     (do (.close ss) {:status :lost-b-read :round r :got read})
-                (not= write :wrote) (do (.close ss) {:status :lost-b-write :round r :got write})
-                :else               (recur (inc r) (+ acc n))))))))))
+            (recur (inc r) (+ acc n))))))))
 
 (def outcome (atom nil))
 

--- a/test/chez/poller-retirement.clj
+++ b/test/chez/poller-retirement.clj
@@ -1,0 +1,204 @@
+;; test/chez/poller-retirement.clj — retiring a registration must not cost the
+;; poller its ability to report readiness. Run through jolt (wired into
+;; host/chez/smoke.sh).
+;;
+;; WHY THIS EXISTS. Two regressions, one per platform, both from making the
+;; poller's registrations per (fd, filter). Neither was caught by any gate:
+;; poller-registration.clj is read-only on eight distinct fds, so no fd there ever
+;; carries two filters and none of them closes while a delete for it is in flight.
+;;
+;; ROUND A — a refused delete must not wedge the loop (kqueue).
+;; poller-round returns an empty event list for TWO different reasons: the wait
+;; itself failed, or every entry the kernel reported was an EV_ERROR that got
+;; filtered out. The loop carried its pending deletes forward on both, but an
+;; EV_ERROR *is* the kernel having processed the changelist and refused an entry —
+;; re-issuing that delete gets it refused again, forever. kevent returns as soon as
+;; a changelist entry errors and reports only the error, so a single refused delete
+;; stopped every readiness report in the process and spun a core doing it. A fiber
+;; closing its own socket the moment its read returns is enough to produce one: the
+;; kernel drops a closed fd from the kqueue set, so the delete the poller had
+;; already scheduled for it comes back ENOENT. Unfixed this wedges within about
+;; three rounds, and the ev-errors counter runs to seven figures.
+;;
+;; ROUND B — retiring one direction must not retire the other (epoll).
+;; epoll keys a registration by fd and carries both directions in ONE mask; there is
+;; no per-direction delete (EPOLL_CTL_DEL takes no mask and ignores one). So a bare
+;; EPOLL_CTL_DEL issued to retire a fired :read also removes a :write registration
+;; the same fd still has a fiber parked on — and that direction is not in :pending
+;; any more, so nothing re-adds it and the writer never wakes. Before the split,
+;; waiters were flat per fd and every event woke all of them, so a waiter that was
+;; not ready re-registered and the loss healed itself; per-filter waiters removed
+;; that. This round parks both directions of one socket at once and then lets the
+;; read fire, which is the shape the whole (fd, filter) split exists to serve.
+;;
+;; Same watchdog structure as poller-registration.clj, and for the same reason: a
+;; lost wakeup here presents as a hang, not a failure, so the MAIN thread does
+;; nothing but watch a deadline while the workload runs on a spawned thread.
+(require '[jolt.socket])
+(require '[jolt.io-poller])
+(require '[clojure.core.async :as a])
+
+(def rounds 12)
+(def per 4)
+(def hang-ms 60000)
+
+(def progress (atom {:round 0 :phase :starting}))
+(defn- at! [phase] (swap! progress assoc :phase phase))
+
+;; ---- round A: the fiber closes its own socket the instant its read returns -----
+;; That close races the EV_DELETE the poller scheduled when the read fired. When the
+;; close wins, the kernel has already dropped the registration and the delete is
+;; refused — the entry this round exists to survive.
+(defn- round-a [ss port]
+  (let [clients (doall (for [_ (range per)] (do (at! :a-connect) (java.net.Socket. "127.0.0.1" port))))
+        srvs (doall (for [_ (range per)] (do (at! :a-accept) (.accept ss))))
+        outs (doall (for [c clients]
+                      (binding [a/*go-backend* :fiber]
+                        (a/go (let [b (byte-array 8)
+                                    n (.read (.getInputStream c) b 0 8)
+                                    v (String. b 0 n "UTF-8")]
+                                (.close c)
+                                v)))))]
+    (at! :a-settling)
+    (Thread/sleep 15)
+    (at! :a-writing)
+    (doseq [s srvs] (.write (.getOutputStream s) (.getBytes "x" "UTF-8") 0 1))
+    (let [got (doall (for [[i o] (map-indexed vector outs)]
+                       (do (at! (str "a-collecting " i " of " per))
+                           (first (a/alts!! [o (a/timeout 2000)])))))]
+      (when (< (count (filter #(= "x" %) got)) per)
+        (println "POLLER-DEBUG" (pr-str (jolt.io-poller/debug-state))))
+      (at! :a-closing)
+      (doseq [s srvs] (.close s))
+      (count (filter #(= "x" %) got)))))
+
+;; ---- round B: both directions of ONE fd parked at once -------------------------
+;; epoll keys a registration by fd and carries both directions in one mask, so
+;; retiring a fired :read with a bare EPOLL_CTL_DEL also drops a :write the same fd
+;; still has parked — and that direction is no longer in :pending, so nothing re-adds
+;; it. This round builds that shape: a writer that fills the socket until it parks on
+;; :write, a reader parked on :read of the SAME fd, and then a byte that fires the
+;; read.
+;;
+;; The shape is the hard part — the send buffer has to be genuinely full, and jolt
+;; exposes no setsockopt to shrink it, so this writes until the poller table SAYS a
+;; :write waiter is parked rather than assuming some byte count is enough. If it
+;; never parks, the round reports :no-shape and the case FAILS: a round that quietly
+;; passed without ever building its shape would gate nothing, which is how this hole
+;; survived the case that was supposed to cover it.
+(def payload (byte-array 262144))
+
+(defn- write-waiter? [fd]
+  (pos? (or (get-in (jolt.io-poller/debug-state) [:fds fd :write :waiters]) 0)))
+
+;; The fd the poller knows this socket by — the one entry with a parked :read, which
+;; is the reader this round just started. Read off the table rather than guessed.
+(defn- read-parked-fd []
+  (first (for [[fd per-filt] (:fds (jolt.io-poller/debug-state))
+               :when (pos? (or (get-in per-filt [:read :waiters]) 0))]
+           fd)))
+
+(defn- round-b [ss port]
+  (at! :b-connect)
+  (let [c (java.net.Socket. "127.0.0.1" port)
+        s (.accept ss)
+        red (binding [a/*go-backend* :fiber]
+              (a/go (try (let [b (byte-array 1)
+                               n (.read (.getInputStream c) b 0 1)]
+                           (if (pos? n) (String. b 0 n "UTF-8") :eof))
+                         (catch Throwable t (str "read threw: " t)))))]
+    (at! :b-read-parking)
+    (Thread/sleep 100)
+    (let [fd (read-parked-fd)
+          wrote (binding [a/*go-backend* :fiber]
+                  (a/go (try (let [os (.getOutputStream c)]
+                               ;; 8 MB against a peer nobody reads. Comfortably past
+                               ;; an autotuned loopback buffer, so send answers EAGAIN
+                               ;; and the fiber parks — and small enough that the
+                               ;; drain below finishes well inside the timeout.
+                               (dotimes [_ 32] (.write os payload 0 (alength payload)))
+                               :wrote)
+                             (catch Throwable t (str "write threw: " t)))))]
+      ;; wait for the writer to actually park on :write — up to 5s, then give up
+      (at! :b-filling)
+      (let [parked? (loop [n 0]
+                      (cond (and fd (write-waiter? fd)) true
+                            (> n 500) false
+                            :else (do (Thread/sleep 10) (recur (inc n)))))]
+        (if-not parked?
+          (do (println "POLLER-DEBUG" (pr-str (jolt.io-poller/debug-state)))
+              (.close c) (.close s)
+              {:shape :no-shape :fd fd})
+          (do
+            ;; both directions of fd are parked now. Fire the read; its retirement is
+            ;; what must not take the write registration with it.
+            (at! :b-poking)
+            (.write (.getOutputStream s) (.getBytes "x" "UTF-8") 0 1)
+            (let [got-read (first (a/alts!! [red (a/timeout 3000)]))]
+              (at! :b-draining)
+              (let [drainer (Thread. (fn [] (try (let [is (.getInputStream s)
+                                                       b (byte-array 262144)]
+                                                   (loop [] (when (pos? (.read is b 0 262144)) (recur))))
+                                                 (catch Throwable _ nil))))]
+                (.start drainer)
+                (let [got-write (first (a/alts!! [wrote (a/timeout 20000)]))]
+                  (at! :b-closing)
+                  (when (or (not= got-read "x") (not= got-write :wrote))
+                    (println "POLLER-DEBUG" (pr-str (jolt.io-poller/debug-state))))
+                  (.close c) (.close s)
+                  (.join drainer 2000)
+                  {:shape :ok :read got-read :write got-write})))))))))
+
+(defn- run-rounds []
+  (let [ss (java.net.ServerSocket. 0)
+        port (.getLocalPort ss)]
+    (loop [r 0 acc 0]
+      (swap! progress assoc :round r)
+      (if (= r rounds)
+        (do (.close ss) {:status :ok :total acc})
+        (let [n (round-a ss port)]
+          (if (< n per)
+            (do (.close ss) {:status :lost-a :missing (- per n) :round r})
+            (let [{:keys [shape read write fd]} (round-b ss port)]
+              (cond
+                (= shape :no-shape) (do (.close ss) {:status :no-shape :round r :got fd})
+                (not= read "x")     (do (.close ss) {:status :lost-b-read :round r :got read})
+                (not= write :wrote) (do (.close ss) {:status :lost-b-write :round r :got write})
+                :else               (recur (inc r) (+ acc n))))))))))
+
+(def outcome (atom nil))
+
+(.start (Thread. (fn []
+                   (reset! outcome
+                           (try (run-rounds)
+                                (catch Throwable t {:status :threw :ex (str t)}))))))
+
+(let [deadline (+ (System/currentTimeMillis) hang-ms)]
+  (loop []
+    (Thread/sleep 25)
+    (let [{:keys [status total missing round ex got]} @outcome]
+      (cond
+        (= status :ok) (do (println "POLLER-RETIREMENT OK" total) (System/exit 0))
+        (= status :lost-a)
+        (do (println (str "POLLER-RETIREMENT LOST " missing " of " per
+                          " readiness reports after a refused delete, round " round))
+            (System/exit 1))
+        (= status :lost-b-read)
+        (do (println (str "POLLER-RETIREMENT LOST the read of a both-directions fd in round "
+                          round " (got " (pr-str got) ")"))
+            (System/exit 1))
+        (= status :lost-b-write)
+        (do (println (str "POLLER-RETIREMENT LOST the parked write when the read's"
+                          " registration was retired, round " round " (got " (pr-str got) ")"))
+            (System/exit 1))
+        (= status :no-shape)
+        (do (println (str "POLLER-RETIREMENT NO-SHAPE in round " round
+                          ": the writer never parked on :write, so the both-directions"
+                          " case tested nothing (fd " (pr-str got) ")"))
+            (System/exit 1))
+        (= status :threw) (do (println (str "POLLER-RETIREMENT THREW " ex)) (System/exit 1))
+        (< (System/currentTimeMillis) deadline) (recur)
+        :else (let [{:keys [round phase]} @progress]
+                (println (str "POLLER-RETIREMENT HUNG after " hang-ms
+                              "ms in round " round " at " phase))
+                (System/exit 1))))))


### PR DESCRIPTION
Review of the PRs merged since v0.7.14 turned up three holes in `jolt.io-poller`, one per platform. Two are regressions from #653/#654 (merged hours ago); the third is older. None is covered by a gate — `poller-registration` is read-only on eight distinct fds, so no fd there carries two filters and none closes with a delete for it in flight.

### kqueue — a refused delete wedges the loop for good

`poller-round` returns an empty event list for two different reasons: the wait failed, or every entry the kernel reported was an `EV_ERROR` that got filtered out. #654 made `poller-loop` carry its pending deletes forward on both. But an `EV_ERROR` *is* the kernel having processed the changelist and refused an entry, so re-issuing that delete gets it refused again — and `kevent` returns as soon as a changelist entry errors, reporting only the error and no readiness. One refused delete stops every readiness report in the process and spins a core.

Semantics probed in C first: with a bad delete in the changelist and a readable fd registered, `kevent` returns `n=1` carrying only the `EV_ERROR`, and repeats that forever.

A fiber closing its own socket the moment its read returns is enough to produce one. Four fibers per round doing that:

| build | wedged |
|---|---|
| `6b8fc895` (before #654) | 0 / 12 |
| `6092c8d1` (main) | 10 / 10, within 3 rounds, `ev-errors` past 1.5M |

`poller-round` now returns `nil` for a failed wait and an empty list for a processed one; only the first carries its deletes.

### epoll — retiring one direction retires the other

`epoll` keys a registration by fd and carries both directions in one mask, and `EPOLL_CTL_DEL` takes no mask and removes the fd outright (verified: it answers `ENOENT` if given one). So the per-direction delete #653 introduced dropped the other direction's live registration, with nothing left in `:pending` to re-add it. The same hole ran the other way: an `ADD` carrying only the newly pending direction dropped the direction already registered. Each round now states the whole fd — `DEL`, then `ADD` with the directions that still have a parked waiter.

`ev-filt` also collapsed a both-ready event (`EPOLLIN|EPOLLOUT` arrives as one event) to a single filter, so the other direction's waiters were never resumed. It reports both now, and reports both for an `EPOLLERR`/`EPOLLHUP` naming neither.

### ARM Linux — the event struct was the wrong shape

`struct epoll_event` is `EPOLL_PACKED` only on x86_64 (12 bytes, `u64` data at offset 4); aarch64 aligns it naturally (16 bytes, offset 8). Both were hardcoded to the x86_64 numbers, so the poller read every event's fd out of the padding, matched nobody, and — level-triggered — was handed the same readiness immediately: 100% of a core reporting nothing, all fiber socket I/O hung. `poller-registration` loses 8 of 8 there; 320 of 320 with the layout taken off `os.arch`. No prebuilt ships for that target, but jolt cross-builds it and it is what an ARM Linux source build gets.

Also: `requeue-adds!` no longer resurrects an fd that `forget!` dropped while the round was in flight.

### Testing

`test/chez/poller-retirement.clj`, wired into `smoke.sh`, covers the first two red-to-green on the platform each belongs to (3/3 both ways). Its round B asserts it actually parked both directions before concluding anything and fails with `NO-SHAPE` otherwise — the first version silently built no shape and passed with the bug present.

- macOS: full `make test`, 81 CI targets, cli smoke 147.
- aarch64 Linux (container): smoke 4 failures → 2; the remaining two are `jolt.process` signal cases that fail identically without this change (container PID-namespace artifacts).