### PR TITLE
Add ProcessBuilder.inheritIO and the redirect getters

### DIFF
--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -301,10 +301,17 @@
 (define (proc-redirect-kind r) (vector-ref (jhost-state r) 0))
 (define (proc-redirect-file r) (vector-ref (jhost-state r) 1))
 
+;; Named so inheritIO() can hand back the SAME object Redirect/INHERIT is. On the
+;; JVM these are singletons — (= (.redirectInput pb) Redirect/INHERIT) is true
+;; after .inheritIO() — and a fresh instance per call would read as a different
+;; redirect to anything comparing them.
+(define proc-redirect-inherit (make-proc-redirect 'inherit #f))
+(define proc-redirect-pipe (make-proc-redirect 'pipe #f))
+
 (define proc-redirect-statics
-  (list (cons "INHERIT" (make-proc-redirect 'inherit #f))
+  (list (cons "INHERIT" proc-redirect-inherit)
         (cons "DISCARD" (make-proc-redirect 'discard #f))
-        (cons "PIPE"    (make-proc-redirect 'pipe #f))
+        (cons "PIPE"    proc-redirect-pipe)
         (cons "to"       (lambda (f) (make-proc-redirect 'write  (file-path-of f))))
         (cons "appendTo" (lambda (f) (make-proc-redirect 'append (file-path-of f))))
         (cons "from"     (lambda (f) (make-proc-redirect 'read   (file-path-of f))))))
@@ -380,10 +387,35 @@
         (cons "environment" (lambda (self)
           (or (proc-pb-env self)
               (let ((em (make-proc-env-map))) (proc-pb-set! self 1 em) em))))
-        (cons "redirectInput"  (lambda (self r) (proc-pb-set! self 3 r) self))
-        (cons "redirectOutput" (lambda (self r) (proc-pb-set! self 4 r) self))
-        (cons "redirectError"  (lambda (self r) (proc-pb-set! self 5 r) self))
-        (cons "redirectErrorStream" (lambda (self b) (proc-pb-set! self 6 (jolt-truthy? b)) self))
+        ;; Each redirect method is a setter with an argument and a GETTER with
+        ;; none, like the JDK's. An unset stream reads back as PIPE, which is the
+        ;; documented default rather than nil.
+        (cons "redirectInput"  (lambda (self . r)
+          (if (null? r) (or (proc-pb-redir-in self) proc-redirect-pipe)
+              (begin (proc-pb-set! self 3 (car r)) self))))
+        (cons "redirectOutput" (lambda (self . r)
+          (if (null? r) (or (proc-pb-redir-out self) proc-redirect-pipe)
+              (begin (proc-pb-set! self 4 (car r)) self))))
+        (cons "redirectError"  (lambda (self . r)
+          (if (null? r) (or (proc-pb-redir-err self) proc-redirect-pipe)
+              (begin (proc-pb-set! self 5 (car r)) self))))
+        (cons "redirectErrorStream" (lambda (self . b)
+          (if (null? b) (and (proc-pb-merge-err? self) #t)
+              (begin (proc-pb-set! self 6 (jolt-truthy? (car b))) self))))
+        ;; inheritIO(): set all three standard streams to INHERIT and return this
+        ;; — the JDK defines it as exactly redirectInput(INHERIT)
+        ;; .redirectOutput(INHERIT).redirectError(INHERIT), and the start path
+        ;; already understands the 'inherit kind. Without it a caller had to spell
+        ;; those three out, and the miss reported as "No matching field found:
+        ;; inheritIO" because jolt reads a 0-arg method miss as a field probe
+        ;; (jolt-674). It does NOT clear redirectErrorStream: on the JVM the two
+        ;; are independent, and a merge set before or after still wins over the
+        ;; error redirect.
+        (cons "inheritIO" (lambda (self)
+                            (proc-pb-set! self 3 proc-redirect-inherit)
+                            (proc-pb-set! self 4 proc-redirect-inherit)
+                            (proc-pb-set! self 5 proc-redirect-inherit)
+                            self))
         (cons "start" (lambda (self) (proc-pb-start self)))))
 
 ;; startPipeline: connect N builders stdout->stdin with pump threads, returning a

--- a/test/chez/process-test.clj
+++ b/test/chez/process-test.clj
@@ -137,6 +137,37 @@
 (check-eq "pb instance?" (instance? java.lang.ProcessBuilder (java.lang.ProcessBuilder. ["true"])) true)
 (check-eq "proc class" (.getName (class (:proc @(process ["true"])))) "java.lang.Process")
 
+;; --- ProcessBuilder.inheritIO and the redirect getters (jolt-674) -------------
+;; inheritIO() is defined as redirectInput(INHERIT).redirectOutput(INHERIT)
+;; .redirectError(INHERIT) returning this. Before it existed the miss reported as
+;; "No matching field found: inheritIO" — jolt reads a 0-arg method miss as a
+;; field probe, like the JVM reflector — and callers had to spell the three out.
+;; Every value below is JVM Clojure's.
+(check-eq "inheritIO runs the issue's repro" (.. (java.lang.ProcessBuilder. ["true"]) inheritIO start waitFor) 0)
+(check-eq "inheritIO propagates a non-zero exit" (.. (java.lang.ProcessBuilder. ["false"]) inheritIO start waitFor) 1)
+(let [pb (java.lang.ProcessBuilder. ["true"])]
+  (check-eq "inheritIO returns this" (identical? pb (.inheritIO pb)) true))
+(let [pb (doto (java.lang.ProcessBuilder. ["true"]) .inheritIO)]
+  (check-eq "inheritIO sets stdin"  (= (.redirectInput pb)  java.lang.ProcessBuilder$Redirect/INHERIT) true)
+  (check-eq "inheritIO sets stdout" (= (.redirectOutput pb) java.lang.ProcessBuilder$Redirect/INHERIT) true)
+  (check-eq "inheritIO sets stderr" (= (.redirectError pb)  java.lang.ProcessBuilder$Redirect/INHERIT) true))
+;; the getters: an unset stream reads back as PIPE, the documented default
+(let [pb (java.lang.ProcessBuilder. ["true"])]
+  (check-eq "an unset redirect is PIPE" (= (.redirectInput pb) java.lang.ProcessBuilder$Redirect/PIPE) true)
+  (check-eq "redirectErrorStream defaults false" (.redirectErrorStream pb) false))
+(check-eq "redirectErrorStream round-trips"
+          (.redirectErrorStream (doto (java.lang.ProcessBuilder. ["true"]) (.redirectErrorStream true))) true)
+;; the two are independent on the JVM: inheritIO does not clear a merge
+(check-eq "inheritIO leaves redirectErrorStream alone"
+          (.redirectErrorStream (doto (java.lang.ProcessBuilder. ["true"])
+                                  (.redirectErrorStream true) .inheritIO)) true)
+;; a later redirect overrides only the stream it names
+(let [pb (doto (java.lang.ProcessBuilder. ["true"])
+           .inheritIO (.redirectOutput java.lang.ProcessBuilder$Redirect/PIPE))]
+  (check-eq "a later redirect overrides one stream"
+            [(= (.redirectOutput pb) java.lang.ProcessBuilder$Redirect/PIPE)
+             (= (.redirectInput pb) java.lang.ProcessBuilder$Redirect/INHERIT)] [true true]))
+
 ;; --- fd-level INHERIT ---------------------------------------------------------
 ;; Redirect.INHERIT hands the child jolt's REAL fds (posix_spawn leaves 0/1/2
 ;; untouched), not a pump-fed pipe. Two things only real inheritance can do:
@@ -153,6 +184,15 @@
       out (:out (sh [jolt-bin "-e" nested]))]
   (check-eq "INHERIT stdout reaches the parent's stdout"
             (str/includes? out "INHERITED-OUT") true))
+
+;; inheritIO is real fd inheritance, not a recorded flag: BOTH streams land on
+;; the nested jolt's stdio, and stderr with them (the single-stream test above
+;; only covers stdout).
+(let [nested (str "(.. (java.lang.ProcessBuilder. [\"sh\" \"-c\" \"echo IIO-OUT; echo IIO-ERR 1>&2\"])"
+                  " inheritIO start waitFor)")
+      r (sh [jolt-bin "-e" nested])]
+  (check-eq "inheritIO stdout reaches the parent" (str/includes? (:out r) "IIO-OUT") true)
+  (check-eq "inheritIO stderr reaches the parent" (str/includes? (str (:out r) (:err r)) "IIO-ERR") true))
 
 ;; isatty: under a pty (script(1)), an INHERIT child's stdout IS the terminal.
 ;; A pump-fed pipe can never answer true here.


### PR DESCRIPTION
Closes the second half of #674.

```bash
jolt -e '(.. (ProcessBuilder. ["true"]) inheritIO start waitFor)'
# before: No matching field found: inheritIO for class java.lang.ProcessBuilder
# after:  0
```

Two things made that error read oddly, and both are worth knowing: jolt reports a **0-arg** method miss as "No matching *field* found", mirroring the JVM reflector's method-then-field order — so a missing no-arg method does not look like one. The documented workaround was spelling the three redirects out by hand.

`inheritIO()` is defined as `redirectInput(INHERIT).redirectOutput(INHERIT).redirectError(INHERIT)` returning `this`, and the start path already understood the `'inherit` kind, so this is purely the missing method.

## Singletons and getters

`Redirect.INHERIT` and `PIPE` are hoisted to named singletons. On the JVM they *are* singletons — `(= (.redirectInput pb) Redirect/INHERIT)` is true after `.inheritIO()` — and a fresh instance per call would compare as a different redirect.

Each redirect method also grows its **0-arg getter** arity, which is what makes that comparison expressible at all. An unset stream reads back as `PIPE`, the documented default, not nil. `redirectErrorStream` gets one too. `inheritIO` deliberately does **not** clear it: the two are independent on the JVM, and a merge set on either side still wins over the error redirect.

## Verified against JVM Clojure

All 11 probe rows identical, plus a behavioral check that this is real fd inheritance and not a recorded flag:

| | reference | jolt |
|---|---|---|
| issue repro exit | 0 | 0 |
| non-zero exit propagates | 1 | 1 |
| returns `this` | true | true |
| stdin/stdout/stderr = INHERIT | true | true |
| unset redirect | PIPE | PIPE |
| `redirectErrorStream` default | false | false |
| `inheritIO` leaves a merge alone | true | true |
| later redirect overrides one stream | true | true |
| child stdout **and stderr** reach the parent | yes | yes |
| PIPE default still captures | `"OUT-PIPED\n"` | `"OUT-PIPED\n"` |

13 checks added to `test/chez/process-test.clj`, alongside the existing fd-level INHERIT tests.

## The `read-line` half is not a jolt bug

Deliberately not addressed. Under `icanon -icrnl` the kernel line discipline never delivers the line to userspace, so no application code can see the CR — the reporter confirmed the reference Go binary behaves identically under that forced termios state, and their own conclusion is that the fix belongs in the sandbox PTY launcher. They also asked specifically that jolt not alter terminal settings merely because `read-line` was called, which is right: having `read-line` shell out to `stty icrnl` would mutate the user's terminal as a side effect of reading a line, and would be a worse bug than the one it papers over.

Worth noting the reported workaround gets easier with this change — `(.. pb inheritIO start)` now works for the `stty` invocation they were spelling out longhand.

## Gates

`make test` green (ci 81 targets, test 3), `make certify` 0 new / 0 stale. `process-test.clj` passes end to end (`PROCESS-TEST OK`).