### PR TITLE
tz: the libc zone probe must put TZ back

### DIFF
--- a/host/chez/java/tz-primitives.ss
+++ b/host/chez/java/tz-primitives.ss
@@ -19,6 +19,8 @@
 (define tzp-setlocale (jolt-foreign-proc-safe "setlocale" '(int string) 'void*))
 (define tzp-strftime  (jolt-foreign-proc-safe "strftime"  '(u8* size_t string void*) 'size_t))
 (define tzp-setenv    (jolt-foreign-proc-safe "setenv"    '(string string int) 'int))
+(define tzp-unsetenv  (jolt-foreign-proc-safe "unsetenv"  '(string) 'int))
+(define tzp-getenv    (jolt-foreign-proc-safe "getenv"    '(string) 'string))
 (define tzp-tzset     (jolt-foreign-proc-safe "tzset"     '() 'void))
 (define tzp-localtime (jolt-foreign-proc-safe "localtime" '(void*) 'void*))
 
@@ -33,16 +35,41 @@
 ;; zone offset in seconds east of UTC at an epoch-second instant, via libc.
 ;; struct tm layout (64-bit): 9 ints(36) + pad(4) + long tm_gmtoff at byte 40.
 ;; localtime returns a STATIC buffer — do NOT foreign-free it.
