### PR TITLE
Hash procedures by identity; answer fn equality ahead of the arm walk

### DIFF
--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -579,6 +579,35 @@
 (define jolt-hasheq-arms '())
 
 ;; Dispatch: fast-path types first, then registered arms, then fallback.
+;; Procedure identity hasheq — the JVM's Object.hashCode shape for fns. The
+;; old route was the (equal-hash x) fallback, and Chez's equal-hash answers ONE
+;; CONSTANT for every procedure (measured 669430755266, for all fns — not even
+;; 32-bit), which collapsed every fn-keyed map into a single collision bucket:
+;; instaparse's GLL msg-cache keys [listener index] made the grammar build
+;; quadratic in listeners, 92% of honeysql's namespace-load time.
+;;
+;; A weak-eq side table hands each procedure a murmured id on first hash. The
+;; table MUST be weak-keyed and unbounded, unlike the intern front cache
+;; (values.ss): an id has to stay stable for the object's lifetime — clearing
+;; on overflow would rehash live map keys out of their maps — and stability
+;; across GC is why this is a table and not an address hash. Entries die with
+;; their fn, and only fns that are actually hashed (fn-keyed maps/sets) ever
+;; get one, so the live-weak-entry volume stays far below the churn that made
+;; a weak table pathological in the intern-cache case. Ids are per-process:
+;; a procedure's hash does not survive an image dump/restore, exactly as
+;; identityHashCode does not survive JVM serialization.
+(define proc-hasheq-tbl (make-weak-eq-hashtable))
+(define proc-hasheq-mu (make-mutex))
+(define proc-hasheq-counter 0)
+(define (procedure-hasheq p)
+  (jolt-with-mutex proc-hasheq-mu
+    (or (hashtable-ref proc-hasheq-tbl p #f)
+        (begin
+          (set! proc-hasheq-counter (fx+ proc-hasheq-counter 1))
+          (let ((h (murmur3-hash-long-flat proc-hasheq-counter)))
+            (hashtable-set! proc-hasheq-tbl p h)
+            h)))))
+
 (define (jolt-hasheq x)
   ;; Fast path for the most common types (matching Util.hasheq order).
   (cond
@@ -606,6 +635,9 @@
     ((jolt-sequential? x) (hash-ordered (jolt-seq x)))
     ((pmap? x) (jolt-hasheq-fallback x))
     ((pset? x) (jolt-hasheq-fallback x))
+    ;; Ahead of the arm walk, like keywords/symbols/collections: a procedure is
+    ;; in hash-fast-probes, so no arm may claim one (values.ss guard).
+    ((procedure? x) (procedure-hasheq x))
     (else
      ;; New hasheq arms (jrec via records.ss, etc.)
      (let loop ((as jolt-hasheq-arms))
@@ -663,7 +695,10 @@
                 (h (mix-coll-hash (car result) (cdr result))))
            (pset-hasheq-set! x h)
            h)))
-    (else (equal-hash x))))
+    ((procedure? x) (procedure-hasheq x))   ; direct fallback callers too
+    ;; equal-hash can exceed the 32-bit hasheq range (a bare procedure's was
+    ;; 669430755266); clamp so every hasheq is a JVM int.
+    (else (i32 (equal-hash x)))))
 
 ;; ============================================================================
 ;; Quick sanity: export a helper for the natives to rebind clojure.core/hash

