### PR TITLE
Add initial Nix flake support for Linux x86_64

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -9,9 +9,19 @@ permissions:
 
 jobs:
   test:
-    name: Linux x86_64
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            os: ubuntu-latest
+            system: x86_64-linux
+          - name: macOS arm64
+            os: macos-latest
+            system: aarch64-darwin
     steps:
       - uses: actions/checkout@v5
         with:
@@ -23,7 +33,7 @@ jobs:
       - name: Check the flake and formatting
         run: |
           nix flake check --no-build --no-write-lock-file
-          nix build .#formatter.x86_64-linux --no-write-lock-file
+          nix build .#formatter.${{ matrix.system }} --no-write-lock-file
           ./result/bin/nixfmt --check flake.nix
 
       - name: Build and smoke-test the packaged Jolt
@@ -35,6 +45,18 @@ jobs:
           trap 'rm -rf "$tmp" result' EXIT
           env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
             "$out/bin/jolt" -e '(+ 40 2)' | grep -Fx '42'
+
+      # jolt.mvn-http's built-in macOS candidates are the Homebrew OpenSSL
+      # paths, and the runner image ships Homebrew OpenSSL — which would let
+      # the fetch below pass without the Nix-provided OpenSSL ever loading.
+      # Remove the Homebrew entries so success can only come through the
+      # wrapper's JOLT_OPENSSL_LIBDIR.
+      - name: Drop Homebrew OpenSSL from the built-in candidate paths (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -f /opt/homebrew/opt/openssl@3 \
+            /opt/homebrew/lib/libcrypto.dylib /opt/homebrew/lib/libssl.dylib
+          sudo rm -rf /usr/local/opt/openssl@3
 
       - name: Verify packaged dependency resolution
         run: |

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -62,12 +62,16 @@ jobs:
           export REAL_GIT="$(command -v git)"
           cat > "$shim/git" <<'GIT'
           #!/usr/bin/env bash
-          case "${1:-}" in
-            clone|fetch)
-              echo "unexpected Make bootstrap: git $1" >&2
-              exit 99
-              ;;
-          esac
+          # Git accepts options before its subcommand (for example,
+          # `git -C DIR fetch`), so inspect every argument rather than $1.
+          for arg; do
+            case "$arg" in
+              clone|fetch)
+                echo "unexpected Make bootstrap: git $*" >&2
+                exit 99
+                ;;
+            esac
+          done
           exec "$REAL_GIT" "$@"
           GIT
           chmod +x "$shim/git"

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -36,7 +36,7 @@ jobs:
           env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
             "$out/bin/jolt" -e '(+ 40 2)' | grep -Fx '42'
 
-      - name: Verify the packaged HTTPS trust store
+      - name: Verify packaged dependency resolution
         run: |
           set -euo pipefail
           out="$(nix path-info .#jolt --no-write-lock-file)"
@@ -46,10 +46,46 @@ jobs:
           cert="$(env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
             "$out/bin/jolt" -e '(System/getenv "SSL_CERT_FILE")' | tr -d '"')"
           test -r "$cert"
