### PR TITLE
bench: cover the hash/equality rounds; give ->int a fixnum path

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -21,7 +21,7 @@ absolute reference.
 | `dispatch` | polymorphic (**megamorphic**) protocol dispatch | devirt, inline-cache | AWFY-style |
 | `mono-dispatch` | **monomorphic** protocol dispatch (devirt/inline-cache *can* fire) | devirt, inline-cache | AWFY-style |
 | `collections` | persistent map/vector churn (HAMT / 32-way tries) + map/filter/take/reduce over the built vector | persistent structures, transients | CLBG k-nucleotide-style |
-| `vecops` | vector-of-vectors: pairwise `into` concatenation, `subvec` windows + reduce, split-at/rejoin loop | vector concat + slice (the RRB axis; today linear per op on jolt, `subvec` an O(1) view on the JVM) | RRB workload |
+| `vecops` | vector-of-vectors: pairwise `into` concatenation, `subvec` windows + reduce, split-at/rejoin loop | vector concat + slice (the RRB axis; `into`/`subvec` are wired through the RRB ops, so concat is O(log n) here and linear in core Clojure) | RRB workload |
 | `mandelbrot` | pure float compute (tight arith loops, no alloc/dispatch) | native arith, loop codegen | CLBG |
 | `arrays` | primitive `double-array` throughput (unboxed `aget`/`aset`, no boxing/collections) | unboxed primitive-array codegen (flvector read/write) | CLBG-style |
 | `mathfns` | transcendental math (`java.lang.Math` sqrt/sin/cos/log/pow/atan2 over doubles) | native `Math` op lowering (`flsqrt`/`flsin`/… vs generic host-static dispatch) | CLBG-style |
@@ -30,36 +30,118 @@ absolute reference.
 | `loop-recur` | tight `loop`/`recur` + per-iteration integer arith (`mod`, `quot`, `bit-xor`) | numeric pass (primitive long loop counters), loop codegen | CLBG-style |
 | `seqs` | lazy-seq + HOF pipelines (`map`/`filter`/`reduce`, `every?`, `iterate`/`take`, `mapcat`) | lazy-seq cell allocation, per-element call overhead | CLBG-style |
 | `transducers` | transducer pipelines (`comp` of `map`/`filter`/`take`) | transducer machinery, `reduce` fast paths | CLBG-style |
+| `transients` | bulk map/set building through the transient write path (`into`, `assoc!`/`conj!`, `dissoc!`/`disj!`, `zipmap`/`frequencies`/`group-by`), with a transient vector build as the control | editable-HAMT transient nodes, `persistent!` spine freeze | — |
 | `keyed-lookup` | scalar KEYS: hashing/comparing keywords, symbols and strings, and looking them up in SMALL maps; a symbol built per lookup, and a collection or keyword-local in head position | hash engine fast paths (`jolt-hasheq`/`jolt=2`), `symbol-t` khash, `jolt-invokeN` lookup shapes | honeysql `format-dsl` |
+| `hash-eq` | composite KEYS AND VALUES: repeat-hashing vectors/maps/sets/records/seqs, vector- record- and fn-keyed map and set lookups, and `=` on equal and unequal collections | per-instance hasheq caches, collection/record probes ahead of the eq and hash arm walks, hash fast-reject in `jolt-coll=?`, procedure identity hash | instaparse GLL msg-cache, honeysql |
+| `literals` | fixed per-call overhead in a library's inner fn: constant map/vector/set literals in the body (incl. quoted symbols), and `true?`/`false?`/`boolean?`/`identical?` | per-site constant hoisting (`hoist-const-per-site`), identity-based boolean predicates, inlined `identical?` | honeysql `format` loop |
 | `string-build` | `StringBuilder` appended to in a loop, and the transducer-over-`join` shape libraries render text with | proven-StringBuilder direct emission vs jhost method-table dispatch | honeysql `format-entity` |
+| `string-ops` | the ordinary String surface — `.indexOf`/`.startsWith`/`.substring`/`.toLowerCase` on hinted and inference-proven targets, `clojure.string` over already-string arguments, `.getName`/`.getNamespace` on a keyword | direct emission for proven-string and proven-keyword interop targets, `clojure.string/to-str` string fast path | honeysql, clojure.string |
 | `char-scan` | walking a string one code point at a time via `.charAt`, with the `int`/`long`/`unchecked-*` casts hinted Clojure puts around it, incl. a `case`-dispatched character state machine | numeric cast fast paths, `.charAt` on a proven string, `case` over small ints | honeysql `alphanumeric?` |
 | `sorted-access` | reads a collection's structure can answer without walking: `count`/`drop` on a vector seq, `rseq`, `first` on a sorted map/set | shape-answered reads (Counted / IDrop / leftmost-node), not traversal | — |
+| `nth-access` | `nth` on a vector, small and large, and with a default — the constant cost of an indexed read | `Indexed`-first ordering in `jolt-nth` ahead of the extension-type probes | — |
 
 ## Scorecard
 
 **vs JVM** is jolt ÷ JVM Clojure on the same source — **lower is better, and
 under 1.0× means jolt is faster**. Two build modes: **opt** is
 `jolt build --direct-link --opt`, **release** is a plain `jolt build` (what a
-default build ships). Times are the mean of 3 runs after warmup, in ms.
+default build ships). Times are the mean of 3 runs after warmup, in ms. Every
+row below is from ONE `MODE_A=1 bench/run.sh` on one machine (M-series) in one
+sitting, which is the only way the ratios mean anything.
 
 | Benchmark | vs JVM | vs JVM (release) | jolt (ms) | JVM (ms) | Axis |
 |---|---:|---:|---:|---:|---|