--- a/host/chez/values.ss
+++ b/host/chez/values.ss
@@ -303,7 +303,11 @@
         ;; here is one whose arms register happily and are then silently dead.
         (cons (jolt-vector 1) (jolt-vector 2))
         (cons (jolt-hash-map (keyword #f "a") 1) (jolt-hash-map (keyword #f "a") 2))
-        (cons (jolt-hash-set 1) (jolt-hash-set 2))))
+        (cons (jolt-hash-set 1) (jolt-hash-set 2))
+        ;; procedures: fn equality is identity, answered ahead of the walk (a
+        ;; collision-bucket compare of fn-keyed map keys paid the whole arm
+        ;; walk per entry) — so no arm may claim one.
+        (cons car cdr)))
 (define (eq-arm-reject-fast-type! who pred)
   (reject-fast-type-claim! who
                            (lambda (probe) (pred (car probe) (cdr probe)))
@@ -395,6 +399,10 @@
         ((and (pvec? a) (pvec? b)) (jolt-coll=? a b))
         ((and (pmap? a) (pmap? b)) (jolt-coll=? a b))
         ((and (pset? a) (pset? b)) (jolt-coll=? a b))
+        ;; fn equality is identity (the eq? clause above already answered the
+        ;; EQUAL case); answering the unequal case here keeps a fn-keyed map's
+        ;; bucket scan off the arm walk. The pair is in eq-fast-probes.
+        ((and (procedure? a) (procedure? b)) #f)
         (else (let loop ((as jolt-eq-arms))
                 (cond ((null? as) (jolt=2-base a b)) 
                       (((caar as) a b) ((cdar as) a b)) 
@@ -418,8 +426,10 @@
 (define (hash-fast-probes)
   (list jolt-nil (keyword #f "k") (jolt-symbol #f "s") 0 "s"
         ;; as in eq-fast-probes: every type jolt-hash / jolt-hasheq answers
-        ;; ahead of the walk, sets included.
-        (jolt-vector 1) (jolt-hash-map (keyword #f "k") 1) (jolt-hash-set 1)))
+        ;; ahead of the walk, sets included. Procedures hash by identity
+        ;; (procedure-hasheq, hasheq.ss) ahead of the walk too.
+        (jolt-vector 1) (jolt-hash-map (keyword #f "k") 1) (jolt-hash-set 1)
+        car))
 (define (hash-arm-reject-fast-type! who pred)
   (reject-fast-type-claim! who pred (hash-fast-probes) "the jolt-hash fast path"))
 (define jolt-hash-arms '())
@@ -440,6 +450,9 @@
         ((symbol-t? x) (jolt-hasheq x))
         ((fixnum? x) (jolt-hasheq x))
         ((string? x) (jolt-hasheq x))
+        ;; identity hasheq (hasheq.ss loads later; resolved at call time), in
+        ;; hash-fast-probes so no arm may claim a procedure.
+        ((procedure? x) (jolt-hasheq x))
         ;; Collections answer before the walk for the same reason (see jolt=2).
         ;; This one is the worse of the two: a pmap already CACHES its hasheq, so
         ;; the arm walk was the entire cost of a repeat `hash` of a map, and it is

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -5102,4 +5102,6 @@
   {:suite "quoted-literal constants" :label "two sites of the same quoted set are separate constants but equal" :expected "true" :actual "(do (defn qlc-s1 [] #{:q (quote q)}) (defn qlc-s2 [] #{:q (quote q)}) (= (qlc-s1) (qlc-s2)))" :portability :common}
   {:suite "identical? lowering" :label "call, apply, and value position agree" :expected "[true true false true]" :actual "[(identical? :a :a) (apply identical? [:x :x]) (identical? \"a\" \"b\") ((fn [f] (f :q :q)) identical?)]" :portability :common}
   {:suite "identical? lowering" :label "boolean predicates keep JVM answers" :expected "[false false true false true]" :actual "[(true? :kw) (false? nil) (boolean? false) (boolean? :kw) (true? true)]" :portability :common}
+  {:suite "fn identity hash" :label "fn equality is identity; hash is a stable int" :expected "[true false true true]" :actual "(let [f (fn [x] x) g (fn [x] x)] [(= f f) (= f g) (int? (hash f)) (= (hash f) (hash f))])" :portability :common}
+  {:suite "fn identity hash" :label "fns work as distinct map keys" :expected "[1 2 2 :missing]" :actual "(let [f (fn []) g (fn []) m {f 1 g 2}] [(get m f) (get m g) (count m) (get m (fn []) :missing)])" :portability :common}
 ]

--- a/test/chez/values-test.ss
+++ b/test/chez/values-test.ss
@@ -53,6 +53,24 @@
 (ok "syms from distinct equal strings are jolt="
     (jolt= (jolt-symbol #f (string-append "ivt-" "four"))
            (jolt-symbol #f (string-append "ivt-" "four"))))
+;; procedure identity hasheq: distinct fns hash distinct (per-process ids, the
+;; JVM's Object.hashCode shape), the id is stable for the object — including
+;; ACROSS a collection, which a raw address hash would break — and equality is
+;; identity answered ahead of the arm walk.
+(ok "distinct procedures hash distinct"
+    (not (= (jolt-hasheq car) (jolt-hasheq cdr))))
+(ok "procedure hasheq stable"
+    (= (jolt-hasheq car) (jolt-hasheq car)))
+(ok "procedure hasheq survives a collection"
+    (let ((h (jolt-hasheq vector->list)))
+      (collect)
+      (= h (jolt-hasheq vector->list))))
+(ok "procedure hasheq is 32-bit"
+    (let ((h (jolt-hasheq car)))
+      (and (fixnum? h) (fx<=? -2147483648 h 2147483647))))
+(ok "jolt=2 identical procedures" (jolt=2 car car))
+(ok "jolt=2 distinct procedures" (not (jolt=2 car cdr)))
+
 (ok "intern cell agrees across threads"
     (let* ((s (string-append "ivt-" "five"))
            (mine (intern-symbol-cell s))


### PR DESCRIPTION
Stacked on #664 (honeysql gap round R3).

Chez's `equal-hash` returns one constant for every procedure (669430755266 — not even in int range), which `jolt-hasheq`'s fallback passed through. Every fn-keyed map key therefore landed in one hash-collision bucket per index: instaparse's GLL msg-cache is keyed `[listener index]`, so test.chuck's grammar build went quadratic in listeners — 92% of honeysql's namespace-load time, with every bucket compare paying the full extension-arm walk on the closure.

`procedure-hasheq` hands each fn a murmured id from a weak-eq side table — the JVM's `Object.hashCode` shape: stable for the object's lifetime including across GC (a raw address hash would break), per-process like `identityHashCode`. The table must be weak and unbounded, unlike the intern front cache: clearing would rehash live map keys out of their maps; entries die with their fn and only hashed fns get one. `jolt=2` and `jolt-hash`/`jolt-hasheq` answer procedures ahead of the arm walk with probe pairs in both registries, and the `equal-hash` fallback is i32-clamped.

test.chuck regexes require: **3.57s → 1.66s** warm (JVM 1.51s — 2.4x → 1.1x); honeysql 12-namespace load 5.4s → 3.6s; full warm suite 21.3s → 19.6s, 2842/0/0. make test green (threadsafety, cts baseline, hasheq value-pinning); libconformance **47 ok / 0 regressed**; values-test 90/90 with rows pinning distinctness, stability across collection, 32-bit range, and identity equality; corpus rows pin fn map-key behavior.