### PR TITLE
Probe jolt sets in the eq and hash fast-path guards

### DIFF
--- a/host/chez/values.ss
+++ b/host/chez/values.ss
@@ -254,9 +254,12 @@
         (cons (keyword #f "a") (keyword #f "b"))
         (cons (jolt-symbol #f "a") (jolt-symbol #f "b"))
         (cons "s1" "s2")
-        ;; jolt's own collection types, now answered ahead of the walk.
+        ;; jolt's own collection types, now answered ahead of the walk. All
+        ;; THREE that jolt=2 hoists must be probed — a hoisted type missing from
+        ;; here is one whose arms register happily and are then silently dead.
         (cons (jolt-vector 1) (jolt-vector 2))
-        (cons (jolt-hash-map (keyword #f "a") 1) (jolt-hash-map (keyword #f "a") 2))))
+        (cons (jolt-hash-map (keyword #f "a") 1) (jolt-hash-map (keyword #f "a") 2))
+        (cons (jolt-hash-set 1) (jolt-hash-set 2))))
 (define (eq-arm-reject-fast-type! who pred)
   (reject-fast-type-claim! who
                            (lambda (probe) (pred (car probe) (cdr probe)))
@@ -339,10 +342,12 @@
         ;; GROWS as libraries load. Loading jolt-lang/time (whose __register-eq!
         ;; arm predicate is a Clojure fn called through jolt-invoke) made
         ;; (= v20 v20) 44% slower and `hash` of a 2-entry map 8.4x slower, purely
-        ;; from the walk. Both pairs are in eq-fast-probes, so the registry
+        ;; from the walk. All three pairs are in eq-fast-probes, so the registry
         ;; REFUSES an arm claiming them — that guard is what makes answering here
-        ;; safe. Narrow on purpose: only pvec/pmap/pset, never jolt-map? (whose
-        ;; own arms let host types masquerade as maps) and never records.
+        ;; safe, and values-test asserts each of the three separately so a probe
+        ;; set losing one cannot go unnoticed. Narrow on purpose: only
+        ;; pvec/pmap/pset, never jolt-map? (whose own arms let host types
+        ;; masquerade as maps) and never records.
         ((and (pvec? a) (pvec? b)) (jolt-coll=? a b))
         ((and (pmap? a) (pmap? b)) (jolt-coll=? a b))
         ((and (pset? a) (pset? b)) (jolt-coll=? a b))
@@ -368,7 +373,9 @@
 ;; rt.ss loads after this file. Every arm registers later still.
 (define (hash-fast-probes)
   (list jolt-nil (keyword #f "k") (jolt-symbol #f "s") 0 "s"
-        (jolt-vector 1) (jolt-hash-map (keyword #f "k") 1)))
+        ;; as in eq-fast-probes: every type jolt-hash / jolt-hasheq answers
+        ;; ahead of the walk, sets included.
+        (jolt-vector 1) (jolt-hash-map (keyword #f "k") 1) (jolt-hash-set 1)))
 (define (hash-arm-reject-fast-type! who pred)
   (reject-fast-type-claim! who pred (hash-fast-probes) "the jolt-hash fast path"))
 (define jolt-hash-arms '())

--- a/test/chez/values-test.ss
+++ b/test/chez/values-test.ss
@@ -122,6 +122,24 @@
     (not (raises? (lambda () (eq-arm-reject-fast-type!
                               'test (lambda (a b) (or (armtest-t? a) (armtest-t? b))))))))
 
+;; jolt's own vector, map and set are answered ahead of BOTH walks (jolt=2,
+;; jolt-hash, jolt-hasheq), so all three have to be in the probe sets — a type
+;; that is hoisted but unprobed is one whose arms register happily and are then
+;; silently dead, which is the exact failure the guard exists to make loud.
+;; Asserting each separately so a probe set losing one type names which.
+(ok "hash arm rejects vector" (raises? (lambda () (hash-arm-reject-fast-type! 'test pvec?))))
+(ok "hash arm rejects map"    (raises? (lambda () (hash-arm-reject-fast-type! 'test pmap?))))
+(ok "hash arm rejects set"    (raises? (lambda () (hash-arm-reject-fast-type! 'test pset?))))
+(ok "eq arm rejects vector pair"
+    (raises? (lambda () (eq-arm-reject-fast-type!
+                         'test (lambda (a b) (and (pvec? a) (pvec? b)))))))
+(ok "eq arm rejects map pair"
+    (raises? (lambda () (eq-arm-reject-fast-type!
+                         'test (lambda (a b) (and (pmap? a) (pmap? b)))))))
+(ok "eq arm rejects set pair"
+    (raises? (lambda () (eq-arm-reject-fast-type!
+                         'test (lambda (a b) (and (pset? a) (pset? b)))))))
+
 ;; and a real arm on a type off the fast path still registers and is consulted
 (ok "hash arm on a plain type registers"
     (not (raises? (lambda () (register-hash-arm! armtest-t? (lambda (x) 4242))))))

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -14,7 +14,7 @@
    :impl-detail
    "representation detail: syntax-quote yields a list? (JVM yields a Cons)",
   :seq-type-model
-  "jolt models every seq as PersistentList (eager) or LazySeq (deferred); JVM reifies a specialized class per producer (Cons/Iterate/LongRange/Repeat/Cycle/ChunkedSeq/StringSeq/KeySeq/RSeq/ArraySeq/SubVector). Values and laziness are correct, only (class …) differs. jolt-aei7",
+  "jolt reifies the JVM's specialized seq class for nearly every producer now (Cons/Iterate/LongRange/Range/Repeat/ChunkedSeq/StringSeq/KeySeq/RSeq/ArraySeq/SubVector). What still collapses to LazySeq is repeat (JVM: Repeat), cycle (Cycle) and drop over a vector (ChunkedSeq) — see the three :entries rows below. Values and laziness are correct, only (class …) differs. jolt-aei7",
   :chunking-model
   "jolt now chunks range/vector seqs through map/filter like the JVM (forcing one element realizes the whole ~32-element chunk). What remains finer-grained: mapcat/dedupe realize 0 at construction where the JVM's (apply concat …) / sequence transformer force the first chunk just to build the seq. jolt-mm6v",
   :integer-box-model

--- a/test/conformance/libs/manifest.edn
+++ b/test/conformance/libs/manifest.edn
@@ -496,14 +496,18 @@
    :paths ["src" "test"]
    :deps ["~time/src"]
    ;; lasertag classifies a value by its class, so every failure here is jolt's class
-   ;; model rather than a behavioral difference: the narrow numeric classes collapse
-   ;; to Long/Double (:integer-box-model) and the specialized seq classes to
-   ;; PersistentList/LazySeq (:seq-type-model), recorded in known-divergences.edn.
+   ;; model rather than a behavioral difference, all recorded in
+   ;; known-divergences.edn. The 9 that remain: six narrow numeric classes collapsing
+   ;; to Long/Double (:integer-box-model), one seq class still collapsing to LazySeq
+   ;; where the JVM says Repeat (:seq-type-model), and two the suite's :bb branches
+   ;; asserting babashka's host model (sci.impl.fns classnames, a :lambda-free tag
+   ;; set), where jolt answers with the real defining class.
    ;; (subvec answers the real SubVector class since #629, which is the 44 -> 46.)
-   ;; Two rows are the suite's :bb branches asserting babashka's host model
-   ;; (sci.impl.fns classnames, a :lambda-free tag set); jolt answers with the
-   ;; real defining class.
-   :expect {:tests 58 :pass 46 :fail 12 :error 0}}
+   ;; 46 -> 49 is the seq classes: #648 gave a seq the class its producer gives it
+   ;; and #659 picked the range flavor from the argument types. The row had not been
+   ;; re-recorded since before #648, so part of that 3 was slack this gate had been
+   ;; carrying — a regression in those rows would have read as "ok".
+   :expect {:tests 58 :pass 49 :fail 9 :error 0}}
 
   {:name "tools.logging"
    :paths ["src/main/clojure" "src/test/clojure"]


### PR DESCRIPTION
#656 hoists pvec, pmap and pset above the eq and hash arm registry walks, but
only added the vector and map probes to eq-fast-probes / hash-fast-probes. So
reject-fast-type-claim! never refused an arm claiming a jolt set: the arm
registered fine and was then never consulted for sets, silently. That is the
shadowing the guard exists to make loud, and it is unreleased — the hoist landed
after v0.7.15 — so it is fixed here rather than shipped in 0.7.16.

Add the set probes, and assert each hoisted type separately in values-test so a
probe set losing one names which type it lost. Not vacuous: reverting just the
set probes fails "hash arm rejects set" and "eq arm rejects set pair" (77/79).

Second commit is gate bookkeeping found while checking the fleet run. lasertag's
row was last recorded before #648, so the seq classes from #648 and the range
flavors from #659 showed up as BETTER rather than a tightened expectation
(46 -> 49 pass). libconformance does not fail on BETTER, so those three rows were
free to regress back and still read "ok". The :seq-type-model legend was stale
the same way — it still said every seq collapses to PersistentList or LazySeq,
which stopped being true at #648; only repeat, cycle and drop-over-a-vector do,
which the :entries rows under it already said.

make test green (ci gate 81 targets, test gate 3 targets); make libconformance
46 ok / 1 better / 0 regressed before the re-record, lasertag ok after it.