-| `tak` | **0.3×** | 0.4× | 6.7 | 19.7 | deep three-way self-recursion + integer arith (beats the JVM) |
-| `fib` | **1.0×** | 1.0× | 7.0 | 7.0 | recursion: call + integer arith |
-| `dispatch` | **1.1×** | 1.1× | 70.3 | 62.7 | megamorphic protocol dispatch |
-| `mathfns` | **1.5×** | 1.5× | 25.0 | 16.7 | transcendental math (`Math` sqrt/sin/cos/log/pow/atan2) |
-| `loop-recur` | **1.6×** | 1.6× | 30.7 | 19.2 | tight loop/recur + per-iteration integer arith |
-| `mandelbrot` | **1.6×** | 1.6× | 23.3 | 14.3 | pure float compute |
-| `collections` | **1.7×** | 1.7× | 22.7 | 13.1 | persistent map/vector churn |
-| `binary-trees` | **1.7×** | 1.7× | 68.3 | 40.7 | escaping short-lived records (allocation/GC) |
-| `seqs` | **2.6×** | 2.6× | 385.7 | 150.4 | lazy-seq + HOF pipelines |
-| `mono-dispatch` | **2.7×** | 2.7× | 38.3 | 14.3 | monomorphic protocol dispatch |
-| `transducers` | **4.2×** | 4.3× | 136.0 | 32.2 | transducer pipelines |
-| `keyed-lookup` | **4.2×** | — | 208.0 | 50.0 | scalar-key hashing + small-map lookup |
-| `string-build` | **4.5×** | — | 205.0 | 46.0 | `StringBuilder` assembly + `join` |
-| `arrays` | **6.3×** | 6.4× | 230.7 | 36.9 | primitive `double-array` throughput |
-| `sorted-access` | **11.7×** | — | 142.8 | 12.2 | shape-answered collection reads |
-| `char-scan` | **26.4×** | — | 343.0 | 13.0 | per-character `.charAt` + numeric casts |
+| `vecops` | **0.3×** | 0.3× | 5.1 | 15.6 | vector concat + slice (beats the JVM) |
+| `tak` | **0.4×** | 0.4× | 6.7 | 18.9 | deep three-way self-recursion + integer arith (beats the JVM) |
+| `dispatch` | **1.2×** | 1.2× | 67.3 | 55.5 | megamorphic protocol dispatch |
+| `fib` | **1.4×** | 1.3× | 9.1 | 6.7 | recursion: call + integer arith |
+| `mathfns` | **1.5×** | 1.5× | 24.9 | 16.4 | transcendental math (`Math` sqrt/sin/cos/log/pow/atan2) |
+| `collections` | **1.8×** | 1.8× | 19.3 | 11.0 | persistent map/vector churn |
+| `binary-trees` | **1.9×** | 1.9× | 74.6 | 39.7 | escaping short-lived records (allocation/GC) |
+| `loop-recur` | **2.0×** | 2.0× | 34.4 | 17.5 | tight loop/recur + per-iteration integer arith |
+| `nth-access` | **2.1×** | 2.1× | 64.4 | 30.4 | `nth` on a vector, small and large |
+| `mandelbrot` | **2.4×** | 2.4× | 30.7 | 12.6 | pure float compute |
+| `mono-dispatch` | **2.6×** | 2.6× | 35.7 | 13.7 | monomorphic protocol dispatch |
+| `seqs` | **2.7×** | 2.6× | 376.3 | 141.4 | lazy-seq + HOF pipelines |
+| `hash-eq` | **3.7×** | 3.7× | 650.0 | 178.0 | composite-value hashing + collection `=` |
+| `transducers` | **3.9×** | 3.9× | 131.5 | 33.6 | transducer pipelines |
+| `transients` | **4.0×** | 4.0× | 223.0 | 56.0 | transient map/set bulk build |
+| `string-build` | **5.5×** | 5.6× | 205.0 | 37.0 | `StringBuilder` assembly + `join` |
+| `keyed-lookup` | **5.8×** | 6.0× | 145.0 | 25.0 | scalar-key hashing + small-map lookup |
+| `arrays` | **6.3×** | 6.3× | 225.1 | 35.8 | primitive `double-array` throughput |
+| `string-ops` | **7.3×** | 7.3× | 504.0 | 69.0 | String/Keyword interop + `clojure.string` |
+| `literals` | **8.2×** | 8.4× | 198.0 | 24.0 | constant literals + boolean predicates, per call |
+| `sorted-access` | **11.7×** | 11.5× | 121.6 | 10.4 | shape-answered collection reads |
+| `char-scan` | **24.4×** | 24.6× | 342.0 | 14.0 | per-character `.charAt` + numeric casts |
+
+`opt` and `release` track each other closely across the whole suite — the plain
+`jolt build` picks up essentially all of the win, and the widest gap between the
+two columns is 0.2 of a ratio point (`keyed-lookup`, `literals`).
+
+### A stale scorecard hid a 1.7× regression for three weeks
+
+The rows above are a full re-measure. The previous table's `loop-recur` (30.7),
+`mandelbrot` (23.3) and `fib` (7.0) figures dated from the 2026-07-26 refresh and
+were carried forward unchanged through three later README edits that added rows
+and prose without re-running the suite. They were wrong by then: bisecting the
+published release binaries puts `loop-recur` at 30.3ms on v0.5.12 (2026-07-29)
+and **51.7ms on v0.5.13** (2026-08-01), flat at ~52ms in every release since,
+including HEAD. The JVM column was unchanged across the same span and Chez has
+been 10.4.1 since June, so it was neither the machine nor the substrate.
+
+The cause was in v0.5.13's bit-op change. `bit-and`/`bit-or`/`bit-xor`/`bit-not`
+moved off the raw Chez primitives — which Chez inlines to native code — onto
+`jolt-bit-*` helpers, so that a bad operand raises a catchable
+`IllegalArgumentException` in call position as well as value position. Correct,
+but the helpers coerce through `->int`, which range-checks against ±2^63. Those
+bounds are **bignums** on Chez's 61-bit fixnum tower, so every `(bit-xor a b)`
+on ordinary integers paid four fixnum-vs-bignum compares — the identical
+pathology the 2026-08-17 numeric-cast round fixed for `int`, `long` and the
+`unchecked-*` forms, which `->int` was not given.
+
+`->int` now tests `fixnum?` first. That is not a semantic narrowing: a Chez
+fixnum here is 61-bit, so it is always an exact integer inside signed 64-bit
+range and always took the slow path's accept branch. Isolated in Chez, 1.28M
+`bit-xor`s cost 26ms through the old `->int`, 8ms through the new one, and 4ms
+as a raw inlined `bitwise-xor`. `loop-recur` went **51.8 → 34.4ms**.
+
+Two residuals from the same window are left, and both are the same shape — a
+Chez primitive that used to inline is now a helper CALL, which cross-unit
+inlining cannot reach:
+
+- `loop-recur`'s remaining ~4ms over v0.5.12 is the `jolt-bit-*` call itself
+  (the 8ms-vs-4ms half of the probe above).
+- `mandelbrot` 23.0 → 30.7ms is the same swap on the float side: a `^double`
+  param/return coercion emits `jolt->fl` where it used to emit a bare
+  `exact->inexact`. `jolt->fl` already tests `flonum?` first, so this is call
+  overhead only, not a bad test.
+
+Both need the back end to emit an inline fast path with the helper as the slow
+arm, rather than a bare call — a codegen change and a seed remint, so it is
+recorded here rather than folded in.
+
+The moral is procedural, and is why this section exists: **the numeric rows were
+carried forward instead of re-measured, and that is what made a 1.7× regression
+invisible for three weeks.** A README edit that touches the scorecard should
+re-run the suite or say plainly which rows it did not.
+
+### Where the rest of the suite stands
+
+The arithmetic/loop half sits at ~1.4–2.4× the JVM. The 2026-07 numeric-pass
+round did most of that: mixed long×double contagion (a `:long` operand beside a
+proven double widens via `fixnum->flonum`, so `Math` calls over it lower to
+native flonum ops instead of generic host dispatch — `mathfns` ~22.7×→~1.5×) and
+JVM literal-init loop semantics (a `(loop [i 0] …)` counter is a primitive long,
+so its `inc`/compare/`mod`/`quot` run as fixnum ops — `loop-recur` ~8.3×→~1.6×,
+and `mandelbrot`'s grid counters took it ~2.0×→~1.6×). Both then gave back part
+of that to the helper-call change above. `tak` and `vecops` beat the JVM
+outright; `fib` is close to level with it.
+
+`vecops` is the row the RRB work moved. Its comment used to say every operation
+in it was linear per op on jolt; wiring `into` and `subvec` through the RRB ops
+made concat O(log n) while core Clojure's `into` stays linear, so jolt now runs
+it at 0.3× — the one place in the suite where jolt has a better ALGORITHM than
+the reference rather than a better or worse constant.
 
 `sorted-access` exists because every operation in it used to be a full traversal
 here while the reference answers it from the collection's shape — and none of
@@ -95,23 +177,60 @@ entity went 597ns → 457ns and a plain code-point sum over 5 characters 330ns �
 plus loop plus `case` dispatch, against ~2ns on the JVM, and closing that needs
 the casts and `.charAt` to inline at the call site rather than be called.
 
-`opt` and `release` track each other closely across the suite — the plain
-`jolt build` picks up most of the win.
+### The hash, equality and per-call-overhead axes
 
-The arithmetic/loop half of the suite now sits at ~1–2× the JVM. The 2026-07
-numeric-pass round did most of that: mixed long×double contagion (a `:long`
-operand beside a proven double widens via `fixnum->flonum`, so `Math` calls
-over it lower to native flonum ops instead of generic host dispatch — `mathfns`
-~22.7×→~1.5×) and JVM literal-init loop semantics (a `(loop [i 0] …)` counter
-is a primitive long, so its `inc`/compare/`mod`/`quot` run as fixnum ops —
-`loop-recur` ~8.3×→~1.6×, and `mandelbrot`'s grid counters took it ~2.0×→~1.6×).
-`tak` beats the JVM outright (direct-linked self-calls + proven fixnum arith);
-`fib` is level with it.
+Four benchmarks cover the 2026-08 rounds that came out of profiling honeysql and
+instaparse. None of the older benchmarks could see any of them: the work they
+measure is per-CALL and per-KEY, and every other benchmark amortises it across a
+data structure or a loop trip count.
 
-The remaining gaps are the allocation-bound axes, and after the 2026-07 rounds
-only `arrays` is still above ~5×. `seqs` (was ~10.9×), `binary-trees` (~140×)
-and `transducers` all came down through the same kind of fix: find the per-item
-work that a composed abstraction was repeating, and do it once.
+- **`hash-eq` 3.7×** is the composite-value half of the hash engine, where
+  `keyed-lookup` is the scalar half. Vectors, maps and sets fell through to a
+  linear walk of the equality and hash arm REGISTRIES before reaching their base
+  cases, so loading an unrelated library made `(hash {:a 1 :b 2})` 8.4× slower;
+  they are answered ahead of that walk now, and `reject-fast-type-claim!`
+  refuses an arm that would claim one. On top of that every collection kind got
+  a hasheq cache it was missing: a pvec had the field since `chez-pvec-v3` but
+  nothing ever wrote it (repeat hash of a 1k vector 131µs → 191ns), a defrecord
+  caches in an instance slot (4-field record 215 → 34ns, record-keyed map get
+  216 → 58ns), a seq caches on its head. `jolt-coll=?` then rejects on differing
+  cached hashes without a structural walk (27× on unequal 1k vectors). The fn
+  row is a bug in its own right: Chez's `equal-hash` returns ONE constant for
+  every procedure, so an fn-keyed map degenerated to a single bucket and
+  instaparse's `[listener index]` cache went quadratic — procedures get an
+  identity hasheq from a weak side table now, which took test.chuck's grammar
+  require 3.57s → 1.66s.
+- **`literals` 8.2×** is the worst new ratio and the purest one: it does no work
+  at all beyond constructing the literals in a function body and calling three
+  predicates. A literal collection is a compile-time constant the reference
+  emits into the class constant pool; rebuilding one per call made `pset-conj`
+  11% of samples in the honeysql profile, all of it set literals. Hoisting has
+  to be PER SITE (two textually identical literals are distinct objects in the
+  reference, and `=` short-circuits on identity), and quoted forms have to hoist
+  too or `#{:for 'for}` stays dynamic. The predicate half is separate: `true?`
+  and `false?` were `(= true x)`, and a mixed-type `=` misses every fast clause
+  and walks the equality arm registry, so `boolean?` on a keyword cost 801ns
+  against 194 now.
+- **`transients` 4.0×** is the bulk-build write path. A transient map or set was
+  a Chez hashtable, so `persistent!` folded every entry back through the
+  ordinary insert and rebuilt the trie from scratch — the transient did not
+  avoid the path-copying build, it deferred it and added a hashtable on top.
+  Writes now claim each node on their path into an editable copy. The transient
+  VECTOR build in the same benchmark is the control: it was always a tail-array
+  append, so if the map/set rows move and it does not, the change is in the trie
+  edit path.
+- **`string-ops` 7.3×** is the ordinary String surface, which `string-build`
+  (StringBuilder) and `char-scan` (`.charAt` plus casts) both miss. An interop
+  call on an unproven target finds its method table by hashing the target's tag
+  string, finds the handler by hashing the method name, and passes arguments as
+  a vector converted back to a list for apply. A target proven a string — by a
+  `^String` hint or by inference — emits the operation directly instead:
+  `(.indexOf ^String s 46)` 140 → 23ns, `(.startsWith ^String s "so")` 142 → 17,
+  `(.substring ^String s 1 4)` 236 → 23. The benchmark carries both proof seams
+  and the `clojure.string` layer over them, where `to-str` used to take
+  `.toString` unconditionally so a plain string paid the full dispatch chain.
+
+### The allocation-bound axes
 
 - **`arrays` ~6.3×** (was ~18.6×): two rounds took it there. The fixnum-first
   index path in `jolt-flaget`/`jolt-flaset` removed the per-access index
@@ -121,10 +240,10 @@ work that a composed abstraction was repeating, and do it once.
   directly, so the flonum stays unboxed through the surrounding `fl+` chain
   instead of being boxed at the wrapper's return (~9.5×→~6.4×). The residual is
   the checked `flvector-ref` + record accessor at O2, Chez boxing the
-  loop-carried flonum accumulator (~145ms of the 229ms on a 40M-iteration
+  loop-carried flonum accumulator (~145ms of the 225ms on a 40M-iteration
   loop), and the JVM SIMD-vectorizing the dot loop. Hoisting the loop-invariant
   `jolt-array-vec` accessor out of the loop is the queued next lever.
-- **`seqs` ~2.6×** (was ~6.3×): the allocation axis idiomatic Clojure hits most
+- **`seqs` ~2.7×** (was ~6.3×): the allocation axis idiomatic Clojure hits most
   — range/map/filter/reduce chains, short-circuiting `every?`, `iterate`/`take`,
   and `mapcat` all build lazy-seq cells and call a closure per element. Two
   rounds took it here, both the same bug in different clothing: a lazy seq
@@ -136,12 +255,12 @@ work that a composed abstraction was repeating, and do it once.
   collection via variadic `jolt-concat`: ~3 lazy nodes and ~5 closures per
   boundary, which swamps the per-element work when inner colls are small
   (302ms → 122ms). Both now emit exactly one cell per element.
-- **`transducers` ~4.2×** (was ~7.0×): `eduction` was a plain lazy seq, so
+- **`transducers` ~3.9×** (was ~7.0×): `eduction` was a plain lazy seq, so
   reducing one allocated a cell per element instead of driving the transducer
   into the accumulator. It is now a real `Eduction` implementing `IReduceInit`,
   as on the JVM — 152ms→61ms, in line with `transduce`. The remainder is the
   per-element reducing-fn call chain, not the pipeline shape.
-- **`binary-trees` ~1.7×** (was ~7.2×): two rounds. Each node walk read a field
+- **`binary-trees` ~1.9×** (was ~7.2×): two rounds. Each node walk read a field
   through a keyword RE-INTERNED at every use site; keyword literals are now
   hoisted to a per-def constant (277ms→171ms). Then the read itself stopped
   being a generic `jolt-get`: typing the walker's parameter needs a record
@@ -155,21 +274,29 @@ work that a composed abstraction was repeating, and do it once.
   `(:left node)` now emits `jrec-field-at` at a static slot (165ms→67ms). What
   is left is allocation and GC — the nodes escape into the tree, so
   scalar-replace can't remove them.
-- **`mono-dispatch` ~2.7×**:
+- **`mono-dispatch` ~2.6×**:
   collapsed from two orders of magnitude by the type-proving / inline-field /
-  bare-read work (`binary-trees` ~140×→~1.7×, `mono-dispatch` ~330×→~2.7×). On a
+  bare-read work (`binary-trees` ~140×→~1.9×, `mono-dispatch` ~330×→~2.6×). On a
   statically proven monomorphic receiver, devirt resolves the impl and a
   per-site inline cache holds it. A NILABLE receiver deliberately does not
   devirtualize: the site caches its first resolution, so serving that impl to a
   later nil receiver would return a wrong value where Clojure raises
   `IllegalArgumentException` — a `some?`/`nil?` guard narrows it back and devirt
   fires again.
-- **`dispatch` ~1.1×**: a megamorphic site runs a per-site polymorphic inline
+- **`dispatch` ~1.2×**: a megamorphic site runs a per-site polymorphic inline
   cache (4-slot descriptor scan, `#3%` reads over the proven cache shape), so
   it no longer pays a registry lookup per call.
-- **`collections` ~1.7×**: JVM-exact Murmur3 hashing plus the array-map
+- **`nth-access` ~2.1×**: `jolt-nth` is `set!`-wrapped several times and the
+  array shim was outermost, so a plain vector read walked a chain of
+  extension-type probes before reaching the arm that answers it. `RT.nth` tests
+  `Indexed` first; so does this now (small vector 34.3 → 16.0ns). The residual
+  is a constant factor, which is why it lives here and not in
+  `test/complexity_test.clj` — two CI runners measured 2.79× and 5.14× for the
+  same commit, and the regression worth watching for lands inside that spread.
+- **`collections` ~1.8×**: JVM-exact Murmur3 hashing plus the array-map
   `(k . v)` fold; the residual is Murmur3 on integer keys, which the JVM JITs
   to a handful of instructions.
+
 
 ## 64-bit integer arithmetic & generators (test.check)
 

--- a/bench/hash_eq.clj
+++ b/bench/hash_eq.clj
@@ -1,0 +1,138 @@
+;; hash-eq — HASHING AND EQUALITY OF COMPOSITE VALUES: vectors, maps, sets,
+;; records, seqs and functions, hashed repeatedly, used as map/set keys, and
+;; compared with `=`. Per-iteration work is one hash or one compare, so the hash
+;; engine and the equality fast paths dominate.
+;;
+;; This is the regime `keyed-lookup` does not reach. That benchmark measures
+;; SCALAR keys — keywords, symbols, strings — which carry (or memoise) their own
+;; hash, so its cost is the lookup shape. Here every key is a COMPOSITE value
+;; whose hash is derived from its contents, which is a different engine:
+;;
+;;   - a collection's hasheq is a fold over its elements, so without a cache
+;;     every `(hash v)` re-walks the whole thing, and every collection-keyed map
+;;     op pays that walk. Vectors, maps and sets each carry a lazily filled
+;;     hasheq field; a seq caches on its head object; a record caches in an
+;;     instance slot. This measures the repeat-hash (cache-hit) path.
+;;   - `=` and `hash` on a collection used to fall through to a linear walk of
+;;     the equality/hash arm registries before reaching their base cases, so the
+;;     cost grew as libraries loaded. Vectors, maps, sets and records are
+;;     answered ahead of that walk now.
+;;   - two collections with DIFFERENT cached hashes are unequal without a
+;;     structural walk. The equal case still walks, so both are timed.
+;;   - a FUNCTION as a hash key. Chez's `equal-hash` gives every procedure the
+;;     same constant, so an fn-keyed map degenerated to one bucket and lookups
+;;     went quadratic in the number of keys; procedures get an identity hasheq
+;;     from a weak side table now.
+;;
+;; The shapes come from the field: instaparse's GLL msg-cache is keyed
+;; `[listener index]` — a vector holding a closure — and honeysql's format path
+;; compares and hashes small maps and vectors per call.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh hash-eq 2000
+(ns hash-eq)
+
+(defrecord Point [x y z w])
+
+;; --- data, all built OUTSIDE the timed region -------------------------------
+
+(def big-vec (vec (range 1000)))
+(def big-vec-eq (vec (range 1000)))                        ; equal, different object
+(def big-vec-ne (assoc (vec (range 1000)) 999 -1))         ; differs in the last slot
+
+(def big-map (zipmap (mapv (fn [i] (keyword (str "k" i))) (range 100)) (range 100)))
+(def big-map-eq (zipmap (mapv (fn [i] (keyword (str "k" i))) (range 100)) (range 100)))
+(def big-map-ne (assoc big-map :k99 -1))
+
+(def big-set (set (range 200)))
+(def big-list (apply list (range 500)))
+;; a seq caches its hasheq on the HEAD object, so the head is held here — a
+;; freshly allocated seq per iteration would measure the fold, not the cache.
+(def big-seq (seq (vec (range 500))))
+
+;; every collection whose hash the equality section relies on is in here, so the
+;; caches are warm by the time the compares run.
+(def hashables [big-vec big-vec-eq big-vec-ne big-map big-map-eq big-map-ne
+                big-set big-list big-seq])
+
+;; instaparse's msg-cache shape: a small vector key holding a scalar and a
+;; keyword, hashed and compared on every cache probe.
+(def composite-keys
+  (vec (for [i (range 256)] [i (keyword (str "p" (mod i 8)))])))
+(def composite-map (zipmap composite-keys (range 256)))
+(def composite-set (set composite-keys))
+
+(def records (mapv (fn [i] (->Point i (inc i) (+ i 2) (+ i 3))) (range 128)))
+(def record-map (zipmap records (range 128)))
+
+;; distinct closures, used as map keys
+(def fns (mapv (fn [i] (fn [x] (+ x i))) (range 64)))
+(def fn-map (zipmap fns (range 64)))
+
+;; --- 1. repeat hash: the hasheq cache ---------------------------------------
+(defn hash-colls [colls]
+  (reduce (fn [acc c] (unchecked-add acc (hash c))) 0 colls))
+
+;; --- 2. composite keys: vector keys in a map and a set ----------------------
+(defn lookup-composite [m ks]
+  (reduce (fn [acc k] (unchecked-add acc (long (get m k 0)))) 0 ks))
+
+(defn probe-composite [s ks]
+  (reduce (fn [acc k] (if (contains? s k) (inc acc) acc)) 0 ks))
+
+;; --- 3. record keys: hash, lookup, and building a record-keyed map ----------
+(defn hash-records [rs]
+  (reduce (fn [acc r] (unchecked-add acc (hash r))) 0 rs))
+
+(defn lookup-records [m rs]
+  (reduce (fn [acc r] (unchecked-add acc (long (get m r 0)))) 0 rs))
+
+;; --- 4. fn keys -------------------------------------------------------------
+(defn lookup-fns [m ks]
+  (reduce (fn [acc k] (unchecked-add acc (long (get m k 0)))) 0 ks))
+
+;; --- 5. equality: the walking case and the hash-reject case -----------------
+;; `a` vs `b` are equal and distinct objects, so this is the structural compare;
+;; `a` vs `c` differ, and both carry a cached hasheq, so it answers on the hash.
+(defn compare-pairs [a b c]
+  (unchecked-add (if (= a b) 1 0) (if (= a c) 0 1)))
+
+;; --- 6. hash-heavy collection ops over composite keys -----------------------
+(defn set-of [ks] (count (set ks)))
+(defn distinct-of [ks] (count (distinct ks)))
+
+(defn run [iters]
+  (loop [i 0 acc 0]
+    (if (< i iters)
+      (recur (inc i)
+             (unchecked-add
+              acc
+              (unchecked-add
+               (unchecked-add
+                (unchecked-add (hash-colls hashables)
+                               (lookup-composite composite-map composite-keys))
+                (unchecked-add (probe-composite composite-set composite-keys)
+                               (hash-records records)))
+               (unchecked-add
+                (unchecked-add (lookup-records record-map records)
+                               (lookup-fns fn-map fns))
+                (unchecked-add
+                 (unchecked-add (compare-pairs big-vec big-vec-eq big-vec-ne)
+                                (compare-pairs big-map big-map-eq big-map-ne))
+                 (unchecked-add (set-of composite-keys)
+                                (distinct-of composite-keys)))))))
+      acc)))
+
+(defn -main [& args]
+  (let [iters (if (seq args) (Integer/parseInt (first args)) 2000)]
+    (dotimes [_ 2] (run (quot iters 4)))                 ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/currentTimeMillis)
+                           r (run iters)
+                           el (- (System/currentTimeMillis) t0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       el))
+                   (range runs))]
+      (println "runs:" ts)
+      (println "mean:" (quot (reduce + ts) runs) "ms"))))

