### PR TITLE
ffi: nil is the only spelling of NULL

### DIFF
--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -11,6 +11,24 @@
 ;; representation `void*` arguments and results use, so pointers flow between
 ;; foreign-fn calls and these helpers transparently.
 
+;; --- a jolt value used AS a string -------------------------------------------
+;; jolt-str-render-one is the `str` coercion, and it renders nil as "". That is
+;; right for str and it is right where the boundary copies a VALUE — string->ptr
+;; and with-c-string document exactly that. It is wrong wherever the string names
+;; something, because an absent name silently became an empty one: dlopen(""), a
+;; foreign type called "", a zero-byte write that reports 0 octets written and is
+;; indistinguishable from writing "".
+;;
+;; nil has no representation in any of those positions. Where it DOES have one it
+;; is already used — NULL, in a :string argument and in string->ptr — so the split
+;; is between "absence means NULL here" and "absence means nothing here", and this
+;; is the second. Every other value keeps the coercion, so 42 still names "42".
+(define (ffi-str-arg what x)
+  (if (jolt-nil? x)
+      (throw-jvm 'IllegalArgumentException
+                 (string-append "jolt.ffi: " what " must be a string, got nil"))
+      (jolt-str-render-one x)))
+
 ;; --- loading shared objects --------------------------------------------------
 ;; (jolt.ffi/load-library name) loads a .so/.dylib by name (resolved by the OS
 ;; loader against the standard search paths). A library typically calls this once
