### PR TITLE
Resolve symlinks in File.getCanonicalPath

### DIFF
--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -259,6 +259,89 @@
         ((char=? (string-ref p 0) #\/) p)
         (else (project-relative p))))
 
+;; --- canonical paths --------------------------------------------------------
+;; getCanonicalPath is realpath(3), not "make it absolute": it resolves
+;; symlinks as well as "." and "..". Answering with the absolute path -- which
+;; is what this used to do -- is not a rougher version of the same answer, it
+;; is a different one, and the difference is load-bearing. The containment
+;; check every Java program writes,
+;;
+;;   (.startsWith (.getCanonicalPath child) (.getCanonicalPath root))
+;;
+;; then passes for a symlink inside root pointing anywhere at all, so a static
+;; file server built on it serves whatever the link names. ring.middleware.file
+;; is written exactly that way.
+(define c-realpath (jolt-foreign-proc-safe "realpath" '(string u8*) 'iptr))
+
+(define (jfile-cstr buf)                        ; buf up to the first NUL, as a string
+  (let loop ((i 0))
+    (cond ((>= i (bytevector-length buf)) (utf8->string buf))
+          ((= 0 (bytevector-u8-ref buf i))
+           (let ((bv (make-bytevector i)))
+             (do ((j 0 (+ j 1))) ((= j i) (utf8->string bv))
+               (bytevector-u8-set! bv j (bytevector-u8-ref buf j)))))
+          (else (loop (+ i 1))))))
+
+;; #f when the path does not exist (realpath fails ENOENT) or the host has no
+;; realpath at all -- a Windows build, where the callers below fall back to
+;; lexical folding, which is what this file could do before.
+(define (jfile-realpath p)
+  (and c-realpath
+       (let ((buf (make-bytevector 4096 0)))     ; >= PATH_MAX
+         (and (not (= 0 (c-realpath p buf))) (jfile-cstr buf)))))
+
+;; "/a/b" -> "/a", "/a" -> "/", "/" -> #f
+(define (path-parent p)
+  (let loop ((i (- (string-length p) 1)))
+    (cond ((< i 0) #f)
+          ((char=? (string-ref p i) #\/) (if (= i 0) "/" (substring p 0 i)))
+          (else (loop (- i 1))))))
+
+;; Fold "." and ".." lexically. Only ever applied to a part of a path that does
+;; NOT exist: where a component is real, realpath resolves it instead, because
+;; POSIX (and the JVM) resolve ".." AFTER following the link before it, and
+;; folding it lexically there would give a different -- wrong -- directory.
+(define (jfile-fold-dots p)
+  (let loop ((segs (let split ((i 0) (start 0) (acc (quote ())))
+                     (cond ((= i (string-length p))
+                            (reverse (cons (substring p start i) acc)))
+                           ((char=? (string-ref p i) #\/)
+                            (split (+ i 1) (+ i 1) (cons (substring p start i) acc)))
+                           (else (split (+ i 1) start acc)))))
+             (out (quote ())))
+    (cond
+      ((null? segs)
+       (if (null? out)
+           "/"
+           (apply string-append (map (lambda (s) (string-append "/" s)) (reverse out)))))
+      ((or (string=? (car segs) "") (string=? (car segs) "."))
+       (loop (cdr segs) out))
+      ((string=? (car segs) "..")
+       (loop (cdr segs) (if (null? out) out (cdr out))))
+      (else (loop (cdr segs) (cons (car segs) out))))))
+
+(define (path-join base segs)
+  (if (null? segs)
+      base
+      (path-join (if (string=? base "/")
+                     (string-append "/" (car segs))
+                     (string-append base "/" (car segs)))
+                 (cdr segs))))
+
+;; The JVM canonicalizes a path whose tail does not exist -- on a host where
+;; /tmp is a link, new File("/tmp/nope").getCanonicalPath is
+;; "/private/tmp/nope" -- while realpath(3) fails outright on ENOENT. So
+;; resolve the longest existing ancestor and re-attach what is left.
+(define (jfile-canonical p)
+  (let ((abs (jfile-abs p)))
+    (or (jfile-realpath abs)
+        (let loop ((dir (path-parent abs)) (tail (list (path-last-segment abs))))
+          (cond
+            ((not dir) (jfile-fold-dots abs))
+            ((jfile-realpath dir)
+             => (lambda (rp) (jfile-fold-dots (path-join rp tail))))
+            (else (loop (path-parent dir) (cons (path-last-segment dir) tail))))))))
+
 ;; --- file metadata over Chez filesystem ops ---------------------------------
 ;; byte size of a regular file (0 for a directory or a missing file).
 (define (file-byte-size p)
@@ -483,7 +566,7 @@
       ((string=? name "getName")        (list (path-last-segment p)))
       ((string=? name "toString")       (list p))
       ((string=? name "getAbsolutePath")(list (jfile-abs fp)))
-      ((string=? name "getCanonicalPath")(list (jfile-abs fp)))
+      ((string=? name "getCanonicalPath")(list (jfile-canonical fp)))
       ;; File.toURI returns a java.net.URI (JVM), not a String.
       ((string=? name "toURI")          (list (uri-parse (string-append "file:" (jfile-abs fp)))))
       ((string=? name "toURL")          (list (make-url (string-append "file:" (jfile-abs fp)))))
@@ -525,7 +608,7 @@
                (else (loop (- i 1))))))
       ((string=? name "toPath")           (list (make-nio-path p)))  ; -> java.nio.file.Path (nio-file.ss)
       ((string=? name "getAbsoluteFile")  (list (make-jfile (jfile-abs fp))))
-      ((string=? name "getCanonicalFile") (list (make-jfile (jfile-abs fp))))
+      ((string=? name "getCanonicalFile") (list (make-jfile (jfile-canonical fp))))
       ((string=? name "compareTo")      (list (->num (let ((o (file-path-of (car args))))
                                                        (cond ((string<? p o) -1) ((string>? p o) 1) (else 0))))))
       ((string=? name "equals")         (list (and (jfile? (car args)) (string=? p (jfile-path (car args))))))

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -708,7 +708,6 @@
       (string-append who " is not supported on this host: unverified struct stat layout for "
                      (sa-host-tag))))))
 (define c-stat (jolt-foreign-proc-safe "stat" '(string u8*) 'int))