--- a/bench/literals.clj
+++ b/bench/literals.clj
@@ -1,0 +1,102 @@
+;; literals — FIXED PER-CALL OVERHEAD inside a library's inner function: the
+;; constant collection literals in its body, and the cheap type predicates it
+;; guards with. No algorithm here at all — every function is a handful of
+;; constructions and predicate calls, repeated.
+;;
+;; Nothing else in the suite sees this. `collections`, `seqs` and `transducers`
+;; measure work that scales with the data; this measures what a call costs before
+;; it touches any. Two costs, both found profiling honeysql's format loop:
+;;
+;;   - a LITERAL collection in a fn body. `{:a 1}`, `#{:for 'for}`, `[:a 'b]` are
+;;     compile-time constants and the reference compiler emits them into the
+;;     class's constant pool, built once. Rebuilding one per evaluation makes a
+;;     membership test against a set literal cost an allocation plus a hash per
+;;     element; `pset-conj` was 11% of samples in the honeysql profile, all of it
+;;     set literals rebuilt per call. Hoisting must be PER SITE, not interned
+;;     across sites — two textually identical literals are distinct objects in
+;;     the reference, and `=` short-circuits on identity — and a literal holding
+;;     a LOCAL is not constant and must still be built per call, which
+;;     `dynamic-pair` here is the control for.
+;;   - `true?`/`false?`/`boolean?`. Spelled `(= true x)`, a mixed-type `=` misses
+;;     every fast clause and walks the equality arm registry, so a library that
+;;     registers an arm makes an unrelated `boolean?` slower. The reference
+;;     bodies are identity checks, and `identical?` is an inline op.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh literals 100000
+(ns literals)
+
+;; --- constant collection literals in a fn body ------------------------------
+
+;; a 12-key options map, the shape a formatter carries defaults in
+(defn default-opts []
+  {:dialect :ansi :quoted false :inline false :checking :none
+   :numbered false :quoted-snake false :pretty false :values nil
+   :registry nil :params nil :cache nil :aliases nil})
+
+;; a small set literal used as a membership test — the honeysql shape, and the
+;; one that showed up in the profile
+(defn special-clause? [k]
+  (contains? #{:for :lateral :values :columns} k))
+
+;; the same test, but the set holds QUOTED SYMBOLS as well as keywords, so the
+;; literal is only constant if quoted forms hoist too
+(defn special-or-sym? [k]
+  (contains? #{:for 'for :lateral 'lateral} k))
+
+;; a vector and a map literal holding quoted symbols
+(defn sym-pair [] ['and 'or])
+(defn sym-map [] {:op 'select :from 'table})
+
+;; the control: an element is a LOCAL, so this genuinely constructs per call
+(defn dynamic-pair [x] [:clause x])
+
+;; two textually identical literals at DIFFERENT sites stay distinct objects
+(defn site-a [] #{:x :y})
+(defn site-b [] #{:x :y})
+
+;; --- cheap type predicates ---------------------------------------------------
+
+(def probes [true false nil :marker "s" 42 'sym [1] false true])
+
+(defn classify [xs]
+  (reduce (fn [acc x]
+            (unchecked-add
+             acc
+             (unchecked-add
+              (unchecked-add (if (true? x) 1 0) (if (false? x) 1 0))
+              (unchecked-add (if (boolean? x) 1 0)
+                             (if (identical? x :marker) 1 0)))))
+          0 xs))
+
+(defn run [iters]
+  (loop [i 0 acc 0]
+    (if (< i iters)
+      (recur (inc i)
+             (unchecked-add
+              acc
+              (unchecked-add
+               (unchecked-add
+                (unchecked-add (count (default-opts))
+                               (if (special-clause? :values) 1 0))
+                (unchecked-add (if (special-or-sym? 'for) 1 0)
+                               (unchecked-add (count (sym-pair)) (count (sym-map)))))
+               (unchecked-add
+                (unchecked-add (count (dynamic-pair i))
+                               (if (identical? (site-a) (site-b)) 0 1))
+                (classify probes)))))
+      acc)))
+
+(defn -main [& args]
+  (let [iters (if (seq args) (Integer/parseInt (first args)) 100000)]
+    (dotimes [_ 2] (run (quot iters 4)))                 ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/currentTimeMillis)
+                           r (run iters)
+                           el (- (System/currentTimeMillis) t0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       el))
+                   (range runs))]
+      (println "runs:" ts)
+      (println "mean:" (quot (reduce + ts) runs) "ms"))))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -46,7 +46,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 keyed-lookup:3000 string-build:60000 char-scan:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 char-scan:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/bench/string_ops.clj
+++ b/bench/string_ops.clj
@@ -1,0 +1,96 @@
+;; string-ops — INTEROP CALLS ON A PROVEN STRING OR KEYWORD, and the
+;; `clojure.string` wrappers over them. Per-iteration work is a handful of method
+;; calls on short strings, so the dispatch shape dominates over the operation.
+;;
+;; `string-build` measures the other side of interop — a StringBuilder target,
+;; where the cost is the appending — and `char-scan` measures `.charAt` plus the
+;; numeric casts around it. Neither reaches the ordinary String surface a library
+;; actually calls: `.indexOf`, `.startsWith`, `.substring`, `.toLowerCase`.
+;;
+;; The axis is whether the call site can be resolved at compile time. An interop
+;; call on an unproven target routes through a generic dispatcher that finds a
+;; method table by hashing the target's tag string, finds the handler by hashing
+;; the method name, and passes the arguments as a vector converted back to a list
+;; for apply. When the target is PROVEN a string — by a `^String` hint on a param
+;; or binding, or by the types pass proving it with no hint in the source — the
+;; back end can emit the operation directly instead. Both proof seams are here:
+;; `scan-hinted` carries the hint, `scan-proven` has none and depends on
+;; inference. Keywords get the same treatment, so `.getName`/`.getNamespace` on a
+;; hinted keyword are timed too.
+;;
+;; `strfns` is the `clojure.string` layer: every fn there coerces its argument
+;; through `to-str`, which took `.toString` unconditionally, so passing a plain
+;; string paid the full dispatch chain to reach the String surface — over 90% of
+;; `(upper-case "sel")` was deciding how to dispatch, on top of a ~40ns upcase.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh string-ops 100000
+(ns string-ops
+  (:require [clojure.string :as str]))
+
+(def entity "some.qualified/entity-name")
+(def words (mapv (fn [i] (str "word" i)) (range 16)))
+(def kws (mapv (fn [i] (keyword "bench" (str "key" i))) (range 16)))
+
+;; --- hinted String target -----------------------------------------------------
+(defn scan-hinted [^String s]
+  (unchecked-add
+   (unchecked-add (.indexOf s ".") (.length s))
+   (unchecked-add (if (.startsWith s "some") 1 0)
+                  (count (.substring s 1 5)))))
+
+;; --- unhinted: the target must be PROVEN a string by inference ---------------
+(defn scan-proven [s]
+  (let [t (str s "!")]
+    (unchecked-add
+     (unchecked-add (.indexOf t "/") (if (.endsWith t "!") 1 0))
+     (count (.toLowerCase t)))))
+
+;; --- the clojure.string layer over arguments that are already strings --------
+(defn strfns [s]
+  (unchecked-add
+   (unchecked-add (count (str/upper-case s)) (count (str/lower-case s)))
+   (unchecked-add (if (str/starts-with? s "some") 1 0)
+                  (if (str/includes? s "entity") 1 0))))
+
+(defn join-words [ws] (count (str/join "," ws)))
+
+;; --- hinted Keyword target ----------------------------------------------------
+(defn kw-parts [^clojure.lang.Keyword k]
+  (unchecked-add (count (.getName k))
+                 (count (.getNamespace k))))
+
+(defn kw-core [k]
+  (unchecked-add (count (name k)) (count (namespace k))))
+
+(defn walk-kws [ks]
+  (reduce (fn [acc k] (unchecked-add acc (unchecked-add (kw-parts k) (kw-core k))))
+          0 ks))
+
+(defn run [iters]
+  (let [s entity]
+    (loop [i 0 acc 0]
+      (if (< i iters)
+        (recur (inc i)
+               (unchecked-add
+                acc
+                (unchecked-add
+                 (unchecked-add (scan-hinted s) (scan-proven s))
+                 (unchecked-add
+                  (unchecked-add (strfns s) (join-words words))
+                  (walk-kws kws)))))
+        acc))))
+
+(defn -main [& args]
+  (let [iters (if (seq args) (Integer/parseInt (first args)) 100000)]
+    (dotimes [_ 2] (run (quot iters 4)))                 ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/currentTimeMillis)
+                           r (run iters)
+                           el (- (System/currentTimeMillis) t0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       el))
+                   (range runs))]
+      (println "runs:" ts)
+      (println "mean:" (quot (reduce + ts) runs) "ms"))))