-          env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
-            "$out/bin/jolt" -e "(require '[jolt.mvn-http]) (if (jolt.mvn-http/fetch \"https://repo1.maven.org/maven2/org/clojure/math.combinatorics/0.2.0/math.combinatorics-0.2.0.pom\" \"$tmp/math.combinatorics.pom\") :ok :fail)" \
-            | grep -Fx ':ok'
-          test -s "$tmp/math.combinatorics.pom"
+
+          # The Maven dependency makes the resolver download and unzip a jar.
+          # The local Git dependency drives jolt.deps through its git shell-out
+          # without adding another network dependency to this CI check.
+          gitdep="$tmp/gitdep"
+          mkdir -p "$gitdep/src/gitdep"
+          cat > "$gitdep/deps.edn" <<'EOF'
+          {:paths ["src"]}
+          EOF
+          cat > "$gitdep/src/gitdep/core.clj" <<'EOF'
+          (ns gitdep.core)
+          (def answer 39)
+          EOF
+          git -C "$gitdep" init --quiet
+          git -C "$gitdep" add .
+          git -C "$gitdep" -c user.name=flake-ci -c user.email=flake-ci@example.invalid \
+            commit --quiet -m initial
+          sha="$(git -C "$gitdep" rev-parse HEAD)"
+
+          app="$tmp/app"
+          mkdir -p "$app/src/app"
+          cat > "$app/deps.edn" <<EOF
+          {:paths ["src"]
+           :deps {org.clojure/math.combinatorics {:mvn/version "0.2.0"}
+                  test/gitdep {:git/url "file://$gitdep"
+                               :git/sha "$sha"}}}
+          EOF
+          cat > "$app/src/app/core.clj" <<'EOF'
+          (ns app.core
+            (:require [clojure.math.combinatorics :as combo]
+                      [gitdep.core :as gitdep]))
+          (defn -main []
+            (println (+ gitdep/answer (count (combo/combinations [1 2 3] 2)))))
+          EOF
+          (
+            cd "$app"
+            env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" \
+              JOLT_MAVEN_REPOSITORY="$tmp/m2" JOLT_GITLIBS_DIR="$tmp/gitlibs" \
+              PATH=/usr/bin:/bin "$out/bin/jolt" run -m app.core
+          ) | grep -Fx '42'
 
       - name: Verify the development shell does not bootstrap Makes from Git
         run: |

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,76 @@
+name: flake
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Linux x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v19
+
+      - name: Check the flake and formatting
+        run: |
+          nix flake check --no-build --no-write-lock-file
+          nix build .#formatter.x86_64-linux --no-write-lock-file
+          ./result/bin/nixfmt --check flake.nix
+
+      - name: Build and smoke-test the packaged Jolt
+        run: |
+          set -euo pipefail
+          nix build .#jolt --no-write-lock-file -L
+          out="$(nix path-info .#jolt --no-write-lock-file)"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp" result' EXIT
+          env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
+            "$out/bin/jolt" -e '(+ 40 2)' | grep -Fx '42'
+
+      - name: Verify the packaged HTTPS trust store
+        run: |
+          set -euo pipefail
+          out="$(nix path-info .#jolt --no-write-lock-file)"
+          nix-store -q --references "$out" | grep -q -- '-nss-cacert-'
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp" result' EXIT
+          cert="$(env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
+            "$out/bin/jolt" -e '(System/getenv "SSL_CERT_FILE")' | tr -d '"')"
+          test -r "$cert"
+          env -i HOME="$tmp/home" XDG_CACHE_HOME="$tmp/cache" PATH=/usr/bin:/bin \
+            "$out/bin/jolt" -e "(require '[jolt.mvn-http]) (if (jolt.mvn-http/fetch \"https://repo1.maven.org/maven2/org/clojure/math.combinatorics/0.2.0/math.combinatorics-0.2.0.pom\" \"$tmp/math.combinatorics.pom\") :ok :fail)" \
+            | grep -Fx ':ok'
+          test -s "$tmp/math.combinatorics.pom"
+
+      - name: Verify the development shell does not bootstrap Makes from Git
+        run: |
+          nix develop --ignore-environment --command bash -seu <<'SH'
+          test -f "$M/init.mk"
+          test ! -e "$M/.git"
+
+          shim="$(mktemp -d)"
+          trap 'rm -rf "$shim"' EXIT
+          export REAL_GIT="$(command -v git)"
+          cat > "$shim/git" <<'GIT'
+          #!/usr/bin/env bash
+          case "${1:-}" in
+            clone|fetch)
+              echo "unexpected Make bootstrap: git $1" >&2
+              exit 99
+              ;;
+          esac
+          exec "$REAL_GIT" "$@"
+          GIT
+          chmod +x "$shim/git"
+          PATH="$shim:$PATH" make shelloutcheck
+          PATH="$shim:$PATH" make makefilesmoke
+          SH

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,17 @@
 # `make remint` rebuilds the seed after a source change.
 
 R := https://github.com/makeplus/makes
-M := .cache/makes
+M ?= .cache/makes
 # PINNED. Unpinned, this clone is whatever makeplus/makes HEAD is on the day of
 # the build — including a release build, whose toolchain would then be decided by
 # a repository this one records no version of. Bump deliberately.
 V := d14cb578c2f04e6f9d00e01c7c4e416a9baf94e9
