### PR TITLE
Fill in InputStream: readNBytes, transferTo, and a mark that marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   move may implement them as the old per-byte loop, which is what the Chez
   side falls back to if `memcpy` does not resolve.
 
+- **`InputStream` gained `readNBytes` and `transferTo`, and `mark`/`reset`
+  now mark.** `readNBytes` (both arities) and `transferTo` were absent, and
+  `markSupported` answered `false` for every stream while `reset` silently
+  seeked to 0 — so a caller that marked mid-stream and reset believed it had
+  gone back to the mark and was actually at the start. `markSupported` is now
+  `true` for `ByteArrayInputStream` and `false` for `FileInputStream` (the JVM's
+  answers), `mark` records the position, `reset` returns to it, and `reset` on a
+  stream that does not support marking throws `IOException` rather than
+  pretending. Every value checked against JVM Clojure, edges included.
+
 ### Fixed
 
 - **A library replacing a host class constructor now says so under

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -36,7 +36,15 @@
 (define (in-stream-port self)
   (let ((p (vector-ref (jhost-state self) 0)))
     (if (eq? p 'stdin) (jolt-stdin-binary-port) p)))
-(define (make-in-stream port) (make-jhost "in-stream" (vector port)))
+;; state: #(port mark-supported? mark-pos). mark/reset are only honoured for a
+;; source that declares support, which on the JVM means ByteArrayInputStream
+;; (and BufferedInputStream) but NOT FileInputStream — a Chez file port is
+;; seekable, so "can I seek" is the wrong test and would answer true where the
+;; JVM answers false. The constructor says.
+(define (make-in-stream port . opt)
+  (make-jhost "in-stream" (vector port (and (pair? opt) (eq? (car opt) 'markable)) 0)))
+(define (in-stream-markable? self) (vector-ref (jhost-state self) 1))
+(define (make-in-stream-markable port) (make-in-stream port 'markable))
 (define (in-stream? x) (and (jhost? x) (string=? (jhost-tag x) "in-stream")))
 
 ;; The port behind a stream, or the JVM's IOException when it has been closed.
@@ -177,9 +185,55 @@
                      (if p (pipe-close-read! p) (close-port (in-stream-port self))))
                    jolt-nil))
    (cons "connect" (lambda (self other) (pipe-connect! self other) jolt-nil))
-   (cons "mark" (lambda (self . _) jolt-nil))
-   (cons "reset" (lambda (self) (guard (e (#t jolt-nil)) (set-port-position! (in-stream-port self) 0) jolt-nil)))
-   (cons "markSupported" (lambda (self) #f))
+   ;; readNBytes(len) reads UP TO len bytes and answers what it got — unlike
+   ;; read(byte[],off,len), it does not stop at the first short read, and it
+   ;; answers an empty array at EOF rather than -1.
+   (cons "readNBytes"
+         (lambda (self . args)
+           (if (= 1 (length args))
+               (let ((len (jnum->exact (car args))))
+                 (when (< len 0) (throw-jvm (quote IllegalArgumentException) "len < 0"))
+                 (let ((bv (get-bytevector-n (in-stream-live-port self) len)))
+                   (na-byte-array (if (eof-object? bv) (make-bytevector 0) bv))))
+               ;; (b off len) -> the count actually read, 0 at EOF (never -1)
+               (let* ((vec (jolt-array-vec (car args)))
+                      (off (jnum->exact (cadr args)))
+                      (len (jnum->exact (caddr args))))
+                 (when (or (< off 0) (< len 0) (> (+ off len) (vector-length vec)))
+                   (throw-jvm (quote IndexOutOfBoundsException) "readNBytes range"))
+                 (if (<= len 0) (->num 0)
+                     (let ((bv (get-bytevector-n (in-stream-live-port self) len)))
+                       (if (eof-object? bv) (->num 0)
+                           (let ((n (bytevector-length bv)))
+                             (let loop ((i 0))
+                               (if (>= i n) (->num n)
+                                   (begin (vector-set! vec (+ off i) (na-u8->byte (bytevector-u8-ref bv i)))
+                                          (loop (+ i 1)))))))))))))
+   ;; transferTo drains this stream into an OutputStream and answers the count.
+   (cons "transferTo"
+         (lambda (self out)
+           (let ((bv (get-bytevector-all (in-stream-live-port self))))
+             (if (eof-object? bv) (->num 0)
+                 (let ((n (bytevector-length bv)))
+                   (if (out-stream? out)
+                       (put-bytevector (out-stream-port out) bv)
+                       ;; any other shape of output stream (a library's shim):
+                       ;; go through its own write(byte[]), the way the JVM does
+                       (record-method-dispatch out "write" (jolt-list (na-byte-array bv))))
+                   (->num n))))))
+   ;; mark/reset only where the source declares support (make-in-stream). The
+   ;; JVM throws from reset() on a stream that does not support it; answering a
+   ;; silent no-op there let a caller believe it had rewound.
+   (cons "mark" (lambda (self . _)
+                  (when (in-stream-markable? self)
+                    (vector-set! (jhost-state self) 2 (port-position (in-stream-port self))))
+                  jolt-nil))
+   (cons "reset" (lambda (self)
+                   (unless (in-stream-markable? self)
+                     (io-throw "mark/reset not supported"))
+                   (set-port-position! (in-stream-port self) (vector-ref (jhost-state self) 2))
+                   jolt-nil))
+   (cons "markSupported" (lambda (self) (if (in-stream-markable? self) #t #f)))
    (cons "toString" (lambda (self) "#<InputStream>"))))
 
 ;; --- byte output stream -----------------------------------------------------
@@ -330,7 +384,7 @@
 (reg-ctor! '("ByteArrayInputStream" "java.io.ByteArrayInputStream")
   (lambda (bytes . rest)
     (let ((bv (src-bytevector bytes)))
-      (make-in-stream (open-bytevector-input-port
+      (make-in-stream-markable (open-bytevector-input-port
                        (if (>= (length rest) 2)
                            (let ((off (jnum->exact (car rest))) (len (jnum->exact (cadr rest))))
                              (let ((sub (make-bytevector len))) (bytevector-copy! bv off sub 0 len) sub))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1001,6 +1001,24 @@ else
   fails=$((fails + 1))
 fi
 
+# InputStream's fuller surface: readNBytes (both arities), transferTo, and
+# mark/reset that actually mark. Every value checked against JVM Clojure,
+# including the edges the JVM is specific about — readNBytes clamps to what
+# remains and throws on a negative count, transferTo answers 0 at EOF, and
+# markSupported is TRUE for ByteArrayInputStream but FALSE for FileInputStream
+# (where reset() throws rather than silently not rewinding, which is what made a
+# caller believe it had gone back to the start).
+check '(seq (.readNBytes (java.io.ByteArrayInputStream. (byte-array [1 2 3])) 2))' '(1 2)'
+check '(seq (.readNBytes (java.io.ByteArrayInputStream. (byte-array [1 2])) 9))' '(1 2)'
+check '(try (.readNBytes (java.io.ByteArrayInputStream. (byte-array [1])) -1) :no-throw (catch Throwable _ :threw))' ':threw'
+check '(let [b (byte-array 4)] [(.readNBytes (java.io.ByteArrayInputStream. (byte-array [1 2 3])) b 1 2) (seq b)])' '[2 (0 1 2 0)]'
+check '(let [o (java.io.ByteArrayOutputStream.)] [(.transferTo (java.io.ByteArrayInputStream. (byte-array [4 5 6])) o) (seq (.toByteArray o))])' '[3 (4 5 6)]'
+check '(.transferTo (java.io.ByteArrayInputStream. (byte-array 0)) (java.io.ByteArrayOutputStream.))' '0'
+check '(.markSupported (java.io.ByteArrayInputStream. (byte-array [1])))' 'true'
+check '(let [s (java.io.ByteArrayInputStream. (byte-array [7 8 9]))] (.read s) (.mark s 0) (.read s) (.reset s) (.read s))' '8'
+check '(.markSupported (java.io.FileInputStream. "Makefile"))' 'false'
+check '(let [s (java.io.FileInputStream. "Makefile")] (try (.reset s) :no-throw (catch Throwable _ :threw)))' ':threw'
+
 # A library replacing a HOST class constructor is a process-wide substitution
 # every other namespace inherits, and the symptoms land far from the cause
 # (jolt-lang/http-client swaps its shim in for java.io.ByteArrayInputStream, and


### PR DESCRIPTION
Split out of #681. This commit was pushed to that branch after it had already been merged, so it never landed — #681 went in with only the FFI-buffer commit, and v0.7.18 carries that half alone.

## What was wrong

`readNBytes` (both arities) and `transferTo` were missing outright, so a caller got `No matching method` for methods every `java.io.InputStream` has.

Worse, `markSupported` answered `false` for every stream while `reset` silently seeked to 0. A caller that marked mid-stream and reset was at the **start**, believing it was at the mark — the failure is silent and the data is wrong rather than absent.

## What it does now

`markSupported` answers what the JVM answers: `true` for `ByteArrayInputStream`, `false` for `FileInputStream`. Which one a stream is comes from the constructor rather than from asking the port whether it can seek — a Chez file port seeks fine, so that test would say `true` where the JVM says `false`.

`mark` records the position, `reset` returns to it, and `reset` on a stream that does not support marking throws `IOException` instead of pretending.

## Tests

Ten smoke checks, values taken from JVM Clojure, including the edges the JVM is specific about: `readNBytes` clamps to what remains and throws on a negative count, `transferTo` answers 0 at EOF, and `reset` throws on a `FileInputStream`.

Gates run on the branch: `smoke` (160 passed), `ffi`, `unit`, `adaptercheck`, `portcheck`.

## Why it matters downstream

jolt-lang/http-client#9 (merged) stops replacing `java.io.ByteArrayInputStream` process-wide — but only when jolt's own streams answer the whole surface, which it probes for. On v0.7.18 that probe fails on exactly these methods, so the shim is still installed and every app that requires that library still gets a `ByteArrayInputStream` that is ~3300x slower to drain (1136 vs 0.34 ns/byte). This is the missing half.