@@ -64,7 +82,7 @@
 ;; followed by use). The old form side-effected the GLOBAL namespace to answer
 ;; a yes/no question.
 (define (ffi-loaded? name)
-  (if (jolt-ffi-load-native (jolt-str-render-one name)) #t #f))
+  (if (jolt-ffi-load-native (ffi-str-arg "loaded? name" name)) #t #f))
 
 ;; --- scoped native libraries: dlopen RTLD_LOCAL + per-handle dlsym ----------
 ;; A :jolt/native library's symbols must NEVER depend on the process-global
@@ -149,7 +167,7 @@
 ;; width expose the same stored bits; wire byte order remains an explicit codec
 ;; or htons/ntohs concern.
 (define (ffi-type->chez kw)
-  (let ((n (if (keyword-t? kw) (keyword-t-name kw) (jolt-str-render-one kw))))
+  (let ((n (if (keyword-t? kw) (keyword-t-name kw) (ffi-str-arg "foreign type" kw))))
     (cond
       ((string=? n "int") 'int)
       ((string=? n "uint") 'unsigned-int)
@@ -239,7 +257,7 @@
     (guard (e (#t (list->string (map integer->char (bytevector->u8-list bv))))) (utf8->string bv))))
 ;; write a string's UTF-8 bytes into ptr (no NUL terminator); return the count.
 (define (ffi-write-bytes ptr s)
-  (let* ((bv (string->utf8 (jolt-str-render-one s))) (n (bytevector-length bv)) (p (jnum->exact ptr)))
+  (let* ((bv (string->utf8 (ffi-str-arg "write-bytes value" s))) (n (bytevector-length bv)) (p (jnum->exact ptr)))
     (sa-foreign-bytes-set! p bv n)
     n))
 (def-var! "jolt.ffi" "read-bytes" ffi-read-bytes)

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -317,14 +317,32 @@
                 (loop (+ i 1) (cons b acc))))))))
 ;; Copy a jolt string's UTF-8 bytes into a freshly alloc'd NUL-terminated buffer;
 ;; the caller frees it. Returns the pointer.
+;;
+;; nil answers NULL, allocating nothing, so it round-trips against ptr->string
+;; above — which has always read NULL back as nil. Before this the pair lost the
+;; distinction in one direction: nil went through jolt-str-render-one, which
+;; renders it "", so it came back as "" and an absent string was indistinguishable
+;; from a present empty one. "" itself still allocates its one NUL byte and still
+;; reads back as "", which is what keeps the two answers apart.
+;;
+;; Every value that is not nil keeps going through jolt-str-render-one, the `str`
+;; coercion: with-c-string documents "Copy VALUE", not "copy a string", and
+;; with-c-string-array maps over arbitrary values. Only nil is special, for the
+;; same reason it is special in a :string position — it is what jolt spells
+;; absence with, and NULL is what C spells it with.
+;;
+;; NULL is safe for both callers to free: free(NULL) is a defined no-op, and
+;; ffi/free reaches it through Chez's foreign-free, which accepts 0.
 (define (ffi-string->ptr s)
-  (let* ((bv (string->utf8 (jolt-str-render-one s))) (n (bytevector-length bv))
-         (p (sa-foreign-alloc (+ n 1))))
-    ;; free on a mid-copy throw — the caller only ever sees a whole buffer
-    (guard (e (#t (guard (_ (#t #f)) (sa-foreign-free p)) (raise e)))
-      (do ((i 0 (+ i 1))) ((= i n)) (sa-foreign-set! 'unsigned-8 p i (bytevector-u8-ref bv i)))
-      (sa-foreign-set! 'unsigned-8 p n 0)
-      p)))
+  (if (jolt-nil? s)
+      ffi-null
+      (let* ((bv (string->utf8 (jolt-str-render-one s))) (n (bytevector-length bv))
+             (p (sa-foreign-alloc (+ n 1))))
+        ;; free on a mid-copy throw — the caller only ever sees a whole buffer
+        (guard (e (#t (guard (_ (#t #f)) (sa-foreign-free p)) (raise e)))
+          (do ((i 0 (+ i 1))) ((= i n)) (sa-foreign-set! 'unsigned-8 p i (bytevector-u8-ref bv i)))
+          (sa-foreign-set! 'unsigned-8 p n 0)
+          p))))
 
 ;; --- callbacks: receive calls FROM C ----------------------------------------
 ;; jolt.ffi/foreign-callable lowers to (jolt-ffi-register-callable! (foreign-callable …)).

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -188,7 +188,26 @@
 ;; foreign-callable is called BY C, so the roles swap: its :string arguments
 ;; convert c->jolt and its :string result converts jolt->c. Position-relative
 ;; names ("arg"/"ret") read backwards on one of the two.
-(define (jolt-ffi-string->c x) (if (jolt-nil? x) #f x))
+;;
+;; jolt->c validates rather than passing the odd value through, because `string`
+;; is the ONE foreign type that takes a non-string quietly. Chez rejects #t, an
+;; integer, a symbol and a bytevector in a `string` position, and rejects #f in
+;; every other position — argument, result and foreign-set! alike. So #f in a
+;; `string` position is the single hole in the boundary's type checking, and what
+;; falls through it lands on precisely the value C reads as "absent": a `when`
+;; that did not fire, a predicate result, a `boolean` of a missing key, silently
+;; becomes NULL. jolt.ffi has no :bool type, so no false ever belongs here — nil
+;; is how NULL is spelled. Naming the whole non-string set in one jolt-level error
+;; also beats Chez's "invalid foreign-procedure argument #[...]" for the rest.
+;;
+;; c->jolt needs no such check: its input comes from Chez, which hands back a
+;; string or #f and nothing else.
+(define (jolt-ffi-string->c x)
+  (cond ((string? x) x)                 ; the common path, one test
+        ((jolt-nil? x) #f)              ; nil IS NULL, in both directions
+        (else (throw-jvm 'IllegalArgumentException
+                         (string-append "jolt.ffi: :string got " (jolt-pr-str x)
+                                        " — NULL is spelled nil")))))
 (define (jolt-ffi-c->string x) (if x x jolt-nil))
 
 ;; --- foreign memory ----------------------------------------------------------

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -57,6 +57,13 @@
   since with-c-string copies a VALUE. NULL is safe to free, so the scoped
   helpers need no special case for it.
 
+  Where NULL is not available to mean it, a nil is rejected instead of rendered
+  as \"\": a nil foreign type (read/write/sizeof), a nil name to loaded?, and a
+  nil value to write-bytes, whose destination is the caller's own buffer so
+  there is no pointer that could carry absence. (load-library nil) keeps its
+  documented meaning — no name at all, the process's own symbols — which is an
+  answer rather than a missing one.
+
       (let [buf (ffi/alloc 65536)
             frame (byte-array total)]
         (loop [off 0]

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -26,6 +26,14 @@
   translation with the directions swapped, since C is the caller there: a null
   char* C passes in arrives as nil, and returning nil hands C a null char*.
 
+  nil is the only spelling of NULL a :string position accepts. false is
+  rejected rather than sent, though Chez's own `string` type would take it as
+  NULL: there is no :bool foreign type for a boolean to have come from, so one
+  arriving here is a mistake — a `when` that did not fire, a predicate result —
+  and silently sending it would land on the one value C reads as \"absent\".
+  Every other non-string is rejected too, which the other foreign types already
+  did on their own.
+
   A struct passed or returned by value uses the same literal descriptor as
   layout, wrapped in [:by-value descriptor]. An argument value is a non-null
   caller-owned pointer to the struct bytes. An aggregate-returning callable takes

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -50,6 +50,13 @@
   it already knows fills one buffer instead of regrowing an accumulator per
   chunk. All of them move the block in one copy, not a byte at a time.
 
+  string->ptr and ptr->string round-trip nil: nil answers NULL and allocates
+  nothing, NULL reads back as nil, and \"\" still allocates its NUL byte and
+  still reads back as \"\" — so an absent string stays distinguishable from a
+  present empty one. Every other value keeps going through the `str` coercion,
+  since with-c-string copies a VALUE. NULL is safe to free, so the scoped
+  helpers need no special case for it.
+
       (let [buf (ffi/alloc 65536)
             frame (byte-array total)]
         (loop [off 0]
@@ -138,7 +145,9 @@
     `(jolt.ffi/with-alloc [~pointer (jolt.ffi/layout-size ~layout)] ~@body)))
 
 (defmacro with-c-string
-  "Copy value to a lexical NUL-terminated UTF-8 C string."
+  "Copy value to a lexical NUL-terminated UTF-8 C string. A nil value binds NULL
+  rather than an empty string, which is how an optional C string argument is
+  passed; freeing it is still a no-op."
   [binding & body]
   (let [[pointer value] (helper-binding "with-c-string" binding)]
     `(let [~pointer (jolt.ffi/string->ptr ~value)]
@@ -147,7 +156,9 @@
 (defmacro with-c-string-array
   "Build a lexical pointer array of count NUL-terminated UTF-8 strings. The
   values expression is evaluated once. Partially built arrays are cleaned up if
-  conversion fails. Neither the array nor its member pointers may escape body."
+  conversion fails. Neither the array nor its member pointers may escape body.
+  A nil member is a NULL entry, which is what an argv/envp-shaped array wants;
+  it is tracked and freed like any other member, freeing NULL being a no-op."
   [binding values & body]
   (let [[pointer count-expr] (helper-binding "with-c-string-array" binding)]
     `(let [values# (vec ~values)

--- a/test/chez/ffi-binding-test.ss
+++ b/test/chez/ffi-binding-test.ss
@@ -188,6 +188,16 @@
         (equal? "hi!" returned))))
 (ev "(jolt.ffi/free-callable cb-str)")
 
+;; A callback RETURNING false must be rejected the same way an argument is. This
+;; is the direction where the old pass-through was most misleading: the callback
+;; hands C a null char*, C acts on "absent", and nothing in jolt ever said so.
+;; nil is how a callback declines to answer.
+(ev "(def cb-false (jolt.ffi/__ccallable (fn [_] false) [:string] :string))")
+(let ((call-cb (foreign-procedure (jnum->exact (var-deref "user" "cb-false")) (string) string)))
+  (ok "a callback returning false from :string raises instead of answering NULL"
+      (guard (e (#t #t)) (call-cb "x") #f)))
+(ev "(jolt.ffi/free-callable cb-false)")
+
 ;; The conversions are emitted ONLY where the signature says :string, so every
 ;; other binding and callable is emitted byte-identically to before they
 ;; existed — that is what keeps this off the hot path of the FFI's scalar and

--- a/test/chez/jolt-ffi-bytes-test.clj
+++ b/test/chez/jolt-ffi-bytes-test.clj
@@ -84,6 +84,18 @@
     (check-eq "the source string is shorter than its encoding" (count s) 6)
     (check-eq "read-bytes decodes the octets back" (ffi/read-bytes buf 8) s))
 
+  ;; nil is not something to encode. It used to reach the `str` coercion, which
+  ;; renders it "", so an absent value wrote 0 octets and answered 0 — the same
+  ;; answer as writing "" on purpose. Unlike a :string argument or string->ptr,
+  ;; there is no NULL to mean it with here: the destination is the caller's own
+  ;; buffer, so absence has nowhere to go and is a caller error.
+  (check-eq "write-bytes rejects nil rather than writing nothing"
+            (try (ffi/write-bytes buf nil) :no-throw
+                 (catch IllegalArgumentException _ :rejected))
+            :rejected)
+  (check-eq "write-bytes still takes the str coercion for a non-nil value"
+            (ffi/write-bytes buf 42) 2)
+
   ;; bytes that are not valid UTF-8 come back through read-array unharmed
   ;; (read-bytes would have to substitute; read-array must not)
   (let [invalid (byte-array [-128 -61 40 0 -1])]

--- a/test/chez/jolt-ffi-scoped-test.clj
+++ b/test/chez/jolt-ffi-scoped-test.clj
@@ -34,6 +34,47 @@
                     (ffi/ptr->string
                      (ffi/read p :pointer (* index (ffi/sizeof :pointer)))))
                   (range 3)))))
+;; nil round-trips as NULL through the string->ptr / ptr->string pair. Before
+;; this nil went through the `str` coercion, which renders it "", so an ABSENT
+;; string was indistinguishable from a present empty one after a round trip.
+;; "" must keep its own answer, which is the half that proves the two are apart.
+(check "string->ptr of nil is NULL"
+       (ffi/null? (ffi/string->ptr nil)))
+(check "nil round-trips through the pair"
+       (nil? (ffi/ptr->string (ffi/string->ptr nil))))
+(check "\"\" is still not nil after a round trip"
+       (= "" (let [p (ffi/string->ptr "")]
+               (try (ffi/ptr->string p) (finally (ffi/free p))))))
+(check "a non-nil value still takes the str coercion"
+       (= "42" (let [p (ffi/string->ptr 42)]
+                 (try (ffi/ptr->string p) (finally (ffi/free p))))))
+;; Freeing the NULL must be a no-op rather than a fault, since the scoped helpers
+;; below free every member unconditionally.
+(check "freeing the NULL from string->ptr is safe"
+       (nil? (ffi/free (ffi/string->ptr nil))))
+
+(check "with-c-string binds NULL for nil"
+       (ffi/with-c-string [p nil] (ffi/null? p)))
+(check "with-c-string of nil still frees cleanly"
+       (= 1 (let [real-free ffi/free frees (atom 0)]
+              (with-redefs [ffi/free (fn [p] (swap! frees inc) (real-free p))]
+                (ffi/with-c-string [p nil] :ok))
+              @frees)))
+;; An argv/envp-shaped array: a nil member is a NULL entry, the strings around it
+;; are untouched, and all three are freed.
+(check "with-c-string-array makes a nil member a NULL entry"
+       (= ["alpha" nil ""]
+          (ffi/with-c-string-array [p 3] ["alpha" nil ""]
+            (mapv (fn [index]
+                    (ffi/ptr->string
+                     (ffi/read p :pointer (* index (ffi/sizeof :pointer)))))
+                  (range 3)))))
+(check "with-c-string-array frees a NULL member like any other"
+       (= 4 (let [real-free ffi/free frees (atom 0)]
+              (with-redefs [ffi/free (fn [p] (swap! frees inc) (real-free p))]
+                (ffi/with-c-string-array [p 3] ["alpha" nil ""] :ok))
+              @frees)))
+
 (check "with-c-string-array evaluates values once"
        (= 1 (let [calls (atom 0)]
               (ffi/with-c-string-array [p 1]

--- a/test/chez/jolt-ffi-string-null-test.clj
+++ b/test/chez/jolt-ffi-string-null-test.clj
@@ -7,6 +7,7 @@
 (ns jolt-ffi-string-null-test)
 
 (require '[jolt.ffi :as ffi])
+(require '[clojure.string :as str])
 
 (def failures (atom []))
 
@@ -47,6 +48,37 @@
 ;; --- nil is only special for :string -----------------------------------------
 ;; :pointer keeps taking ffi/null as the integer 0; nothing here changes that.
 (check-eq "ffi/null is still 0" (ffi/null? ffi/null) true)
+
+;; --- and nil is the ONLY spelling of NULL ------------------------------------
+;; `string` is the one foreign type Chez takes a non-string on: it rejects #t, an
+;; integer, a symbol and a bytevector there, and rejects #f in every other
+;; position, but accepts #f in a `string` position as NULL. So false was the
+;; single value that could cross this boundary silently, and it landed on exactly
+;; the value C reads as "absent" — a `when` that did not fire, a predicate
+;; result. There is no :bool foreign type for it to have legitimately come from.
+;; Asserted on the MESSAGE, not merely on "something threw": the other non-strings
+;; did already throw before this, but as a raw Chez condition — class :object,
+;; reading "invalid foreign-procedure argument #[keyword-v1 #f \"kw\" 1158308175]"
+;; — so a bare threw? check would pass either way and prove nothing about them.
+(defn- rejected? [f]
+  (let [m (try (f) nil (catch Throwable t (str (.getMessage t))))]
+    (and (some? m) (str/includes? m "jolt.ffi: :string got"))))
+
+(check-eq "false as a :string argument is rejected, not sent as NULL"
+          (rejected? #(c-setlocale 0 false)) true)
+(check-eq "false's rejection is an IllegalArgumentException"
+          (try (c-setlocale 0 false) false
+               (catch IllegalArgumentException _ true))
+          true)
+(check-eq "true as a :string argument is rejected in jolt's own words"
+          (rejected? #(c-setlocale 0 true)) true)
+(check-eq "a non-string :string argument is rejected in jolt's own words"
+          (rejected? #(c-setlocale 0 42)) true)
+
+;; The rejection must not have cost the two values that ARE legal, which is the
+;; property a validating conversion is most likely to break.
+(check-eq "nil still reaches C as NULL after the check" (string? (c-setlocale 0 nil)) true)
+(check-eq "a string still marshals after the check" (string? (c-setlocale 0 "C")) true)
 
 (if (empty? @failures)
   (println "JOLT-FFI-STRING-NULL-TEST OK")

--- a/test/chez/jolt-ffi-string-null-test.clj
+++ b/test/chez/jolt-ffi-string-null-test.clj
@@ -60,9 +60,17 @@
 ;; did already throw before this, but as a raw Chez condition — class :object,
 ;; reading "invalid foreign-procedure argument #[keyword-v1 #f \"kw\" 1158308175]"
 ;; — so a bare threw? check would pass either way and prove nothing about them.
+(defn- threw-message [f]
+  (try (f) nil (catch Throwable t (str (.getMessage t)))))
+
 (defn- rejected? [f]
-  (let [m (try (f) nil (catch Throwable t (str (.getMessage t))))]
+  (let [m (threw-message f)]
     (and (some? m) (str/includes? m "jolt.ffi: :string got"))))
+
+;; "<what> must be a string, got nil" — the naming positions further down.
+(defn- rejected-name? [f]
+  (let [m (threw-message f)]
+    (and (some? m) (str/includes? m "must be a string, got nil"))))
 
 (check-eq "false as a :string argument is rejected, not sent as NULL"
           (rejected? #(c-setlocale 0 false)) true)
@@ -79,6 +87,21 @@
 ;; property a validating conversion is most likely to break.
 (check-eq "nil still reaches C as NULL after the check" (string? (c-setlocale 0 nil)) true)
 (check-eq "a string still marshals after the check" (string? (c-setlocale 0 "C")) true)
+
+;; --- where NULL is NOT available, nil is an error ----------------------------
+;; The positions above can say "absent" — NULL is exactly that. The ones below
+;; cannot: they use the string to NAME something. nil reached the `str` coercion
+;; there, which renders it "", so an absent name became an empty one and the
+;; boundary acted on it — a foreign type called "", a dlopen of "".
+(check-eq "a nil foreign type is rejected, not read as the type named \"\""
+          (rejected-name? #(ffi/sizeof nil)) true)
+(check-eq "a real foreign type still resolves" (pos? (ffi/sizeof :int32)) true)
+(check-eq "a nil library name is rejected, not dlopen'd as \"\""
+          (rejected-name? #(ffi/loaded? nil)) true)
+;; load-library keeps its documented nil: no name means "the process's own
+;; symbols are already resolvable", which is an answer, not an absent name.
+(check-eq "(load-library nil) is still the documented no-op"
+          (nil? (ffi/load-library nil)) true)
 
 (if (empty? @failures)
   (println "JOLT-FFI-STRING-NULL-TEST OK")


### PR DESCRIPTION
Closes the `:string`/`false` footgun noted at the end of #717 and, following the
sweep it prompted, makes one rule hold across the whole boundary:

> **nil is how jolt spells absence. NULL is how C spells it. Where NULL can carry
> absence, nil means NULL; where it cannot, nil is an error — never an empty
> string.**

Three commits: reject `false` on `:string`, round-trip `nil` through
`string->ptr`/`ptr->string`, and stop the remaining sites rendering `nil` as `""`.

## The hole

`:string` is the **only** place in the whole boundary where a wrong-typed jolt
value crosses silently, and what falls through lands on precisely the value C
reads as "absent". Probed against Chez directly (`scheme --script`, glibc):

| position | `#f` | `#t` / int / symbol / bytevector / char / list |
| --- | --- | --- |
| `string` argument | **accepted → NULL** | raises |
| `void*` argument | raises | — |
| `int` argument | raises | — |
| `foreign-set!` `void*` | raises | — |
| `foreign-set!` int/double/u8 | raises | — |

So every other type rejects `#f`, and `string` rejects every other non-string —
`#f` in a `string` position is the single gap. `jolt.ffi` has no `:bool` foreign
type, so no boolean ever legitimately arrives there: what does arrive is a `when`
that did not fire, a predicate result, a `boolean` of a missing key. Before this,
that became NULL and C acted on it.

Same in the callable return direction, where it was worse — the callback hands C
a null `char*`, C acts on "absent", and nothing in jolt ever said so.

## The fix

`jolt-ffi-string->c` validates instead of passing the odd value through: a string
goes out as itself, `nil` goes out as NULL, everything else raises. `c->jolt`
needs no check — its input comes from Chez, which hands back a string or `#f` and
nothing else.

That also upgrades the message for the non-strings that *were* already rejected,
which turned out to be leaking Chez internals rather than raising a jolt error:

```
before   :object | invalid foreign-procedure argument #[keyword-v1 #f "kw" 1158308175]
after    java.lang.IllegalArgumentException | jolt.ffi: :string got :kw — NULL is spelled nil
```

The common path is one `string?` test, so the validating version is if anything
cheaper than the `jolt-nil?` test it replaces on the hot path.

## The sweep

**NULL-read-as-truthy** — the class the `setlocale` bug in #717 belonged to (a C
function answering NULL, read as the address `0`, which is truthy in Scheme). I
checked every pointer-returning foreign binding in the tree. All of the rest are
already correct, and pointedly so:

- `ffi-dlopen` / `ffi-dlsym` — `(and h (integer? h) (positive? h))`
- `c-iconv-open` — checks both `(iconv_t)-1` and `0`
- `tzp-localtime` — `(and tm (not (eq? tm 0)) …)`
- `proc-libc-signal` — `eqv?` against SIG_IGN `1` and SIG_ERR `-1`; SIG_DFL `0`
  is a *valid* previous handler and is deliberately put back
- `proc-errno-loc` — never NULL by contract

`tzp-setlocale` was the only broken one. Nothing further to fix here.

**Value-means-something-else** — covered by the table above: `:string`/`false` was
the only silent case, and it is fixed.

## nil now round-trips through string->ptr / ptr->string (second commit)

`ptr->string` has always read NULL back as `nil`. `string->ptr` went the other
way through `jolt-str-render-one`, which renders `nil` as `""` — so `nil` came
back as `""` and the pair lost the distinction in one direction. An **absent**
string and a present **empty** one were the same thing after a round trip, which
for a path, a name or an optional argument is exactly the difference C cares
about.

`nil` now answers NULL and allocates nothing. `""` still allocates its one NUL
byte and still reads back as `""` — that is the half that proves the two answers
stay apart. Every other value keeps the `str` coercion, so `42` is still `"42"`:
`with-c-string` documents "Copy **value**", not "copy a string", and
`with-c-string-array` maps over arbitrary values. Only `nil` is special, for the
same reason it is special in a `:string` position.

**Both scoped helpers keep working with no change**, which is worth stating
because it is not obvious:

- `with-c-string` binds NULL for a `nil` value — which is how an optional C
  string argument is passed — and its `finally` frees it. `free(NULL)` is a
  defined no-op and Chez's `foreign-free` accepts `0`; I verified that directly
  rather than assuming it.
- `with-c-string-array` writes NULL into the slot (argv/envp shape) and its
  cleanup frees every tracked member including that one. `foreign-set!` takes `0`
  for a `void*` — it rejects `#f`, which is why this is `0` and not `false`.

Nothing outside the two macros calls `string->ptr`: no other host code, no
sibling library (`time`, `transit-jolt`, `jolt-fressian`), and none of the
conformance suites. The only existing test that touches the empty-string case
passes `""`, not `nil`, so it is unaffected.

## The rest of the coercion sweep (third commit)

`jolt-str-render-one` is the `str` coercion, so it renders `nil` as `""`. That is
right where the boundary copies a **value** — `string->ptr` and `with-c-string`
document exactly that — and wrong wherever the string **names** something,
because an absent name became an empty one and the boundary acted on it. Three
sites did that:

| site | before | now |
| --- | --- | --- |
| `write-bytes` | wrote 0 octets, answered `0` — same as writing `""` | rejects nil |
| `read` / `write` / `sizeof` | `"unknown foreign type :"` — loud but naming nothing | rejects nil |
| `loaded?` | `dlopen("")`, answered `false` — a definite-looking no | rejects nil |

`write-bytes` is the one the other two commits cannot reach by making `nil` mean
NULL: the destination is the **caller's** buffer, so there is no pointer that
could carry absence. Absence has nowhere to go, which is what makes it an error
rather than a spelling.

Every other value keeps the coercion — a type or name still stringifies, and
`write-bytes` of `42` still writes `"42"`. The change is only about `nil`.

**`(load-library nil)` is deliberately untouched**: it is documented to mean "no
name at all, the process's own symbols are already resolvable", which is an
answer rather than a missing one. Its two internal coercion calls turned out to be
unreachable for `nil` anyway — the `cond`'s first clause returns for a nil name,
and the per-OS map branch raises `no :<os> entry in the per-OS spec` first — so I
reverted the guards I had added there rather than ship dead code, and pinned the
no-op in the gate instead.

## One thing I did NOT change

`:pointer` still raises Chez's `invalid foreign-procedure argument
#[jolt-nil-v1]` on `nil`, which leaks Scheme the way `:string` did before #708.
Loud, so not a footgun — and 0.7.24 deliberately kept `ffi/null` as the
`:pointer` spelling of NULL, so I have not blurred that. Wrapping every pointer
argument to improve one message did not seem worth the hot path.

## Gates

Extended the four gates that already own these surfaces rather than adding a
file. Every new check is discriminating — verified by reverting only `ffi.ss` and
re-running:

```
jolt-ffi-string-null-test    4 new checks FAIL before, all pass after
ffi-binding-test.ss          27/28 before (callback-returns-false), 28/28 after
jolt-ffi-scoped-test         4 new checks FAIL before, all pass after
jolt-ffi-bytes-test          1 new check  FAILs before, passes after
jolt-ffi-string-null-test    2 more checks FAIL before, pass after
```

For the round-trip commit the four discriminating checks are: `string->ptr` of
`nil` is NULL, `nil` round-trips, `with-c-string` binds NULL, and the array makes
a `nil` member a NULL entry. The rest are regression guards that must pass both
ways — `""` keeps its own answer, `42` keeps the coercion, freeing the NULL is a
no-op, and the free counts stay 1 and 4.

The argument-side checks assert on the message text, not merely that something
threw: `true`/`42` threw before this too, so a bare `threw?` would have passed
either way and proved nothing about them.

No re-mint: `host/chez/java/ffi.ss` is loaded at runtime and `jolt.ffi` is not one
of the seven stdlib namespaces in `ei-prelude-ns-files`.