+;; TZ is process-global, so it is saved and restored around the write. Without
+;; that, this leaves the process in whichever zone it last probed: the capability
+;; check below ends on "UTC", so every jolt process was left in UTC and any later
+;; localtime() — jolt's own, or a user's through jolt.ffi — answered UTC while
+;; the machine was somewhere else. getenv returns #f when TZ was unset, which is
+;; the common case and restores with unsetenv rather than an empty TZ (an empty
+;; TZ means UTC, not "unset").
+;;
+;; Chez's `string` return copies the char* into a Scheme string, so `saved`
+;; survives the setenv that immediately follows it; a raw pointer into environ
+;; would not.
+;;
+;; dynamic-wind rather than straight-line code so a throw between the two cannot
+;; leave TZ clobbered — the same shape jolt-with-mutex itself uses.
+(define (tzp-restore-tz! saved)
+  (if saved
+      (tzp-setenv "TZ" saved 1)
+      (and tzp-unsetenv (tzp-unsetenv "TZ")))
+  (tzp-tzset))
+
 (define (tzp-offset-raw zone epoch)
   (and tzp-tz-symbols?
        (jolt-with-mutex tzp-mutex
-         (tzp-setenv "TZ" zone 1)
-         (tzp-tzset)
-         (let ((tp (sa-foreign-alloc 8)))
-           (sa-foreign-set! 'long tp 0 epoch)
-           (let ((tm (tzp-localtime tp)))
-             (sa-foreign-free tp)
-             (and tm (not (eq? tm 0)) (sa-foreign-ref 'long tm 40)))))))
+         (let ((saved (and tzp-getenv (tzp-getenv "TZ"))))
+           (dynamic-wind
+             (lambda ()
+               (tzp-setenv "TZ" zone 1)
+               (tzp-tzset))
+             (lambda ()
+               (let ((tp (sa-foreign-alloc 8)))
+                 (sa-foreign-set! 'long tp 0 epoch)
+                 (let ((tm (tzp-localtime tp)))
+                   (sa-foreign-free tp)
+                   (and tm (not (eq? tm 0)) (sa-foreign-ref 'long tm 40)))))
+             (lambda () (tzp-restore-tz! saved)))))))
 
 ;; Capability probe: trust libc only if it returns known-correct offsets for known
 ;; zones/instants. Rejects Windows (garbage tm_gmtoff) and missing tzdata.

--- a/host/chez/java/tz-primitives.ss
+++ b/host/chez/java/tz-primitives.ss
@@ -29,8 +29,12 @@
        (guard (e (#t #f))
          (let ((r (tzp-setlocale tzp-LC_TIME "en_US.UTF-8"))) (and r (not (eq? r 0)))))))
 
-;; FFI symbols present? (setenv is POSIX-only, so this is #f on Windows).
-(define tzp-tz-symbols? (and tzp-setenv tzp-tzset tzp-localtime))
+;; FFI symbols present? (setenv/getenv/unsetenv are POSIX-only, so this is #f on
+;; Windows). getenv and unsetenv are required here too: tzp-offset-raw needs both
+;; to save/restore TZ around its write, and without that guarantee a resolve
+;; failure on either would silently reintroduce the TZ leak this file exists to
+;; prevent, rather than falling back to the DST-table backend.
+(define tzp-tz-symbols? (and tzp-setenv tzp-tzset tzp-localtime tzp-getenv tzp-unsetenv))
 
 ;; zone offset in seconds east of UTC at an epoch-second instant, via libc.
 ;; struct tm layout (64-bit): 9 ints(36) + pad(4) + long tm_gmtoff at byte 40.
@@ -52,13 +56,13 @@
 (define (tzp-restore-tz! saved)
   (if saved
       (tzp-setenv "TZ" saved 1)
-      (and tzp-unsetenv (tzp-unsetenv "TZ")))
+      (tzp-unsetenv "TZ"))
   (tzp-tzset))
 
 (define (tzp-offset-raw zone epoch)
   (and tzp-tz-symbols?
        (jolt-with-mutex tzp-mutex
-         (let ((saved (and tzp-getenv (tzp-getenv "TZ"))))
+         (let ((saved (tzp-getenv "TZ")))
            (dynamic-wind
              (lambda ()
                (tzp-setenv "TZ" zone 1)

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1040,6 +1040,24 @@ else
   fails=$((fails + 1))
 fi
 
+# jolt.host's libc timezone probe must not leave TZ set. It is process global,
+# and the capability check at boot ends on "UTC", so an unrestored write left
+# every jolt process answering UTC from localtime() while the machine was
+# somewhere else. Self-checks, one marker; same capture rules as the gates above.
+tzprobe_out="$($jolt run test/chez/jolt-tz-probe-test.clj 2>&1)"
+if printf '%s' "$tzprobe_out" | grep -q 'JOLT-TZ-PROBE-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.host tz probe"
+  if printf '%s\n' "$tzprobe_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$tzprobe_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$tzprobe_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$tzprobe_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
 # jolt.ffi :string <-> NULL. Chez's `string` type carries NULL as #f in both
 # directions; these gates prove jolt's nil translates to it and back, so a C
 # API where NULL is a real argument (setlocale) or a real result (getenv of an

--- a/test/chez/jolt-tz-probe-test.clj
+++ b/test/chez/jolt-tz-probe-test.clj
@@ -1,0 +1,68 @@
+;; jolt.host tz gate — the libc timezone probe must not leave TZ behind.
+;;
+;; tz-offset-seconds sets TZ, calls tzset and reads tm_gmtoff. TZ is process
+;; global, so without a restore the process is left in whichever zone was probed
+;; last — and the capability check at boot ends on "UTC". Every jolt process then
+;; answered UTC from localtime(), including user code calling it through jolt.ffi,
+;; while the machine was somewhere else entirely.
+;;
+;; Run: bin/jolt run test/chez/jolt-tz-probe-test.clj (smoke.sh greps for
+;; "JOLT-TZ-PROBE-TEST OK").
+(ns jolt-tz-probe-test)
+
+(require '[jolt.ffi :as ffi])
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+(ffi/defcfn c-getenv "getenv" [:string] :string)
+(ffi/defcfn c-setenv "setenv" [:string :string :int] :int)
+(ffi/defcfn c-unsetenv "unsetenv" [:string] :int)
+(ffi/defcfn c-time "time" [:pointer] :long)
+(ffi/defcfn c-localtime "localtime" [:pointer] :pointer)
+(ffi/defcfn c-gmtime "gmtime" [:pointer] :pointer)
+
+(defn- hour-of [f]
+  (let [b (ffi/alloc 8)]
+    (try (c-time b) (ffi/read (f b) :int 8)     ; tm_hour is the third int
+         (finally (ffi/free b)))))
+
+;; The boot-time capability probe has already run by the time this loads, so an
+;; unrestored TZ would be observable right here.
+(check-eq "TZ is not left set by the boot probe" (c-getenv "TZ") nil)
+
+;; A named zone under a KNOWN TZ must come back unchanged. This is the case the
+;; boot probe broke: it left TZ=UTC, so a caller who had set TZ themselves lost it.
+(c-setenv "TZ" "America/New_York" 1)
+(check-eq "a zone query answers correctly"
+          (jolt.host/tz-offset-seconds "Australia/Sydney" 1768478400) 39600)
+(check-eq "TZ survives a zone query" (c-getenv "TZ") "America/New_York")
+(c-unsetenv "TZ")
+
+;; ...and an UNSET TZ must stay unset rather than become an empty string, which
+;; libc reads as UTC rather than as "use the system zone".
+(check-eq "a zone query still answers with TZ unset"
+          (jolt.host/tz-offset-seconds "America/New_York" 1768478400) -18000)
+(check-eq "TZ is still unset afterwards" (c-getenv "TZ") nil)
+
+;; The end-to-end symptom: with the system zone in effect, localtime and gmtime
+;; agree only if the machine really is on UTC. On a UTC machine this check cannot
+;; discriminate, so it is skipped there rather than asserted as a pass.
+(let [local (hour-of c-localtime)
+      utc   (hour-of c-gmtime)
+      sys-tz (c-getenv "TZ")]
+  (if (= local utc)
+    (println (str "  .. (skipped: this machine's local time IS UTC, TZ=" (pr-str sys-tz) ")"))
+    (check-eq "localtime is not silently gmtime" (= local utc) false)))
+
+(if (empty? @failures)
+  (println "JOLT-TZ-PROBE-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "JOLT-TZ-PROBE-TEST FAILED:" (count @failures))))

--- a/test/chez/jolt-tz-probe-test.clj
+++ b/test/chez/jolt-tz-probe-test.clj
@@ -29,10 +29,8 @@
 (ffi/defcfn c-localtime "localtime" [:pointer] :pointer)
 (ffi/defcfn c-gmtime "gmtime" [:pointer] :pointer)
 
-(defn- hour-of [f]
-  (let [b (ffi/alloc 8)]
-    (try (c-time b) (ffi/read (f b) :int 8)     ; tm_hour is the third int
-         (finally (ffi/free b)))))
+(defn- hour-of [f epoch-buf]
+  (ffi/read (f epoch-buf) :int 8))     ; tm_hour is the third int
 
 ;; The boot-time capability probe has already run by the time this loads, so an
 ;; unrestored TZ would be observable right here.
@@ -55,12 +53,16 @@
 ;; The end-to-end symptom: with the system zone in effect, localtime and gmtime
 ;; agree only if the machine really is on UTC. On a UTC machine this check cannot
 ;; discriminate, so it is skipped there rather than asserted as a pass.
-(let [local (hour-of c-localtime)
-      utc   (hour-of c-gmtime)
-      sys-tz (c-getenv "TZ")]
-  (if (= local utc)
-    (println (str "  .. (skipped: this machine's local time IS UTC, TZ=" (pr-str sys-tz) ")"))
-    (check-eq "localtime is not silently gmtime" (= local utc) false)))
+(let [b (ffi/alloc 8)]
+  (try
+    (c-time b)                          ; one shared epoch for both calls below
+    (let [local  (hour-of c-localtime b)
+          utc    (hour-of c-gmtime b)
+          sys-tz (c-getenv "TZ")]
+      (if (= local utc)
+        (println (str "  .. (skipped: this machine's local time IS UTC, TZ=" (pr-str sys-tz) ")"))
+        (check-eq "localtime is not silently gmtime" (= local utc) false)))
+    (finally (ffi/free b))))
 
 (if (empty? @failures)
   (println "JOLT-TZ-PROBE-TEST OK")


### PR DESCRIPTION
Fixes #713.

The libc timezone probe sets `TZ` and never puts it back, so every jolt process is left in whichever zone it probed last — and the capability check at boot ends on `"UTC"`.

```clojure
;; TZ is unset in the shell; the machine is on Australia/Sydney (UTC+10)
(ffi/defcfn c-getenv "getenv" [:string] :string)
(ffi/defcfn c-time "time" [:pointer] :long)
(ffi/defcfn c-localtime "localtime" [:pointer] :pointer)

(c-getenv "TZ")                                  ;; => "UTC"   <- nobody set this
(let [b (ffi/alloc 8)] (c-time b)
  (ffi/read (c-localtime b) :int 8))              ;; => 4       <- system clock says 15
```

`localtime()` answers UTC for the rest of the process. Plain C on the same machine and the same epoch answers 15, so this is not the environment or tzdata.

## Where it comes from

`tzp-offset-raw` in `host/chez/java/tz-primitives.ss`:

```scheme
(tzp-setenv "TZ" zone 1)
(tzp-tzset)
;; ... read tm_gmtoff ...
```

There is exactly one `setenv` in the file and no matching restore. `tzp-tz-usable?` calls it three times at load to validate libc against known offsets, last with `"UTC"`, so the process settles there. It also leaks per call at runtime: a caller who had set `TZ` themselves loses it to whichever zone `tz-offset-seconds` was last asked about.

The locale probe a few lines below *does* restore (`tzp-setlocale ... "C"`), which is what made me read this as an oversight rather than a decision.

## Who it affects

Anything calling libc time in a jolt process, not just jolt's own code. I found it because a raylib example that draws a clock from `localtime()` had been showing UTC — it isn't a raylib problem, and nothing in that repo touches `TZ`.

I don't think `jolt.host/tz-offset-seconds` itself is wrong, since it sets the zone it's about to read. It's the absence of a restore that escapes.

## The fix

Save `TZ` before the write, restore after, in `dynamic-wind` so a throw between the two can't leave it clobbered — the shape `jolt-with-mutex` itself uses.

- `getenv` returns `#f` when `TZ` was unset, which is the common case; that restores with `unsetenv` rather than an empty `TZ`, since an empty `TZ` means UTC to libc rather than "use the system zone".
- Chez's `string` return copies the `char*` into a Scheme string, so the saved value survives the `setenv` that immediately follows it. A raw pointer into `environ` would not.
- `unsetenv` is guarded like the others, so a platform without it degrades rather than aborting.

## Tests

`test/chez/jolt-tz-probe-test.clj`, wired into `smoke.sh` beside the FFI gates. It covers the boot leak, a set `TZ` surviving a query, an unset `TZ` staying unset, and the end-to-end symptom that `localtime` isn't silently `gmtime`.

Confirmed it fails on unfixed code before fixing it:

```
FAIL: TZ is not left set by the boot probe: want nil got "UTC"
FAIL: TZ survives a zone query: want "America/New_York" got "Australia/Sydney"
FAIL: TZ is still unset afterwards: want nil got "America/New_York"
JOLT-TZ-PROBE-TEST FAILED: 3
```

and passes after.

The last check can't discriminate on a machine whose local time really is UTC — most CI runners — so it reports itself as skipped there rather than counting as a pass. The three `TZ` assertions above it are machine-independent and do the real work.

## Gates

`make test` in full. Neither seed changed: `tz-primitives.ss` isn't compiled into the image, so `make remint` and `make gambitseed` both produce no diff. I ran them anyway to be sure, having learned that the hard way on #708.

---

Found while upgrading a raylib port to raylib 6.0 (https://github.com/burinc/b12n-raylib-jlt). Happy to adjust the test's shape if you'd rather it live somewhere other than the smoke gate.