-$(shell [ -d '$M' ] || git clone -q $R '$M')
-# Fetch only when the pin is absent, so a normal build stays offline.
-$(shell git -C '$M' cat-file -e '$V^{commit}' 2>/dev/null || git -C '$M' fetch -q origin)
-$(shell git -C '$M' rev-parse -q --verify HEAD 2>/dev/null | grep -qx '$V' || git -C '$M' checkout -q '$V')
+# Nix supplies a locked, source-only tree through M. Ordinary checkouts retain
+# the Git clone so their pinned revision is verified and provisioned on demand.
+$(shell [ -f '$M/init.mk' ] || git clone -q $R '$M')
+# Fetch only when the pin is absent, so a normal build stays offline. A
+# source-only Nix input has no .git directory, so there is nothing to fetch.
+$(shell [ ! -d '$M/.git' ] || { git -C '$M' cat-file -e '$V^{commit}' 2>/dev/null || git -C '$M' fetch -q origin; git -C '$M' rev-parse -q --verify HEAD 2>/dev/null | grep -qx '$V' || git -C '$M' checkout -q '$V'; })
 
 include $M/init.mk
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "makes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785480273,
+        "narHash": "sha256-/g8O4PW0v3NNChKyrWw/EqpEAUCKiI9/KFE2EiXoUlA=",
+        "owner": "makeplus",
+        "repo": "makes",
+        "rev": "d14cb578c2f04e6f9d00e01c7c4e416a9baf94e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "makeplus",
+        "repo": "makes",
+        "rev": "d14cb578c2f04e6f9d00e01c7c4e416a9baf94e9",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1787135253,
@@ -18,6 +35,7 @@
     },
     "root": {
       "inputs": {
+        "makes": "makes",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,19 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    makes = {
+      url = "github:makeplus/makes/d14cb578c2f04e6f9d00e01c7c4e416a9baf94e9";
+      flake = false;
+    };
     self.submodules = true;
   };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      makes,
+    }:
     let
       # macOS support is intentionally deferred. Keep this flake's support claim Linux-only.
       systems = [ "x86_64-linux" ];
@@ -102,6 +110,9 @@
       devShells = forAllSystems (pkgs: {
         default = pkgs.mkShell {
           packages = [
+            # Required by makeplus/makes during Makefile initialization.
+            pkgs.bash
+            pkgs.which
             pkgs.chez
             pkgs.stdenv.cc
             pkgs.gnumake
@@ -120,6 +131,8 @@
             pkgs.libuuid
           ];
 
+          # Make uses this locked source-only input instead of cloning makes.
+          M = makes;
           JOLT_CHEZ = "${pkgs.chez}/bin/scheme";
           CHEZ = "${pkgs.chez}/bin/scheme";
           LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,115 @@
+{
+  description = "Jolt, a Clojure implementation on Chez Scheme";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    self.submodules = true;
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+      mkJolt =
+        pkgs:
+        pkgs.stdenv.mkDerivation {
+          pname = "jolt";
+          version = self.shortRev or "dev";
+          src = self;
+
+          nativeBuildInputs = [
+            pkgs.chez
+            pkgs.pkg-config
+            pkgs.xxd
+          ];
+          buildInputs = [
+            pkgs.lz4
+            pkgs.zlib
+            pkgs.ncurses
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.libuuid ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+
+          dontConfigure = true;
+
+          buildPhase = ''
+            runHook preBuild
+            scheme --script host/chez/build-jolt.ss release target/release/jolt
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/bin"
+            install -m755 target/release/jolt "$out/bin/jolt"
+            runHook postInstall
+          '';
+
+          meta = {
+            description = "Clojure implementation on Chez Scheme";
+            homepage = "https://jolt-lang.net";
+            license = pkgs.lib.licenses.epl20;
+            mainProgram = "jolt";
+          };
+        };
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          jolt = mkJolt pkgs;
+        in
+        {
+          inherit jolt;
+          default = jolt;
+        }
+      );
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${self.packages.${pkgs.stdenv.hostPlatform.system}.jolt}/bin/jolt";
+          meta.description = "Run Jolt";
+        };
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.chez
+            pkgs.stdenv.cc
+            pkgs.gnumake
+            pkgs.pkg-config
+            pkgs.xxd
+
+            # Jolt deps.edn support
+            pkgs.git
+            pkgs.unzip
+            pkgs.openssl
+
+            # Chez/Jolt native-link dependencies
+            pkgs.lz4
+            pkgs.zlib
+            pkgs.ncurses
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.libuuid ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+
+          JOLT_CHEZ = "${pkgs.chez}/bin/scheme";
+          CHEZ = "${pkgs.chez}/bin/scheme";
+
+          shellHook = ''
+            echo "Jolt development environment"
+            printf 'Chez: '
+            printf '(display (scheme-version)) (newline)\n' | scheme -q
+          '';
+        };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,12 @@
       makes,
     }:
     let
-      # macOS support is intentionally deferred. Keep this flake's support claim Linux-only.
-      systems = [ "x86_64-linux" ];
+      # Intel macOS is deferred: releases cross-build x86_64-macos from the
+      # arm64 runner, and Nix has no equivalent cross path here to validate.
+      systems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
       mkJolt =
         pkgs:
@@ -47,9 +51,10 @@
             pkgs.lz4
             pkgs.zlib
             pkgs.ncurses
-            pkgs.libuuid
             pkgs.openssl
-          ];
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.libuuid ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
 
           # Flake sources contain no .git directory, so build-jolt.ss cannot
           # derive the version with git describe.