--- a/bench/transients.clj
+++ b/bench/transients.clj
@@ -1,0 +1,95 @@
+;; transients — the TRANSIENT WRITE PATH for maps and sets. Builds the same
+;; collections four ways: `into` (which drives a transient under the hood), an
+;; explicit `assoc!`/`conj!` loop, and the removal side (`dissoc!`/`disj!`), with
+;; a transient VECTOR build as the control.
+;;
+;; `collections` measures the PERSISTENT write path — `assoc`/`conj` one at a
+;; time, path-copying per write — and its read side. This measures the bulk-build
+;; path libraries and core actually use: `into`, `zipmap`, `frequencies`,
+;; `group-by`, `set` and `mapv` all run transient-backed.
+;;
+;; The axis is whether a transient map/set is a real editable trie. Backed by a
+;; plain hashtable instead, a transient does not avoid the path-copying build —
+;; it DEFERS it, and adds a hashtable on top, so `persistent!` folds every entry
+;; through the ordinary insert and rebuilds the trie from scratch. That is
+;; strictly more work than the persistent build it is supposed to beat, and it
+;; is invisible to a value test. A write should claim each node on its path into
+;; an editable copy and mutate in place; `persistent!` should freeze the claimed
+;; spine and keep untouched subtrees by pointer.
+;;
+;; Transient VECTORS were always a tail-array append and are here as the
+;; control: if the map/set rows move and the vector row does not, the change is
+;; in the trie edit path and not in the surrounding reduce.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh transients 50000
+(ns transients)
+
+;; keys built OUTSIDE the timed region — this measures the write path, not
+;; keyword construction (see `keyed-lookup` for that).
+(def kws (mapv (fn [i] (keyword (str "k" i))) (range 50000)))
+
+(defn- take-kws [n] (subvec kws 0 (min n (count kws))))
+
+;; --- into: the transducing bulk build ---------------------------------------
+(defn into-map [n]
+  (count (into {} (map (fn [i] [i (* i 2)])) (range n))))
+
+(defn into-set [n]
+  (count (into #{} (map (fn [i] (mod i (quot (inc n) 2)))) (range n))))
+
+;; the control: a transient vector build over the same source
+(defn into-vec [n]
+  (count (into [] (map (fn [i] (* i 2))) (range n))))
+
+;; --- explicit transient loops ------------------------------------------------
+(defn assoc-loop [ks]
+  (count (persistent!
+          (reduce (fn [t k] (assoc! t k 1)) (transient {}) ks))))
+
+(defn conj-loop [ks]
+  (count (persistent!
+          (reduce (fn [t k] (conj! t k)) (transient #{}) ks))))
+
+;; --- the removal side --------------------------------------------------------
+(defn dissoc-loop [m ks]
+  (count (persistent!
+          (reduce (fn [t k] (dissoc! t k)) (transient m) ks))))
+
+(defn disj-loop [s ks]
+  (count (persistent!
+          (reduce (fn [t k] (disj! t k)) (transient s) ks))))
+
+;; --- core fns that are transient-backed in the reference ---------------------
+(defn build-zipmap [ks] (count (zipmap ks ks)))
+(defn build-freqs [n] (count (frequencies (map (fn [i] (mod i 512)) (range n)))))
+(defn build-groups [n] (count (group-by (fn [i] (mod i 512)) (range n))))
+
+(defn run [n]
+  (let [ks (take-kws n)
+        half (subvec ks 0 (quot (count ks) 2))
+        m (zipmap ks ks)
+        s (set ks)]
+    (unchecked-add
+     (unchecked-add
+      (unchecked-add (into-map n) (into-set n))
+      (unchecked-add (into-vec n) (assoc-loop ks)))
+     (unchecked-add
+      (unchecked-add (conj-loop ks) (dissoc-loop m half))
+      (unchecked-add
+       (unchecked-add (disj-loop s half) (build-zipmap ks))
+       (unchecked-add (build-freqs n) (build-groups n)))))))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 50000)]
+    (dotimes [_ 2] (run (quot n 4)))                     ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/currentTimeMillis)
+                           r (run n)
+                           el (- (System/currentTimeMillis) t0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       el))
+                   (range runs))]
+      (println "runs:" ts)
+      (println "mean:" (quot (reduce + ts) runs) "ms"))))

