### PR TITLE
Grow the scaling gates' arms above the CI noise floor

### DIFF
--- a/test/complexity_test.clj
+++ b/test/complexity_test.clj
@@ -133,9 +133,13 @@
                      (= (dec n1) (get m1 (dec n1))) (nil? (get m1 -1)))
         (println "FAIL complexity transient-write-few: wrong values before timing")
         (System/exit 1))
+      ;; 2000 reps, not 200: at 200 the small arm measured ~1ms, under the CI
+      ;; noise floor — one GC pause or scheduler blip in the 4n arm read 2.06
+      ;; against the 2.0 ceiling on a shared runner (fixed sits ~1.1, broken
+      ;; ~4.0). Bigger arms amortize the noise; the ceiling stays meaningful.
       (judge "transient write-few"
-             (best-of 3 #(dotimes [_ 200] (touch m1)))
-             (best-of 3 #(dotimes [_ 200] (touch m2)))
+             (best-of 3 #(dotimes [_ 2000] (touch m1)))
+             (best-of 3 #(dotimes [_ 2000] (touch m2)))
              "persistent! is rebuilding the whole map instead of freezing only the nodes the writes claimed (transients.ss jolt-persistent!, collections.ss enode-freeze)"))
 
     (if (pos? @failures)

--- a/test/hotpath_scaling_test.clj
+++ b/test/hotpath_scaling_test.clj
@@ -77,12 +77,17 @@
     (println "FAIL hotpath: wrong results from a fixed path")
     (System/exit 1))
 
+  ;; Each timed arm repeats its drain 4x: the deque small arm measured ~3ms,
+  ;; under the CI noise floor, and read 8.33 against the 8.0 ceiling on a
+  ;; shared runner (a regressed shifting impl sits ~16). Repetition grows the
+  ;; measurement without growing n, so a quadratic regression's per-drain cost
+  ;; — what "still finishes when broken" was sized around — is unchanged.
   (let [n1 4000]
-    (judge "split" (best-of 3 #(split-drain n1)) (best-of 3 #(split-drain (* 4 n1))) 8.0
+    (judge "split" (best-of 3 #(dotimes [_ 4] (split-drain n1))) (best-of 3 #(dotimes [_ 4] (split-drain (* 4 n1)))) 8.0
            "re-split is recomputing (length out) per part again (natives-str.ss)")
-    (judge "deque" (best-of 3 #(deque-drain n1)) (best-of 3 #(deque-drain (* 4 n1))) 8.0
+    (judge "deque" (best-of 3 #(dotimes [_ 4] (deque-drain n1))) (best-of 3 #(dotimes [_ 4] (deque-drain (* 4 n1)))) 8.0
            "ArrayDeque front ops are shifting the backing vector again (host-static-classes.ss)")
-    (judge "tokenizer" (best-of 3 #(tok-drain n1)) (best-of 3 #(tok-drain (* 4 n1))) 8.0
+    (judge "tokenizer" (best-of 3 #(dotimes [_ 4] (tok-drain n1))) (best-of 3 #(dotimes [_ 4] (tok-drain (* 4 n1)))) 8.0
            "StringTokenizer is scanning its token list per token again (host-static-classes.ss)"))
 
   ;; timeout arming: single measurement per size (arming is not idempotent —

--- a/test/io_scaling_test.clj
+++ b/test/io_scaling_test.clj
@@ -42,7 +42,13 @@
 (defn- best-of [k f]
   (reduce min (map first (repeatedly k #(timed f)))))
 
-(def ^:private n1 2000)
+;; 8000, not 2000: the small arm measured 2-3ms on a millisecond clock, so
+;; quantization plus one scheduler blip on a shared runner read 8.33 against
+;; the 8.0 ceiling (locally the drain sits ~4.5; the quadratic bug this gates
+;; sat ~16). At 8000 the small arm is ~10ms and the ratio stops moving with
+;; the clock's granularity. A regressed quadratic drain at 32000 items still
+;; finishes in seconds, so the gate keeps failing fast when it should.
+(def ^:private n1 8000)
 (def ^:private factor 4)
 (def ^:private max-ratio 8.0)
 

--- a/test/vec_scaling_test.clj
+++ b/test/vec_scaling_test.clj
@@ -31,8 +31,11 @@
 (def ^:private n1 50000)
 (def ^:private factor 4)
 ;; enough calls that the structural op's batch sits above the ms-timer floor —
-;; at 1ms both sides clamp and the ratio measures nothing.
-(def ^:private reps 5000)
+;; at 1ms both sides clamp and the ratio measures nothing. 15000, not 5000:
+;; the catvec arms measured 6ms/4ms, the same sub-noise-floor size that made
+;; three sibling gates flake a hair over their ceilings on shared runners
+;; (allocating arms + one GC pause moves a small ratio). ~18ms/12ms now.
+(def ^:private reps 15000)
 
 ;; Logarithmic measures ~1 and a linear rebuild ~4, so the line goes between
 ;; them, with room for a loaded machine.


### PR DESCRIPTION
Both flakes today (PR #663's `complexity transient write-few` at 2.06/2.0, PR #664's `io-scaling read-line` at 8.33/8.0) were sub-noise-floor small arms — 1-3ms, the io gate on a millisecond clock — failing a hair over their ceilings while the identical commits passed sibling runs at 1.07-1.14 and ~4.5. The regressions they guard sit at ~4.0 and ~16.0, so the ceilings separate fine once the arms are measurable: write-few 200→2000 reps (~18ms arms, 5 runs 1.06-1.12), read-line n1 2000→8000 (~10/38ms arms, 5 runs 3.80-4.22). A quadratic drain at 32000 items still finishes in seconds, so a real regression still fails fast.