### PR TITLE
#() no longer strips metadata from its body's collection literals

### DIFF
--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -581,19 +581,40 @@
      (for-each (lambda (x) (rdr-anon-scan x max-box rest-box)) (seq->list (jolt-get f rdr-kw-value))))
     ((pmap? f)
      (for-each (lambda (x) (rdr-anon-scan x max-box rest-box)) (or (rdr-map-order-ref f) '())))))
+;; rdr-anon-replace REBUILDS every collection it walks, and a rebuilt collection
+;; is a fresh object — so all reader metadata on a nested literal was dropped.
+;; #() therefore stripped ^meta from every vector/map/set in its body at any
+;; depth, which is how #((fn ^long [x] x) v) lost its return hint: the ^long
+;; lives on the arglist VECTOR, and that vector got rebuilt. (meta ^{:a 1} [1 2])
+;; read nil inside #() and {:a 1} outside it.
+;;
+;; Carry the metadata across as a FORM — unlike rdr-carry-meta, which converts it
+;; to data for a value position; here the body is still code to be analyzed. A
+;; pmap copy loses its rdr-map-order side-table entry (source key order for
+;; left-to-right literal eval), so carry that too, the way the ^meta reader does.
+(define (rdr-anon-keep-meta src dst)
+  (let ((m (jolt-meta src)))
+    (if (jolt-nil? m)
+        dst
+        (let ((c (jolt-with-meta dst m)))
+          (let ((order (and (pmap? dst) (rdr-map-order-ref dst))))
+            (when order (rdr-map-order-set! c order)))
+          c))))
+
 (define (rdr-anon-replace f slots rest-sym)
   (cond
     ((symbol-t? f)
      (let ((idx (rdr-pct-index (symbol-t-name f))))
        (cond ((eq? idx 'rest) rest-sym) (idx (vector-ref slots (- idx 1))) (else f))))
-    ((pvec? f) (apply jolt-vector (map (lambda (x) (rdr-anon-replace x slots rest-sym)) (seq->list f))))
+    ((pvec? f)
+     (rdr-anon-keep-meta f (apply jolt-vector (map (lambda (x) (rdr-anon-replace x slots rest-sym)) (seq->list f)))))
     ((or (cseq? f) (empty-list-t? f))
-     (apply jolt-list (map (lambda (x) (rdr-anon-replace x slots rest-sym)) (seq->list f))))
+     (rdr-anon-keep-meta f (apply jolt-list (map (lambda (x) (rdr-anon-replace x slots rest-sym)) (seq->list f)))))
     ((rdr-anon-set? f)
-     (rdr-make-set (map (lambda (x) (rdr-anon-replace x slots rest-sym)) (seq->list (jolt-get f rdr-kw-value)))))
+     (rdr-anon-keep-meta f (rdr-make-set (map (lambda (x) (rdr-anon-replace x slots rest-sym)) (seq->list (jolt-get f rdr-kw-value))))))
     ((pmap? f)
      (let ((kv (rdr-map-order-ref f)))
-       (if kv (rdr-make-map (map (lambda (x) (rdr-anon-replace x slots rest-sym)) kv)) f)))
+       (if kv (rdr-anon-keep-meta f (rdr-make-map (map (lambda (x) (rdr-anon-replace x slots rest-sym)) kv))) f)))
     (else f)))
 (define (rdr-read-anon-fn s i end)       ; i at the '(' after '#'
   (let-values (((form j) (rdr-read-form s i end)))

--- a/host/chez/run-corpus.ss
+++ b/host/chez/run-corpus.ss
@@ -96,6 +96,9 @@
     "reader conditional" "reader cond :jolt" "reader cond no match"
     "reader cond splice" "reader cond splice no match"
     "nil nested" "bool nested"
+    ;; jolt's numeric casts accept a char for the FLOAT widths too; the reference
+    ;; only does for the integer ones. See known-divergences.edn (:permissive).
+    "double and float reject a char; the integer casts take its code point"
     "no param vector"))
 (define known-fail (make-hashtable string-hash string=?))
 (for-each (lambda (l) (hashtable-set! known-fail l #t)) known-fail-labels)

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -2109,6 +2109,12 @@
   {:suite "numbers / primitive hint coercion" :label "each arity of a multi-arity fn carries its own" :expected "[0 0]" :actual "(do (def arl4 (fn (^long [x] x) (^long [x y] (+ x y)))) [(arl4 18446744073709551616N) (arl4 18446744073709551616N 0)])" :portability :common}
   {:suite "numbers / primitive hint coercion" :label "a ^double arglist hint widens the return" :expected "[5.0 5.0 2.5]" :actual "(do (def arl5 (fn ^double [x] x)) (defn arl6 ^double [x] x) [(arl5 5) (arl6 5) (arl5 5/2)])" :portability :common}
   {:suite "numbers / primitive hint coercion" :label "a non-numeric arglist tag is still ignored" :expected "18446744073709551616N" :actual "(do (def arl7 (fn ^String [x] x)) (arl7 18446744073709551616N))" :portability :common}
+  {:suite "numbers / char in a numeric cast" :label "double and float reject a char; the integer casts take its code point" :expected "[:cce :cce 97 97 97 97]" :actual "[(try (double \\a) (catch ClassCastException _ :cce)) (try (float \\a) (catch ClassCastException _ :cce)) (long \\a) (int \\a) (short \\a) (byte \\a)]" :portability :common}
+  {:suite "reader / anonymous fn literal" :label "#() keeps reader metadata on a nested collection literal" :expected "[{:a 1} {:b 2} {:c 3}]" :actual "[(#(meta ^{:a 1} [1 2])) (#(meta ^{:b 2} {:k 1})) (#(meta ^{:c 3} #{1}))]" :portability :common}
+  {:suite "reader / anonymous fn literal" :label "#() keeps it at depth, not just at the top" :expected "[{:d 4} {:e 5}]" :actual "[(#(meta (first [^{:d 4} [1]]))) (#(meta (get-in {:x [^{:e 5} [1]]} [:x 0])))]" :portability :common}
+  {:suite "reader / anonymous fn literal" :label "a ^long return hint survives #()" :expected "[0 0]" :actual "(do (def B18 18446744073709551616N) [(#((fn ^long [x] x) B18)) (#(let [g (fn ^long [x] x)] (g B18)))])" :portability :common}
+  {:suite "reader / anonymous fn literal" :label "a ^double return hint survives #() too" :expected "5.0" :actual "(#((fn ^double [x] x) 5))" :portability :common}
+  {:suite "reader / anonymous fn literal" :label "#() still substitutes its params" :expected "[[2 4 6] [:b :a] [1 2 3]]" :actual "[(mapv #(* % 2) [1 2 3]) (#(vector %2 %1) :a :b) ((fn [& xs] (apply #(vec %&) xs)) 1 2 3)]" :portability :common}
   ;; var-reference cell caching (runtime path): a ref inside a fn caches the
   ;; resolved cell, but stays correct under redefinition (cell root mutated in
   ;; place) and dynamic binding (read goes through the binding-aware path).

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -118,6 +118,24 @@
    :jvm "throws IllegalArgumentException — a map has no fields"
    :jolt "41 — the map-as-object read"
    :note "A key the map does not have throws on both. jolt's own values (deftype/defrecord slots) follow the JVM exactly: an undeclared slot is an error, not nil."}
+  ;; A char reaches the reference's INTEGER casts through RT.intCast/longCast's
+  ;; char overload — (int \\a) and (long \\a) are 97 on both — but `double` and
+  ;; `float` are declared ^Number, so a Character is a ClassCastException there.
+  ;; jolt's casts share one coercion that accepts a char at every width, so the
+  ;; float pair answers 97.0 where the reference throws. A superset in the same
+  ;; direction the reference already goes for the integer widths, and the code
+  ;; point is the only reasonable reading; narrowing it would mean a second
+  ;; coercion existing solely to reject. NOT the ^long/^double HINT path, which
+  ;; does reject a char (RT.longCast(Object)) — see jolt->fx / jolt->fx-ret.
+  ;; Corpus row "numbers / char in a numeric cast" carries the JVM's answer and
+  ;; is allowlisted in run-corpus.ss, so this is prose here rather than a keyed
+  ;; entry: keyed entries are rows whose :expected departs from the JVM, and this
+  ;; row's does not.
+  {:category :permissive
+   :behavior "(double \\a) / (float \\a)"
+   :jvm "throws ClassCastException — double/float are declared ^Number"
+   :jolt "97.0 — the char's code point, as the integer casts already give"
+   :note "(int \\a) / (long \\a) / (short \\a) / (byte \\a) are 97 on BOTH runtimes; only the float widths differ."}
   ;; jolt's strings are indexed by Unicode CODE POINT where the JVM's are indexed
   ;; by UTF-16 code unit, and (char n) follows the string model rather than the
   ;; JVM's 16-bit char: it has to accept the whole scalar-value range or it could


### PR DESCRIPTION
## The bug

`rdr-anon-replace` rebuilds every collection it walks in order to substitute the `%`-params, and `jolt-vector`/`jolt-list`/`rdr-make-map`/`rdr-make-set` build **fresh** objects. So all reader metadata on a nested literal was dropped — `#()` stripped `^meta` from every vector, map and set in its body, at any depth:

| | reference | jolt before |
|---|---|---|
| `(meta ^{:a 1} [1 2])` | `{:a 1}` | `{:a 1}` |
| `(#(meta ^{:a 1} [1 2]))` | `{:a 1}` | **`nil`** |
| `(#(meta ^{:b 2} {:k 1}))` | `{:b 2}` | **`nil`** |
| `(#(meta ^{:c 3} #{1}))` | `{:c 3}` | **`nil`** |
| at depth, `(#(meta (first [^{:d 4} [1]])))` | `{:d 4}` | **`nil`** |

Symbol metadata was never affected — that branch returns the symbol unchanged — which is why `^long` on a *parameter* always worked and only the arglist-vector spelling broke.

## I had this misdiagnosed

A `^long`/`^double` **return** hint lives on the arglist **vector**, so that vector being rebuilt is why `#((fn ^long [x] x) 2^64)` answered `2^64` where the reference answers `0`.

In #679 I filed this as the inliner beta-reducing without carrying the return coercion. That was wrong, and worth stating plainly: the var-call inliner *does* carry it (`inline.clj`'s `rbody (if ret (coerce-node ret rbody0) …)`), and none of my failing cases had a var in call position. What they actually had in common was being wrapped in `#()` — I had used `#(…)` as the probe harness in every one of them, so the harness was the bug.

Isolating the nesting shape is what showed it:

```clojure
((fn ^long [x] x) BIG)                          ; 0  — top level
(defn nested-defn [] ((fn ^long [x] x) BIG))    ; 0  — in a defn
(def nested-fn (fn [] ((fn ^long [x] x) BIG)))  ; 0  — in a def'd fn
((fn [] ((fn ^long [x] x) BIG)))                ; 0  — immediately applied
(call-it (fn [] ((fn ^long [x] x) BIG)))        ; 0  — passed to a fn
#((fn ^long [x] x) BIG)                         ; 2^64  <- only this
```

## The fix

Carry the metadata across the rebuild as a **form** — unlike `rdr-carry-meta`, which converts it to data for a value position; a `#()` body is still code to be analyzed. A pmap copy loses its `rdr-map-order` side-table entry (source key order for left-to-right literal eval), so that is carried too, the way the `^meta` reader already does for its own copy.

17 differential cases against JVM Clojure now match: collection meta at top level and at depth, both return hints through every wrapper, the `^long` *parameter* rejection, and that `%` / `%2` / `%&` substitution is unchanged. Five corpus rows pin them.

## A divergence documented rather than fixed

`(double \a)` and `(float \a)` answer `97.0` where the reference raises `ClassCastException`. jolt's numeric casts share one coercion that takes a char at every width; the reference only does for the integer casts, since `double`/`float` are declared `^Number` — `(int \a)` and `(long \a)` are `97` on **both**.

Prose in `known-divergences.edn`'s `:documented` section, with the label allowlisted in `run-corpus.ss` and a corpus row carrying the JVM's answer. Deliberately **not** an `:entries` row: those are keyed by corpus row and gate staleness, and they exist for rows whose `:expected` departs from the JVM. This row's `:expected` *is* the JVM's, so a keyed entry there is stale by construction — which certify duly reported when I first put it in the wrong section.

Note this is not the `^long`/`^double` **hint** path, which correctly rejects a char (`RT.longCast(Object)` does) — see `jolt->fx` / `jolt->fx-ret`.

## Gates

`corpus`, `certify` (0 NEW / 0 stale), `unit`, `values`, `cts`, `hasheq`, `infer`, `inline`, `readscaling` all pass.

**`make test` is currently red**, on `jolt.ffi bulk byte buffers`. That belongs to unrelated in-progress FFI work sitting uncommitted in the working tree (`host/chez/java/ffi.ss`, `stdlib/jolt/ffi.clj`, `smoke.sh`, the scheme-adapter files, CHANGELOG) — none of it is in this branch, which touches only `reader.ss`, `run-corpus.ss`, `corpus.edn` and `known-divergences.edn`. CI here runs against a clean tree and will tell us for certain.