--- a/bench/vecops.clj
+++ b/bench/vecops.clj
@@ -1,12 +1,12 @@
 ;; vecops — VECTOR CONCATENATION AND SLICING, the axis no other suite measures.
 ;; collections churns one vector with conj/assoc; this suite makes vectors OUT
 ;; OF vectors: pairwise `into` concatenation, `subvec` windows consumed by
-;; reduce, and a split-at-then-rejoin loop (the classic RRB workload). Today
-;; every one of these is linear per operation on jolt; when pvec grows RRB
-;; concat/slice AND core's `into`/`subvec` are wired through it (the follow-up
-;; beads to the rrb epic), these rows are where the change shows. On the JVM,
-;; `into` is linear too (core Clojure has no RRB) and `subvec` is an O(1) view
-;; that retains its parent — the ratio columns stay honest about both.
+;; reduce, and a split-at-then-rejoin loop (the classic RRB workload). These
+;; were all linear per operation on jolt until pvec grew RRB concat/slice and
+;; core's `into`/`subvec` were wired through it; concat is O(log n) here now. On
+;; the JVM, `into` is still linear (core Clojure has no RRB) and `subvec` is an
+;; O(1) view that retains its parent — the ratio columns stay honest about both,
+;; and this is the one row where jolt wins on ALGORITHM rather than constants.
 ;;
 ;; Portable Clojure (jolt + JVM Clojure).
 ;;   bench/run.sh vecops 60000

