### PR TITLE
Preserve Windows absolute paths through project resolution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,10 +159,16 @@ jobs:
       # Use PowerShell so JOLT_PWD retains its native drive-rooted spelling.
       # The MSYS shell can translate it before the runtime sees the value,
       # which would make this regression check vacuous.
-      - name: Resolve from a native absolute project directory
+      - name: Resolve a fixture from a native absolute project directory
         shell: powershell
         run: |
-          $env:JOLT_PWD = (Resolve-Path '.').Path
+          $project = Join-Path $env:RUNNER_TEMP 'absolute-path-project'
+          $marker = Join-Path $project 'marker-src'
+          New-Item -ItemType Directory -Force -Path $marker | Out-Null
+          Set-Content -NoNewline -Encoding ascii `
+            -Path (Join-Path $project 'deps.edn') `
+            -Value '{:paths ["marker-src"]}'
+          $env:JOLT_PWD = (Resolve-Path $project).Path
           if ($env:JOLT_PWD -notmatch '^[A-Za-z]:[\\/]') {
             throw "expected a drive-absolute JOLT_PWD, got: $env:JOLT_PWD"
           }
@@ -170,8 +176,8 @@ jobs:
           $resolved = (& $scheme --script host\chez\cli.ss -Spath 2>&1 | Out-String)
           Write-Host $resolved
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          if (-not $resolved.Contains('jolt-core')) {
-            throw "resolved path did not contain the project's jolt-core root"
+          if (-not $resolved.Contains('marker-src')) {
+            throw "resolved path did not contain the fixture's declared marker root"
           }
           $probe = '(let [u (System/getProperty "user.dir") p "\\rooted.txt" f (java.io.File. p)] (and (false? (.isAbsolute f)) (= (str (subs u 0 2) p) (.getAbsolutePath f))))'
           $rooted = (& $scheme --script host\chez\cli.ss -e $probe 2>&1 | Out-String).Trim()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,7 +180,9 @@ jobs:
             throw "resolved path did not contain the fixture's declared marker root"
           }
           $env:JOLT_EXPECTED_ROOTED = $env:JOLT_PWD.Substring(0, 2) + '\rooted.txt'
-          $probe = '(let [p "\\rooted.txt" f (java.io.File. p)] (and (false? (.isAbsolute f)) (= (System/getenv "JOLT_EXPECTED_ROOTED") (.getAbsolutePath f))))'
+          # Avoid string literals in the native `-e` argument: Windows
+          # PowerShell 5.1 removes their quotes while constructing argv.
+          $probe = '(let [p (str (char 92) (name (quote rooted.txt))) f (java.io.File. p)] (and (false? (.isAbsolute f)) (= (System/getenv (name (quote JOLT_EXPECTED_ROOTED))) (.getAbsolutePath f))))'
           $rooted = (& $scheme --script host\chez\cli.ss -e $probe 2>&1 | Out-String).Trim()
           Write-Host $rooted
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,3 +155,28 @@ jobs:
 
       - name: Gate native dependency paths
         run: make CHEZ=./chez-install/bin/chez depsunit
+
+      # Use PowerShell so JOLT_PWD retains its native drive-rooted spelling.
+      # The MSYS shell can translate it before the runtime sees the value,
+      # which would make this regression check vacuous.
+      - name: Resolve from a native absolute project directory
+        shell: powershell
+        run: |
+          $env:JOLT_PWD = (Resolve-Path '.').Path
+          if ($env:JOLT_PWD -notmatch '^[A-Za-z]:[\\/]') {
+            throw "expected a drive-absolute JOLT_PWD, got: $env:JOLT_PWD"
+          }
+          $scheme = Join-Path $env:GITHUB_WORKSPACE 'chez-install\bin\scheme.exe'
+          $resolved = (& $scheme --script host\chez\cli.ss -Spath 2>&1 | Out-String)
+          Write-Host $resolved
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not $resolved.Contains('jolt-core')) {
+            throw "resolved path did not contain the project's jolt-core root"
+          }
+          $probe = '(let [u (System/getProperty "user.dir") p "\\rooted.txt" f (java.io.File. p)] (and (false? (.isAbsolute f)) (= (str (subs u 0 2) p) (.getAbsolutePath f))))'
+          $rooted = (& $scheme --script host\chez\cli.ss -e $probe 2>&1 | Out-String).Trim()
+          Write-Host $rooted
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if ($rooted -ne 'true') {
+            throw "current-drive-rooted File resolution did not match user.dir's drive"
+          }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,8 @@ jobs:
           if (-not $resolved.Contains('marker-src')) {
             throw "resolved path did not contain the fixture's declared marker root"
           }
