### PR TITLE
FFI byte buffers in one copy; fill in InputStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`jolt.ffi/read-into!`** — read a foreign buffer into a slice of an
+  existing byte-array (`(read-into! ptr arr off n)`, the
+  `InputStream.read(b, off, len)` argument order). A caller reading a stream
+  whose total length it already knows now fills one buffer instead of
+  allocating and regrowing an accumulator per chunk; a read outside the
+  array's bounds throws rather than truncating. `write-array` gained the
+  matching slice arity `(write-array ptr arr off n)`.
+
+### Changed
+
+- **FFI buffer moves copy the whole block instead of one byte at a time.**
+  `read-array`, `write-array`, `read-bytes` and `write-bytes` crossed the
+  foreign boundary once per octet, which cost ~30ns each — so a 64K socket
+  read spent ~2ms in the copy alone, dwarfing the work around it. They now
+  move the block in a single copy and do the signed-byte fold or the UTF-8
+  decode on the Scheme side. Measured on the same 64K buffer: `read-array`
+  29.9 → 2.9 ns/byte, `write-array` 31.1 → 4.9, `read-bytes` 29.8 → 1.1,
+  `write-bytes` 31.4 → 1.6. Two adapter capability entry points carry it
+  (`sa-foreign-bytes-ref!` / `sa-foreign-bytes-set!`); a target with no block
+  move may implement them as the old per-byte loop, which is what the Chez
+  side falls back to if `memcpy` does not resolve.
+
+### Fixed
+
+- **A library replacing a host class constructor now says so under
+  `JOLT_DEBUG`.** `clojure.core/__register-class-ctor!` exists so a shim can
+  register a class jolt does not model, but nothing stopped it from replacing
+  one jolt *does* — process-wide, for every namespace, silently.
+  jolt-lang/http-client substitutes its own tagged-table shim for
+  `java.io.ByteArrayInputStream`; any library loaded alongside it then finds
+  `(.readAllBytes body)` unresolvable and `io/copy` over that stream ~3600x
+  slower (0.3 → 1092 ns/byte measured), with nothing in the error pointing at
+  the override. Registering a class the host does not model — the intended
+  use — stays silent.
+
 ## [0.7.17] - 2026-08-19
 
 A performance and conformance release, out of profiling the honeysql test

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -172,16 +172,22 @@
 (define ffi-null 0)
 
 ;; --- buffer I/O (known length) ----------------------------------------------
