### PR TITLE
Follow-ups to 0.7.24: the LC_TIME probes leak like the TZ one did, and setlocale's NULL read as success

### DIFF
--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -133,6 +133,20 @@
           (string-append "sh " qf " && rm -f " qf)))
       cmd))
 
+;; The directory holding an executable named the way the shell would find it. A
+;; BARE command name — JOLT_CHEZ=scheme, which runs perfectly well since PATH is
+;; what locates it — has no directory part to take, and path-parent answers "" for
+;; it where dirname answers ".": unhandled, the csv candidate built from it became
+;; an absolute "/../lib/csv<ver>" off the filesystem root. PATH is the only thing
+;; that knows where such a name lives, so ask it.
+(define (bld-exe-dir exe)
+  (let ((parent (path-parent exe)))
+    (if (string=? parent "")
+        (let ((p (bld-sh-capture
+                  (string-append "dirname \"$(command -v " (bld-sh-quote exe) ")\""))))
+          (if (> (string-length p) 0) p "."))
+        parent)))
+
 ;; The Chez executable, for the isolated compile pass (see build-binary step 4).
 ;; $JOLT_CHEZ — the interpreter this script is itself running under — is
 ;; authoritative when set, for the same reason as bld-host-csv-dir above: a
@@ -171,7 +185,7 @@
     (or (and env (> (string-length env) 0) env)
         (let* ((chez (getenv "JOLT_CHEZ"))
                (bindir (if (and chez (> (string-length chez) 0))
-                           (path-parent chez)
+                           (bld-exe-dir chez)
                            (bld-sh-capture "dirname \"$(command -v chez || command -v scheme || command -v petite)\"")))
                (cand (string-append bindir "/../lib/csv" bld-version "/" bld-machine)))
           cand))))