-          $probe = '(let [u (System/getProperty "user.dir") p "\\rooted.txt" f (java.io.File. p)] (and (false? (.isAbsolute f)) (= (str (subs u 0 2) p) (.getAbsolutePath f))))'
+          $env:JOLT_EXPECTED_ROOTED = $env:JOLT_PWD.Substring(0, 2) + '\rooted.txt'
+          $probe = '(let [p "\\rooted.txt" f (java.io.File. p)] (and (false? (.isAbsolute f)) (= (System/getenv "JOLT_EXPECTED_ROOTED") (.getAbsolutePath f))))'
           $rooted = (& $scheme --script host\chez\cli.ss -e $probe 2>&1 | Out-String).Trim()
           Write-Host $rooted
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,3 +81,77 @@ jobs:
         # -j overlaps the independent gates (ci is a plain dependency list);
         # -Oline keeps per-recipe output contiguous for failure reading.
         run: make CHEZ=/opt/chez/bin/chez -j"$(nproc)" -Oline test
+
+  windows-deps:
+    name: Windows dependency paths
+    runs-on: windows-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive   # vendor/irregex, used by the Chez regex shim
+
+      # Match the release builder: a native MINGW64 toolchain and threaded
+      # Chez 10.4.1 built as ta6nt. Keep this job focused on dependency paths;
+      # the full gate still contains POSIX-specific cases and runs above.
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: false
+          # inherit the runner PATH so GITHUB_PATH additions (the chez wrapper
+          # dir) are visible inside the msys2 shell
+          path-type: inherit
+          install: >-
+            git make vim unzip zip
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-lz4
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-ntldd
+
+      - name: Cache Chez Scheme
+        id: cache-chez-win
+        uses: actions/cache@v4
+        with:
+          path: chez-install
+          key: chez-windows-latest-v10.4.1-mingw64
+
+      - name: Build Chez Scheme from source
+        if: steps.cache-chez-win.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v10.4.1 https://github.com/cisco/ChezScheme.git /tmp/chez-src
+          cd /tmp/chez-src
+          ./configure --threads
+          make -j"$(nproc)"
+          # `make install` drives the unix installsh through cmd and dies; the
+          # build tree has everything — assemble the layout by hand. Boot files
+          # sit next to scheme.exe (that's where the Windows kernel looks).
+          inst="$GITHUB_WORKSPACE/chez-install"
+          mkdir -p "$inst/bin" "$inst/csv"
+          cp ta6nt/bin/ta6nt/*.exe "$inst/bin/"
+          cp ta6nt/bin/ta6nt/*.dll "$inst/bin/" 2>/dev/null || true
+          cp ta6nt/boot/ta6nt/petite.boot ta6nt/boot/ta6nt/scheme.boot "$inst/bin/"
+          cp ta6nt/boot/ta6nt/petite.boot ta6nt/boot/ta6nt/scheme.boot "$inst/csv/"
+          cp ta6nt/boot/ta6nt/scheme.h "$inst/csv/"
+          cp ta6nt/boot/ta6nt/equates.h "$inst/csv/" 2>/dev/null || true
+          cp ta6nt/boot/ta6nt/libkernel.a "$inst/csv/" || { echo "libkernel.a not found:"; find ta6nt -name "*.a" -o -name "kernel*"; exit 1; }
+
+      - name: Put chez on PATH
+        run: |
+          bindir="$GITHUB_WORKSPACE/chez-install/bin"
+          { echo '#!/bin/sh'; echo "exec \"$bindir/scheme.exe\" \"\$@\""; } > "$bindir/chez"
+          chmod +x "$bindir/chez"
+          echo "$bindir" >> "$GITHUB_PATH"
+          echo "JOLT_CHEZ_CSV=$GITHUB_WORKSPACE/chez-install/csv" >> "$GITHUB_ENV"
+          # cc is the build's compiler name; alias it to mingw gcc
+          { echo '#!/bin/sh'; echo 'exec gcc "$@"'; } > "$bindir/cc"
+          chmod +x "$bindir/cc"
+
+      - name: Show Chez version
+        run: chez --version
+
+      - name: Gate native dependency paths
+        run: make CHEZ=./chez-install/bin/chez depsunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same reason. A `:jolt/native`'s own symbols are still exported, so
   `(load-shared-object #f)` resolution is unchanged.
 
+- **Windows absolute paths survive both project and dependency resolution.** A
+  drive-rooted `JOLT_PWD` such as `D:\work\app` was treated as relative by the
+  host file layer, producing paths such as
+  `D:\work\app/D:\work\app/deps.edn` before any program could run. The File
+  shim now recognizes drive-rooted and UNC spellings consistently for file
+  access, `getAbsolutePath`, and `isAbsolute`; a single-leading-separator path
+  remains non-absolute but resolves against `user.dir`'s drive. Dependency
+  roots independently preserve drive, UNC, and device paths with either
+  separator and resolve root-relative paths against the declaring base's drive;
+  ambiguous drive-relative forms such as `C:project` fail with a targeted
+  error that asks for a drive-absolute path.
+
 - **`java.lang.ThreadLocal` is per-thread again, and the class exists.** The
   value lived in a Chez thread parameter, which a forked thread inherits, so a
   child observed the parent's stored value instead of running its own
@@ -2787,12 +2799,6 @@ call. Memoizing the probe by `(zone, instant)` undoes it: a repeated
 `jolt-lang/time`'s zone-aware `now` speeds up by roughly 100x.
 
 ### Fixed
-
-- **Dependency roots preserve absolute Windows paths.** `:local/root` and cache
-  paths with drive, UNC, device, or root-relative spellings are no longer
-  prefixed with Jolt's launch directory, and both `/` and `\` are accepted as
-  Windows separators. Ambiguous drive-relative paths such as `C:project` now
-  fail with a targeted error that asks for a drive-absolute path.
 
 - **`jolt.ffi` `:string` carries NULL in both directions.** Chez's `string`
   foreign type already spells NULL as `#f`, but jolt's own nil is a separate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2788,6 +2788,12 @@ call. Memoizing the probe by `(zone, instant)` undoes it: a repeated
 
 ### Fixed
 
+- **Dependency roots preserve absolute Windows paths.** `:local/root` and cache
+  paths with drive, UNC, device, or root-relative spellings are no longer
+  prefixed with Jolt's launch directory, and both `/` and `\` are accepted as
+  Windows separators. Ambiguous drive-relative paths such as `C:project` now
+  fail with a targeted error that asks for a drive-absolute path.
+
 - **`jolt.ffi` `:string` carries NULL in both directions.** Chez's `string`
   foreign type already spells NULL as `#f`, but jolt's own nil is a separate
   sentinel, so the boundary leaked Scheme: passing `nil` to a `:string`

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -251,21 +251,31 @@
   (or (and (char>=? c #\A) (char<=? c #\Z))
       (and (char>=? c #\a) (char<=? c #\z))))
 
+(define (windows-drive-prefix? p)
+  (and (>= (string-length p) 2)
+       (ascii-drive-letter? (string-ref p 0))
+       (char=? (string-ref p 1) #\:)))
+
+(define (windows-root-relative? p)
+  (and (eq? (sa-os-family) 'windows)
+       (> (string-length p) 0)
+       (path-separator-char? (string-ref p 0))
+       (or (= (string-length p) 1)
+           (not (path-separator-char? (string-ref p 1))))))
+
 ;; java.io.File.isAbsolute is host-platform-specific. POSIX has one absolute
 ;; prefix (/). Windows has drive-rooted paths (C:\x or C:/x) and UNC paths
 ;; (\\server\share); drive-relative C:x and current-drive-rooted \x are not
-;; absolute in the JVM sense. Keep absolute recognition shared with filesystem
-;; resolution and getAbsolutePath so introspection/build commands cannot
-;; disagree about drive-rooted or UNC inputs. This deliberately does not claim
-;; full emulation of Windows' two special *relative* forms (`C:child` uses that
-;; drive's process-local current directory and `\child` uses the current drive);
-;; their resolution remains an older File-shim compatibility gap.
+;; absolute in the JVM sense. Drive-rooted and UNC recognition is shared by
+;; filesystem resolution, getAbsolutePath, and isAbsolute. The rooted-but-
+;; relative case is resolved separately by project-relative below. `C:child`
+;; still depends on Windows' process-local current directory for that drive and
+;; remains an older File-shim compatibility gap.
 (define (jfile-path-absolute? p)
   (let ((n (string-length p)))
     (if (eq? (sa-os-family) 'windows)
         (or (and (>= n 3)
-                 (ascii-drive-letter? (string-ref p 0))
-                 (char=? (string-ref p 1) #\:)
+                 (windows-drive-prefix? p)
                  (path-separator-char? (string-ref p 2)))
             (and (>= n 2)
                  (path-separator-char? (string-ref p 0))
@@ -273,12 +283,22 @@
         (and (> n 0) (char=? (string-ref p 0) #\/)))))
 
 (define (project-relative p)
-  (if (or (= (string-length p) 0) (jfile-path-absolute? p))
-      p
-      (let ((base (jolt-user-dir)))
-        ;; "." adds nothing the OS won't do itself when it resolves a relative
-        ;; path — leave it alone rather than prefixing "./".
-        (if (string=? base ".") p (string-append base "/" p)))))
+  (cond
+    ((or (= (string-length p) 0) (jfile-path-absolute? p)) p)
+    ;; A single leading separator is rooted on the current drive but is not an
+    ;; absolute File pathname on Windows. The JVM resolves it against user.dir's
+    ;; drive; the process cwd is Jolt's source tree, so leaving it to the OS can
+    ;; select the wrong drive after the launcher changes directory.
+    ((windows-root-relative? p)
+     (let ((base (jolt-user-dir)))
+       (if (windows-drive-prefix? base)
+           (string-append (substring base 0 2) p)
+           (string-append base p))))
+    (else
+     (let ((base (jolt-user-dir)))
+       ;; "." adds nothing the OS won't do itself when it resolves a relative
+       ;; path — leave it alone rather than prefixing "./".
+       (if (string=? base ".") p (string-append base "/" p))))))
 
 ;; (io/file path) / (io/file parent child) — join children with "/". The File
 ;; keeps the path AS GIVEN (like the JVM: new File("rel").getPath() is "rel");

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -297,9 +297,20 @@
     ;; select the wrong drive after the launcher changes directory.
     ((windows-root-relative? p)
      (let ((base (jolt-user-dir)))
-       (if (windows-drive-prefix? base)
-           (string-append (substring base 0 2) p)
-           (string-append (trim-trailing-path-separator base) p))))
+       (cond
+         ;; The base names a drive, so the current-drive-rooted path takes it.
+         ((windows-drive-prefix? base) (string-append (substring base 0 2) p))
+         ;; A UNC base has no drive letter; its \\server\share IS the root.
+         ((jfile-path-absolute? base)
+          (string-append (trim-trailing-path-separator base) p))
+         ;; Nothing to root against: JOLT_PWD is unset, so jolt-user-dir is ".".
+         ;; Prefixing that turns a ROOTED path into a relative one, which is
+         ;; strictly worse than leaving the OS to resolve it against the process
+         ;; drive — the drive is at least a plausible answer, "./\x" is not.
+         ;; jolt.deps/root-relative-for keeps the same arm for the same reason,
+         ;; and its (absolute true "." "\project") case pins it; without this
+         ;; the two classifiers disagree on the one input neither can resolve.
+         (else p))))
     (else
      (let ((base (jolt-user-dir)))
        ;; "." adds nothing the OS won't do itself when it resolves a relative
@@ -351,10 +362,11 @@
 ;; (current-directory) here instead reported paths under the jolt repo root the
 ;; launcher cd'd into, diverging from the JVM where io/file and getAbsolutePath
 ;; are user.dir-relative.
+;; project-relative answers an absolute path with itself, so asking it twice —
+;; once here to decide, once inside — only pays the host-specific classification
+;; twice per call. The empty path is the one case it does not cover.
 (define (jfile-abs p)
-  (cond ((= (string-length p) 0) (jolt-user-dir))
-        ((jfile-path-absolute? p) p)
-        (else (project-relative p))))
+  (if (= (string-length p) 0) (jolt-user-dir) (project-relative p)))
 
 ;; --- canonical paths --------------------------------------------------------
 ;; getCanonicalPath is realpath(3), not "make it absolute": it resolves

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -263,6 +263,12 @@
        (or (= (string-length p) 1)
            (not (path-separator-char? (string-ref p 1))))))
 
+(define (trim-trailing-path-separator p)
+  (let ((n (string-length p)))
+    (if (and (> n 2) (path-separator-char? (string-ref p (- n 1))))
+        (substring p 0 (- n 1))
+        p)))
+
 ;; java.io.File.isAbsolute is host-platform-specific. POSIX has one absolute
 ;; prefix (/). Windows has drive-rooted paths (C:\x or C:/x) and UNC paths
 ;; (\\server\share); drive-relative C:x and current-drive-rooted \x are not
@@ -293,7 +299,7 @@
      (let ((base (jolt-user-dir)))
        (if (windows-drive-prefix? base)
            (string-append (substring base 0 2) p)
-           (string-append base p))))
+           (string-append (trim-trailing-path-separator base) p))))
     (else
      (let ((base (jolt-user-dir)))
        ;; "." adds nothing the OS won't do itself when it resolves a relative

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -244,8 +244,36 @@
 ;; the launcher cd'd to the jolt repo root — matching the JVM, where io/file is
 ;; cwd-relative. (io/resource builds jfiles from the source roots directly, so it
 ;; isn't routed through here.)
+(define (path-separator-char? c)
+  (or (char=? c #\/) (char=? c #\\)))
+
+(define (ascii-drive-letter? c)
+  (or (and (char>=? c #\A) (char<=? c #\Z))
+      (and (char>=? c #\a) (char<=? c #\z))))
+
+;; java.io.File.isAbsolute is host-platform-specific. POSIX has one absolute
+;; prefix (/). Windows has drive-rooted paths (C:\x or C:/x) and UNC paths
+;; (\\server\share); drive-relative C:x and current-drive-rooted \x are not
+;; absolute in the JVM sense. Keep absolute recognition shared with filesystem
+;; resolution and getAbsolutePath so introspection/build commands cannot
+;; disagree about drive-rooted or UNC inputs. This deliberately does not claim
+;; full emulation of Windows' two special *relative* forms (`C:child` uses that
+;; drive's process-local current directory and `\child` uses the current drive);
+;; their resolution remains an older File-shim compatibility gap.
+(define (jfile-path-absolute? p)
+  (let ((n (string-length p)))
+    (if (eq? (sa-os-family) 'windows)
+        (or (and (>= n 3)
+                 (ascii-drive-letter? (string-ref p 0))
+                 (char=? (string-ref p 1) #\:)
+                 (path-separator-char? (string-ref p 2)))
+            (and (>= n 2)
+                 (path-separator-char? (string-ref p 0))
+                 (path-separator-char? (string-ref p 1))))
+        (and (> n 0) (char=? (string-ref p 0) #\/)))))
+
 (define (project-relative p)
-  (if (or (= (string-length p) 0) (char=? (string-ref p 0) #\/))
+  (if (or (= (string-length p) 0) (jfile-path-absolute? p))
       p
       (let ((base (jolt-user-dir)))
         ;; "." adds nothing the OS won't do itself when it resolves a relative
@@ -299,7 +327,7 @@
 ;; are user.dir-relative.
 (define (jfile-abs p)
   (cond ((= (string-length p) 0) (jolt-user-dir))
-        ((char=? (string-ref p 0) #\/) p)
+        ((jfile-path-absolute? p) p)
         (else (project-relative p))))
 
 ;; --- canonical paths --------------------------------------------------------
@@ -697,7 +725,7 @@
       ((string=? name "exists")         (list (if (file-exists? fp) #t #f)))
       ((string=? name "isDirectory")    (list (if (file-directory? fp) #t #f)))
       ((string=? name "isFile")         (list (if (and (file-exists? fp) (not (file-directory? fp))) #t #f)))
-      ((string=? name "isAbsolute")     (list (if (and (> (string-length p) 0) (char=? (string-ref p 0) #\/)) #t #f)))
+      ((string=? name "isAbsolute")     (list (if (jfile-path-absolute? p) #t #f)))
       ;; listFiles builds each child from the path AS GIVEN (new File(this, name)
       ;; on the JVM), so a File made from a relative path lists relative children.
       ((string=? name "listFiles")

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -180,8 +180,30 @@
 ;; the else-branch called every bytecode build 'linux, including one running on
 ;; macOS — which picks the Linux SIGCHLD, EAGAIN, O_NONBLOCK, LC_TIME and
 ;; struct-stat values on a Darwin host. Probe instead.
+;;
+;; Memoized, which is what the note on sa-probed-os-family below already asks
+;; for and does not deliver: that cache sits on the PROBE, which only a pb tag
+;; reaches, so every real tag (ta6le, ta6nt, tarm64osx) re-derived on every
+;; call. The derivation is not free — sa-host-tag allocates a fresh string per
+;; call through symbol->string, and each sa-tag-contains? walks it allocating a
+;; substring per position, five needles deep. machine-type cannot change while
+;; the process runs, so one derivation is all there is to do.
+;;
+;; It matters because path classification is host-specific: java.io.File's
+;; isAbsolute and the project-relative base every filesystem touch goes through
+;; (java/io.ss jfile-fs) ask this per call. Uncached, .isAbsolute measured 355ms
+;; per 200k calls against 141ms; .exists, syscall included, 167ms per 50k
+;; against 116ms.
+;;
+;; The memo is module state in a file the runtime LOADS, not a saved heap, so it
+;; starts empty in every process and a cross-built binary cannot carry the build
+;; host's answer.
+(define sa-os-family-memo #f)
 (define (sa-os-family)
-  (sa-os-family-for-tag (sa-host-tag)))
+  (or sa-os-family-memo
+      (let ((fam (sa-os-family-for-tag (sa-host-tag))))
+        (set! sa-os-family-memo fam)
+        fam)))
 
 ;; (sa-os-family-for-tag tag) -> 'macos | 'windows | 'linux
 ;; The derivation above, as a function OF the tag, so the gate can pin the whole

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -204,9 +204,21 @@
 (defn- windows? []
   (str/includes? (str/lower-case (or (System/getProperty "os.name") "")) "win"))
 
+(defn- windows-drive-prefix? [p]
+  (and (>= (count p) 2)
+       (ascii-alpha? (nth p 0))
+       (= \: (nth p 1))))
+
+(defn- root-relative-for [dir p]
+  (cond
+    (windows-drive-prefix? dir) (str (subs dir 0 2) p)
+    (= :absolute (native-path-kind-for true dir)) (str dir p)
+    :else p))
+
 (defn- abspath-for [windows? dir p]
   (case (native-path-kind-for windows? p)
-    (:absolute :root-relative) p
+    :absolute p
+    :root-relative (root-relative-for dir p)
     :drive-relative
     (throw (ex-info (str "drive-relative path " (pr-str p)
                          " is ambiguous; use a drive-absolute path such as C:/path")

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -212,7 +212,12 @@
 (defn- root-relative-for [dir p]
   (cond
     (windows-drive-prefix? dir) (str (subs dir 0 2) p)
-    (= :absolute (native-path-kind-for true dir)) (str dir p)
+    (= :absolute (native-path-kind-for true dir))
+    (str (if (and (> (count dir) 2)
+                  (path-separator? (nth dir (dec (count dir)))))
+           (subs dir 0 (dec (count dir)))
+           dir)
+         p)
     :else p))
 
 (defn- abspath-for [windows? dir p]

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -173,8 +173,48 @@
          (catch :default e
            (throw (ex-info (str path ": " (ex-message e)) {:path path :error e}))))))
 
+(defn- ascii-alpha? [c]
+  (let [n (int c)]
+    (or (<= (int \A) n (int \Z))
+        (<= (int \a) n (int \z)))))
+
+(defn- path-separator? [c] (or (= c \/) (= c \\)))
+
+(defn- native-path-kind-for
+  "Classify P without touching the filesystem. Windows has four useful forms:
+  drive-absolute (C:/x), UNC/device (//server/share, //?/C:/x), root-relative
+  (/x), and drive-relative (C:x). The last one depends on Windows' hidden
+  per-drive current directory, which the source launcher cannot preserve after
+  it changes directory, so the resolver rejects it rather than inventing a
+  different path."
+  [windows? p]
+  (let [n (count p)
+        drive? (and (>= n 2) (ascii-alpha? (nth p 0)) (= \: (nth p 1)))
+        sep0? (and (pos? n) (path-separator? (nth p 0)))]
+    (cond
+      (not windows?) (if (str/starts-with? p "/") :absolute :relative)
+      drive? (if (and (>= n 3) (path-separator? (nth p 2)))
+               :absolute
+               :drive-relative)
+      sep0? (if (and (>= n 2) (path-separator? (nth p 1)))
+              :absolute
+              :root-relative)
+      :else :relative)))
+
+(defn- windows? []
+  (str/includes? (str/lower-case (or (System/getProperty "os.name") "")) "win"))
+
+(defn- abspath-for [windows? dir p]
+  (case (native-path-kind-for windows? p)
+    (:absolute :root-relative) p
+    :drive-relative
+    (throw (ex-info (str "drive-relative path " (pr-str p)
+                         " is ambiguous; use a drive-absolute path such as C:/path")
+                    {:path p :kind :drive-relative}))
+    (str dir "/" p)))
+
 (defn- abspath [dir p]
-  (if (str/starts-with? p "/") p (str dir "/" p)))
+  (abspath-for (windows?) dir p))
 
 ;; --- git cache --------------------------------------------------------------
 ;; jolt's own clone cache. $GITLIBS (the tools.gitlibs location knob) is

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1605,7 +1605,7 @@
   ;; Stage B — getAbsoluteFile/getCanonicalFile share getAbsolutePath's JOLT_PWD base
   {:suite "io-file-base" :expr "(= (.getAbsolutePath (java.io.File. \"rel.txt\")) (.getPath (.getAbsoluteFile (java.io.File. \"rel.txt\"))))" :expected "true"}
   {:suite "io-file-base"
-   :expr "(let [windows? (.contains (.toLowerCase (System/getProperty \"os.name\")) \"win\")] (and (= windows? (.isAbsolute (java.io.File. \"C:\\\\work\\\\report.edn\"))) (= windows? (.isAbsolute (java.io.File. \"C:/work/report.edn\"))) (= windows? (.isAbsolute (java.io.File. \"\\\\\\\\server\\\\share\\\\report.edn\"))) (false? (.isAbsolute (java.io.File. \"C:report.edn\"))) (= (not windows?) (.isAbsolute (java.io.File. \"/work/report.edn\")))))"
+   :expr "(let [windows? (.contains (.toLowerCase (System/getProperty \"os.name\")) \"win\")] (and (= windows? (.isAbsolute (java.io.File. \"C:\\\\work\\\\report.edn\"))) (= windows? (.isAbsolute (java.io.File. \"C:/work/report.edn\"))) (= windows? (.isAbsolute (java.io.File. \"\\\\\\\\server\\\\share\\\\report.edn\"))) (false? (.isAbsolute (java.io.File. \"C:report.edn\"))) (false? (.isAbsolute (java.io.File. \"\\\\work\\\\report.edn\"))) (= (not windows?) (.isAbsolute (java.io.File. \"/work/report.edn\")))))"
    :expected "true"}
   {:suite "io-file-base" :expr "(.exists (.getCanonicalFile (java.io.File. \".\")))" :expected "true"}
   ;; Stage C — getenv single-key matches map lookup

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1604,6 +1604,9 @@
   {:suite "binding-no-autoderef" :expr "(do (def ^:dynamic *bd11* 10) (def bd11v 20) (.getName (class (binding [*bd11* (var bd11v)] *bd11*))))" :expected "\"clojure.lang.Var\""}
   ;; Stage B — getAbsoluteFile/getCanonicalFile share getAbsolutePath's JOLT_PWD base
   {:suite "io-file-base" :expr "(= (.getAbsolutePath (java.io.File. \"rel.txt\")) (.getPath (.getAbsoluteFile (java.io.File. \"rel.txt\"))))" :expected "true"}
+  {:suite "io-file-base"
+   :expr "(let [windows? (.contains (.toLowerCase (System/getProperty \"os.name\")) \"win\")] (and (= windows? (.isAbsolute (java.io.File. \"C:\\\\work\\\\report.edn\"))) (= windows? (.isAbsolute (java.io.File. \"C:/work/report.edn\"))) (= windows? (.isAbsolute (java.io.File. \"\\\\\\\\server\\\\share\\\\report.edn\"))) (false? (.isAbsolute (java.io.File. \"C:report.edn\"))) (= (not windows?) (.isAbsolute (java.io.File. \"/work/report.edn\")))))"
+   :expected "true"}
   {:suite "io-file-base" :expr "(.exists (.getCanonicalFile (java.io.File. \".\")))" :expected "true"}
   ;; Stage C — getenv single-key matches map lookup
   {:suite "getenv" :expr "(= (get (System/getenv) \"HOME\") (System/getenv \"HOME\"))" :expected "true"}

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -74,13 +74,19 @@
   (is= "Windows relative path joins its declaring root" "D:/base/../lib"
        (absolute true "D:/base" "../lib"))
 
-  ;; A leading separator is relative to the current drive, but prefixing the
-  ;; project directory would change its meaning. Preserve both accepted Windows
-  ;; separator spellings, matching the old leading-slash behavior.
+  ;; A leading separator is rooted on the declaring project's drive. Resolve
+  ;; the drive explicitly so later raw filesystem checks cannot accidentally
+  ;; use the runtime checkout's drive instead.
   (doseq [p ["/project" "\\project"]]
     (is= (str "Windows root-relative path kind " (pr-str p)) :root-relative (kind true p))
-    (is= (str "Windows root-relative path spelling " (pr-str p)) p
+    (is= (str "Windows root-relative path drive " (pr-str p)) (str "D:" p)
          (absolute true "D:/base" p)))
+  (is= "Windows root-relative path under UNC base"
+       "\\\\server\\share\\base\\project"
+       (absolute true "\\\\server\\share\\base" "\\project"))
+  (is= "Windows root-relative path without a rooted base stays rooted"
+       "\\project"
+       (absolute true "." "\\project"))
 
   ;; C:path resolves against Windows' per-drive current directory, not the
   ;; declaring project's directory. The launcher changes cwd before resolution,

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -84,6 +84,9 @@
   (is= "Windows root-relative path under UNC base"
        "\\\\server\\share\\base\\project"
        (absolute true "\\\\server\\share\\base" "\\project"))
+  (is= "Windows root-relative path under trailing-separator UNC base"
+       "\\\\server\\share\\project"
+       (absolute true "\\\\server\\share\\" "\\project"))
   (is= "Windows root-relative path without a rooted base stays rooted"
        "\\project"
        (absolute true "." "\\project"))

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -51,6 +51,49 @@
 
 (is= "portable facade returns nil" nil (portable-deps/add-deps {}))
 
+;;;; native path roots
+
+(let [kind (var jolt.deps/native-path-kind-for)
+      absolute (var jolt.deps/abspath-for)]
+  ;; POSIX has one root spelling; a backslash and a Windows drive prefix are
+  ;; ordinary filename characters there.
+  (is= "POSIX slash path is absolute" :absolute (kind false "/project"))
+  (is= "POSIX Windows drive path is relative" :relative (kind false "C:/project"))
+  (is= "POSIX backslash path is relative" :relative (kind false "\\project"))
+  (is= "POSIX absolute path keeps its spelling" "/project/../lib"
+       (absolute false "/base" "/project/../lib"))
+
+  ;; Windows accepts either separator in drive roots and UNC/device paths. Keep
+  ;; the input bytes: joining roots must not normalize away dot segments or
+  ;; rewrite separators behind a caller's back.
+  (doseq [p ["C:/project" "d:\\project" "//server/share/project"
+             "\\\\server\\share\\project" "\\\\?\\C:\\project"]]
+    (is= (str "Windows absolute path kind " (pr-str p)) :absolute (kind true p))
+    (is= (str "Windows absolute path spelling " (pr-str p)) p
+         (absolute true "D:/base" p)))
+  (is= "Windows relative path joins its declaring root" "D:/base/../lib"
+       (absolute true "D:/base" "../lib"))
+
+  ;; A leading separator is relative to the current drive, but prefixing the
+  ;; project directory would change its meaning. Preserve both accepted Windows
+  ;; separator spellings, matching the old leading-slash behavior.
+  (doseq [p ["/project" "\\project"]]
+    (is= (str "Windows root-relative path kind " (pr-str p)) :root-relative (kind true p))
+    (is= (str "Windows root-relative path spelling " (pr-str p)) p
+         (absolute true "D:/base" p)))
+
+  ;; C:path resolves against Windows' per-drive current directory, not the
+  ;; declaring project's directory. The launcher changes cwd before resolution,
+  ;; so fail with the form named instead of manufacturing D:/base/C:path.
+  (doseq [p ["C:project" "d:"]]
+    (is= (str "Windows drive-relative path kind " (pr-str p))
+         :drive-relative (kind true p))
+    (is= (str "Windows drive-relative path rejected " (pr-str p))
+         {:path p :kind :drive-relative}
+         (try (absolute true "D:/base" p)
+              nil
+              (catch Exception e (ex-data e))))))
+
 ;;;; the repo from tools.deps test_deps.clj
 
 (def base-repo


### PR DESCRIPTION
## Problem

Running Jolt from source on native Windows with a drive-absolute `JOLT_PWD`
fails before user code starts. For example, a project at
`D:\a\app` is read as:

```text
D:\a\app/D:\a\app/deps.edn
```

The same leading-slash assumption also affects absolute `:local/root` and
cache paths during dependency expansion. A drive-rooted or UNC path can be
prefixed with the project directory a second time.

This surfaced independently in casselc/jolt-tcp#6 against released Jolt
v0.8.1. Its native Windows x86_64 and ARM64 jobs both fail in
`jolt.deps/read-deps-file` before any TCP test executes.

## Root cause

There are two path boundaries, and each recognized only a leading `/` as
absolute:

- the Chez `java.io.File` host layer resolves paths used by `slurp`,
  `getAbsolutePath`, and `isAbsolute`; and
- the Clojure dependency resolver makes roots absolute while walking the
  project graph.

Fixing only the dependency classifier does not repair a drive-absolute
`JOLT_PWD`, because the host layer must first open the project's `deps.edn`.

## Change

- Recognize Windows drive-rooted paths with either separator and UNC/device
  paths without touching the filesystem.
- Recognize drive-rooted and UNC paths as absolute for filesystem access,
  `getAbsolutePath`, and `File.isAbsolute`.
- Keep a single-leading-separator path non-absolute, as on the JVM, while
  resolving it against `JOLT_PWD`'s drive rather than the launcher's drive.
- Preserve dependency root spelling for drive and UNC/device inputs, and
  resolve current-drive-rooted inputs against the declaring base's drive.
- Reject ambiguous drive-relative forms such as `C:project` with structured
  `{:path ... :kind :drive-relative}` data rather than manufacturing a path
  under the launch directory.
- Add a native Windows source-mode gate that passes a real drive-absolute
  `JOLT_PWD` for a temporary project through `-Spath` and asserts that the
  unique root declared by its `deps.edn` resolves. Stock code misses that file
  after doubling its path and falls back to `src`, so this marker makes the
  check non-vacuous. The same native step checks that `\rooted.txt` is
  non-absolute but resolves from `user.dir`'s drive.

The native source gate uses PowerShell so MSYS path conversion cannot turn the
drive-rooted input into a leading-slash form and make the reproducer vacuous.

## Validation

All local Jolt commands used Chez Scheme 10.4.1.

- dependency expansion: 65/65 passed;
- host unit suite: 1657/1657 passed;
- workflow lint: passed;
- `git diff --check`: passed.

The added Windows assertions and source-mode invocation fail on the exact
current-upstream base `05b573a98e4b834e65e924d69d84df53a94b771f`:
drive/UNC `File.isAbsolute` is classified incorrectly, and a drive-absolute
`JOLT_PWD` is duplicated while opening `deps.edn`.

Hosted run 33947866847 job 101257111802 passed on candidate
`f7f5dd31251e0b04dc4f8f377a7779f89b932379`: 65/65 dependency-expansion
cases, the temporary project's unique `marker-src` root through native
source-mode `-Spath`, and the current-drive-rooted `File` assertion all passed.
The same run's aggregate job 101257111669 passed. Flake run 33947866809 also
passed on Linux x86_64 and macOS arm64.
