### PR TITLE
io: clojure.java.io/resource accepts a ClassLoader argument

### DIFF
--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -220,6 +220,17 @@ if ! printf '%s' "$got_sbjoin" | grep -q '^sbjoin: a\.b\.c  x$'; then
   echo "--- got ----"; echo "$got_sbjoin"; exit 1
 fi
 
+# The ClassLoader resource surface resolves what io/resource resolves. It used to
+# walk the source roots on its own and never consult the embedded table, so a
+# baked-in resource answered nil through RT/baseLoader while io/resource served
+# it — invisible in the source tree, and only ever wrong in a built binary, which
+# is why the check lives here.
+got_rl="$(cd / && "$out" --resloader 2>&1)"
+if ! printf '%s' "$got_rl" | grep -q '^resloader: true true 1 true true$'; then
+  echo "  FAIL: ClassLoader resource surface — want 'resloader: true true 1 true true'"
+  echo "--- got ----"; echo "$got_rl"; exit 1
+fi
+
 # Portable embed: remove the build-time source tree and run from / — the
 # embedded resource must still resolve (contents baked as literals, not
 # read-file-string at startup).

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1084,6 +1084,29 @@
                   rel)))
     (make-url (string-append "file:" (jfile-abs rel)))))
 
+;; The name argument, or an NPE. The JVM throws NullPointerException for a null
+;; resource name from ClassLoader.getResource / getResources /
+;; getResourceAsStream and Class.getResource alike (probed directly), and
+;; clojure.java.io/resource is a bare .getResource, so it throws too. jolt sent
+;; the name through jolt-str-render-one, the `str` coercion, which renders nil as
+;; "" — and "" is a DIFFERENT question with a real answer, since the empty name is
+;; the classpath root. (io/resource nil) therefore handed back a URL for the first
+;; source root: a caller whose name came from a missing config key or an absent
+;; optional path got a directory, and only found out when something far away tried
+;; to read it. "" itself keeps answering the root, which is what the JVM does with
+;; it — verified, not assumed.
+(define (resource-name-arg name)
+  (if (jolt-nil? name)
+      (throw-jvm (quote NullPointerException) "resource name is nil")
+      (jolt-str-render-one name)))
+
+;; This is THE resource resolver: clojure.java.io/resource and every ClassLoader
+;; method in the java.lang.ClassLoader section below (getResource / getResources /
+;; getResourceAsStream, on the loader and on a Class) answer through it, so all of
+;; them see the embedded branch and announce the same candidates. They used to
+;; walk the roots themselves, which silently made the loader the weaker resolver;
+;; cl-get-resource carries what that cost.
+;;
 ;; Every candidate probed is announced to the AOT cache (io-note-file-read!),
 ;; not just the one that answered — including the ones that were not there. Which
 ;; root wins is part of the answer, so a file appearing at an EARLIER root has to
@@ -1091,14 +1114,8 @@
 ;; resource is finally added (a new migration is exactly that). An embedded
 ;; resource is baked into the binary and covered by the runtime fingerprint, so it
 ;; contributes nothing here.
