### PR TITLE
gc-full!: retry a contended collect, degrade to a no-op

### DIFF
--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -43,8 +43,27 @@
 ;; System.gc callers mean: weak references clear and guardians fire.
 ;; Contract: perform a full collection. Degradation: may no-op (WASM) —
 ;; callers already guard the call and the JVM semantic is only a hint.
+;;
+;; An explicit (collect) raises "cannot collect when multiple threads are
+;; active" when any OTHER thread is active at that instant, and jolt always
+;; has service threads (io-poller, fiber carriers, the timer) that are
+;; collect-safe while blocked but active for the microseconds between waits —
+;; so a single attempt can lose that race at any time. Retry over a short
+;; window; a thread that stays active through all of it (a compute loop)
+;; degrades the call to a no-op, because System.gc must hint, never throw.
+;; Any other collector error still raises.
 (define (sa-gc-collect)
-  (collect (collect-maximum-generation)))
+  (let loop ((tries 100))
+    (let ((r (guard (e (#t (if (and (message-condition? e)
+                                    (string=? (condition-message e)
+                                              "cannot collect when multiple threads are active"))
+                               'busy
+                               (raise e))))
+               (collect (collect-maximum-generation))
+               'ok)))
+      (when (and (eq? r 'busy) (fx>? tries 0))
+        (sleep (make-time 'time-duration 1000000 0))   ; 1 ms
+        (loop (fx- tries 1))))))
 
 ;; (sa-gc-max-generation) -> exact integer
 ;; The deepest collectable generation, for callers mapping JVM generations.

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1895,4 +1895,10 @@
   {:suite "var-form" :expr "(let [x 1] (var x))" :expected :throws}
   {:suite "var-form" :expr "(var nosuchns/foo)" :expected :throws}
   {:suite "var-form" :expr "(= (var map) (var map inc))" :expected "true"}
+
+  ;; System/gc parity: gc-full! is a hint and never throws. With a compute
+  ;; thread pinned active, an explicit Chez collect would raise "cannot
+  ;; collect when multiple threads are active"; the adapter retries and then
+  ;; degrades to a no-op instead.
+  {:suite "concurrency" :expr "(let [stop (atom false) f (future (loop [] (when-not @stop (recur))))] (try (do (jolt.host/gc-full!) :ok) (finally (reset! stop true))))" :expected ":ok"}
 ]


### PR DESCRIPTION
System/gc via jolt.host/gc-full! was a bare (collect (collect-maximum-generation)), and an explicit collect raises "cannot collect when multiple threads are active" if any other thread is active at that instant. jolt always has service threads (io-poller, fiber carriers, the timer) that are collect-safe while blocked but active for the microseconds between waits, so the call could spuriously throw at any time — which is exactly how the fibers gate failed on main's CI (run 32551956381, check 3: gc-full! against the poller mid-registration). On the JVM System.gc is a hint and never throws.

The adapter now retries over a 100ms window (1ms sleeps); a thread that stays active the whole time — a compute loop — degrades the call to a no-op, which the sa-gc-collect contract already allows. Any other collector error still raises (exact-message match on the busy condition).

Red/green: a spinning-future + gc-full! expression raises on main, returns :ok here; pinned as a unit row (concurrency suite). Worktree gates green: unit 1394/1394, fibers, threadsafety, adaptercheck.