+;; Every one of these moves the block in ONE sa-foreign-bytes-ref!/-set! call
+;; and does any per-element work (signed-byte fold, UTF-8 decode) on the Scheme
+;; side. A byte at a time across the foreign boundary costs ~30ns each — an
+;; order of magnitude more than the same loop over a bytevector — so a 64K
+;; socket read used to spend ~2ms in the copy alone.
+
 ;; read n bytes at ptr as a string (UTF-8, falling back to latin1 for invalid
 ;; sequences) — for a socket recv buffer and similar fixed-length reads.
 (define (ffi-read-bytes ptr n)
   (let* ((n (jnum->exact n)) (p (jnum->exact ptr)) (bv (make-bytevector n)))
-    (do ((i 0 (+ i 1))) ((= i n)) (bytevector-u8-set! bv i (sa-foreign-ref 'unsigned-8 p i)))
+    (sa-foreign-bytes-ref! p bv n)
     (guard (e (#t (list->string (map integer->char (bytevector->u8-list bv))))) (utf8->string bv))))
 ;; write a string's UTF-8 bytes into ptr (no NUL terminator); return the count.
 (define (ffi-write-bytes ptr s)
   (let* ((bv (string->utf8 (jolt-str-render-one s))) (n (bytevector-length bv)) (p (jnum->exact ptr)))
-    (do ((i 0 (+ i 1))) ((= i n)) (sa-foreign-set! 'unsigned-8 p i (bytevector-u8-ref bv i)))
+    (sa-foreign-bytes-set! p bv n)
     n))
 (def-var! "jolt.ffi" "read-bytes" ffi-read-bytes)
 (def-var! "jolt.ffi" "write-bytes" ffi-write-bytes)
@@ -190,18 +196,60 @@
 ;; Move raw bytes between a jolt byte-array (jolt-array kind 'byte) and foreign
 ;; memory, byte-exact (no UTF-8 / latin1 decode) — for socket recv/send and the
 ;; zlib / OpenSSL buffers an HTTP client passes through. read-array returns a
-;; fresh byte-array of n bytes; write-array copies a byte-array's bytes into ptr
-;; and returns the count. Foreign memory is unsigned octets and a byte-array element
-;; is a signed byte, so the two directions fold and mask across that seam.
+;; fresh byte-array of n bytes; read-into! fills an EXISTING one (so a caller
+;; that knows the total length up front reads a stream into one buffer instead
+;; of regrowing an accumulator per chunk); write-array copies a byte-array's
+;; bytes — all of them, or a slice — into ptr and returns the count. Foreign
+;; memory is unsigned octets and a byte-array element is a signed byte, so the
+;; two directions fold and mask across that seam (bytevector-s8-ref/-u8-set!
+;; are that fold).
+(define (ffi-bv->byte-vec! bv v off n)
+  (do ((i 0 (+ i 1))) ((= i n)) (vector-set! v (+ off i) (bytevector-s8-ref bv i))))
+(define (ffi-byte-vec->bv! v off n)
+  (let ((bv (make-bytevector n)))
+    (do ((i 0 (+ i 1))) ((= i n))
+      (bytevector-u8-set! bv i (bitwise-and (exact (vector-ref v (+ off i))) #xff)))
+    bv))
+
 (define (ffi-read-array ptr n)
-  (let* ((n (jnum->exact n)) (p (jnum->exact ptr)) (v (make-vector n 0)))
-    (do ((i 0 (+ i 1))) ((= i n)) (vector-set! v i (na-u8->byte (sa-foreign-ref 'unsigned-8 p i))))
+  (let* ((n (jnum->exact n)) (p (jnum->exact ptr)) (bv (make-bytevector n)) (v (make-vector n 0)))
+    (sa-foreign-bytes-ref! p bv n)
+    (ffi-bv->byte-vec! bv v 0 n)
     (make-jolt-array v 'byte)))
-(define (ffi-write-array ptr arr)
-  (let* ((v (jolt-array-vec arr)) (n (vector-length v)) (p (jnum->exact ptr)))
-    (do ((i 0 (+ i 1))) ((= i n)) (sa-foreign-set! 'unsigned-8 p i (bitwise-and (exact (vector-ref v i)) #xff)))
-    n))
+
+;; (read-into! ptr arr off n) -> n. Copy n bytes at ptr into arr starting at off
+;; (the java.io.InputStream/read argument order). Throws rather than writing out
+;; of bounds — a short read that silently truncated would corrupt the buffer.
+(define (ffi-read-into! ptr arr off n)
+  (let* ((n (jnum->exact n)) (off (jnum->exact off)) (p (jnum->exact ptr))
+         (v (jolt-array-vec arr)) (cap (vector-length v)))
+    (when (or (< off 0) (< n 0) (> (+ off n) cap))
+      (jolt-throw (jolt-ex-info "jolt.ffi/read-into!: range outside the byte-array"
+                                (jolt-hash-map (jolt-keyword "offset") off
+                                               (jolt-keyword "length") n
+                                               (jolt-keyword "capacity") cap))))
+    (let ((bv (make-bytevector n)))
+      (sa-foreign-bytes-ref! p bv n)
+      (ffi-bv->byte-vec! bv v off n)
+      n)))
+
+(define ffi-write-array
+  (case-lambda
+    ((ptr arr)
+     (let ((v (jolt-array-vec arr)))
+       (ffi-write-array ptr arr 0 (vector-length v))))
+    ((ptr arr off n)
+     (let* ((n (jnum->exact n)) (off (jnum->exact off)) (p (jnum->exact ptr))
+            (v (jolt-array-vec arr)) (cap (vector-length v)))
+       (when (or (< off 0) (< n 0) (> (+ off n) cap))
+         (jolt-throw (jolt-ex-info "jolt.ffi/write-array: range outside the byte-array"
+                                   (jolt-hash-map (jolt-keyword "offset") off
+                                                  (jolt-keyword "length") n
+                                                  (jolt-keyword "capacity") cap))))
+       (sa-foreign-bytes-set! p (ffi-byte-vec->bv! v off n) n)
+       n))))
 (def-var! "jolt.ffi" "read-array" ffi-read-array)
+(def-var! "jolt.ffi" "read-into!" ffi-read-into!)
 (def-var! "jolt.ffi" "write-array" ffi-write-array)
 
 ;; --- string / bytevector marshaling ------------------------------------------

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1348,7 +1348,7 @@
         (let ((e (jolt-first s)))
           (loop (jolt-seq (jolt-rest s)) (cons (cons (jolt-nth e 0) (jolt-nth e 1)) acc))))))
 (def-var! "clojure.core" "__register-class-ctor!"
-  (lambda (name proc) (register-class-ctor! name proc) jolt-nil))
+  (lambda (name proc) (register-class-ctor-user! name proc) jolt-nil))
 (def-var! "clojure.core" "__register-class-statics!"
   (lambda (name members) (register-class-statics! name (jmap->static-alist members)) jolt-nil))
 

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -75,7 +75,30 @@
                 (hashtable-set! h (car p) (cdr p)))
               members)))
 
-(define (register-class-ctor! name proc) (hashtable-set! class-ctors-tbl name proc))
+;; Names the HOST registered (io.ss, io-streams.ss, …), as opposed to a library
+;; registering a class jolt does not model. Only the host's own boot-time calls
+;; land here — the Clojure-visible hook goes through register-class-ctor-user!.
+(define host-class-ctors-tbl (make-hashtable string-hash string=?))
+
+(define (register-class-ctor! name proc)
+  (hashtable-set! host-class-ctors-tbl name #t)
+  (hashtable-set! class-ctors-tbl name proc))
+
+;; clojure.core/__register-class-ctor! lands here. Registering a class jolt does
+;; not model is the intended use; REPLACING one it does is a process-wide
+;; substitution that every other namespace silently inherits, and the symptoms
+;; are remote from the cause — jolt-lang/http-client swaps its own tagged-table
+;; shim in for java.io.ByteArrayInputStream, and any library loaded alongside it
+;; then finds (.readAllBytes body) unresolvable and io/copy ~3600x slower, with
+;; nothing pointing at the override. Report it under JOLT_DEBUG the way
+;; register-class-statics! reports a colliding static, so the cause is one env
+;; var away instead of a bisect.
+(define (register-class-ctor-user! name proc)
+  (when (and (getenv "JOLT_DEBUG") (hashtable-ref host-class-ctors-tbl name #f))
+    (fprintf (current-error-port)
+             "warning: a library replaced the host constructor for ~a — every (~a. ...) in this process now builds its shim, including in namespaces that never asked for it\n"
+             name name))
+  (hashtable-set! class-ctors-tbl name proc))
 
 (define (register-host-methods! tag members)
   (let ((h (or (hashtable-ref host-methods-tbl tag #f)

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -313,6 +313,60 @@
 ;; the typed write. Degradation: none.
 (define (sa-foreign-set! type addr off v) (foreign-set! type addr off v))
 
+;; --- bulk octet moves --------------------------------------------------------
+;; sa-foreign-ref/-set! carry ONE value per call. Moving a buffer that way costs
+;; ~30ns per byte on Chez (measured against ~4ns for the same loop over a
+;; bytevector, and ~0 for bytevector-copy!), so every socket read, every FFI
+;; buffer hand-off, and every jolt.ffi/read-array paid a per-byte constant that
+;; dwarfed the work around it. These two move a whole block at once.
+;;
+;; The bytevector crosses to C BY ADDRESS (Chez's u8* argument type). A plain
+;; foreign call keeps the calling thread ACTIVE for the collector, so the
+;; bytevector cannot be moved out from under C for the duration of the call --
+;; which is exactly why neither of these may ever be made __collect_safe.
+;;
+;; Resolution is lazy and probe-only: the boot already loaded the process-global
+;; handle, so memcpy resolves without another sa-load-shared-object -- and must
+;; not take one, since re-loading that handle re-promotes it above every
+;; :jolt/native loaded so far (the libboringssl hijack, see java/ffi.ss).
+(define sa-fbytes-probed? #f)
+(define sa-fbytes-in #f)     ; memcpy(bytevector, foreign, n)
+(define sa-fbytes-out #f)    ; memcpy(foreign, bytevector, n)
+(define (sa-fbytes-init!)
+  (unless sa-fbytes-probed?
+    (set! sa-fbytes-probed? #t)                ; probe once, even if it throws
+    (guard (e (#t #f))
+      (when (foreign-entry? "memcpy")
+        (set! sa-fbytes-in (foreign-procedure "memcpy" (u8* void* size_t) void*))
+        (set! sa-fbytes-out (foreign-procedure "memcpy" (void* u8* size_t) void*))))))
+
+;; (sa-foreign-bytes-ref! addr bv n) -> void
+;; Copy the N octets at foreign address ADDR into BV[0,N). Contract: a
+;; binary-faithful block copy, foreign -> bytevector. Degradation: a target with
+;; no block move may loop over its foreign-ref (correct, just slow) -- the
+;; fallback below is that loop, taken when memcpy does not resolve.
+(define (sa-foreign-bytes-ref! addr bv n)
+  (sa-fbytes-init!)
+  (if sa-fbytes-in
+      (begin (sa-fbytes-in bv addr n) (if #f #f))
+      (let loop ((i 0))
+        (when (fx< i n)
+          (bytevector-u8-set! bv i (foreign-ref 'unsigned-8 addr i))
+          (loop (fx+ i 1))))))
+
+;; (sa-foreign-bytes-set! addr bv n) -> void
+;; Copy BV[0,N) to the N octets at foreign address ADDR. Contract: a
+;; binary-faithful block copy, bytevector -> foreign. Degradation: as
+;; sa-foreign-bytes-ref!.
+(define (sa-foreign-bytes-set! addr bv n)
+  (sa-fbytes-init!)
+  (if sa-fbytes-out
+      (begin (sa-fbytes-out addr bv n) (if #f #f))
+      (let loop ((i 0))
+        (when (fx< i n)
+          (foreign-set! 'unsigned-8 addr i (bytevector-u8-ref bv i))
+          (loop (fx+ i 1))))))
+
 ;; (sa-foreign-sizeof type) -> exact integer
 ;; Size in bytes of a foreign type (struct layout, array allocation). Contract:
 ;; the type's byte size. Degradation: none.

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1001,6 +1001,40 @@ else
   fails=$((fails + 1))
 fi
 
+# A library replacing a HOST class constructor is a process-wide substitution
+# every other namespace inherits, and the symptoms land far from the cause
+# (jolt-lang/http-client swaps its shim in for java.io.ByteArrayInputStream, and
+# an unrelated namespace then finds .readAllBytes unresolvable). JOLT_DEBUG must
+# name the class that was replaced. Registering a class the host does NOT model
+# is the intended use and must stay silent.
+override_out="$(JOLT_DEBUG=1 $jolt -e '(do (clojure.core/__register-class-ctor! "java.io.ByteArrayInputStream" (fn [& _] :shim)) (clojure.core/__register-class-ctor! "com.example.NotAHostClass" (fn [& _] :ok)) nil)' 2>&1)"
+if printf '%s' "$override_out" | grep -q 'replaced the host constructor for java.io.ByteArrayInputStream' &&
+   ! printf '%s' "$override_out" | grep -q 'com.example.NotAHostClass'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: host-class override is not reported under JOLT_DEBUG"
+  printf '%s\n' "$override_out" | tail -3 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
+# jolt.ffi bulk byte buffers — the foreign<->bytevector block moves under
+# read-array / read-into! / write-array / read-bytes / write-bytes. Binary
+# faithfulness across the unsigned-octet/signed-byte fold, offsets, and bounds.
+# Self-checks, one marker; same capture rules as the errno gate.
+ffibytes_out="$($jolt run test/chez/jolt-ffi-bytes-test.clj 2>&1)"
+if printf '%s' "$ffibytes_out" | grep -q 'JOLT-FFI-BYTES-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.ffi bulk byte buffers"
+  if printf '%s\n' "$ffibytes_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$ffibytes_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$ffibytes_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$ffibytes_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # jolt.fibers — the public lower-level fiber API (spawn/join/monitor!, states,
 # knobs) over the carrier pool. Self-checks, one marker; same capture rules as
 # the socket gate above.

--- a/host/scheme-adapter/CONTRACT.txt
+++ b/host/scheme-adapter/CONTRACT.txt
@@ -166,11 +166,19 @@ sa-procedure-info
 #   ONLY if the collector never stops other threads (the R4 collect-safety
 #   semantic);
 # - the data-plane entries (alloc/free/ref/set!/sizeof) degrade none — a target
-#   with the ffi capability provides them; without it, jolt.ffi raises cleanly.
+#   with the ffi capability provides them; without it, jolt.ffi raises cleanly;
+# - sa-foreign-bytes-ref!/-set! are the BULK octet moves (a block copy between
+#   foreign memory and a bytevector). A target with no block move may implement
+#   them as a loop over its own foreign-ref/-set! — correct, and the constant
+#   they exist to remove comes back. They pass the bytevector to C by address,
+#   so a target must keep it address-stable for the call's duration and must
+#   NOT make them collect-safe.
 sa-foreign-alloc
 sa-foreign-free
 sa-foreign-ref
 sa-foreign-set!
+sa-foreign-bytes-ref!
+sa-foreign-bytes-set!
 sa-foreign-sizeof
 sa-lock-object
 sa-unlock-object

--- a/host/scheme-adapter/guile.ss
+++ b/host/scheme-adapter/guile.ss
@@ -112,6 +112,14 @@
 ;;   sa-foreign-ref         UNIMPLEMENTED  ?? (parse-c-struct ...) candidate.
 ;;   sa-foreign-set!        UNIMPLEMENTED  ?? (make-c-struct ...) candidate.
 ;;   sa-foreign-sizeof      UNIMPLEMENTED  ?? (sizeof) — must verify (Guile has (sizeof)).
+;;   sa-foreign-bytes-ref!  UNIMPLEMENTED  Guile: (pointer->bytevector ptr n) + bytevector-copy!
+;;   sa-foreign-bytes-set!  UNIMPLEMENTED  — (system foreign) gives a bytevector VIEW over
+;;                                        foreign memory, so both directions are a
+;;                                        bytevector-copy!. A target with no block move may
+;;                                        loop over sa-foreign-ref/-set! instead; that is
+;;                                        correct and gives back the ~30ns/byte these exist
+;;                                        to remove. Never collect-safe: the bytevector
+;;                                        crosses to C by address.
 ;;   sa-lock-object         UNIMPLEMENTED  may BOTH no-op on a non-moving collector; Guile's
 ;;   sa-unlock-object       UNIMPLEMENTED  Boehm GC is non-moving — no-op candidate;
 ;;                                        must verify (never just one, or it leaks/crashes).

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -15,7 +15,22 @@
   :iptr :uptr :double :float :pointer :string :void :uint8 :char.
 
   The memory/library primitives (alloc/free/read/write/sizeof/load-library/
-  ptr->string/string->ptr/null/null?) are provided by the host. foreign-fn lowers
+  ptr->string/string->ptr/null/null?) are provided by the host, as are the
+  buffer moves: read-bytes/write-bytes decode and encode UTF-8, read-array/
+  write-array move raw octets to and from a byte-array, and read-into! fills a
+  slice of an EXISTING byte-array — so a caller reading a stream whose length
+  it already knows fills one buffer instead of regrowing an accumulator per
+  chunk. All of them move the block in one copy, not a byte at a time.
+
+      (let [buf (ffi/alloc 65536)
+            frame (byte-array total)]
+        (loop [off 0]
+          (when (< off total)
+            (let [n (recv fd buf 65536 0)]
+              (ffi/read-into! buf frame off n)     ; no per-chunk array
+              (recur (+ off n))))))
+
+  foreign-fn lowers
   a compile-time-typed signature to a real Chez foreign-procedure. foreign-callable
   is the inverse — it wraps a jolt fn as a C-callable function pointer so C can
   call back into jolt (e.g. GTK signal handlers); free-callable releases it.")

--- a/test/chez/jolt-ffi-bytes-test.clj
+++ b/test/chez/jolt-ffi-bytes-test.clj
@@ -1,0 +1,99 @@
+;; jolt.ffi bulk byte-buffer gate — the foreign<->bytevector block moves
+;; (sa-foreign-bytes-ref!/-set!) that read-array / read-into! / write-array /
+;; read-bytes / write-bytes are built on. The property under test is that a
+;; block move is BINARY-FAITHFUL: 0x00, 0x80 and 0xff survive the unsigned-octet
+;; to signed-byte fold in both directions, and a byte that is not valid UTF-8
+;; never reaches a decoder.
+;; Run: bin/jolt run test/chez/jolt-ffi-bytes-test.clj (smoke.sh greps for
+;; "JOLT-FFI-BYTES-TEST OK").
+(ns jolt-ffi-bytes-test)
+
+(require '[jolt.ffi :as ffi])
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; every byte value, so nothing in the fold is exercised only by accident
+(def all-bytes (byte-array (map #(byte (if (> % 127) (- % 256) %)) (range 256))))
+
+(let [buf (ffi/alloc 512)]
+  (ffi/write-array buf all-bytes)
+  (check-eq "write-array returns the octet count" (ffi/write-array buf all-bytes) 256)
+  (check-eq "read-array round-trips all 256 byte values"
+            (seq (ffi/read-array buf 256)) (seq all-bytes))
+  (check-eq "read-array of 0 bytes is an empty array"
+            (alength (ffi/read-array buf 0)) 0)
+
+  ;; unsigned octets on the foreign side, signed bytes on the jolt side
+  (check-eq "0x80 reads back as -128" (ffi/read (+ buf 128) :uint8 0) 128)
+  (check-eq "0xff reads back as -1" (aget (ffi/read-array (+ buf 255) 1) 0) -1)
+
+  ;; --- read-into! -----------------------------------------------------------
+  (let [dst (byte-array 300)]
+    (check-eq "read-into! returns the octet count" (ffi/read-into! buf dst 20 256) 256)
+    (check-eq "read-into! lands at the offset"
+              (seq (java.util.Arrays/copyOfRange dst 20 276)) (seq all-bytes))
+    (check-eq "read-into! leaves the prefix alone"
+              (seq (java.util.Arrays/copyOfRange dst 0 20)) (repeat 20 0))
+    (check-eq "read-into! leaves the suffix alone"
+              (seq (java.util.Arrays/copyOfRange dst 276 300)) (repeat 24 0))
+    (check-eq "read-into! of 0 bytes is a no-op" (ffi/read-into! buf dst 0 0) 0))
+
+  ;; a stream read in chunks fills one buffer — the reason read-into! exists
+  (let [dst (byte-array 256)]
+    (dotimes [i 4] (ffi/read-into! (+ buf (* i 64)) dst (* i 64) 64))
+    (check-eq "chunked read-into! reassembles the whole block"
+              (seq dst) (seq all-bytes)))
+
+  ;; --- bounds ---------------------------------------------------------------
+  (check-eq "read-into! past the end throws"
+            (try (ffi/read-into! buf (byte-array 8) 4 8) :no-throw
+                 (catch Throwable _ :threw))
+            :threw)
+  (check-eq "read-into! at a negative offset throws"
+            (try (ffi/read-into! buf (byte-array 8) -1 2) :no-throw
+                 (catch Throwable _ :threw))
+            :threw)
+  (check-eq "write-array past the end throws"
+            (try (ffi/write-array buf all-bytes 200 100) :no-throw
+                 (catch Throwable _ :threw))
+            :threw)
+
+  ;; --- write-array slice ----------------------------------------------------
+  (let [zeros (byte-array 512)]
+    (ffi/write-array buf zeros)
+    (check-eq "write-array slice returns its length" (ffi/write-array buf all-bytes 250 6) 6)
+    (check-eq "write-array slice writes exactly that slice"
+              (seq (ffi/read-array buf 6))
+              (seq (java.util.Arrays/copyOfRange all-bytes 250 256)))
+    (check-eq "write-array slice writes nothing past its length"
+              (seq (ffi/read-array (+ buf 6) 4)) (repeat 4 0)))
+
+  ;; --- string forms still frame by octets -----------------------------------
+  ;; write-bytes returns the UTF-8 OCTET count, not the character count, and
+  ;; read-bytes decodes exactly the octets it was given.
+  (let [s "he—llo"]                       ; em dash: 3 octets, 1 character
+    (check-eq "write-bytes returns octets, not characters" (ffi/write-bytes buf s) 8)
+    (check-eq "the source string is shorter than its encoding" (count s) 6)
+    (check-eq "read-bytes decodes the octets back" (ffi/read-bytes buf 8) s))
+
+  ;; bytes that are not valid UTF-8 come back through read-array unharmed
+  ;; (read-bytes would have to substitute; read-array must not)
+  (let [invalid (byte-array [-128 -61 40 0 -1])]
+    (ffi/write-array buf invalid)
+    (check-eq "invalid UTF-8 survives the byte-array path"
+              (seq (ffi/read-array buf 5)) (seq invalid)))
+
+  (ffi/free buf))
+
+(if (empty? @failures)
+  (println "JOLT-FFI-BYTES-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "JOLT-FFI-BYTES-TEST FAILED:" (count @failures))))


### PR DESCRIPTION
Found while profiling a jolt HTTP server (jolt-lang/ring-chez-adapter#12): every FFI buffer transfer was paying a per-byte constant an order of magnitude larger than the work around it.

## The copy

`read-array`, `write-array`, `read-bytes` and `write-bytes` all crossed the foreign boundary once per octet. Measured on Chez 10.x / arm64:

| | ns/byte |
|---|---|
| `foreign-ref 'unsigned-8` in a loop | 29.5 |
| the same loop over a bytevector | 3.8 |
| `bytevector-copy!` | ~0.01 |

So a 64K socket read spent ~2ms in the copy alone. Two adapter capability entry points (`sa-foreign-bytes-ref!` / `sa-foreign-bytes-set!`) now move the block at once — `memcpy` through Chez's `u8*` argument type — and the signed-byte fold and UTF-8 decode happen on the Scheme side, where a byte costs ~3ns instead of ~30.

Measured on a 64K buffer, before → after:

| | before | after | |
|---|---|---|---|
| `read-array` | 29.9 | 2.9 | 10.2x |
| `write-array` | 31.1 | 4.9 | 6.4x |
| `read-bytes` | 29.8 | 1.1 | 27.6x |
| `write-bytes` | 31.4 | 1.6 | 19.5x |

Resolution is lazy and probe-only — the boot already loaded the process-global handle, so `memcpy` resolves without another `sa-load-shared-object`, which it must not take (re-loading that handle re-promotes it above every `:jolt/native` loaded so far — the libboringssl hijack `java/ffi.ss` documents). If `memcpy` does not resolve, both entry points fall back to the old per-byte loop, which is also the degradation the contract permits a non-Chez target.

The bytevector crosses to C by address, so neither may ever be made `__collect_safe` — a plain foreign call keeps the thread active and the collector cannot move it. That is stated on both the contract entry and the definitions.

## `read-into!`

New: `(ffi/read-into! ptr arr off n)` — read a foreign buffer into a slice of an **existing** byte-array, in `InputStream.read(b, off, len)` argument order. A caller reading a stream whose total length it already knows now fills one buffer instead of allocating a fresh array per chunk and regrowing an accumulator around it. `write-array` gained the matching slice arity `(write-array ptr arr off n)`. Both throw rather than writing out of bounds — a silent truncation there corrupts the buffer.

## Host-class overrides are no longer silent

Separate, and the reason this took a while to find. `clojure.core/__register-class-ctor!` exists so a shim can register a class jolt does not model. Nothing stopped it from replacing one jolt *does* — process-wide, for every namespace, with no report. jolt-lang/http-client substitutes its own tagged-table shim for `java.io.ByteArrayInputStream` / `ByteArrayOutputStream`; any library loaded alongside it then finds `(.readAllBytes s)` unresolvable and `io/copy` over that stream **3600x slower** (0.3 → 1092 ns/byte measured), with nothing in the error naming the override.

`__register-class-ctor!` now reports a replaced *host* constructor under `JOLT_DEBUG`, the way `register-class-statics!` already reports a colliding static. It does not refuse the override — http-client's own `__register-instance-check!` ties `(instance? java.io.InputStream x)` to its shim tag, so refusing would break it. The real fix belongs in that library (register the shim only when the host does not model the class); this just makes the cause one env var away instead of a bisect. Registering a class the host does not model stays silent.

```
$ JOLT_DEBUG=1 jolt -e '(require (quote jolt.http-client)) ...'
warning: a library replaced the host constructor for java.io.ByteArrayInputStream — every (java.io.ByteArrayInputStream. ...) in this process now builds its shim, including in namespaces that never asked for it
```

## InputStream's missing surface

Third piece, found when jolt-lang/http-client#9 tried to stop shimming these classes and its tests caught what jolt could not do. `readNBytes` (both arities) and `transferTo` were absent outright. Worse, `markSupported` answered `false` for every stream while `reset` silently seeked to 0 — so a caller that marked mid-stream and reset was at the start, believing it was at the mark.

`markSupported` now answers what the JVM answers: `true` for `ByteArrayInputStream`, `false` for `FileInputStream`. Which one a stream is comes from the constructor rather than from asking the port whether it can seek — a Chez file port seeks fine, so that test would say true where the JVM says false. `mark` records the position, `reset` returns to it, and `reset` on a stream that does not support marking throws `IOException` instead of pretending.

## Tests

New gate `test/chez/jolt-ffi-bytes-test.clj`, wired into `smoke.sh`. It asserts the property that matters for a block move — **binary faithfulness**: all 256 byte values round-trip, `0x80`/`0xff` survive the unsigned-octet/signed-byte fold in both directions, and bytes that are not valid UTF-8 come back through the byte-array path unharmed. Plus `read-into!` offsets (including a chunked reassembly, the case it exists for), the `write-array` slice, out-of-bounds throws, and that the string forms still frame by octets rather than characters. A second smoke check asserts the host-override warning fires for a host class and stays silent for one jolt does not model.

Gates run: `smoke` (150 passed), `ffi` (17/17), `unit`, `adaptercheck` (74 contract names), `portcheck`.

## Downstream effect

The adapter that prompted this reads request bodies through `read-array` and writes responses through `write-bytes`, so it inherits the whole speedup without changing a line. Its 8 MB upload path, separately fixed to stop regrowing its accumulator per chunk, went 7910ms → 829ms on today's jolt; the copy constant here is most of what is left.

## Not done

jolt byte-arrays are backed by a boxed Chez vector, so the bytevector→vector fold is the ~3ns/byte floor these now sit at, and `aget` on a byte-array costs ~13ns through the generic `jolt-nth` dispatch (there is an inline `flvector-ref` path for `^doubles`, and `tag->akind` already recognises `^longs`/`^ints`, but nothing consumes them). Both are worth doing and both are bigger than this change.