@@ -70,12 +75,14 @@
             runHook postInstall
           '';
 
-          # jolt.deps invokes git and unzip, while jolt.mvn-http loads OpenSSL
-          # dynamically by soname. Pin all three to the Nix package closure.
+          # jolt.deps invokes git and unzip; jolt.mvn-http dlopens OpenSSL at
+          # fetch time through the JOLT_OPENSSL_LIBDIR seam (its macOS built-in
+          # candidates are Homebrew paths, so no loader-path variable could
+          # cover Darwin). Pin all of them to the Nix package closure.
           postFixup = ''
             wrapProgram "$out/bin/jolt" \
               --prefix PATH : "${runtimePath}" \
-              --prefix LD_LIBRARY_PATH : "${opensslLibraryPath}" \
+              --set-default JOLT_OPENSSL_LIBDIR "${opensslLibraryPath}" \
               --set-default SSL_CERT_FILE "${cacertFile}"
           '';
 
@@ -128,14 +135,15 @@
             pkgs.lz4
             pkgs.zlib
             pkgs.ncurses
-            pkgs.libuuid
-          ];
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.libuuid ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
 
           # Make uses this locked source-only input instead of cloning makes.
           M = makes;
           JOLT_CHEZ = "${pkgs.chez}/bin/scheme";
           CHEZ = "${pkgs.chez}/bin/scheme";
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
+          JOLT_OPENSSL_LIBDIR = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
 
           shellHook = ''
             echo "Jolt development environment"

--- a/flake.nix
+++ b/flake.nix
@@ -9,20 +9,28 @@
   outputs =
     { self, nixpkgs }:
     let
-      systems = [
-        "x86_64-linux"
-        "aarch64-darwin"
-      ];
+      # macOS support is intentionally deferred. Keep this flake's support claim Linux-only.
+      systems = [ "x86_64-linux" ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
       mkJolt =
         pkgs:
+        let
+          version = self.shortRev or "dev";
+          runtimePath = pkgs.lib.makeBinPath [
+            pkgs.git
+            pkgs.unzip
+          ];
+          opensslLibraryPath = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
+        in
         pkgs.stdenv.mkDerivation {
           pname = "jolt";
-          version = self.shortRev or "dev";
+          inherit version;
           src = self;
 
+          strictDeps = true;
           nativeBuildInputs = [
             pkgs.chez
+            pkgs.makeWrapper
             pkgs.pkg-config
             pkgs.xxd
           ];
@@ -30,9 +38,13 @@
             pkgs.lz4
             pkgs.zlib
             pkgs.ncurses
-          ]
-          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.libuuid ]
-          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+            pkgs.libuuid
+            pkgs.openssl
+          ];
+
+          # Flake sources contain no .git directory, so build-jolt.ss cannot
+          # derive the version with git describe.
+          JOLT_VERSION = version;
 
           dontConfigure = true;
 
