### PR TITLE
Record Clojure-as-a-terminal-dependency as a tracked divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ divergences:
   portable Clojure. It resolves first, so a library can ship a portable
   `foo.cljc` next to a `foo.jolt` that wins on jolt, the way `.clj` wins over
   `.cljc` on the JVM. `data_readers.jolt` works like `data_readers.clj` too.
+- **Clojure is a terminal dependency.** jolt *is* Clojure, so
+  `org.clojure/clojure` in a `deps.edn` contributes neither an artifact nor
+  children. On the JVM that artifact pulls in `org.clojure/spec.alpha`, so a
+  project declaring only Clojure still gets `clojure.spec.alpha`; here it has to
+  be declared. See [Runtime dependencies](#runtime-dependencies).
 
 The tracked, gated list of value-level divergences is
 [test/conformance/known-divergences.edn](test/conformance/known-divergences.edn);

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -26,7 +26,9 @@
   :permissive
   "jolt succeeds where the JVM throws, on operations with one reasonable meaning: ex-info accepts nil data, count works on eduction, keys on a vector of pairs, (empty MapEntry) => []. A superset: portable JVM code behaves identically.",
   :namespace-model
-  "jolt's namespace layer is permissive: clojure.core always resolves (a :refer-clojure :exclude/:only affects syntax-quote qualification but not resolve/ns-resolve) and var privacy is not enforced across namespaces. A superset — code that resolves on the JVM resolves on jolt."},
+  "jolt's namespace layer is permissive: clojure.core always resolves (a :refer-clojure :exclude/:only affects syntax-quote qualification but not resolve/ns-resolve) and var privacy is not enforced across namespaces. A superset — code that resolves on the JVM resolves on jolt.",
+  :deps-model
+  "jolt resolves deps.edn itself (grenadine, no JVM toolchain) and jolt IS Clojure, so a host-supplied coordinate is TERMINAL: it contributes neither an artifact nor children. Not a superset — the JVM's org.clojure/clojure carries dependencies of its own, and those do not arrive here."},
  :documented
  [;; Deliberate/tracked divergences that are NOT corpus rows, so they live here (not in
   ;; :entries, which certify.clj gates for staleness against the corpus).
@@ -500,7 +502,32 @@
    :behavior "(.start (Thread. f)) as the last act of a program, without a join"
    :jvm "the process stays up until f returns — a non-daemon thread holds it open"
    :jolt "the process exits when the main thread returns; f may never finish"
-   :note "Inherent to Chez's thread model. .setDaemon is a no-op because every thread is already a daemon. Explicit .join / a latch / a deref of a promise all work."}]
+   :note "Inherent to Chez's thread model. .setDaemon is a no-op because every thread is already a daemon. Explicit .join / a latch / a deref of a promise all work."}
+  ;; jolt IS Clojure, so org.clojure/clojure is TERMINAL during deps.edn expansion:
+  ;; the coordinate contributes no artifact (its source on the roots would shadow
+  ;; core) and, since #645, no children either. On the JVM that artifact's POM
+  ;; depends on org.clojure/spec.alpha and org.clojure/core.specs.alpha, so a
+  ;; project declaring only Clojure still gets clojure.spec.alpha — and libraries
+  ;; lean on that, requiring spec without ever naming it (kaocha does, rewrite-clj's
+  ;; suite does). jolt used to substitute those two children in filter-deps; #645
+  ;; dropped the substitution for one uniform rule over host-supplied libraries, so
+  ;; the coordinates now have to be declared. org.clojure/clojurescript is terminal
+  ;; the same way.
+  ;;
+  ;; This one misleads because the failure names a namespace rather than a missing
+  ;; dependency: the require reports "Could not locate clojure/spec/alpha", which
+  ;; reads like a jolt coverage gap rather than a deps.edn that needs one more line.
+  ;;
+  ;; Not a corpus row, and not certifiable: the divergence is in deps RESOLUTION,
+  ;; which a corpus row evaluating an expression in an already-built basis cannot
+  ;; observe. Nothing gates it either — test/chez/deps-alias/specproj declares the
+  ;; spec coordinates explicitly now, and the conformance manifest hand-lists
+  ;; @spec.alpha/src/main/clojure as a source root rather than resolving a deps.edn.
+  {:category :deps-model
+   :behavior "a deps.edn whose only :deps entry is org.clojure/clojure, then (require '[clojure.spec.alpha :as s])"
+   :jvm "loads — spec.alpha and core.specs.alpha arrive transitively with the Clojure artifact"
+   :jolt "raises \"Could not locate clojure/spec/alpha.jolt (or .clj/.cljc) on the source roots\""
+   :note "Declare org.clojure/spec.alpha and org.clojure/core.specs.alpha explicitly; declared that way they resolve as ordinary Maven dependencies. Affects any library that requires spec without declaring it."}]
  :entries
  [;; SimpleDateFormat with no Locale answers for ROOT in jolt but the machine's
   ;; DEFAULT locale on the JVM ("March|Mar|Saturday|Sat" under en), so this row's


### PR DESCRIPTION
Follow-up to #645, which made `org.clojure/clojure` terminal during deps.edn expansion so that the coordinate contributes no children as well as no artifact.

On the JVM that artifact's POM depends on `org.clojure/spec.alpha` and `org.clojure/core.specs.alpha`, so a project whose only declared dependency is Clojure still gets `clojure.spec.alpha`. jolt used to substitute those two children in `filter-deps`; #645 dropped the substitution in favour of one uniform rule for host-supplied libraries. The observable effect is that this project works on `main` before #645 and raises after it:

```clojure
;; deps.edn
{:paths ["src"] :deps {org.clojure/clojure {:mvn/version "1.12.4"}}}
;; src/app.clj
(ns app (:require [clojure.spec.alpha :as s]))
```

We are treating that as a deliberate design decision rather than a bug, so this PR just writes it down. It adds a `:deps-model` legend category, since none of the existing ones are about dependency resolution, and a `:documented` entry carrying the reproducer, the reason the failure misleads (the require reports a missing namespace, which reads like a jolt coverage gap rather than a deps.edn needing one more line), and the reason nothing gates it. That last part is worth having on the record: the divergence is in resolution rather than in a value, so a corpus row evaluating an expression in an already-built basis cannot observe it, `test/chez/deps-alias/specproj` declares the spec coordinates explicitly as of #645, and `test/conformance/libs/manifest.edn` hand-lists `@spec.alpha/src/main/clojure` as a source root rather than resolving a deps.edn. So there is no gate that would catch a regression here in either direction.

The README gets a matching bullet in the divergences list. That section is byte capped by `readmecheck` and now ends at 11053 against the 12000 ceiling, so there is still room.

`make certify` reports 100 of 100 divergences known, 0 new, 0 stale, unchanged: `certify.clj` only reads `:entries`, and `:documented` and `:legend` are prose. I also checked that every `:documented` category resolves in `:legend` and that the file still parses.

Two things I deliberately left out, both worth their own change if you want them:

The prose docs at `jolt-lang.github.io/resources/md/differences.md` have no section for this yet. That file also still carries a "No BigDecimal" section, which the README contradicts (`BigDecimal` with `M` literals and `with-precision` works), so it needs a pass of its own rather than one bullet grafted on.

The error a user actually hits is `Could not locate clojure/spec/alpha.jolt (or .clj/.cljc) on the source roots`, which does not hint at the fix. Since this is now intended behaviour, the loader could recognise the handful of namespaces that live in a Clojure-artifact child and suggest the coordinate to declare, the way the "Did you mean?" diagnostic does for symbols.
