### PR TITLE
Cache pvec hasheq, hash fast-reject in coll=, zero caches on image dump

### DIFF
--- a/host/chez/collections.ss
+++ b/host/chez/collections.ss
@@ -1486,12 +1486,24 @@
 ;; equality / hash hooks called from values.ss (jolt=2 / jolt-hash)
 ;; ============================================================================
 (define (jolt-coll? x) (or (pvec? x) (pmap? x) (pset? x)))
+;; SPIKE: hash fast-REJECT. Two colls whose CACHED hasheqs differ cannot be =
+;; (hasheq is =-consistent, pinned by the hasheq gate), so answer #f without
+;; walking. Only ever consults hashes both sides already paid for — an unset
+;; side (0) skips straight to the structural walk, so nothing ever computes a
+;; hash just to compare. Equal hashes prove nothing and fall through.
+(define (hasheq-rejects? ha hb)
+  (and (fixnum? ha) (fixnum? hb)
+       (not (fx=? ha 0)) (not (fx=? hb 0))
+       (not (fx=? ha hb))))
+
 (define (jolt-coll=? a b)
   (cond
     ((and (pvec? a) (pvec? b))
      ;; leaf-run lockstep: a's and b's leaves needn't align (RRB tries have
      ;; partial leaves), so each stride is the min of both remaining runs.
      ;; Classic vectors take full-32 strides exactly as before.
+     (if (hasheq-rejects? (pvec-hasheq a) (pvec-hasheq b))
+         #f
      (let ((na (pvec-count a)))
        (and (fx=? na (pvec-count b))
             (let loop ((i 0))
@@ -1506,17 +1518,22 @@
                             ;; jolt=2, not the variadic jolt=: the latter conses a
                             ;; rest list on EVERY element compare.
                             (and (jolt=2 (vector-ref ca (fx+ oa j)) (vector-ref cb (fx+ ob j)))
-                                 (cloop (fx+ j 1))))))))))))
+                                 (cloop (fx+ j 1)))))))))))))
     ((and (pmap? a) (pmap? b))
-     (and (fx=? (pmap-cnt a) (pmap-cnt b))
-          (pmap-fold a (lambda (k v ok) (and ok (jolt=2 (pmap-get b k pmap-absent) v))) #t)))
+     (if (hasheq-rejects? (pmap-hasheq a) (pmap-hasheq b))
+         #f
+         (and (fx=? (pmap-cnt a) (pmap-cnt b))
+              (pmap-fold a (lambda (k v ok) (and ok (jolt=2 (pmap-get b k pmap-absent) v))) #t))))
     ((and (pset? a) (pset? b))
-     (and (fx=? (pset-count a) (pset-count b))
-          (pset-fold a (lambda (e ok) (and ok (pset-contains? b e))) #t)))
+     (if (hasheq-rejects? (pset-hasheq a) (pset-hasheq b))
+         #f
+         (and (fx=? (pset-count a) (pset-count b))
+              (pset-fold a (lambda (e ok) (and ok (pset-contains? b e))) #t))))
     (else #f)))
 (define (jolt-coll-hash x)
   (cond
-    ((pvec? x) (hash-ordered (jolt-seq x)))
+    ;; cached + leaf-run (hasheq.ss, runtime forward ref like hash-ordered)
+    ((pvec? x) (pvec-hasheq-cached x))
     ;; maps hash as hashUnordered of entries; each entry contributes hash-ordered of [k v]
     ;; (APersistentMap.mapHasheq = Murmur3.hashUnordered, MapEntry.hasheq = ordered [k v])
     ((pmap? x)

--- a/host/chez/hasheq.ss
+++ b/host/chez/hasheq.ss
@@ -608,6 +608,32 @@
             (hashtable-set! proc-hasheq-tbl p h)
             h)))))
 
+;; pvec hasheq, cached in the field the record has carried since chez-pvec-v3
+;; (mk-pvec inits it 0 = unset; pvec-with-ent already forwards it) but nothing
+;; ever FILLED: every (hash v) re-walked the vector through a freshly allocated
+;; seq. Fill it the way pmap/pset do — lazily, on first hash — and compute by
+;; leaf runs (pv-leaf-for) with no seq cells, the same stride jolt-coll=? walks.
+;; The 0-means-unset convention shares pmap's one-in-2^32 flaw: a content whose
+;; hash IS 0 recomputes per call, harmlessly.
+(define (pvec-hasheq-cached p)
+  (let ((c (pvec-hasheq p)))
+    (if (and (fixnum? c) (not (fx=? c 0)))
+        c
+        (let ((n (pvec-count p)))
+          (let loop ((i 0) (h 1))
+            (if (fx=? i n)
+                (let ((r (mix-coll-hash h n)))
+                  (pvec-hasheq-set! p r)
+                  r)
+                (let-values (((leaf off) (pv-leaf-for p i)))
+                  (let ((run (fxmin (fx- (vector-length leaf) off) (fx- n i))))
+                    (let cloop ((j 0) (h h))
+                      (if (fx>=? j run)
+                          (loop (fx+ i run) h)
+                          (cloop (fx+ j 1)
+                                 (i32 (#3%fx+ (#3%fx* 31 h)
+                                              (jolt-hasheq (vector-ref leaf (fx+ off j))))))))))))))))
+
 (define (jolt-hasheq x)
   ;; Fast path for the most common types (matching Util.hasheq order).
   (cond
@@ -632,6 +658,8 @@
     ;; __register-eq!/__register-hash! arm predicates are Clojure fns called
     ;; through jolt-invoke, made (hash {:a 1 :b 2}) 8.4x slower purely from this.
     ;; Routing is copied from jolt-hasheq-fallback, so hash VALUES are unchanged.
+    ;; pvec before the generic sequential walk: cached field + leaf-run compute.
+    ((pvec? x) (pvec-hasheq-cached x))
     ((jolt-sequential? x) (hash-ordered (jolt-seq x)))
     ((pmap? x) (jolt-hasheq-fallback x))
     ((pset? x) (jolt-hasheq-fallback x))

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -1241,6 +1241,20 @@
 (define (image-collect-meta v)
   (let ((acc '()))
     (image-walk v (lambda (x path)
+                    ;; Same write-side walk, second job: drop cached hasheqs so
+                    ;; no cache lands in the fasl. A content-derived hash would
+                    ;; be stable across processes, but a collection holding a
+                    ;; VAR-REFERENCED fn travels raw (only anon closures are
+                    ;; rebuilt into fnsrc records), and procedure hasheq is
+                    ;; per-process identity (hasheq.ss) — a restored coll would
+                    ;; carry a hash its own contents no longer produce,
+                    ;; corrupting the = fast-reject and any post-restore keying.
+                    ;; Zeroing the LIVE object (v* shares untouched subgraphs)
+                    ;; is harmless: it is a cache, and the next hash refills it.
+                    ;; The JVM marks these fields transient for serialization.
+                    (cond ((pvec? x) (pvec-hasheq-set! x 0))
+                          ((pmap? x) (pmap-hasheq-set! x 0))
+                          ((pset? x) (pset-hasheq-set! x 0)))
                     (unless (var-cell? x)
                       (let ((m (call/cc (lambda (k)
                                  (with-exception-handler (lambda (e) (k jolt-nil))

--- a/host/chez/values.ss
+++ b/host/chez/values.ss
@@ -460,7 +460,10 @@
         ;; exactly — a pvec is jolt-sequential?, and seq-hash and jolt-coll-hash's
         ;; pvec arm are both (hash-ordered (jolt-seq x)) — so hash VALUES are
         ;; unchanged and the HAMT keeps working.
-        ((pvec? x) (seq-hash x))
+        ;; pvec-hasheq-cached (hasheq.ss, loads later — runtime forward ref like
+        ;; seq-hash below): cached-field read, leaf-run compute on a miss. Same
+        ;; hash VALUES as the seq walk, so the HAMT keeps working.
+        ((pvec? x) (pvec-hasheq-cached x))
         ((pmap? x) (jolt-coll-hash x))
         ((pset? x) (jolt-coll-hash x))
         (else (let loop ((as jolt-hash-arms))

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -142,6 +142,55 @@
 (is "scan of a natural sorted map is empty"
     "(count (jolt.host/image-scan (sorted-map :b 2 :a 1)))"
     "0")
+
+;; A collection HASHED before the dump must not carry that cache into the
+;; image: procedure hasheq is identity-based and per-process (hasheq.ss), so a
+;; restored fn hashes differently than the one the cache was computed over. A
+;; stale cached hash made the restored vector compare UNEQUAL to an equal
+;; vector rebuilt around the restored fn (the = fast-reject trusts cached
+;; hashes), and their hashes disagreed. The dump walk zeroes hasheq caches, so
+;; the restored side recomputes from what it actually holds.
+(begin
+  (cleanup!)
+  (is "hashed fn-carrying vector: restored = rebuilt, hashes agree"
+      (string-append
+        "(let [f (fn [x] (+ x 1)) v [f :a]]"
+        " (hash v)"
+        " (jolt.host/image-write! \"" tmp "\" v)"
+        " (let [v2 (jolt.host/image-read \"" tmp "\")"
+        "       fresh [(nth v2 0) :a]]"
+        "   (vector (= v2 fresh) (= (hash v2) (hash fresh)))))")
+      "[true true]")
+  (cleanup!)
+  (is "hashed fn-carrying set: restored membership via rebuilt element"
+      (string-append
+        "(let [f (fn [x] x) s (hash-set [f :k])]"
+        " (hash s)"
+        " (jolt.host/image-write! \"" tmp "\" s)"
+        " (let [s2 (jolt.host/image-read \"" tmp "\")"
+        "       f2 (first (first s2))]"
+        "   (vector (= (hash s2) (hash (hash-set [f2 :k]))) (= s2 (hash-set [f2 :k])))))")
+      "[true true]"))
+
+;; The zeroing mechanism itself, pinned at the Scheme level: the write walk
+;; must drop a pre-armed hasheq cache from every collection it visits. The
+;; in-process fixtures above cannot show the cross-process staleness (a
+;; var-referenced fn restores to the SAME live object here), so pin the guard
+;; directly: after image-write!, the graph's collections carry no cache.
+(begin
+  (cleanup!)
+  (ok "write walk zeroes armed hasheq caches (vec/map/set)"
+      (let* ((v (jolt-vector 1 2 3))
+             (m (jolt-hash-map (keyword #f "a") v))
+             (s (jolt-hash-set v)))
+        (jolt-hasheq v) (jolt-hasheq m) (jolt-hasheq s)
+        (and (not (fx=? 0 (pvec-hasheq v)))     ; armed before
+             (begin
+               ((var-deref "jolt.host" "image-write!") tmp (jolt-vector v m s))
+               (and (fx=? 0 (pvec-hasheq v))
+                    (fx=? 0 (pmap-hasheq m))
+                    (fx=? 0 (pset-hasheq s)))))))
+  (cleanup!))
 ;; (partial compare) would be compare ITSELF (partial's 1-arg arity), a named
 ;; fn — (comp - compare) is a real core-tier closure with no registration
 (is "scan of a sorted-map-by with an unregistered closure reports one finding at the comparator"

--- a/test/chez/values-test.ss
+++ b/test/chez/values-test.ss
@@ -71,6 +71,32 @@
 (ok "jolt=2 identical procedures" (jolt=2 car car))
 (ok "jolt=2 distinct procedures" (not (jolt=2 car cdr)))
 
+;; pvec cached hasheq: the leaf-run compute must equal the seq walk (vectors
+;; and lists hash EQUAL as ordered colls), repeat, and survive the cache; the
+;; equality fast-reject must never change an answer.
+(ok "pvec hash equals list hash of same elements"
+    (= (jolt-hasheq (jolt-vector 1 "two" (keyword #f "three")))
+       (hash-ordered (jolt-seq (jolt-list 1 "two" (keyword #f "three"))))))
+(ok "pvec hash stable on repeat"
+    (let ((v (jolt-vector 1 2 3 4 5)))
+      (= (jolt-hasheq v) (jolt-hasheq v))))
+(ok "equal vecs stay equal after both are hashed"
+    (let ((a (jolt-vector 1 2 3)) (b (jolt-vector 1 2 3)))
+      (jolt-hasheq a) (jolt-hasheq b)
+      (jolt=2 a b)))
+(ok "unequal vecs stay unequal after both are hashed (reject path)"
+    (let ((a (jolt-vector 1 2 3)) (b (jolt-vector 1 2 4)))
+      (jolt-hasheq a) (jolt-hasheq b)
+      (not (jolt=2 a b))))
+(ok "unequal vecs stay unequal when only one is hashed"
+    (let ((a (jolt-vector 1 2 3)) (b (jolt-vector 1 2 4)))
+      (jolt-hasheq a)
+      (not (jolt=2 a b))))
+(ok "equal maps stay equal after both are hashed"
+    (let ((a (jolt-hash-map (keyword #f "k") 1)) (b (jolt-hash-map (keyword #f "k") 1)))
+      (jolt-hasheq a) (jolt-hasheq b)
+      (jolt=2 a b)))
+
 (ok "intern cell agrees across threads"
     (let* ((s (string-append "ivt-" "five"))
            (mine (intern-symbol-cell s))


### PR DESCRIPTION
Stacked on #666 (honeysql gap round R4; beads jolt-e403.6/.7).

**pvec hasheq was never cached.** The record has carried a mutable hasheq field since `chez-pvec-v3` (constructors init it 0, `pvec-with-ent` forwards it) but nothing ever wrote it — every `(hash v)` re-walked the vector through a freshly allocated seq. `pvec-hasheq-cached` fills it lazily the way pmap/pset already do, computing by leaf runs with no seq cells: repeat hash of a 1k vector **131µs → 191ns**, 32 elements 3.5µs → 192ns, first-time hash 1.7x faster, writes unchanged (an eager variant measured 6.7x a plain conj and stays rejected).

**`jolt-coll=?` gets a hash fast-reject**: cached hasheqs that differ answer false without walking (hasheq is =-consistent, pinned by the hasheq gate); an unset side or equal hashes fall through to the structural walk, so nothing ever computes a hash to compare and equal-input compares are unchanged. Unequal compares of already-hashed values: 27x on 1k vectors, 16x on 100-key maps; composite-key lookups (instaparse's `[index parser]`) 13.5x — the test.chuck grammar require drops another 8% on top of #666 (1.74 → 1.60s; JVM 1.51s).

**The image write walk zeroes pvec/pmap/pset hasheq caches** (same walk that collects meta — the JVM marks these fields transient for serialization). Anon-closure-bearing collections were already safe by accident (the fnsrc rebuild drops caches); collections holding var-referenced fns travel raw while procedure hasheq is per-process identity, so a restored collection would carry a hash its contents no longer produce. state-image rows pin both the round-trip behavior and the zeroing mechanism. Residual filed as jolt-e403.9: fn-KEYED HAMTs have trie placement baked from pre-dump hashes, which zeroing cannot fix.

make test green (values 96/96, state-image 158/158, hasheq value-pinning, threadsafety, cts baseline); libconformance 47 ok / 0 regressed; honeysql loops flat-to-−1% (its format path doesn't re-hash vectors — the wins are hash/equality-heavy workloads).