### PR TITLE
java: support Thread.getId

### DIFF
--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1268,6 +1268,7 @@
 (register-host-methods! "thread"
   (list (cons "getContextClassLoader" (lambda (self) the-classloader))
         (cons "getName" (lambda (self) "main"))
+        (cons "getId" (lambda (self) (get-thread-id)))
         ;; no reified call stack (jolt does TCO, so caller frames are erased) — an
         ;; empty StackTraceElement[]. clojure.spec.test.alpha's instrument reads it
         ;; to name the caller var; it degrades to no ::caller, the conform error

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -162,6 +162,8 @@
   {:suite "interrupt" :expr "(let [t (jolt.host/make-interrupt)] (jolt.host/interrupt! t) (try (jolt.host/run-interruptible t (fn [] (loop [i 0] (recur (inc i))))) :not-interrupted (catch :default e (:jolt/interrupted (ex-data e)))))" :expected "true"}
   {:suite "interrupt" :expr "(do (Thread/yield) :ok)" :expected ":ok"}
   {:suite "interrupt" :expr "(nil? (Thread/yield))" :expected "true"}
+  {:suite "threads / id" :expr "(let [t (Thread/currentThread) a (.getId t) b (.getId t)] (and (integer? a) (= a b)))" :expected "true"}
+  {:suite "threads / id" :expr "(let [current-id (.getId (Thread/currentThread)) ready (java.util.concurrent.CountDownLatch. 1) release (java.util.concurrent.CountDownLatch. 1) f (future (let [id (.getId (Thread/currentThread))] (.countDown ready) (.await release 5 java.util.concurrent.TimeUnit/SECONDS) id))] (.await ready 5 java.util.concurrent.TimeUnit/SECONDS) (.countDown release) (let [child-id (deref f)] (and (integer? child-id) (not= current-id child-id))))" :expected "true"}
   {:suite "interrupt" :expr "(.isInterrupted (Thread/currentThread))" :expected "false"}
   {:suite "interrupt" :expr "(let [t (Thread/currentThread)] (.interrupt t) (.isInterrupted t))" :expected "true"}
   {:suite "interrupt" :expr "(let [t (Thread/currentThread)] (.interrupt t) [(.isInterrupted t) (.isInterrupted t)])" :expected "[true true]"}


### PR DESCRIPTION
## Summary

Add `Thread.getId` compatibility using Jolt's stable numeric identity for the
running thread. This is the surface SCI reaches during Context initialization;
it does not claim JVM Thread semantics beyond Jolt's thread model.

## Tests

- Direct unit coverage for numeric, repeatable current-thread identity.
- Direct coverage that simultaneously live threads observe distinct IDs.
- Both cases fail on pristine upstream and pass with this change.
- `make unit`
- `make threadsafety`
- `make fibers`
- `make selfhost` (exact fixpoint)

All local Jolt commands used Chez 10.4.1.