--- a/host/chez/natives-num.ss
+++ b/host/chez/natives-num.ss
@@ -12,12 +12,22 @@
 ;; not supported for" as closely as the model allows).
 (define ->int-long-min -9223372036854775808)
 (define ->int-long-max 9223372036854775807)
+;; A fixnum is already an exact integer inside signed 64-bit range — Chez's
+;; fixnum width is 61 here, so it cannot reach ±2^63 — and it is what every
+;; ordinary bit operation is handed. Test it first: the bounds are BIGNUMS on a
+;; 61-bit tower, so the general path pays two fixnum-vs-bignum compares per
+;; operand, four per (bit-xor a b). That was ~22ms per 1.28M bit ops, i.e. all
+;; of the loop-recur benchmark's regression when the bit ops moved off the raw
+;; Chez primitives onto these helpers. Same fix the int/long/unchecked-* casts
+;; already carry.
 (define (->int x)
-  (if (and (number? x) (exact? x) (integer? x)
-           (>= x ->int-long-min) (<= x ->int-long-max))
+  (if (fixnum? x)
       x
-      (throw-jvm (quote IllegalArgumentException)
-                 (string-append "bit operation not supported for: " (jolt-final-str x)))))
+      (if (and (number? x) (exact? x) (integer? x)
+               (>= x ->int-long-min) (<= x ->int-long-max))
+          x
+          (throw-jvm (quote IllegalArgumentException)
+                     (string-append "bit operation not supported for: " (jolt-final-str x))))))
 ;; Mask shift count to low 6 bits (JVM long shift semantics), then wrap result
 ;; to 64-bit signed two's complement.
 (define (shift-mask n) (bitwise-and (->int n) 63))


