### PR TITLE
build: prefer JOLT_CHEZ over a fresh PATH search across every Chez-discovery script

### DIFF
--- a/bench/dyn-binding/run.sh
+++ b/bench/dyn-binding/run.sh
@@ -26,7 +26,8 @@ set -e
 cd "$(dirname "$0")/../.."
 root="$PWD"
 
-CHEZ_BIN="${CHEZ:-$(command -v chez || command -v scheme || true)}"
+# JOLT_CHEZ wins (see host/chez/selfcheck.sh).
+CHEZ_BIN="${JOLT_CHEZ:-${CHEZ:-$(command -v chez || command -v scheme || true)}}"
 [ -n "$CHEZ_BIN" ] || { echo "chez not found on PATH (set CHEZ)" >&2; exit 1; }
 HARNESS="$root/bench/dyn-binding/bench-dyn.ss"
 

--- a/bench/fibers/run.sh
+++ b/bench/fibers/run.sh
@@ -14,7 +14,8 @@ set -e
 cd "$(dirname "$0")/../.."
 root="$PWD"
 
-CHEZ_BIN="${CHEZ:-$(command -v chez || command -v scheme || true)}"
+# JOLT_CHEZ wins (see host/chez/selfcheck.sh).
+CHEZ_BIN="${JOLT_CHEZ:-${CHEZ:-$(command -v chez || command -v scheme || true)}}"
 [ -n "$CHEZ_BIN" ] || { echo "chez not found on PATH (set CHEZ)" >&2; exit 1; }
 HARNESS="$root/bench/fibers/bench-fibers.ss"
 

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -27,7 +27,9 @@ export JOLT_PWD="$PWD"
 # Locate Chez's kernel dev files for the optimized build (as build-smoke.sh does).
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/build-lib-smoke.sh
+++ b/host/chez/build-lib-smoke.sh
@@ -17,7 +17,9 @@ case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
 # (libkernel.a + scheme.h) and a C compiler. Skip cleanly where absent.
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -19,7 +19,9 @@ case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
 # csv dir we validate so the build uses exactly it.
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/jolt-selfbuild-smoke.sh
+++ b/host/chez/jolt-selfbuild-smoke.sh
@@ -11,7 +11,9 @@ cd "$root"
 # ships neither, so skip there (CI included).
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/process-suite.sh
+++ b/host/chez/process-suite.sh
@@ -24,7 +24,9 @@ if [ ! -f "$vend/test-resources/print-dirs.sh" ]; then
   exit 0
 fi
 
-chez="$(command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)"
+# JOLT_CHEZ wins (see host/chez/selfcheck.sh) so the toolbin symlinked below for
+# the jolt subprocess is the same Chez this run was actually invoked with.
+chez="${JOLT_CHEZ:-$(command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)}"
 if [ -z "$chez" ]; then echo "process-suite: no chez on PATH"; exit 1; fi
 
 # Canonicalize the temp dir: on macOS mktemp returns /var/… (a symlink to

--- a/host/chez/remint.sh
+++ b/host/chez/remint.sh
@@ -6,7 +6,9 @@
 set -e
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
-CHEZ="${CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme)}"
+# JOLT_CHEZ wins (see host/chez/selfcheck.sh) — re-minting the seed under the
+# wrong Chez is exactly the mistake this script exists to avoid.
+CHEZ="${JOLT_CHEZ:-${CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme)}}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 

--- a/host/chez/selfcheck.sh
+++ b/host/chez/selfcheck.sh
@@ -5,7 +5,11 @@
 set -e
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
-CHEZ="${CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme)}"
+# JOLT_CHEZ wins (the Makefile exports it, never CHEZ, so a bare ${CHEZ:-...}
+# fallback here would silently re-search PATH instead of using the Chez make
+# actually selected — the seed self-host check would then run under whichever
+# Chez happens to be on PATH).
+CHEZ="${JOLT_CHEZ:-${CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme)}}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 "$CHEZ" --script host/chez/bootstrap.ss \