--- a/host/chez/java/tz-primitives.ss
+++ b/host/chez/java/tz-primitives.ss
@@ -16,7 +16,13 @@
 
 ;; Guard-wrapped FFI via jolt-foreign-proc-safe (deferred symbol lookup so a
 ;; missing entry doesn't abort boot). nil on failure -> graceful fallback.
-(define tzp-setlocale (jolt-foreign-proc-safe "setlocale" '(int string) 'void*))
+;; setlocale's result is read as `string`, not void*: it is a locale NAME, and the
+;; two things this file does with it both need it as one. NULL (the failure answer,
+;; and what an uninstalled locale returns) then arrives as #f rather than the
+;; address 0 — which is TRUTHY in Scheme, so a void* result made every failure read
+;; as success. And `string` COPIES out of libc's static buffer, which the next
+;; setlocale call is free to overwrite, so a saved name survives its own restore.
+(define tzp-setlocale (jolt-foreign-proc-safe "setlocale" '(int string) 'string))
 (define tzp-strftime  (jolt-foreign-proc-safe "strftime"  '(u8* size_t string void*) 'size_t))
 (define tzp-setenv    (jolt-foreign-proc-safe "setenv"    '(string string int) 'int))
 (define tzp-unsetenv  (jolt-foreign-proc-safe "unsetenv"  '(string) 'int))
@@ -24,10 +30,33 @@
 (define tzp-tzset     (jolt-foreign-proc-safe "tzset"     '() 'void))
 (define tzp-localtime (jolt-foreign-proc-safe "localtime" '(void*) 'void*))
 
+;; LC_TIME is process-global, exactly like TZ below, so every probe that writes it
+;; puts it back. setlocale(cat, NULL) queries without setting, which is how the
+;; previous value is read; a #f query answer means libc would not tell us, and
+;; there is nothing safe to restore to, so that case leaves the category alone
+;; rather than guessing at "C".
+(define (tzp-locale-restore! saved)
+  (when saved (tzp-setlocale tzp-LC_TIME saved)))
+
+;; Capability probe: has libc a real en_US locale to name months from?
+;;
+;; It RESTORES LC_TIME, for the same reason tzp-offset-probe restores TZ. This runs
+;; at boot, unconditionally, so leaving it set left every jolt process in
+;; en_US.UTF-8 — a C program starts in "C" — and any later strftime, localtime or
+;; nl_langinfo, jolt's own or a user's through jolt.ffi, silently answered from a
+;; locale nobody selected. An embedder that had chosen its own locale before
+;; calling into jolt lost it.
+;;
+;; dynamic-wind, not straight-line code, so the throw the guard is here to catch
+;; cannot leave the category clobbered on its way out.
 (define tzp-locale-available?
   (and tzp-setlocale tzp-strftime
        (guard (e (#t #f))
-         (let ((r (tzp-setlocale tzp-LC_TIME "en_US.UTF-8"))) (and r (not (eq? r 0)))))))
+         (let ((saved (tzp-setlocale tzp-LC_TIME #f)))
+           (dynamic-wind
+             (lambda () #f)
+             (lambda () (and (tzp-setlocale tzp-LC_TIME "en_US.UTF-8") #t))
+             (lambda () (tzp-locale-restore! saved)))))))
 
 ;; FFI symbols present? (setenv/getenv/unsetenv are POSIX-only, so this is #f on
 ;; Windows). getenv and unsetenv are required here too: tzp-offset-raw needs both
@@ -149,28 +178,48 @@
 
 ;; strftime-based locale name (libc only; nil when unavailable so the library uses
 ;; its own English fallback). fmt is a strftime spec: "%B"/"%b"/"%A"/"%a".
+;;
+;; The requested locale has to be REQUESTED, not assumed: setlocale answers NULL
+;; for one the OS does not have installed, which is the common case (most images
+;; carry only C and en_US). Read as void* that NULL was the address 0 and so
+;; truthy, and strftime then ran under whatever locale happened to be in effect
+;; and its answer was returned as if it were the requested one's — English on a
+;; stock box, or genuinely the wrong language wherever some other locale was
+;; current. nil is what the caller wants: jolt.time.fmt's `or` falls through to
+;; its own bundled tables, which are right everywhere.
+;;
+;; LC_TIME is restored to the name that was in effect, not to "C". Restoring to a
+;; constant is its own clobber — it just happens to be a tidy-looking one — and
+;; this ran on any locale-aware format call, so the previous value did not survive
+;; the first one.
 (define (tzp-locale-name locale tm-mon tm-wday fmt)
   (and tzp-locale-available?
        (let ((libc-loc (tzp-locale->libc locale))
              (buf (make-bytevector 128))
              (tm (sa-foreign-alloc 56)))
-         (sa-foreign-set! 'integer-32 tm 0 0) (sa-foreign-set! 'integer-32 tm 4 0)
-         (sa-foreign-set! 'integer-32 tm 8 0) (sa-foreign-set! 'integer-32 tm 12 1)
-         (sa-foreign-set! 'integer-32 tm 16 tm-mon) (sa-foreign-set! 'integer-32 tm 20 70)
-         (sa-foreign-set! 'integer-32 tm 24 tm-wday) (sa-foreign-set! 'integer-32 tm 28 0)
-         (sa-foreign-set! 'integer-32 tm 32 -1)
-         (let ((result (jolt-with-mutex tzp-mutex
-                         (let ((saved (tzp-setlocale tzp-LC_TIME libc-loc)))
-                           (if saved
-                               (let ((n (tzp-strftime buf 128 fmt tm)))
-                                 (tzp-setlocale tzp-LC_TIME "C")
-                                 (and (> n 0) n))
-                               #f)))))
-           (sa-foreign-free tm)
-           (and result
-                (let ((bv (make-bytevector result)))
-                  (bytevector-copy! buf 0 bv 0 result)
-                  (utf8->string bv)))))))
+         ;; tm is freed on the way out however the body leaves, throw included.
+         (dynamic-wind
+           (lambda () #f)
+           (lambda ()
+             (sa-foreign-set! 'integer-32 tm 0 0) (sa-foreign-set! 'integer-32 tm 4 0)
+             (sa-foreign-set! 'integer-32 tm 8 0) (sa-foreign-set! 'integer-32 tm 12 1)
+             (sa-foreign-set! 'integer-32 tm 16 tm-mon) (sa-foreign-set! 'integer-32 tm 20 70)
+             (sa-foreign-set! 'integer-32 tm 24 tm-wday) (sa-foreign-set! 'integer-32 tm 28 0)
+             (sa-foreign-set! 'integer-32 tm 32 -1)
+             (let ((result (jolt-with-mutex tzp-mutex
+                             (let ((saved (tzp-setlocale tzp-LC_TIME #f)))
+                               (dynamic-wind
+                                 (lambda () #f)
+                                 (lambda ()
+                                   (and (tzp-setlocale tzp-LC_TIME libc-loc)
+                                        (let ((n (tzp-strftime buf 128 fmt tm)))
+                                          (and (> n 0) n))))
+                                 (lambda () (tzp-locale-restore! saved)))))))
+               (and result
+                    (let ((bv (make-bytevector result)))
+                      (bytevector-copy! buf 0 bv 0 result)
+                      (utf8->string bv)))))
+           (lambda () (sa-foreign-free tm))))))
 
 ;; Clojure-facing seam. tz-offset returns nil (jolt-nil) when libc is unusable.
 (define (tzp->jolt x) (if x x jolt-nil))

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1044,7 +1044,12 @@ fi
 # and the capability check at boot ends on "UTC", so an unrestored write left
 # every jolt process answering UTC from localtime() while the machine was
 # somewhere else. Self-checks, one marker; same capture rules as the gates above.
-tzprobe_out="$($jolt run test/chez/jolt-tz-probe-test.clj 2>&1)"
+# TZ is scrubbed for this one: the gate's first check is that the BOOT probe left
+# no TZ behind, and an inherited TZ (a container's ENV TZ=UTC, an exporting shell)
+# is indistinguishable from that leak from inside the process — the test skips the
+# check rather than fail on it, so unsetting here is what keeps it covered. The
+# subshell is the command substitution's own, so nothing below sees the unset.
+tzprobe_out="$(unset TZ; $jolt run test/chez/jolt-tz-probe-test.clj 2>&1)"
 if printf '%s' "$tzprobe_out" | grep -q 'JOLT-TZ-PROBE-TEST OK'; then
   pass=$((pass + 1))
 else
@@ -1054,6 +1059,25 @@ else
   elif [ -n "$tzprobe_out" ]; then
     echo "    (no verdict; last check reached was:)"
     printf '%s\n' "$tzprobe_out" | tail -3 | sed 's/^/    /'
+  fi
+  fails=$((fails + 1))
+fi
+
+# The same file's OTHER libc probe: LC_TIME is process global just like TZ, and
+# both the boot capability check and locale-name itself write it. An unrestored
+# write left every jolt process in en_US.UTF-8 and moved to "C" on the first
+# format call. Also gates that a locale the OS lacks reads as nil rather than
+# borrowing a name from whichever locale was current.
+localeprobe_out="$($jolt run test/chez/jolt-locale-probe-test.clj 2>&1)"
+if printf '%s' "$localeprobe_out" | grep -q 'JOLT-LOCALE-PROBE-TEST OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: jolt.host locale probe"
+  if printf '%s\n' "$localeprobe_out" | grep -q '^FAIL'; then
+    printf '%s\n' "$localeprobe_out" | grep '^FAIL' | head -5 | sed 's/^/    /'
+  elif [ -n "$localeprobe_out" ]; then
+    echo "    (no verdict; last check reached was:)"
+    printf '%s\n' "$localeprobe_out" | tail -3 | sed 's/^/    /'
   fi
   fails=$((fails + 1))
 fi

--- a/test/chez/jolt-locale-probe-test.clj
+++ b/test/chez/jolt-locale-probe-test.clj
@@ -1,0 +1,77 @@
+;; jolt.host's libc locale probe — the sibling of jolt-tz-probe-test.clj.
+;;
+;; LC_TIME is process global exactly like TZ, and tz-primitives.ss writes it in
+;; two places: a boot capability probe asking whether libc has a real en_US to
+;; name months from, and locale-name itself around each strftime. Neither put it
+;; back, so every jolt process ran in en_US.UTF-8 (a C program starts in "C") and
+;; the first locale-name call moved it to "C" for good — visible to jolt's own
+;; strftime/localtime and to user code calling either through jolt.ffi, and
+;; destroying an embedder's own setlocale choice.
+;;
+;; The other half is that setlocale answers NULL for a locale the OS does not
+;; have, which read as the address 0 — truthy in Scheme — so a failed request was
+;; taken for a success and strftime answered from whatever locale was current.
+;;
+;; Run: bin/jolt run test/chez/jolt-locale-probe-test.clj (smoke.sh greps for
+;; "JOLT-LOCALE-PROBE-TEST OK").
+(ns jolt-locale-probe-test)
+
+(require '[jolt.ffi :as ffi])
+
+(def failures (atom []))
+
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# ~got w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; LC_TIME is 2 on glibc, 5 on macOS — the same split tz-primitives.ss keys on.
+(def LC_TIME (if (= "Mac OS X" (System/getProperty "os.name")) 5 2))
+
+;; NULL queries the current locale instead of setting it, so this reads LC_TIME
+;; without disturbing it (jolt.ffi carries nil across :string as of 0.7.24).
+(ffi/defcfn c-setlocale "setlocale" [:int :string] :string)
+
+;; A C process starts every category in "C" and jolt must hand it back that way.
+(check-eq "the boot probe leaves LC_TIME at the process default"
+          (c-setlocale LC_TIME nil) "C")
+
+;; A caller's own choice must survive a locale-aware format call — and the choice
+;; has to be something other than "C" for the check to have teeth: restoring to a
+;; hardcoded "C", which is what the code did, is indistinguishable from a real
+;; restore when "C" is what was there anyway. locale-name is inert unless the boot
+;; probe found en_US.UTF-8, so wherever it answers at all, that locale is installed
+;; and serves as the non-"C" witness.
+(if (some? (jolt.host/locale-name "en" 0 1 "%B"))
+  (do (c-setlocale LC_TIME "en_US.UTF-8")
+      (jolt.host/locale-name "en" 0 1 "%B")
+      (check-eq "a caller's own LC_TIME survives a locale-name call"
+                (c-setlocale LC_TIME nil) "en_US.UTF-8"))
+  (println "  .. (skipped: libc has no en_US.UTF-8, so locale-name is inert here)"))
+(c-setlocale LC_TIME "C")
+
+;; An UNINSTALLED locale must read as nil, not as a name borrowed from whichever
+;; locale was current. Every box has "C"; essentially none has all of these, and
+;; a name coming back for one that setlocale refused is the bug. Where a locale
+;; IS installed a real name is correct, so each check accepts nil or a name and
+;; the gate is that the two agree — a name only when setlocale took the locale.
+(doseq [[id libc] [["fr" "fr_FR.UTF-8"] ["ja" "ja_JP.UTF-8"]
+                   ["de" "de_DE.UTF-8"] ["ru" "ru_RU.UTF-8"]]]
+  (let [installed? (some? (do (c-setlocale LC_TIME "C")
+                             (c-setlocale LC_TIME libc)))]
+    (c-setlocale LC_TIME "C")
+    (check-eq (str "locale-name \"" id "\" answers only if " libc " is installed")
+              (some? (jolt.host/locale-name id 0 1 "%B"))
+              installed?)))
+
+;; ...and none of those calls may have left the category somewhere of their own.
+(check-eq "LC_TIME is where the test left it after the uninstalled-locale checks"
+          (c-setlocale LC_TIME nil) "C")
+
+(if (empty? @failures)
+  (println "JOLT-LOCALE-PROBE-TEST OK")
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (println "JOLT-LOCALE-PROBE-TEST FAILED:" (count @failures))))

--- a/test/chez/jolt-tz-probe-test.clj
+++ b/test/chez/jolt-tz-probe-test.clj
@@ -33,8 +33,18 @@
   (ffi/read (f epoch-buf) :int 8))     ; tm_hour is the third int
 
 ;; The boot-time capability probe has already run by the time this loads, so an
-;; unrestored TZ would be observable right here.
-(check-eq "TZ is not left set by the boot probe" (c-getenv "TZ") nil)
+;; unrestored TZ would be observable right here — but only in a process that did
+;; not INHERIT one. A TZ in the environment is an ordinary setup (a container's
+;; ENV TZ=UTC, a shell that exports it), and from in here it is indistinguishable
+;; from a leak, so asserting nil unconditionally failed the gate on the
+;; environment rather than on the code. smoke.sh runs this with TZ scrubbed so
+;; the assertion below is what the gate actually reports; run by hand with TZ
+;; set, it says so and moves on to the checks that carry their own TZ.
+(let [inherited (c-getenv "TZ")]
+  (if (nil? inherited)
+    (check-eq "TZ is not left set by the boot probe" inherited nil)
+    (println (str "  .. (skipped: TZ=" (pr-str inherited)
+                  " was inherited, so a leak is not observable here)"))))
 
 ;; A named zone under a KNOWN TZ must come back unchanged. This is the case the
 ;; boot probe broke: it left TZ=UTC, so a caller who had set TZ themselves lost it.


### PR DESCRIPTION
Follow-up to the v0.7.24 changes, from reviewing what landed in it. Three
findings, all reproduced before fixing and re-checked after.

## 1. The LC_TIME probes leak, the way the TZ probe did before #712

`#712`/`#716` fixed "a libc capability probe must put process-global state back"
for `TZ`. The same file writes `LC_TIME` in two places and neither put it back.

`tzp-locale-available?` — the boot probe asking whether libc has a real en_US to
name months from — set `en_US.UTF-8` and left it. It runs unconditionally, so
every jolt process ran in it where a C program starts in `"C"`:

```
LC_TIME after boot = "en_US.UTF-8"     # a C program's default is "C"
```

Any later `strftime`, `localtime` or `nl_langinfo` — jolt's own or a user's
through `jolt.ffi` — then answered from a locale nobody selected, and an
embedder that had chosen its own before calling in lost it.

`tzp-locale-name` restored to a hardcoded `"C"` rather than to the value it
displaced, so the first locale-aware format call moved the process there for
good. Restoring to a constant is its own clobber; it just looks tidy.

Both now save with `setlocale(cat, NULL)` — which queries without setting — and
restore under `dynamic-wind`, the shape `tzp-offset-probe` already uses for `TZ`
so a throw between the two cannot leave the category clobbered. `tm` is now
freed on the way out however the body leaves, throw included.

## 2. `setlocale`'s NULL read as success

Its result was typed `void*`, so the NULL it answers on failure arrived as the
address `0` — **truthy in Scheme** — and every failure read as success. Not a
rare path: `setlocale` answers NULL for a locale the OS does not have installed,
which is the common case, most images carrying only C and en_US. `locale-name`
then ran `strftime` under whatever locale was current and returned the answer as
if it were the requested locale's:

```
setlocale(LC_TIME, "fr_FR.UTF-8") -> 0        # not installed
jolt.host/locale-name "fr" %B     -> "January"   # contract says nil
"ja" -> "January"   "de" -> "January"   "ru" -> "January"
```

English on a stock box, and genuinely the wrong language wherever some other
locale was current — with LC_TIME left at `en_US.UTF-8` by (1) and at `"C"` after
the first call, which is what decided the answer.

Reading the result as `string` — which it is, a locale *name* — spells NULL as
`#f` and fixes the check by construction. It also copies out of libc's static
buffer, which the restoring call is free to overwrite, so a saved name survives
its own restore. The correct idiom was already in the file, 130 lines up.

`nil` is what the caller wants: `jolt.time.fmt`'s `or` falls through to its
bundled tables, which are right everywhere, and its comment already says
strftime "silently falls back to English when it does not" have the locale. So
this is a broken contract and a dead fallback branch rather than wrong output
downstream today — but the primitive is public, and the next caller to trust the
documented `nil` gets English named as Japanese.

## 3. The new tz gate fails on an inherited TZ

`jolt-tz-probe-test.clj`'s first check asserts the boot probe left no `TZ`
behind, but from inside the process an inherited `TZ` is indistinguishable from a
leaked one — so it failed on the environment rather than on the code. On a tree
with #712 in it:

```
TZ unset            -> JOLT-TZ-PROBE-TEST OK
TZ=America/Toronto  -> FAIL: ... want nil got "America/Toronto"
TZ=UTC              -> FAIL: ... want nil got "UTC"
```

A `TZ` in the environment is an ordinary setup — a container's `ENV TZ=UTC`, a
shell that exports it. Actions sets none, so CI never saw this; it was
contributors and containerized dev environments that would, on a gate unrelated
to their change. The check now skips with a note when `TZ` was inherited, and
`smoke.sh` scrubs `TZ` for this gate so the assertion stays covered where it is
meaningful. The other TZ checks set and unset `TZ` themselves and are untouched.

## 4. A bare-name `JOLT_CHEZ` in build.ss

`#715` made `$JOLT_CHEZ` authoritative for `bld-host-csv-dir` and read its
directory with `path-parent`, which is not the `dirname` it replaced: for a bare
command name `path-parent` answers `""` where `dirname` answers `"."`.
`JOLT_CHEZ=scheme` runs fine — PATH is what locates it — but the csv candidate
became an absolute `/../lib/csv<ver>/<machine>` off the filesystem root, failing
`bld-check-toolchain` against a path that never existed.

Not reachable through the supported entry points (the Makefile always computes an
absolute path, `bin/jolt` runs the value through `command -v` before exporting
it), so this is robustness for build.ss invoked directly.

## Gate

`test/chez/jolt-locale-probe-test.clj`, wired into `smoke.sh` next to the tz one.
It fails on all six counts before this change and passes after:

```
FAIL: the boot probe leaves LC_TIME at the process default: want "C" got "en_US.UTF-8"
FAIL: a caller's own LC_TIME survives a locale-name call: want "en_US.UTF-8" got "C"
FAIL: locale-name "fr" answers only if fr_FR.UTF-8 is installed: want false got true
FAIL: locale-name "ja" ... / "de" ... / "ru" ...
JOLT-LOCALE-PROBE-TEST FAILED: 6
```

The uninstalled-locale checks assert that a name comes back *only* where
`setlocale` took the locale, so they hold on a box that does have fr/ja/de/ru.
The LC_TIME survival check uses `en_US.UTF-8` rather than `"C"` deliberately —
against `"C"` it cannot tell a real restore from the hardcoded one.

Verified: `make smoke` 174 passed / 0 failed on a rebuilt binary; the tz gate
green with `TZ` unset, `TZ=America/Toronto` and `TZ=UTC`; `bld-exe-dir` checked
against bare, absolute and relative values. `make libconformance LIBS=cuerdas`
— the suite that formats through jolt-lang/time's Locale — is unchanged at its
recorded tally (`tests=71 pass=298 fail=0 error=2`), which is the downstream
path (2) alters: for an uninstalled locale it now returns nil and `fmt`'s `or`
supplies the same English name strftime was supplying.

No re-mint: `tz-primitives.ss` is `load`ed by `rt.ss` at runtime, not compiled
into the seed.

I left `CHANGELOG.md` alone, since entries here look curated at release time
rather than per-PR — happy to add one if you'd rather.