### PR DESCRIPTION
Four benchmarks for perf work that had no coverage, a full scorecard re-measure, and a regression the old scorecard hid.

## Coverage

| new bench | what it measures | PRs |
|---|---|---|
| `hash-eq` | repeat-hashing vectors/maps/sets/records/seqs, vector- record- and fn-keyed map and set lookups, `=` on equal and unequal collections | #650 #656 #662 #666 #667 #668 #669 #672 |
| `literals` | constant map/vector/set literals in a fn body (incl. quoted symbols), `true?`/`false?`/`boolean?`/`identical?` | #663 #664 |
| `transients` | `into`/`assoc!`/`conj!`/`dissoc!`/`disj!` map and set bulk build, with the vector build as the control | #638 |
| `string-ops` | `.indexOf`/`.startsWith`/`.substring`/`.toLowerCase` on hinted and inference-proven targets, `clojure.string` over already-string args, keyword interop | #634 #640 #644 |

`hash-eq` is the composite half of the hash engine where `keyed-lookup` is the scalar half — the distinction matters, because `collections` amortises a per-key hash across 32-way nodes and `keyed-lookup`'s keys carry or memoise their own. `literals` is the purest ratio in the suite: it does no work beyond constructing the literals in a function body and calling three predicates, which is exactly why nothing else could see that axis.