@@ -47,6 +59,14 @@
             mkdir -p "$out/bin"
             install -m755 target/release/jolt "$out/bin/jolt"
             runHook postInstall
+          '';
+
+          # jolt.deps invokes git and unzip, while jolt.mvn-http loads OpenSSL
+          # dynamically by soname. Pin all three to the Nix package closure.
+          postFixup = ''
+            wrapProgram "$out/bin/jolt" \
+              --prefix PATH : "${runtimePath}" \
+              --prefix LD_LIBRARY_PATH : "${opensslLibraryPath}"
           '';
 
           meta = {
@@ -95,12 +115,12 @@
             pkgs.lz4
             pkgs.zlib
             pkgs.ncurses
-          ]
-          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.libuuid ]
-          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+            pkgs.libuuid
+          ];
 
           JOLT_CHEZ = "${pkgs.chez}/bin/scheme";
           CHEZ = "${pkgs.chez}/bin/scheme";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
 
           shellHook = ''
             echo "Jolt development environment"

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             pkgs.unzip
           ];
           opensslLibraryPath = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
+          cacertFile = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
         in
         pkgs.stdenv.mkDerivation {
           pname = "jolt";
@@ -66,7 +67,8 @@
           postFixup = ''
             wrapProgram "$out/bin/jolt" \
               --prefix PATH : "${runtimePath}" \
-              --prefix LD_LIBRARY_PATH : "${opensslLibraryPath}"
+              --prefix LD_LIBRARY_PATH : "${opensslLibraryPath}" \
+              --set-default SSL_CERT_FILE "${cacertFile}"
           '';
 
           meta = {

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -45,9 +45,19 @@
                        (string-append "jolt.ffi/load-library: no :" key
                                       " entry in the per-OS spec")
                        (car args))))
-       (jolt-ffi-load-native (jolt-str-render-one name))
+       (ffi-load-native-or-throw (jolt-str-render-one name))
        jolt-nil))