--- a/host/chez/static-native-smoke.sh
+++ b/host/chez/static-native-smoke.sh
@@ -18,7 +18,9 @@ case "$jolt" in /*) joltabs="$jolt" ;; *) joltabs="$root/$jolt" ;; esac
 # kernel dev files, same as build-smoke. Skip otherwise (CI on a distro package).
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/host/chez/tree-shake-smoke.sh
+++ b/host/chez/tree-shake-smoke.sh
@@ -28,7 +28,9 @@ if [ "$scope" != "local" ] && [ ! -d "$examples" ]; then echo "shake smoke: skip
 
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do [ -f "${d}libkernel.a" ] && csv="${d%/}" && break; done

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -215,7 +215,10 @@ fi
 # (i) install-owned namespaces (stdlib/jolt-core — embedded in the binary) are
 # NEVER cached. Run in SOURCE mode (chez --script cli.ss) so clojure.set actually
 # loads on demand (the devcache preloads it); ldr-install-file? must bypass it.
-chez_bin="$(command -v chez || command -v scheme || command -v chezscheme)"
+# JOLT_CHEZ wins (see host/chez/selfcheck.sh) — otherwise this runs (i) under
+# whatever Chez happens to be on PATH, independent of the one the rest of this
+# gate actually built with.
+chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v scheme || command -v chezscheme)}"
 n_i="(not cached)"
 if [ -n "$chez_bin" ]; then
   cache_i="$(mktemp -d)"

--- a/test/chez/compile-path-smoke.sh
+++ b/test/chez/compile-path-smoke.sh
@@ -131,7 +131,9 @@ esac
 # Needs a C toolchain; skipped like build-smoke without one.
 csv="$JOLT_CHEZ_CSV"
 if [ -z "$csv" ]; then
-  chez_bin="$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)"
+  # JOLT_CHEZ wins (see host/chez/selfcheck.sh) — else this can pair a
+  # PATH-resolved Chez's csv dir with a running interpreter built elsewhere.
+  chez_bin="${JOLT_CHEZ:-$(command -v chez || command -v chezscheme || command -v scheme || command -v petite || true)}"
   if [ -n "$chez_bin" ]; then
     base="$(cd "$(dirname "$chez_bin")/.." 2>/dev/null && pwd)"
     for d in "$base"/lib/csv*/*/; do

--- a/test/chez/gateboot-smoke.sh
+++ b/test/chez/gateboot-smoke.sh
@@ -11,7 +11,9 @@
 set -u
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
-CHEZ="${CHEZ:-$(command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)}"
+# JOLT_CHEZ wins (see host/chez/selfcheck.sh) — the Makefile only ever exports
+# JOLT_CHEZ, not CHEZ, so this must check it first or silently re-search PATH.
+CHEZ="${JOLT_CHEZ:-${CHEZ:-$(command -v chez 2>/dev/null || command -v chezscheme 2>/dev/null || command -v scheme 2>/dev/null)}}"
 pass=0; fail=0
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 


### PR DESCRIPTION
## Summary

Follow-up to the `bld-chez`/`bld-host-csv-dir` fix in `host/chez/build.ss` (which preferred `$JOLT_CHEZ` over a fresh `command -v chez/scheme/petite` PATH search). A repo-wide sweep found the same shape in 14 more sites across 12 files:

- **`host/chez/selfcheck.sh`, `host/chez/remint.sh`, `test/chez/gateboot-smoke.sh`, `bench/dyn-binding/run.sh`, `bench/fibers/run.sh`** — a `${CHEZ:-command -v ...}` fallback that *looks* safe, but the Makefile only ever exports `JOLT_CHEZ`, never `CHEZ` — so `$CHEZ` is unset in these scripts' environment when invoked via `make`, and they always fell through to the PATH search regardless. `selfcheck.sh` (the self-host byte-fixpoint gate, part of `make test`) and `remint.sh` (which **overwrites** the checked-in compiler seed) are the two where running under the wrong Chez is most consequential.
- **`test/chez/aot-cache-smoke.sh`, `host/chez/process-suite.sh`** — no override check at all. Confirmed via `make ci` that `aot-cache-smoke.sh`'s case (i) crashes outright (exit 255, cases (i)-(u) never even print) when it resolves a Chez other than the one actually running the gate.
- **`host/chez/build-smoke.sh`, `build-lib-smoke.sh`, `static-native-smoke.sh`, `tree-shake-smoke.sh`, `jolt-selfbuild-smoke.sh`, `test/chez/compile-path-smoke.sh`, `bench/run.sh`** — the same `csv<ver>/<machine>` dir derivation already fixed once in `build.ss`'s `bld-host-csv-dir`, duplicated per-script with no override check.

Every fix follows the existing `JOLT_CHEZ`-first idiom already used in `host/chez/park-lock-check.sh`/`portability-check.sh`.

## Test plan

- [x] Syntax-checked all 14 edited scripts (`sh -n`/`bash -n`)
- [x] Verified each script individually with only `$JOLT_CHEZ` set (no `CHEZ`, no `chez`/`scheme` on `PATH`) — the exact condition that previously silently skipped or crashed:
  - `gatebootsmoke`: 8/8 passed
  - `selfcheck.sh`: self-host fixpoint confirmed
  - `aot-cache-smoke.sh`: 23/23 passed (including case (i), which used to crash)
  - `build-smoke.sh`, `build-lib-smoke.sh`, `static-native-smoke.sh`, `compile-path-smoke.sh`, `jolt-selfbuild-smoke.sh`: all exit 0
  - `process-suite.sh`: 22 assertions passed
  - `bench/dyn-binding/run.sh`, `bench/fibers/run.sh`: confirmed `CHEZ_BIN` resolves to `$JOLT_CHEZ`
- [x] Full `make ci` green locally with `CHEZ` explicitly set (matching CI's own invocation)
- [x] GitHub Actions (`tests`, `flake`) green on this branch: https://github.com/jolt-lang/jolt/actions/runs/32666967543, https://github.com/jolt-lang/jolt/actions/runs/32666967521

🤖 Generated with [Claude Code](https://claude.com/claude-code)