### PR TITLE
core: expose compatibility vars used by hosted Clojure libraries

### DIFF
--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -617,7 +617,8 @@
     (cons "min" min) (cons "max" max)
     (cons "mod" modulo) (cons "rem" remainder) (cons "quot" quotient)
     (cons "vector" jolt-vector) (cons "hash-map" jolt-hash-map) (cons "hash-set" jolt-hash-set)
-    (cons "conj" jolt-conj) (cons "get" jolt-get) (cons "nth" jolt-nth) (cons "count" jolt-count)
+    (cons "conj" jolt-conj) (cons "imap-cons" jolt-conj)
+    (cons "get" jolt-get) (cons "nth" jolt-nth) (cons "count" jolt-count)
     (cons "assoc" jolt-assoc) (cons "dissoc" jolt-dissoc) (cons "contains?" jolt-contains?)
     (cons "empty?" jolt-empty?) (cons "peek" jolt-peek) (cons "pop" jolt-pop)
     (cons "first" jolt-first) (cons "rest" jolt-rest) (cons "next" jolt-next) (cons "seq" jolt-seq)
@@ -654,6 +655,7 @@
 (def-var! "clojure.core" "refer" jolt-refer)
 (def-var! "clojure.core" "refer-clojure" jolt-refer-clojure)
 (mark-macro! "clojure.core" "refer-clojure")
+(def-var! "clojure.core" "system-newline" "\n")
 ;; Runtime half of the refer-clojure macro: the expansion calls this AFTER the
 ;; enclosing ns form's in-ns has switched chez-current-ns (see jolt-refer-clojure).
 (def-var! "clojure.core" "refer-clojure-register!" jolt-refer-clojure-register!)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -423,6 +423,8 @@
   {:suite "ns" :expr "(do (in-ns 'my.ns) (symbol? 'x))" :expected "true"}
   {:suite "ns" :expr "(str (ns-name *ns*))" :expected "\"user\""}
   {:suite "ns" :expr "(var? (find-var 'clojure.core/map))" :expected "true"}
+  {:suite "ns / core compatibility" :expr "(let [v (find-var 'clojure.core/imap-cons)] (and (var? v) (= {:a 1 :b 2} ((var-get v) {:a 1} [:b 2]))))" :expected "true"}
+  {:suite "ns / core compatibility" :expr "(let [v (find-var 'clojure.core/system-newline)] (and (var? v) (= \"\\n\" (var-get v))))" :expected "true"}
   {:suite "ns" :expr "(= 'user (ns-name (the-ns 'user)))" :expected "true"}
   {:suite "ns" :expr "(= 'foo.bar (ns-name (create-ns 'foo.bar)))" :expected "true"}
   {:suite "reader" :expr "(= 42 (read-string \"42\"))" :expected "true"}


### PR DESCRIPTION
## Summary

Expose the private `clojure.core/imap-cons` and
`clojure.core/system-newline` Vars used by ordinary hosted Clojure library
code paths.

`imap-cons` reuses Jolt's existing map-conj implementation.
`system-newline` uses Jolt's portable newline convention.

SCI provided the concrete compatibility pressure, but both changes are tested
directly as Jolt behavior.

## Tests

- Added direct unit cases proving each Var resolves and behaves correctly.
- Both cases fail on pristine upstream and pass with this change.
- `make unit`
- `make selfhost` (exact fixpoint)

All local Jolt commands used Chez 10.4.1.
