### PR TITLE
Answer collection = and hash before the arm registry walk

### DIFF
--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -1503,11 +1503,13 @@
                                       (fx- na i))))
                       (let cloop ((j 0))
                         (if (fx>=? j run) (loop (fx+ i run))
-                            (and (jolt= (vector-ref ca (fx+ oa j)) (vector-ref cb (fx+ ob j)))
+                            ;; jolt=2, not the variadic jolt=: the latter conses a
+                            ;; rest list on EVERY element compare.
+                            (and (jolt=2 (vector-ref ca (fx+ oa j)) (vector-ref cb (fx+ ob j)))
                                  (cloop (fx+ j 1))))))))))))
     ((and (pmap? a) (pmap? b))
      (and (fx=? (pmap-cnt a) (pmap-cnt b))
-          (pmap-fold a (lambda (k v ok) (and ok (jolt= (pmap-get b k pmap-absent) v))) #t)))
+          (pmap-fold a (lambda (k v ok) (and ok (jolt=2 (pmap-get b k pmap-absent) v))) #t)))
     ((and (pset? a) (pset? b))
      (and (fx=? (pset-count a) (pset-count b))
           (pset-fold a (lambda (e ok) (and ok (pset-contains? b e))) #t)))

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -595,6 +595,17 @@
     ;; matching JVM's Long.hasheq.
     ((fixnum? x) (murmur3-hash-long-flat x))
     ((string? x) (string-hasheq x))
+    ;; Collections sit up here for the same reason symbols do, and the cost they
+    ;; were paying is worse: a collection reached the fallback only after walking
+    ;; BOTH registries (jolt-hasheq-arms, then jolt-hash-arms), and a map or set
+    ;; already CACHES its hasheq — so the two walks were the entire cost of every
+    ;; repeat hash, paid again per nested collection. Loading jolt-lang/time, whose
+    ;; __register-eq!/__register-hash! arm predicates are Clojure fns called
+    ;; through jolt-invoke, made (hash {:a 1 :b 2}) 8.4x slower purely from this.
+    ;; Routing is copied from jolt-hasheq-fallback, so hash VALUES are unchanged.
+    ((jolt-sequential? x) (hash-ordered (jolt-seq x)))
+    ((pmap? x) (jolt-hasheq-fallback x))
+    ((pset? x) (jolt-hasheq-fallback x))
     (else
      ;; New hasheq arms (jrec via records.ss, etc.)
      (let loop ((as jolt-hasheq-arms))

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -1493,7 +1493,8 @@
   (let loop ((sa (jolt-seq a)) (sb (jolt-seq b)))
     (cond ((and (jolt-nil? sa) (jolt-nil? sb)) #t)
           ((or (jolt-nil? sa) (jolt-nil? sb)) #f)
-          ((jolt= (seq-first sa) (seq-first sb)) (loop (jolt-seq (seq-more sa)) (jolt-seq (seq-more sb))))
+          ;; jolt=2, not the variadic jolt=: the latter conses a rest list per element.
+          ((jolt=2 (seq-first sa) (seq-first sb)) (loop (jolt-seq (seq-more sa)) (jolt-seq (seq-more sb))))
           (else #f))))
 (define (seq-hash x)
   ;; JVM-compatible ordered-collection hash (Murmur3.hashOrdered via mixCollHash).

--- a/host/chez/values.ss
+++ b/host/chez/values.ss
@@ -253,7 +253,10 @@
   (list (cons 0 1) (cons 1.5 2.5)
         (cons (keyword #f "a") (keyword #f "b"))
         (cons (jolt-symbol #f "a") (jolt-symbol #f "b"))
-        (cons "s1" "s2")))
+        (cons "s1" "s2")
+        ;; jolt's own collection types, now answered ahead of the walk.
+        (cons (jolt-vector 1) (jolt-vector 2))
+        (cons (jolt-hash-map (keyword #f "a") 1) (jolt-hash-map (keyword #f "a") 2))))
 (define (eq-arm-reject-fast-type! who pred)
   (reject-fast-type-claim! who
                            (lambda (probe) (pred (car probe) (cdr probe)))
@@ -276,6 +279,12 @@
     ((and (char? a) (char? b)) (char=? a b))
     ((and (string? a) (string? b)) (string=? a b))
     ((and (boolean? a) (boolean? b)) (eq? a b))
+    ;; Two jolt vectors take the chunked leaf-run compare in jolt-coll=? — it
+    ;; walks both leaf arrays in lockstep instead of allocating a seq cell per
+    ;; element. A pvec IS jolt-sequential?, so this MUST precede the sequential
+    ;; arm below or it is unreachable and every vector compare pays the seq walk
+    ;; (measured 5.1 us against 0.19 us on the JVM for two 20-element vectors).
+    ((and (pvec? a) (pvec? b)) (jolt-coll=? a b))
     ;; sequential (vector / list / lazy seq) compare element-wise, cross-type:
     ;; (= [1 2 3] (list 1 2 3)) is true. Forward to seq.ss (loaded by rt.ss).
     ((and (jolt-sequential? a) (jolt-sequential? b)) (seq=? a b))
@@ -324,6 +333,19 @@
            (and (or (eq? nsa nsb)
                     (and (string? nsa) (string? nsb) (string=? nsa nsb)))
                 (or (eq? na nb) (string=? na nb)))))
+        ;; Jolt's OWN collection types answer here too, for the same reason the
+        ;; keyword and string clauses do: a compare of two vectors or two maps
+        ;; otherwise pays one predicate call per registered arm, and the registry
+        ;; GROWS as libraries load. Loading jolt-lang/time (whose __register-eq!
+        ;; arm predicate is a Clojure fn called through jolt-invoke) made
+        ;; (= v20 v20) 44% slower and `hash` of a 2-entry map 8.4x slower, purely
+        ;; from the walk. Both pairs are in eq-fast-probes, so the registry
+        ;; REFUSES an arm claiming them — that guard is what makes answering here
+        ;; safe. Narrow on purpose: only pvec/pmap/pset, never jolt-map? (whose
+        ;; own arms let host types masquerade as maps) and never records.
+        ((and (pvec? a) (pvec? b)) (jolt-coll=? a b))
+        ((and (pmap? a) (pmap? b)) (jolt-coll=? a b))
+        ((and (pset? a) (pset? b)) (jolt-coll=? a b))
         (else (let loop ((as jolt-eq-arms))
                 (cond ((null? as) (jolt=2-base a b)) 
                       (((caar as) a b) ((cdar as) a b)) 
@@ -344,7 +366,9 @@
 ;; all still reach the arms and an arm claiming one of those is legal.
 ;; Built on demand, not at load: interning a keyword needs hasheq.ss, which
 ;; rt.ss loads after this file. Every arm registers later still.
-(define (hash-fast-probes) (list jolt-nil (keyword #f "k") (jolt-symbol #f "s") 0 "s"))
+(define (hash-fast-probes)
+  (list jolt-nil (keyword #f "k") (jolt-symbol #f "s") 0 "s"
+        (jolt-vector 1) (jolt-hash-map (keyword #f "k") 1)))
 (define (hash-arm-reject-fast-type! who pred)
   (reject-fast-type-claim! who pred (hash-fast-probes) "the jolt-hash fast path"))
 (define jolt-hash-arms '())
@@ -365,6 +389,16 @@
         ((symbol-t? x) (jolt-hasheq x))
         ((fixnum? x) (jolt-hasheq x))
         ((string? x) (jolt-hasheq x))
+        ;; Collections answer before the walk for the same reason (see jolt=2).
+        ;; This one is the worse of the two: a pmap already CACHES its hasheq, so
+        ;; the arm walk was the entire cost of a repeat `hash` of a map, and it is
+        ;; paid again per nested collection. Routing matches jolt-hash-base
+        ;; exactly — a pvec is jolt-sequential?, and seq-hash and jolt-coll-hash's
+        ;; pvec arm are both (hash-ordered (jolt-seq x)) — so hash VALUES are
+        ;; unchanged and the HAMT keeps working.
+        ((pvec? x) (seq-hash x))
+        ((pmap? x) (jolt-coll-hash x))
+        ((pset? x) (jolt-coll-hash x))
         (else (let loop ((as jolt-hash-arms))
                 (cond ((null? as) (jolt-hash-base x))
                       (((caar as) x) ((cdar as) x))


### PR DESCRIPTION
`jolt=2`, `jolt-hash` and `jolt-hasheq` each hoist a few scalar types and then fall through to a linear walk of the eq/hash arm registries before they reach their base cases. Vectors, maps and sets were never hoisted, so every compare or hash of one paid a predicate call per registered arm. The registries grow as libraries load, and the Clojure-facing seams `__register-eq!` and `__register-hash!` register arms whose predicate is a Clojure fn called through `jolt-invoke`. So the cost is invisible on a bare runtime and shows up in the field as an unrelated dependency slowing down core operations. Loading `jolt-lang/time` made `(hash {:a 1 :b 2})` 8.4x slower and `(= v20 v20)` 44% slower. Keywords were already immune because they are hoisted, and that contrast is what identified the mechanism.

There was a second problem hiding behind the same walk. `jolt-coll=?` already had a chunked leaf-run compare for two vectors, but it was unreachable: `jolt=2-base` tests `jolt-sequential?` before `jolt-coll?`, and a pvec is sequential, so two vectors always took the generic seq walk instead. That walk allocates a seq cell per element, and it called the variadic `jolt=`, which conses a rest list per element on top of that.

This hoists pvec, pmap and pset above both walks, puts the vector case ahead of the sequential one in `jolt=2-base` so the chunked compare is finally reachable, and uses `jolt=2` rather than `jolt=` in the element loops. Hash routing is copied from the existing fallbacks, so hash values do not change.

The hoist is deliberately narrow: only jolt's own pvec/pmap/pset, never `jolt-map?` (whose own arms let host types masquerade as maps) and never records, which still route through the walk. Both new types are added to `eq-fast-probes` and `hash-fast-probes`, so `reject-fast-type-claim!` now refuses an arm that would claim them, which is what makes answering ahead of the walk safe.

## Measurements

Taken on an M-series Mac, with JVM Clojure for reference.

| | before | after | JVM |
|---|---|---|---|
| `(= v20 v20)` | 1534ms | 63.6ms | 156ms |
| `(hash {:a 1 :b 2})` | 162ms | 10.9ms | |
| honeysql cached format | 4573ms | 2864ms | 555ms |

Vector equality is now faster than the JVM's on that shape. The `hash` figure is the one taken with `jolt-lang/time` loaded, and it is now identical loaded or not (10.859 vs 10.853), which is the property that was broken. The uncached honeysql path is unchanged, as expected, since it barely compares collections.

## Verification

`make test` passes (ci gate 81 targets, test gate 3 targets) and `make certify` reports 0 new and 0 stale divergences. Collection equality results and hash values were diffed against JVM Clojure and are identical, covering cross-type vector/list/lazy-seq compares, nested collections, map entries, records versus maps, sorted maps and sets, exactness (`(= 1 1.0)`), and maps and sets keyed by collections. honeysql's own suite passes on jolt: 177 tests, 2842 assertions, 0 failures.

One note for whoever reviews: the `printscaling` and `readscaling` gates are marginal on my machine and each failed once during this work. I reproduced the `printscaling` record check failing on clean `main` with none of this branch applied (ratio 8.71 against a ceiling of 8.0), so it is pre-existing rather than caused here. The check times record construction plus printing, and each iteration allocates ~16000 intermediate records, so a GC episode spanning all three best-of-3 runs eats the ~1.7x headroom between the typical 4.57 and the 8.0 ceiling. Worth tightening separately.