-(define c-realpath (jolt-foreign-proc-safe "realpath" '(string u8*) 'iptr))
 (define (nio-stat-mode fp)
   (and c-stat
        (begin
@@ -718,18 +717,10 @@
                 (if nio-macos?
                     (bytevector-u16-ref buf 4 (native-endianness))
                     (bytevector-u32-ref buf 24 (native-endianness))))))))
-(define (nio-cstr buf)                          ; buf up to the first NUL, as a string
-  (let loop ((i 0))
-    (cond ((>= i (bytevector-length buf)) (utf8->string buf))
-          ((= 0 (bytevector-u8-ref buf i))
-           (let ((bv (make-bytevector i)))
-             (do ((j 0 (+ j 1))) ((= j i) (utf8->string bv))
-               (bytevector-u8-set! bv j (bytevector-u8-ref buf j)))))
-          (else (loop (+ i 1))))))
-(define (nio-realpath fp)                        ; resolve symlinks; #f if the path is absent
-  (and c-realpath
-       (let ((buf (make-bytevector 4096 0)))
-         (and (not (= 0 (c-realpath fp buf))) (nio-cstr buf)))))
+;; resolve symlinks; #f if the path is absent. One binding of realpath(3) for
+;; the whole runtime, in java/io.ss, which loads before this file and needs it
+;; for File.getCanonicalPath.
+(define (nio-realpath fp) (jfile-realpath fp))
 (define (nio-mode->perm-set mode)
   (let ((low (bitwise-and mode #o777)))
     (make-perm-set

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -917,6 +917,18 @@ else
   fails=$((fails + 1))
 fi
 
+# java.io.File/getCanonicalPath — realpath semantics: symlinks, "." and ".."
+# resolve, and a path that does not exist still canonicalizes. Self-checks, one
+# marker. stderr is captured so a run that dies before its first check says why.
+canon_out="$($jolt run test/chez/canonical-path-test.clj 2>&1)"
+if printf '%s' "$canon_out" | grep -q 'CANONICAL-PATH OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: File.getCanonicalPath"
+  printf '%s\n' "$canon_out" | tail -8 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # jolt.socket — the java.net.Socket/ServerSocket surface over real loopback TCP
 # (roundtrip, EOF, broken pipe, ephemeral ports, class model). Self-checks, one marker.
 # stderr goes into the capture: a run that dies before its first check must leave

--- a/test/chez/canonical-path-test.clj
+++ b/test/chez/canonical-path-test.clj
@@ -1,0 +1,128 @@
+;; java.io.File/getCanonicalPath gate — it is realpath(3), not "make it
+;; absolute": symlinks, "." and ".." all resolve. The containment check every
+;; Java program writes,
+;;
+;;   (.startsWith (.getCanonicalPath child) (.getCanonicalPath root))
+;;
+;; is only a check at all if links resolve; when getCanonicalPath merely
+;; absolutized, a symlink inside a served root passed it while pointing
+;; anywhere on the filesystem.
+;;
+;; Run: bin/jolt run test/chez/canonical-path-test.clj (smoke.sh greps for
+;; "CANONICAL-PATH OK").
+(ns canonical-path-test
+  (:import [java.io File]
+           [java.nio.file Files Path Paths LinkOption]))
+
+(def failures (atom []))
+(defn check [label got want]
+  (when-not (= got want)
+    (swap! failures conj (str label ": want " (pr-str want) " got " (pr-str got)))))
+
+(defn- path ^Path [s] (Paths/get (str s) (into-array String [])))
+(defn- real-path [s] (str (.toRealPath (path s) (into-array LinkOption []))))
+
+(def root (str (System/getProperty "java.io.tmpdir")
+               "/jolt-canon-" (System/currentTimeMillis)))
+(def inside (str root "/inside"))
+(def outside (str root "/outside"))
+
+(.mkdirs (File. inside))
+(.mkdirs (File. outside))
+(spit (str outside "/secret.txt") "outside")
+(spit (str inside "/plain.txt") "inside")
+
+;; a link INSIDE the tree pointing OUT of it — the case a path check exists for
+(Files/createSymbolicLink (path (str inside "/escape.txt"))
+                          (path (str outside "/secret.txt"))
+                          (into-array java.nio.file.attribute.FileAttribute []))
+;; and a link to a directory, so the walk has to resolve an interior component
+(Files/createSymbolicLink (path (str inside "/out-dir"))
+                          (path outside)
+                          (into-array java.nio.file.attribute.FileAttribute []))
+
+(def canon-root (.getCanonicalPath (File. inside)))
+
+;; --- symlinks resolve --------------------------------------------------------
+
+(check "link resolves to its target"
+       (.getCanonicalPath (File. (str inside "/escape.txt")))
+       (real-path (str outside "/secret.txt")))
+
+(check "link is not reported as itself"
+       (= (.getCanonicalPath (File. (str inside "/escape.txt")))
+          (.getAbsolutePath (File. (str inside "/escape.txt"))))
+       false)
+
+(check "interior link component resolves"
+       (.getCanonicalPath (File. (str inside "/out-dir/secret.txt")))
+       (real-path (str outside "/secret.txt")))
+
+;; the whole point: a containment check written the usual way now catches it
+(check "escape fails a containment check"
+       (.startsWith (.getCanonicalPath (File. (str inside "/escape.txt")))
+                    (str canon-root "/"))
+       false)
+(check "a real file passes the same check"
+       (.startsWith (.getCanonicalPath (File. (str inside "/plain.txt")))
+                    (str canon-root "/"))
+       true)
+
+;; --- agreement with java.nio, which already resolved ------------------------
+
+(check "agrees with Path/toRealPath"
+       (.getCanonicalPath (File. (str inside "/escape.txt")))
+       (real-path (str inside "/escape.txt")))
+
+(check "getCanonicalFile agrees with getCanonicalPath"
+       (.getPath (.getCanonicalFile (File. (str inside "/escape.txt"))))
+       (.getCanonicalPath (File. (str inside "/escape.txt"))))
+
+;; --- "." and ".." ------------------------------------------------------------
+
+(check "dot segments fold"
+       (.getCanonicalPath (File. (str inside "/./plain.txt")))
+       (str canon-root "/plain.txt"))
+
+(check "dotdot folds"
+       (.getCanonicalPath (File. (str inside "/sub/../plain.txt")))
+       (str canon-root "/plain.txt"))
+
+;; a relative path is still resolved against user.dir, as before
+(check "relative path is absolute"
+       (.startsWith (.getCanonicalPath (File. "project.clj")) "/")
+       true)
+
+;; --- paths that do not exist -------------------------------------------------
+;; the JVM canonicalizes these too, resolving as far as it can rather than
+;; throwing: realpath(3) fails on ENOENT, so the tail is re-attached by hand.
+
+(check "missing leaf still canonicalizes"
+       (.getCanonicalPath (File. (str inside "/nope.txt")))
+       (str canon-root "/nope.txt"))
+
+(check "missing directories still canonicalize"
+       (.getCanonicalPath (File. (str inside "/no/such/dir/file.txt")))
+       (str canon-root "/no/such/dir/file.txt"))
+
+(check "missing path under a link resolves the link"
+       (.getCanonicalPath (File. (str inside "/out-dir/nope.txt")))
+       (str (real-path outside) "/nope.txt"))
+
+(check "dotdot folds in a missing tail"
+       (.getCanonicalPath (File. (str inside "/no/such/../dir/f.txt")))
+       (str canon-root "/no/dir/f.txt"))
+
+(check "root canonicalizes to itself" (.getCanonicalPath (File. "/")) "/")
+
+;; --- cleanup + report --------------------------------------------------------
+
+(doseq [f [(str inside "/escape.txt") (str inside "/out-dir") (str inside "/plain.txt")
+           (str outside "/secret.txt") inside outside root]]
+  (try (.delete (File. f)) (catch Throwable _ nil)))
+
+(if (seq @failures)
+  (do (println "CANONICAL-PATH FAILURES:")
+      (doseq [f @failures] (println " " f))
+      (System/exit 1))
+  (println "CANONICAL-PATH OK"))


### PR DESCRIPTION
`getCanonicalPath` answered with the absolute path: `(list (jfile-abs fp))`. It never resolved a symlink, a `.` or a `..`.

That is not a rougher version of the same answer, it is a different one, and the difference is load-bearing. The containment check every Java program writes —

```clojure
(.startsWith (.getCanonicalPath child) (.getCanonicalPath root))
```

— passes for a symlink inside `root` pointing anywhere on the filesystem. A static file server built on it serves whatever the link names. `ring.middleware.file` is written exactly that way, and so was `ring-chez-adapter`'s static middleware until it worked around this by calling `Path/toRealPath` instead.

Measured on 0.7.19:

```
/tmp/symprobe/root/link.txt -> /tmp/symprobe/secret.txt

  .getCanonicalPath  => /tmp/symprobe/root/link.txt        (unresolved)
  Path/toRealPath    => /private/tmp/symprobe/secret.txt
```

## What changed

`getCanonicalPath` / `getCanonicalFile` are `realpath(3)` now.

`realpath` fails outright on `ENOENT`, but the JVM canonicalizes a path whose tail does not exist rather than throwing — `new File("/tmp/nope").getCanonicalPath()` is `/private/tmp/nope` on a host where `/tmp` is a link. So the longest existing ancestor is resolved and the remainder re-attached, with `.` and `..` folded lexically.

That folding happens **only** in the part of the path that does not exist. Where a component is real, `realpath` resolves it instead, because POSIX (and the JVM) resolve `..` *after* following the link before it — folding `a/link/..` lexically to `a` names a different directory than the one you get by walking it.

`java.nio`'s `toRealPath` already did all this and carried its own `realpath` binding. It delegates now, so there is one binding of the symbol for the whole runtime, in `java/io.ss`, which loads first. `nio-cstr` went with it (that binding was its only caller).

A host with no `realpath` symbol — a Windows build — degrades to the old behavior plus dot folding, rather than failing to boot: `jolt-foreign-proc-safe` yields `#f` and the fallback path takes over.

## Tests

New gate `test/chez/canonical-path-test.clj`, wired into `smoke.sh` beside the `fs-test` gate. Against `bin/jolt` at 0.7.19 **9 of its checks fail**, including:

```
link resolves to its target: want ".../outside/secret.txt" got ".../inside/escape.txt"
escape fails a containment check: want false got true
agrees with Path/toRealPath: want ".../outside/secret.txt" got ".../inside/escape.txt"
dotdot folds: want ".../inside/plain.txt" got ".../inside/sub/../plain.txt"
```

It plants a link inside a tree pointing out of it, a link to a directory (so an interior component has to resolve), and checks agreement with `Path/toRealPath` and `getCanonicalFile`, `.`/`..` folding, relative paths, missing leaves, missing directories, a missing path *under* a link, `..` in a missing tail, and `/`.

- `make smoke` — 161 passed, 0 failed
- `make unit` — green
- `make build` — clean

No CHANGELOG entry: that looked like it's written at release time in its own commit. Happy to add one if you'd rather.