-    (else (jolt-ffi-load-native (jolt-str-render-one (car args))) jolt-nil)))
+    (else (ffi-load-native-or-throw (jolt-str-render-one (car args))) jolt-nil)))
+
+;; A named load that fails must RAISE: callers probe candidate lists with
+;; try/catch around load-library (jolt.mvn-http), and the pre-scoped-loader
+;; implementation raised through sa-load-shared-object. Silently returning nil
+;; turned every fallback list into "first candidate wins, loaded or not".
+(define (ffi-load-native-or-throw path)
+  (unless (jolt-ffi-load-native path)
+    (jolt-throw (jolt-ex-info
+                  (string-append "jolt.ffi/load-library: cannot load " path)
+                  (jolt-hash-map (jolt-keyword "path") path)))))
 
 ;; Loadable without mutating resolution state: probe with a LOCAL dlopen through
 ;; the scoped loader (registering the handle — a probe that succeeds will be

--- a/stdlib/jolt/mvn_http.clj
+++ b/stdlib/jolt/mvn_http.clj
@@ -2,8 +2,9 @@
   "Minimal cert-verifying HTTPS GET-to-file for dependency download. A plain
   TCP socket (getaddrinfo/socket/connect) carries ciphertext; TLS runs against
   in-memory BIOs over the system OpenSSL via jolt.ffi, so no raw fd reaches
-  OpenSSL. libcrypto then libssl lazy-load on first use (candidate lists,
-  Homebrew first on macOS). fetch returns true on a 2xx, false on any failure,
+  OpenSSL. libcrypto then libssl lazy-load on first use (candidate lists —
+  a JOLT_OPENSSL_LIBDIR directory first when set, then Homebrew paths on
+  macOS / bare sonames elsewhere). fetch returns true on a 2xx, false on any failure,
   so jolt.deps falls through to the next repo. HTTPS only; the server
   certificate is verified (default verify paths + VERIFY_PEER + hostname check).
   macOS and Linux are validated; the Windows path (ws2_32 + WSAStartup +
@@ -21,21 +22,43 @@
 ;; (an uncatchable SIGABRT, not a Scheme error) — so only explicit real-OpenSSL
 ;; paths are tried; the bare "libcrypto.dylib" name is deliberately NOT a
 ;; candidate. If none of these exist, fetch fails gracefully.
-(def ^:private crypto-candidates
+(def ^:private crypto-names
   (cond
-    macos?   ["/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib"
-              "/opt/homebrew/lib/libcrypto.dylib"
-              "/usr/local/opt/openssl@3/lib/libcrypto.dylib"]
+    macos?   ["libcrypto.3.dylib" "libcrypto.dylib"]
     windows? ["libcrypto-3-x64.dll" "libcrypto-3.dll" "libcrypto-1_1-x64.dll"]
     :else    ["libcrypto.so.3" "libcrypto.so.1.1" "libcrypto.so"]))
 
-(def ^:private ssl-candidates
+(def ^:private ssl-names
   (cond
-    macos?   ["/opt/homebrew/opt/openssl@3/lib/libssl.dylib"
-              "/opt/homebrew/lib/libssl.dylib"
-              "/usr/local/opt/openssl@3/lib/libssl.dylib"]
+    macos?   ["libssl.3.dylib" "libssl.dylib"]
     windows? ["libssl-3-x64.dll" "libssl-3.dll" "libssl-1_1-x64.dll"]
     :else    ["libssl.so.3" "libssl.so.1.1" "libssl.so"]))
+
+;; Everywhere but macOS the bare names double as the system candidates (the
+;; dynamic loader owns the search); macOS gets the explicit real-OpenSSL paths.
+(def ^:private crypto-candidates
+  (if macos?
+    ["/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib"
+     "/opt/homebrew/lib/libcrypto.dylib"
+     "/usr/local/opt/openssl@3/lib/libcrypto.dylib"]
+    crypto-names))
+
+(def ^:private ssl-candidates
+  (if macos?
+    ["/opt/homebrew/opt/openssl@3/lib/libssl.dylib"
+     "/opt/homebrew/lib/libssl.dylib"
+     "/usr/local/opt/openssl@3/lib/libssl.dylib"]
+    ssl-names))
+
+;; JOLT_OPENSSL_LIBDIR names a directory whose libcrypto/libssl are tried
+;; before the platform candidates — the seam for an OpenSSL living outside
+;; the built-in paths (Nix, MacPorts, Guix, a nonstandard Homebrew prefix).
+;; The macOS hazard above does not apply to it: the entries are absolute
+;; paths into the named directory, never the bare Apple-shadowed sonames.
+(defn- lib-candidates [libdir names fallbacks]
+  (if (and libdir (not (str/blank? libdir)))
+    (into (mapv #(str libdir "/" %) names) fallbacks)
+    fallbacks))
 
 (def ^:private native-ready? (volatile! false))
 
@@ -63,14 +86,17 @@
 
 (defn- ensure-native!
   "Lazy-load the native transport on first use: (Windows) ws2_32 + WSAStartup,
-  then libcrypto then libssl. Returns true once ready; a later fetch retries."
+  then libcrypto then libssl. JOLT_OPENSSL_LIBDIR is read here, at fetch time,
+  so baked app binaries and restored images honor the runtime environment.
+  Returns true once ready; a later fetch retries."
   []
   (or @native-ready?
-      (when (and (init-sockets!)
-                 (try-candidates crypto-candidates)
-                 (try-candidates ssl-candidates))
-        (vreset! native-ready? true)
-        true)))
+      (let [libdir (System/getenv "JOLT_OPENSSL_LIBDIR")]
+        (when (and (init-sockets!)
+                   (try-candidates (lib-candidates libdir crypto-names crypto-candidates))
+                   (try-candidates (lib-candidates libdir ssl-names ssl-candidates)))
+          (vreset! native-ready? true)
+          true))))
 
 ;; --- BSD socket layer. On POSIX these are the process's own symbols (libc);
 ;; on Windows they live in ws2_32.dll (loaded, with WSAStartup, by ensure-native!

--- a/test/chez/ffi-binding-test.ss
+++ b/test/chez/ffi-binding-test.ss
@@ -21,6 +21,21 @@
 (ev "(def c-abs (jolt.ffi/__cfn \"abs\" [:int] :int))")
 
 (ok "foreign-procedure built for strlen" (procedure? (var-deref "user" "c-strlen")))
+
+;; load-library contract: a failed named load RAISES. Regression — the scoped
+;; native loader returned nil whether or not dlopen succeeded, so candidate
+;; probes (try/catch around load-library, as in jolt.mvn-http) accepted the
+;; first candidate loaded-or-not and fallback lists never advanced.
+(ok "load-library raises on a nonexistent path"
+    (jolt-truthy?
+      (ev "(try (jolt.ffi/load-library \"/nonexistent-dir/libjolt-no-such.so\") false
+                (catch :default e true))")))
+(ok "load-library per-OS map raises on a nonexistent path"
+    (jolt-truthy?
+      (ev "(try (jolt.ffi/load-library {:darwin \"/nonexistent-dir/no.dylib\"
+                                        :linux \"/nonexistent-dir/no.so\"
+                                        :windows \"Z:/nonexistent-dir/no.dll\"}) false
+                (catch :default e true))")))
 (ok "typed call: strlen(\"hello\") = 5" (= 5 (jnum->exact (ev "(c-strlen \"hello\")"))))
 (ok "typed call: abs(-7) = 7"          (= 7 (jnum->exact (ev "(c-abs -7)"))))
 

--- a/test/mvn_http_test.clj
+++ b/test/mvn_http_test.clj
@@ -16,6 +16,7 @@
 (def ctl-free?        (var jolt.mvn-http/ctl-free?))
 (def classify-status  (var jolt.mvn-http/classify-status))
 (def with-retries     (var jolt.mvn-http/with-retries))
+(def lib-candidates   (var jolt.mvn-http/lib-candidates))
 (def max-attempts     @(var jolt.mvn-http/max-attempts))
 
 (def ^:private fails (atom []))
@@ -100,6 +101,23 @@
   (ok= :failed    (classify-status 401) "classify 401 -> failed")
   (ok= :failed    (classify-status 403) "classify 403 -> failed")
   (ok= :failed    (classify-status 418) "classify 418 -> failed")
+
+  ;; --- JOLT_OPENSSL_LIBDIR candidate construction ----------------------------
+  ;; ensure-native! reads the env var at fetch time; the list construction is
+  ;; the pure part under test. An explicit lib dir is tried before the
+  ;; platform fallbacks; an unset or blank dir leaves the fallbacks untouched.
+  (ok= ["/nix/lib/libssl.3.dylib" "/nix/lib/libssl.dylib" "/opt/homebrew/lib/libssl.dylib"]
+       (lib-candidates "/nix/lib" ["libssl.3.dylib" "libssl.dylib"] ["/opt/homebrew/lib/libssl.dylib"])
+       "lib-candidates: explicit dir entries come first, in name order")
+  (ok= ["/d/libcrypto.so.3" "/d/libcrypto.so" "libcrypto.so.3" "libcrypto.so"]
+       (lib-candidates "/d" ["libcrypto.so.3" "libcrypto.so"] ["libcrypto.so.3" "libcrypto.so"])
+       "lib-candidates: bare-name fallbacks stay after the dir entries")
+  (ok= ["libcrypto.so.3"]
+       (lib-candidates nil ["libcrypto.so.3"] ["libcrypto.so.3"])
+       "lib-candidates: nil dir means fallbacks only")
+  (ok= ["libcrypto.so.3"]
+       (lib-candidates "" ["libcrypto.so.3"] ["libcrypto.so.3"])
+       "lib-candidates: blank dir means fallbacks only")
 
   ;; --- retry policy (jolt-ktiz.2) --------------------------------------------
   ;; Driven through an injectable attempt fn so the gate stays network-free.


### PR DESCRIPTION
Provides reproducible devShells, standalone packages.default, nix run app, formatter, and recursive submodule support.

Validated on x86_64 Linux:

- nix flake check --no-build
- nix develop --command bin/jolt -e '(+ 1 2)'
- nix build and built binary execution
- nix run . -- -e '(+ 40 2)' → 42

Related https://github.com/jolt-lang/jolt/issues/383