### PR TITLE
build: derive the toolchain Chez from JOLT_CHEZ, not a fresh PATH search

### DIFF
--- a/bin/jolt
+++ b/bin/jolt
@@ -47,6 +47,11 @@ if [ -z "${JOLT_CHEZ:-}" ]; then
   fi
 fi
 CHEZ="$JOLT_CHEZ"
+# Resolved to a path and exported: build.ss's toolchain-dir lookup reads
+# JOLT_CHEZ from its own environment to find the csv dir next to the running
+# interpreter, rather than re-deriving it from a `command -v` PATH search that
+# can silently disagree with the interpreter actually selected above.
+export JOLT_CHEZ="$(command -v "$CHEZ" 2>/dev/null || echo "$CHEZ")"
 
 # Version for --version / banners: git describe of this checkout, else "dev".
 export JOLT_VERSION="${JOLT_VERSION:-$(git -C "$root" describe --tags --always --dirty 2>/dev/null || echo dev)}"

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -134,9 +134,16 @@
       cmd))
 
 ;; The Chez executable, for the isolated compile pass (see build-binary step 4).
+;; $JOLT_CHEZ — the interpreter this script is itself running under — is
+;; authoritative when set, for the same reason as bld-host-csv-dir above: a
+;; fresh `command -v` PATH search can silently name a different Chez than the
+;; one actually selected to run the build.
 (define bld-chez
-  (let ((p (bld-sh-capture "command -v chez || command -v scheme || command -v petite")))
-    (if (> (string-length p) 0) p "chez")))
+  (let ((env (getenv "JOLT_CHEZ")))
+    (if (and env (> (string-length env) 0))
+        env
+        (let ((p (bld-sh-capture "command -v chez || command -v scheme || command -v petite")))
+          (if (> (string-length p) 0) p "chez")))))
 
 ;; Chez version off (scheme-version) "Chez Scheme Version X.Y.Z" — last token.
 (define bld-version
@@ -148,10 +155,24 @@
 
 ;; The HOST csv<ver>/<machine> dir holding scheme.h, libkernel.a, *.boot. Derived
 ;; from the chez executable's location; JOLT_CHEZ_CSV overrides.
+;;
+;; The executable's location comes from $JOLT_CHEZ (the same interpreter this
+;; script is running under — bin/jolt exports it) when set, rather than a fresh
+;; `command -v chez/scheme/petite` PATH search: that search re-derives an
+;; independent answer, which silently disagrees with the running interpreter
+;; whenever the one actually selected (make's local .cache/local provision, or
+;; any JOLT_CHEZ override) isn't also the one PATH would resolve — producing a
+;; mismatched dir (e.g. a PATH-resolved 9.x scheme paired with bld-version read
+;; off the running 10.x interpreter) that then fails bld-check-toolchain. The
+;; PATH search remains the fallback for a chez invoked directly, with no
+;; JOLT_CHEZ in its environment at all.
 (define bld-host-csv-dir
   (let ((env (getenv "JOLT_CHEZ_CSV")))
     (or (and env (> (string-length env) 0) env)
-        (let* ((bindir (bld-sh-capture "dirname \"$(command -v chez || command -v scheme || command -v petite)\""))
+        (let* ((chez (getenv "JOLT_CHEZ"))
+               (bindir (if (and chez (> (string-length chez) 0))
+                           (path-parent chez)
+                           (bld-sh-capture "dirname \"$(command -v chez || command -v scheme || command -v petite)\"")))
                (cand (string-append bindir "/../lib/csv" bld-version "/" bld-machine)))
           cand))))
 ;; The csv dir supplying the boots + kernel + scheme.h that get baked into the


### PR DESCRIPTION
bld-host-csv-dir and bld-chez in host/chez/build.ss both re-derived "the Chez executable" via `command -v chez || command -v scheme || command -v petite` — a fresh PATH search independent of whichever interpreter is actually running the build. Whenever that search disagrees with the real one (a locally-provisioned Chez under .cache/local not on PATH, or any other JOLT_CHEZ override), the mismatch either misidentifies the csv<ver>/<machine> dir (pairing a PATH-resolved Chez's bin dir with bld-version read off the *running* interpreter) or spawns the isolated compile pass under the wrong Chez entirely — both reproduced locally via `jolt build` in a bare directory with only a 9.5.4 system Chez on PATH and a threaded 10.4.1 provisioned separately.

Both now prefer $JOLT_CHEZ when set. bin/jolt resolves and exports it (mirroring the existing command -v fallback used elsewhere in the same file) so the Chez it selects is the one the build script's own getenv sees, rather than a second, potentially different answer.