-;; This is THE resource resolver: clojure.java.io/resource and every ClassLoader
-;; method in the java.lang.ClassLoader section below (getResource / getResources /
-;; getResourceAsStream, on the loader and on a Class) answer through it, so all of
-;; them see the embedded branch and announce the same candidates. They used to
-;; walk the roots themselves, which silently made the loader the weaker resolver;
-;; cl-get-resource carries what that cost.
 (define (resolve-resource name)
-  (let* ((nm (jolt-str-render-one name))
+  (let* ((nm (resource-name-arg name))
          (emb (hashtable-ref embedded-resources nm #f)))
     (if emb (make-embedded-res nm emb)
         (let loop ((roots (get-source-roots)))
@@ -1164,7 +1181,7 @@
 ;; An embedded hit leads, matching the precedence the singular resolver gives it,
 ;; and every candidate is announced for the reason resolve-resource announces.
 (define (cl-get-resources self name)
-  (let* ((nm (jolt-str-render-one name))
+  (let* ((nm (resource-name-arg name))
          (emb (hashtable-ref embedded-resources nm #f)))
     (let loop ((roots (get-source-roots))
                (acc (if emb (list (make-embedded-res nm emb)) '())))
@@ -1214,11 +1231,11 @@
         (cons "getResource"
               (lambda (self name)
                 (cl-get-resource the-classloader
-                                 (class-resource-name (jclass-name self) (jolt-str-render-one name)))))
+                                 (class-resource-name (jclass-name self) (resource-name-arg name)))))
         (cons "getResourceAsStream"
               (lambda (self name)
                 (cl-resource-stream the-classloader
-                                    (class-resource-name (jclass-name self) (jolt-str-render-one name)))))))
+                                    (class-resource-name (jclass-name self) (resource-name-arg name)))))))
 ;; clojure.lang.RT/nextID — process-unique increasing id (AtomicInteger(1)
 ;; getAndIncrement), used by id generators such as core.logic's lvar.
 (define rt-next-id-counter 1)

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1091,15 +1091,13 @@
 ;; resource is finally added (a new migration is exactly that). An embedded
 ;; resource is baked into the binary and covered by the runtime fingerprint, so it
 ;; contributes nothing here.
-;; (resource n) and (resource n loader). The JVM's 2-arity resolves against the
-;; ClassLoader it is handed; jolt has a single "classloader" whose getResource
-;; scans the same source roots this does (see the java.lang.ClassLoader section
-;; below), so every loader resolves the same resources and the argument is
-;; accepted and ignored. Libraries pass it to pin resolution to one loader
-;; across threads — cognitect aws-api's `cognitect.aws.resources/resource` is
-;; (io/resource n (RT/baseLoader)) — and without the arity they fail to load at
-;; all rather than degrading.
-(define (jolt-io-resource name . _loader)
+;; This is THE resource resolver: clojure.java.io/resource and every ClassLoader
+;; method in the java.lang.ClassLoader section below (getResource / getResources /
+;; getResourceAsStream, on the loader and on a Class) answer through it, so all of
+;; them see the embedded branch and announce the same candidates. They used to
+;; walk the roots themselves, which silently made the loader the weaker resolver;
+;; cl-get-resource carries what that cost.
+(define (resolve-resource name)
   (let* ((nm (jolt-str-render-one name))
          (emb (hashtable-ref embedded-resources nm #f)))
     (if emb (make-embedded-res nm emb)
@@ -1111,6 +1109,21 @@
                 (if (file-exists? cand)
                     (resource-file-url (car roots) nm)
                     (loop (cdr roots)))))))))
+
+;; (resource n) and (resource n loader). The JVM's 2-arity resolves against the
+;; ClassLoader it is handed; jolt has a single "classloader" that resolves through
+;; resolve-resource just as this does (see the java.lang.ClassLoader section
+;; below), so every loader resolves the same resources and the argument is
+;; accepted and ignored. Libraries pass it to pin resolution to one loader
+;; across threads — cognitect aws-api's `cognitect.aws.resources/resource` is
+;; (io/resource n (RT/baseLoader)) — and without the arity they fail to load at
+;; all rather than degrading. case-lambda rather than a rest argument so the JVM's
+;; two arities are the only two: (resource n loader extra) is an arity error there
+;; and has to stay one here.
+(define jolt-io-resource
+  (case-lambda
+    ((name) (resolve-resource name))
+    ((name _loader) (resolve-resource name))))
 (def-var! "clojure.java.io" "resource" jolt-io-resource)
 ;; as-url honors a library-registered URL class (e.g. jolt-lang/http-client's full
 ;; java.net.URL shim) so io/as-url and (URL. spec) agree; else the file-only jhost.
@@ -1131,23 +1144,45 @@
 ;; back this loader. Libraries that probe the classpath (e.g. migratus's migration-
 ;; dir discovery) then fall back to the filesystem when a resource isn't a root.
 (define the-classloader (make-jhost "classloader" (vector)))
-(define (cl-get-resource self name)
-  (let ((nm (jolt-str-render-one name)))
-    (let loop ((roots (get-source-roots)))
-      (cond ((null? roots) jolt-nil)
-            ((file-exists? (string-append (car roots) "/" nm))
-             (resource-file-url (car roots) nm))
-            (else (loop (cdr roots)))))))
+;; Straight through to io/resource's resolver. This walked the roots itself until
+;; it was found to be resolving LESS than io/resource did, in two ways that both
+;; only bite where they are hardest to see:
+;;
+;;   - it never consulted embedded-resources, so in a `jolt build` binary with
+;;     :jolt/build :embed a baked-in resource answered nil here while
+;;     (io/resource n) served it. Every classpath-probing library that goes
+;;     through a loader rather than io/resource — .getResourceAsStream on
+;;     RT/baseLoader is the common spelling — therefore saw nothing in the built
+;;     artifact and everything in the source tree it was developed against.
+;;   - it announced no candidate to the AOT cache, so a compile-time lookup
+;;     through a loader was not part of the cache key: exactly the staleness
+;;     jolt#576 fixed for io/resource, still live on this path.
+(define (cl-get-resource self name) (resolve-resource name))
 ;; getResources: every source root that holds the named resource, as file: URLs
 ;; (enumeration-seq just calls seq, so a list serves). ring's static-resource
 ;; symlink check enumerates these to confirm a served file sits under a root.
+;; An embedded hit leads, matching the precedence the singular resolver gives it,
+;; and every candidate is announced for the reason resolve-resource announces.
 (define (cl-get-resources self name)
-  (let ((nm (jolt-str-render-one name)))
-    (let loop ((roots (get-source-roots)) (acc '()))
+  (let* ((nm (jolt-str-render-one name))
+         (emb (hashtable-ref embedded-resources nm #f)))
+    (let loop ((roots (get-source-roots))
+               (acc (if emb (list (make-embedded-res nm emb)) '())))
       (cond ((null? roots) (list->cseq (reverse acc)))
-            ((file-exists? (string-append (car roots) "/" nm))
-             (loop (cdr roots) (cons (resource-file-url (car roots) nm) acc)))
-            (else (loop (cdr roots) acc))))))
+            (else
+             (let ((cand (string-append (car roots) "/" nm)))
+               (io-note-file-read! cand)
+               (if (file-exists? cand)
+                   (loop (cdr roots) (cons (resource-file-url (car roots) nm) acc))
+                   (loop (cdr roots) acc))))))))
+;; The stream for whatever the resolver answered. Both branches of a resolved
+;; resource are java.net.URLs with an openStream — a file: URL reads its target,
+;; an embedded-res hands back its baked content — so dispatching the method is
+;; what makes an embedded hit readable. Stripping the scheme and slurping the
+;; path, which is what this did, only ever worked for the file: branch.
+(define (cl-resource-stream self name)
+  (let ((u (cl-get-resource self name)))
+    (if (jolt-nil? u) jolt-nil (record-method-dispatch u "openStream" jolt-nil))))
 (register-host-methods! "classloader"
   (list (cons "getResource" cl-get-resource)
         (cons "getResources" cl-get-resources)
@@ -1155,10 +1190,7 @@
         ;; JVM's bootstrap loader gives, which terminates the usual
         ;; (take-while identity (iterate #(.getParent %) loader)) walk.
         (cons "getParent" (lambda (self) jolt-nil))
-        (cons "getResourceAsStream"
-              (lambda (self name)
-                (let ((u (cl-get-resource self name)))
-                  (if (jolt-nil? u) jolt-nil (host-new "StringReader" (jolt-slurp (url-strip-scheme (url-spec u))))))))))
+        (cons "getResourceAsStream" cl-resource-stream)))
 (register-class-statics! "java.lang.ClassLoader" (list (cons "getSystemClassLoader" (lambda () the-classloader))))
 ;; clojure.lang.RT/baseLoader — the resource-resolving class loader (RT/baseLoader
 ;; is how libraries reach Clojure's base loader, e.g. aws-api's resources ns).
@@ -1185,9 +1217,8 @@
                                  (class-resource-name (jclass-name self) (jolt-str-render-one name)))))
         (cons "getResourceAsStream"
               (lambda (self name)
-                (let ((u (cl-get-resource the-classloader
-                                          (class-resource-name (jclass-name self) (jolt-str-render-one name)))))
-                  (if (jolt-nil? u) jolt-nil (host-new "StringReader" (jolt-slurp (url-strip-scheme (url-spec u))))))))))
+                (cl-resource-stream the-classloader
+                                    (class-resource-name (jclass-name self) (jolt-str-render-one name)))))))
 ;; clojure.lang.RT/nextID — process-unique increasing id (AtomicInteger(1)
 ;; getAndIncrement), used by id generators such as core.logic's lvar.
 (define rt-next-id-counter 1)

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1091,7 +1091,15 @@
 ;; resource is finally added (a new migration is exactly that). An embedded
 ;; resource is baked into the binary and covered by the runtime fingerprint, so it
 ;; contributes nothing here.
-(define (jolt-io-resource name)
+;; (resource n) and (resource n loader). The JVM's 2-arity resolves against the
+;; ClassLoader it is handed; jolt has a single "classloader" whose getResource
+;; scans the same source roots this does (see the java.lang.ClassLoader section
+;; below), so every loader resolves the same resources and the argument is
+;; accepted and ignored. Libraries pass it to pin resolution to one loader
+;; across threads — cognitect aws-api's `cognitect.aws.resources/resource` is
+;; (io/resource n (RT/baseLoader)) — and without the arity they fail to load at
+;; all rather than degrading.
+(define (jolt-io-resource name . _loader)
   (let* ((nm (jolt-str-render-one name))
          (emb (hashtable-ref embedded-resources nm #f)))
     (if emb (make-embedded-res nm emb)

--- a/test/chez/aot-cache-smoke.sh
+++ b/test/chez/aot-cache-smoke.sh
@@ -480,6 +480,27 @@ else
   echo "FAIL: (q2) cold='$q2_cold' (want none) after-add='$q2_warm' (want appeared)"; fails=$((fails+1))
 fi
 
+# (q3) the same probe through a ClassLoader. RT/baseLoader's getResource is the
+# other spelling of the same lookup, and libraries that reach the classpath
+# rather than clojure.java.io use it — but it walked the roots on its own and
+# announced nothing, so a compile-time probe through it was invisible to the key
+# and an added resource kept serving the "not there" answer. It resolves through
+# io/resource's resolver now, so it announces what that announces.
+printf '(ns proj.clopt)\n(defmacro embed [] (if-let [u (.getResource (clojure.lang.RT/baseLoader) "clopt.sql")] (slurp u) "none"))\n(defn run [] (embed))\n' > "$q/src/proj/clopt.clj"
+q3run() {
+  JOLT_AOT_CACHE=1 JOLT_CACHE_DIR="$cache" JOLT_QUIET=1 "$jolt" -e "
+    (require 'jolt.deps) (jolt.deps/add-deps {:deps {'proj/proj {:local/root \"$q\"}}})
+    (require 'proj.clopt) (println (proj.clopt/run))" 2>/dev/null | tail -1
+}
+q3_cold="$(q3run)"
+printf 'appeared' > "$q/resources/clopt.sql"
+q3_warm="$(q3run)"
+if [ "$q3_cold" = "none" ] && [ "$q3_warm" = "appeared" ]; then
+  echo "PASS: (q3) an added resource invalidated the ns that probed the loader"; pass=$((pass+1))
+else
+  echo "FAIL: (q3) cold='$q3_cold' (want none) after-add='$q3_warm' (want appeared)"; fails=$((fails+1))
+fi
+
 # (r) the read happens while compiling the CONSUMER (the macro lives one
 # namespace away), so the resource belongs to the consumer's key, and editing it
 # has to move that key even though neither .clj changed.

--- a/test/chez/build-app/src/app/core.clj
+++ b/test/chez/build-app/src/app/core.clj
@@ -37,6 +37,22 @@
                         (util/redef-fn)))
     (println "dyn:" (binding [util/*config* :bound]
                       util/*config*)))
+  ;; --resloader: the ClassLoader surface must resolve exactly what io/resource
+  ;; resolves, INCLUDING a resource baked into this binary. It used to walk the
+  ;; source roots on its own and never look at the embedded table, so every
+  ;; classpath-probing library that reaches resources through RT/baseLoader
+  ;; rather than clojure.java.io found nothing in a built artifact and everything
+  ;; in the source tree it was developed against. Only a built binary has an
+  ;; embedded resource, so this is the only place the claim can be checked.
+  (when (= (first args) "--resloader")
+    (let [cl (clojure.lang.RT/baseLoader)]
+      (println "resloader:"
+               (= (str (io/resource "greeting.txt")) (str (.getResource cl "greeting.txt")))
+               (= (slurp (io/resource "greeting.txt"))
+                  (slurp (.getResourceAsStream cl "greeting.txt")))
+               (count (enumeration-seq (.getResources cl "greeting.txt")))
+               (some? (.getResource String "/greeting.txt"))
+               (nil? (.getResource cl "no-such-resource.txt")))))
   ;; the resource is baked into the binary (deps.edn :jolt/build :embed), so this
   ;; resolves with no resources/ dir on disk, run from any cwd.
   (println (slurp (io/resource "greeting.txt")))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -291,6 +291,10 @@
   ;; Restores the roots in a finally: set-source-roots! is global, and leaving a
   ;; temp dir as the only root breaks every later row that needs to require.
   {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/joltresunit\") prior (jolt.host/source-roots)] (.mkdirs (io/file d)) (spit (io/file d \"probe.txt\") \"hello\") (try (jolt.host/set-source-roots! [d]) (let [u (io/resource \"probe.txt\")] [(instance? java.net.URL u) (.getName (class u)) (slurp u) (io/resource \"absent.txt\")]) (finally (jolt.host/set-source-roots! prior)))))" :expected "[true \"java.net.URL\" \"hello\" nil]"}
+  ;; The 2-arity (resource n loader) resolves the same as the 1-arity: jolt has
+  ;; one source-root classloader, so the loader argument is accepted and
+  ;; ignored. cognitect aws-api calls it this way and used to fail to load.
+  {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/joltresloader\") prior (jolt.host/source-roots)] (.mkdirs (io/file d)) (spit (io/file d \"probe2.txt\") \"hello\") (try (jolt.host/set-source-roots! [d]) [(slurp (io/resource \"probe2.txt\" (clojure.lang.RT/baseLoader))) (= (str (io/resource \"probe2.txt\")) (str (io/resource \"probe2.txt\" nil))) (io/resource \"absent2.txt\" (clojure.lang.RT/baseLoader))] (finally (jolt.host/set-source-roots! prior)))))" :expected "[\"hello\" true nil]"}
   ;; a file: URL is a first-class source — slurp / .openStream / io/reader /
   ;; io/input-stream read its bytes (verified by content, not type) and io/file
   ;; strips the scheme. All five must hold before io/resource can return a URL.

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -298,6 +298,18 @@
   ;; The JVM's resource has exactly two arities, so a third argument is an arity
   ;; error there and must stay one here — a rest argument would have swallowed it.
   {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (io/resource \"probe.txt\" nil nil))" :expected :throws}
+  ;; A nil resource name is an NPE on the JVM — from io/resource and from every
+  ;; ClassLoader method — because nil is a MISSING name, not the empty one. It
+  ;; used to render as "" through the str coercion, and "" is the classpath root,
+  ;; so the answer was a URL for the first source root. "" keeps that answer,
+  ;; which is the JVM's.
+  {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (io/resource nil))" :expected :throws}
+  {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (io/resource nil (clojure.lang.RT/baseLoader)))" :expected :throws}
+  {:suite "ioreader" :expr "(.getResource (clojure.lang.RT/baseLoader) nil)" :expected :throws}
+  {:suite "ioreader" :expr "(.getResourceAsStream (clojure.lang.RT/baseLoader) nil)" :expected :throws}
+  {:suite "ioreader" :expr "(.getResources (clojure.lang.RT/baseLoader) nil)" :expected :throws}
+  {:suite "ioreader" :expr "(.getResource String nil)" :expected :throws}
+  {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/joltresnil\") prior (jolt.host/source-roots)] (.mkdirs (io/file d)) (try (jolt.host/set-source-roots! [d]) (some? (io/resource \"\")) (finally (jolt.host/set-source-roots! prior)))))" :expected "true"}
   ;; Every ClassLoader resource method answers through io/resource's resolver, so
   ;; the loader surface resolves neither more nor less than io/resource does:
   ;; getResource agrees on the URL, getResourceAsStream reads the same content,

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -295,6 +295,16 @@
   ;; one source-root classloader, so the loader argument is accepted and
   ;; ignored. cognitect aws-api calls it this way and used to fail to load.
   {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/joltresloader\") prior (jolt.host/source-roots)] (.mkdirs (io/file d)) (spit (io/file d \"probe2.txt\") \"hello\") (try (jolt.host/set-source-roots! [d]) [(slurp (io/resource \"probe2.txt\" (clojure.lang.RT/baseLoader))) (= (str (io/resource \"probe2.txt\")) (str (io/resource \"probe2.txt\" nil))) (io/resource \"absent2.txt\" (clojure.lang.RT/baseLoader))] (finally (jolt.host/set-source-roots! prior)))))" :expected "[\"hello\" true nil]"}
+  ;; The JVM's resource has exactly two arities, so a third argument is an arity
+  ;; error there and must stay one here — a rest argument would have swallowed it.
+  {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (io/resource \"probe.txt\" nil nil))" :expected :throws}
+  ;; Every ClassLoader resource method answers through io/resource's resolver, so
+  ;; the loader surface resolves neither more nor less than io/resource does:
+  ;; getResource agrees on the URL, getResourceAsStream reads the same content,
+  ;; getResources enumerates the one root holding it, Class.getResource takes an
+  ;; absolute "/name", and an absent name is nil on all of them. (The embedded
+  ;; branch of the same claim needs a built binary — build-smoke's --resloader.)
+  {:suite "ioreader" :expr "(do (require (quote [clojure.java.io :as io])) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/joltrescl\") prior (jolt.host/source-roots)] (.mkdirs (io/file d)) (spit (io/file d \"probe3.txt\") \"hello\") (try (jolt.host/set-source-roots! [d]) (let [cl (clojure.lang.RT/baseLoader)] [(= (str (io/resource \"probe3.txt\")) (str (.getResource cl \"probe3.txt\"))) (slurp (.getResourceAsStream cl \"probe3.txt\")) (count (enumeration-seq (.getResources cl \"probe3.txt\"))) (= (str (io/resource \"probe3.txt\")) (str (.getResource String \"/probe3.txt\"))) [(.getResource cl \"absent3.txt\") (.getResourceAsStream cl \"absent3.txt\")]]) (finally (jolt.host/set-source-roots! prior)))))" :expected "[true \"hello\" 1 true [nil nil]]"}
   ;; a file: URL is a first-class source — slurp / .openStream / io/reader /
   ;; io/input-stream read its bytes (verified by content, not type) and io/file
   ;; strips the scheme. All five must hold before io/resource can return a URL.


### PR DESCRIPTION
## What

Three commits on the resource-resolution path, the second and third found while reviewing the first.

**1. `(io/resource n loader)` threw `Wrong number of args (2)`** — `jolt-io-resource` only took the name. Libraries pass a loader to pin resource resolution to one loader across threads, and they do it at namespace load, so the missing arity is a *load* failure rather than a degraded call. cognitect aws-api's `cognitect.aws.resources/resource` is exactly `(io/resource n (RT/baseLoader))`, which made every `cognitect.aws.*` namespace unloadable:

```
Unhandled exception: Wrong number of args (2) passed to: clojure.java.io/resource
  cognitect.aws.resources/resource (.../cognitect/aws/resources.clj:19)
  cognitect.aws.service/descriptor-resource (.../cognitect/aws/service.clj:21)
  cognitect.aws.client.api/client (.../cognitect/aws/client/api.clj:73)
```

The loader argument is accepted and ignored, the same treatment `.setDaemon` gets on the `Thread` shim. With this, `(aws/client {:api :kms :region "us-east-1"})` and `{:api :s3 ...}` both build, and the KMS/S3 service descriptors load (52 and 99 ops).

**2. That justification did not hold, so the second commit makes it true.** "jolt has one classloader that resolves the same resources io/resource does" was the whole basis for ignoring the argument — but `cl-get-resource` walked the source roots itself, and that copy was missing two things the real resolver has:

- **the embedded-resources branch.** In a `jolt build` binary with `:jolt/build :embed`, a baked-in resource answered `nil` through `RT/baseLoader` while `(io/resource n)` served it. Libraries that reach the classpath through a loader rather than `clojure.java.io` — `.getResourceAsStream` on `RT/baseLoader` is the usual spelling — found nothing in the built artifact and everything in the source tree they were developed against.
- **`io-note-file-read!`.** A compile-time lookup through a loader announced no candidate, so it never entered the AOT cache key and an added resource kept serving the "not there" answer — the staleness jolt#576 fixed for `io/resource`, still live on this path.

`getResource`, `getResources`, `getResourceAsStream` and the two `Class` arms now all answer through one `resolve-resource`. `getResourceAsStream` dispatches `openStream` on what that returned instead of stripping the scheme and slurping the path, which is what makes an embedded hit readable at all.

`resource` itself becomes a `case-lambda`: the JVM has exactly two arities, so `(resource n loader extra)` is an arity error there, and a rest argument was quietly accepting it.

**3. A nil resource name answered the classpath root.** The name went through `jolt-str-render-one`, the `str` coercion, which renders nil as `""` — and `""` is a name with a real answer, since the empty name *is* the classpath root. So `(io/resource nil)`, and the same on every loader method, handed back a URL for the first source root. A name that came from a missing config key or an absent optional path became a directory, and the caller only found out somewhere far away, when something tried to read it. The JVM throws `NullPointerException` from all four (probed directly, not assumed); `""` keeps answering the root on both, so only nil changes.

## Tests

`make test` passes. Gates, each verified discriminating by reverting only `io.ss`:

- `ioreader` rows in `unit.edn`: the 2-arity reads a resource off a source root and agrees with the 1-arity on the URL; a third argument is an arity error; the loader surface agrees with `io/resource` on URL, content, enumeration and the absent case; nil raises from each of the six entry points (five discriminating — `.getResourceAsStream` already threw, but from slurping the directory it had resolved rather than from the nil), and `""` still answers the root.
- `build-smoke --resloader`: the embedded half of the loader claim. Only a built binary has an embedded resource, so nowhere else can check it. Fails before as `Cannot open <nil> as a Reader`.
- `(q3)` in `aot-cache-smoke`: a resource added after a compile-time probe through `RT/baseLoader` invalidates the namespace that probed. Fails before with `after-add='none'`.

`host/chez/java/` has no Gambit counterpart, so no `make gambitgen`; no new `def-var!`, so no manifest line.

## Not fixed here

aws-api still does not run end-to-end on jolt, for a second and unrelated reason: **a jar containing no `.clj` is dropped from the resolved source roots**, so a resource-only artifact is unreachable.

```
$ echo '{:deps {com.cognitect.aws/endpoints {:mvn/version "1.1.12.504"}}}' > deps.edn
$ jolt -Spath
./src
$ jolt -Stree | grep endpoints
com.cognitect.aws/endpoints 1.1.12.504
```

The jar *is* extracted (`.../endpoints-1.1.12.504.jar.jolt/cognitect/aws/endpoints.edn` exists) and `-Stree` lists it, but its extraction never reaches `-Spath`, so `(io/resource "cognitect/aws/endpoints.edn")` answers `nil` and `cognitect.aws.endpoint/read-endpoints-description` throws inside a `go` block — which surfaces as a hang, since the result channel closes with nothing on it. Worth its own issue.