Already covered and left alone: #636/#637 (`sorted-access`, `nth-access`), #607/#614/#620 (`vecops`), #610 (`startup.sh`), #657 (gates, not a bench). `vecops` and `nth-access` were in `run.sh` but missing from the scorecard; both are in it now, and `vecops` runs at 0.3× — the one row where jolt has a better algorithm than the reference rather than a better constant.

## A stale scorecard hid a 1.7× regression for three weeks

`loop-recur` (30.7), `mandelbrot` (23.3) and `fib` (7.0) dated from the 2026-07-26 refresh and were carried forward through three later README edits that added rows and prose without re-running the suite. Bisecting the published release binaries:

| | v0.5.12 (Jul 29) | v0.5.13 (Aug 1) | HEAD |
|---|---:|---:|---:|
| `loop-recur` | 30.3 ms | **51.7 ms** | 51.8 ms |
| `mandelbrot` | 23.0 ms | 32.0 ms | 30.7 ms |

Flat at ~52ms in every release since. The JVM column did not move across the same span and Chez has been 10.4.1 since June, so it was neither the machine nor the substrate.

The cause is in v0.5.13's bit-op change. `bit-and`/`bit-or`/`bit-xor`/`bit-not` moved off the raw Chez primitives — which Chez inlines to native code — onto `jolt-bit-*` helpers, so a bad operand raises a catchable `IllegalArgumentException` in call position as well as value position. Correct, but the helpers coerce through `->int`, which range-checks against ±2^63. Those bounds are **bignums** on Chez's 61-bit fixnum tower, so every `(bit-xor a b)` on ordinary integers paid four fixnum-vs-bignum compares — the identical pathology f89d3ff6 fixed for `int`, `long` and the `unchecked-*` forms, which `->int` was not given. `loop-recur`'s inner loop is `(bit-xor i j)`, 64 trips per outer iteration.

`->int` now tests `fixnum?` first. Not a semantic narrowing: a Chez fixnum here is 61-bit, so it is always an exact integer inside signed 64-bit range and always took the slow path's accept branch. Isolated in Chez, 1.28M `bit-xor`s:

| | ms |
|---|---:|
| raw inlined `bitwise-xor` | 4 |
| `jolt-bit-xor`, `->int` today | 26 |
| `jolt-bit-xor`, `->int` + fixnum path | 8 |

`loop-recur` **51.8 → 34.4 ms**.

## What is left, and why it is not here

Two residuals from the same window, both the same shape — a Chez primitive that used to inline is now a helper CALL, which cross-unit inlining cannot reach:

- `loop-recur`'s remaining ~4ms over v0.5.12 is the `jolt-bit-*` call itself (the 8-vs-4 half of the probe above).
- `mandelbrot` 23.0 → 30.7ms is the same swap on the float side: a `^double` param/return coercion emits `jolt->fl` where it used to emit a bare `exact->inexact`. `jolt->fl` already tests `flonum?` first, so this is call overhead only.

Both need the back end to emit an inline fast path with the helper as the slow arm — a codegen change and a seed remint. Recorded in the README with the numbers rather than folded in here.

The procedural point is in the README too: the numeric rows were carried forward instead of re-measured, and that is what made a 1.7× regression invisible for three weeks.

## Gates

`make test` green (ci gate 81 targets, test gate 3 targets), `make certify` 0 new / 0 stale divergences.