### PR TITLE
tz: memoize the libc zone probe, which the TZ restore made expensive

### DIFF
--- a/host/chez/java/tz-primitives.ss
+++ b/host/chez/java/tz-primitives.ss
@@ -59,21 +59,66 @@
       (tzp-unsetenv "TZ"))
   (tzp-tzset))
 
+(define (tzp-offset-probe zone epoch)   ; caller holds tzp-mutex
+  (let ((saved (tzp-getenv "TZ")))
+    (dynamic-wind
+      (lambda ()
+        (tzp-setenv "TZ" zone 1)
+        (tzp-tzset))
+      (lambda ()
+        (let ((tp (sa-foreign-alloc 8)))
+          (sa-foreign-set! 'long tp 0 epoch)
+          (let ((tm (tzp-localtime tp)))
+            (sa-foreign-free tp)
+            (and tm (not (eq? tm 0)) (sa-foreign-ref 'long tm 40)))))
+      (lambda () (tzp-restore-tz! saved)))))
+
+;; Memo over that probe. The offset of a zone at an instant is a pure function of
+;; the two, and the probe is expensive for a reason the restore above introduced:
+;; leaving TZ clobbered meant libc had already loaded that zone, so the NEXT
+;; call's tzset had nothing to re-read. Restoring TZ — which it must — means every
+;; call now performs two real zone loads instead of none. Measured on
+;; darwin-arm64, one probe call in a repeated same-zone loop:
+;;
+;;   leaving TZ clobbered   ~0.9-1.6 us
+;;   restoring TZ           ~1.1-2.4 ms      (~1000x, four runs)
+;;
+;; A tzset that re-reads is what costs: with TZ unchanged it is ~240ns, and even
+;; a fixed-offset TZ string with no tzfile to read is ~215us on this platform.
+;;
+;; This does not make a first lookup cheaper; it stops repeated ones paying again.
+;; That covers the common shape: jolt-lang/time's resolve-zone asks every named
+;; zone for its offset at epoch 0, so id -> offset resolution hit libc every time
+;; a ZoneId was built. A query about a LIVE instant still pays, since its epoch
+;; differs on every call — answering those from memory needs the zone's
+;; transition table (i.e. reading tzfiles directly), which is a bigger change
+;; than this one.
+;;
+;; Bounded and cleared wholesale on overflow rather than evicted one at a time:
+;; live-instant queries would otherwise grow it for the process's lifetime, and
+;; an LRU is not worth the code here. Inside the mutex because Chez hashtables
+;; are not thread-safe; the probe is called with it already held.
+;;
+;; A tzdata change mid-process is not picked up for an already-answered
+;; (zone, instant). The JVM caches zone rules per process too, and a running
+;; process seeing a tzdata upgrade is not a case worth the invalidation
+;; machinery.
+(define tzp-offset-memo-cap 1024)
+(define tzp-offset-memo (make-hashtable equal-hash equal?))
+
 (define (tzp-offset-raw zone epoch)
   (and tzp-tz-symbols?
        (jolt-with-mutex tzp-mutex
-         (let ((saved (tzp-getenv "TZ")))
-           (dynamic-wind
-             (lambda ()
-               (tzp-setenv "TZ" zone 1)
-               (tzp-tzset))
-             (lambda ()
-               (let ((tp (sa-foreign-alloc 8)))
-                 (sa-foreign-set! 'long tp 0 epoch)
-                 (let ((tm (tzp-localtime tp)))
-                   (sa-foreign-free tp)
-                   (and tm (not (eq? tm 0)) (sa-foreign-ref 'long tm 40)))))
-             (lambda () (tzp-restore-tz! saved)))))))
+         (let* ((key (cons zone epoch))
+                (hit (hashtable-ref tzp-offset-memo key #f)))
+           ;; `or` is safe: a real offset of 0 (UTC) is not #f in Scheme.
+           (or hit
+               (let ((off (tzp-offset-probe zone epoch)))
+                 (when off
+                   (when (> (hashtable-size tzp-offset-memo) tzp-offset-memo-cap)
+                     (hashtable-clear! tzp-offset-memo))
+                   (hashtable-set! tzp-offset-memo key off))
+                 off))))))
 
 ;; Capability probe: trust libc only if it returns known-correct offsets for known
 ;; zones/instants. Rejects Windows (garbage tm_gmtoff) and missing tzdata.

--- a/test/chez/jolt-tz-probe-test.clj
+++ b/test/chez/jolt-tz-probe-test.clj
@@ -64,6 +64,26 @@
         (check-eq "localtime is not silently gmtime" (= local utc) false)))
     (finally (ffi/free b))))
 
+;; The probe is memoized per (zone, epoch), so the gate has to prove the memo
+;; distinguishes both parts of that key rather than answering the first offset it
+;; ever computed. A same-zone DST pair is the sharp case: identical zone string,
+;; different instants, genuinely different offsets.
+(check-eq "memo: same zone, southern summer" (jolt.host/tz-offset-seconds "Australia/Sydney" 1768478400) 39600)
+(check-eq "memo: same zone, southern winter" (jolt.host/tz-offset-seconds "Australia/Sydney" 1784203200) 36000)
+(check-eq "memo: re-asking summer still answers summer"
+          (jolt.host/tz-offset-seconds "Australia/Sydney" 1768478400) 39600)
+(check-eq "memo: same instant, different zone" (jolt.host/tz-offset-seconds "Europe/Paris" 1768478400) 3600)
+
+;; A cached 0 must read as a hit, not as "nothing cached": UTC's offset IS 0, and
+;; only #f is false in Scheme, so a memo written with `or` has to keep answering
+;; from the table rather than re-probing (or, worse, returning nil).
+(check-eq "memo: a zero offset caches" (jolt.host/tz-offset-seconds "UTC" 1768478400) 0)
+(check-eq "memo: a zero offset stays cached" (jolt.host/tz-offset-seconds "UTC" 1768478400) 0)
+
+;; Memo hits must not skip the TZ restore, which they cannot — they never touch
+;; TZ at all — but the whole point of the file is that this stays true.
+(check-eq "TZ is still unset after the memo checks" (c-getenv "TZ") nil)
+
 (if (empty? @failures)
   (println "JOLT-TZ-PROBE-TEST OK")
   (do (doseq [f @failures] (println "FAIL:" f))


### PR DESCRIPTION
"tz: memoize the libc zone probe, which the TZ restore made expensive\n\n#712 fixed a real bug — tzp-offset-raw set TZ and never put it back, so\nevery jolt process was left in whichever zone it probed last and any\nlater localtime() answered that zone instead of the machine's. It also,\nunintentionally, made the probe about a thousand times slower, and the\nreason is the fix itself: leaving TZ clobbered meant libc had already\nloaded that zone, so the NEXT call's tzset() had nothing to re-read.\nRestoring TZ means every call now performs two real zone loads instead\nof none. The leak was subsidising performance.\n\nMeasured on darwin-arm64 (Darwin 25.5), replicating tzp-offset-raw's\nexact body in a repeated same-zone loop, both variants returning the\ncorrect 36000:\n\n  leaving TZ clobbered      880 / 1190 / 1623 / 1023 ns\n  restoring TZ         1.10 / 2.01 / 2.39 / 2.04 ms      (four runs each)\n\nA tzset that actually re-reads is the whole cost: with TZ unchanged it\nis ~240ns, and even a fixed-offset TZ string with no tzfile to read\ncosts ~215us on this platform.\n\nDownstream, before this commit:\n\n  jolt.host/tz-offset-seconds        1.68 ms\n  jolt-lang/time z/resolve-zone      1.64 ms\n  jolt-lang/time ZonedDateTime/now   1.14 ms\n\nso (t/in (t/now) \"Australia/Sydney\") — the one correct way to ask for\nlocal time under that library today — cost about a millisecond.\n\nThe offset of a zone at an instant is a pure function of the two, so\nthis memoizes it, keyed on both. After:\n\n  tz-offset-seconds, repeated key     1.68 ms ->   103 ns\n  z/resolve-zone (named)              1.64 ms ->  4.2 us   (~390x)\n  z/zone-offset-at-instant            2.05 ms ->  3.9 us\n  ZonedDateTime/now                   1.14 ms ->  10.0 us  (~114x)\n\nresolve-zone gains the most because it asks every named zone for its\noffset at epoch 0 — a constant key, so id -> offset resolution stops\nhitting libc entirely after the first time a zone is seen.\nZonedDateTime/now gains because consecutive calls within one second\nshare an epoch; the first call of each new second still pays.\n\nWhat this does NOT do is make a genuinely new (zone, instant) cheaper —\nmeasured at 2.17ms with distinct epochs, unchanged. Answering those from\nmemory needs the zone's transition table, i.e. reading tzfiles directly\nrather than driving libc through TZ, which is a much bigger change than\nthis one and is left alone here.\n\nBounded at 1024 entries and cleared wholesale on overflow rather than\nevicted one at a time: live-instant queries would otherwise grow it for\nthe process's lifetime, and an LRU is not worth the code. The lookup\nruns inside the existing tzp-mutex because Chez hashtables are not\nthread-safe, so tzp-offset-raw now takes the mutex and the renamed\ntzp-offset-probe is called with it already held. `or` on the hit is safe\nbecause a real offset of 0 (UTC) is not #f in Scheme — there is a gate\nfor exactly that below.\n\nOne accepted consequence: a tzdata change mid-process is not picked up\nfor an already-answered (zone, instant). The JVM caches zone rules per\nprocess too, and a running process seeing a tzdata upgrade is not worth\nthe invalidation machinery.\n\nGates: bin/jolt run test/chez/jolt-tz-probe-test.clj OK, with six new\nchecks — a same-zone DST pair (identical zone string, different\ninstants, genuinely different offsets), a re-ask, a same-instant\ndifferent-zone pair, and a zero offset caching and staying cached.\nVerified they FAIL on a broken memo before trusting them: keying on zone\nalone gives \"memo: same zone, southern winter: want 36000 got 39600\".\nmake smoke is 173 passed / 0 failed, unchanged, including a full release\nbuild. jolt-lang/time's own suite is 99 tests / 1036 assertions with one\nfailure, a French locale month name (\"3030-mai-03\" vs an expected\n\"3030-May-03\") that fails identically on an unpatched jolt on this\nmachine, which has fr_FR installed.\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>\n"