### PR TITLE
java: add clojure.lang.Numbers statics used by hosted libraries

### DIFF
--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -271,7 +271,16 @@
 (register-class-statics! "BigInt" identity-num-statics)
 (register-class-statics! "clojure.lang.BigInt" identity-num-statics)
 (register-class-statics! "clojure.lang.Numbers"
-  (list (cons "reduceBigInt" (lambda (x) x)) (cons "toRatio" (lambda (x) x))))
+  (list (cons "reduceBigInt" (lambda (x) x)) (cons "toRatio" (lambda (x) x))
+        (cons "inc" jolt-inc) (cons "dec" jolt-dec)
+        (cons "unchecked_inc" jolt-uncinc) (cons "unchecked_dec" jolt-uncdec)
+        (cons "isZero" jolt-zero?) (cons "isPos" jolt-pos?) (cons "isNeg" jolt-neg?)
+        (cons "add" jolt-add2) (cons "minus" jolt-sub2) (cons "multiply" jolt-mul2)
+        (cons "unchecked_add" jolt-uncadd2) (cons "unchecked_minus" jolt-uncsub2)
+        (cons "unchecked_multiply" jolt-uncmul2) (cons "remainder" jolt-rem)
+        (cons "lt" jolt-lt2) (cons "gt" jolt-gt2)
+        (cons "lte" jolt-le2) (cons "gte" jolt-ge2)
+        (cons "equiv" jolt-num-equiv)))
 
 (define (now-millis)
   (let ((t (current-time 'time-utc)))
@@ -1024,4 +1033,3 @@
 (for-each (lambda (nm)
             (register-class-ctor! nm (lambda _ (lambda (rdr . _) (lrsr-read-literal rdr)))))
           '("LispReader$StringReader" "clojure.lang.LispReader$StringReader"))
-

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -335,6 +335,12 @@
   {:suite "javastatic" :expr "(Math/sqrt 16)" :expected "4.0"}
   {:suite "javastatic" :expr "(Math/abs -3)" :expected "3"}
   {:suite "javastatic" :expr "(Math/max 2 7)" :expected "7"}
+  {:suite "javastatic / Numbers" :expr "[(clojure.lang.Numbers/inc 41) (clojure.lang.Numbers/dec -1) (clojure.lang.Numbers/unchecked_inc 9) (clojure.lang.Numbers/unchecked_dec 9)]" :expected "[42 -2 10 8]"}
+  {:suite "javastatic / Numbers" :expr "[(clojure.lang.Numbers/isZero 0) (clojure.lang.Numbers/isPos 1/2) (clojure.lang.Numbers/isNeg -1)]" :expected "[true true true]"}
+  {:suite "javastatic / Numbers" :expr "[(clojure.lang.Numbers/add 2 3) (clojure.lang.Numbers/minus 2 3) (clojure.lang.Numbers/multiply 6 7) (clojure.lang.Numbers/remainder -7 3)]" :expected "[5 -1 42 -1]"}
+  {:suite "javastatic / Numbers" :expr "[(clojure.lang.Numbers/add 1 1/2) (clojure.lang.Numbers/multiply 3 1/2) (clojure.lang.Numbers/add 100000000000000000000 1)]" :expected "[3/2 3/2 100000000000000000001N]"}
+  {:suite "javastatic / Numbers" :expr "[(clojure.lang.Numbers/unchecked_inc Long/MAX_VALUE) (clojure.lang.Numbers/unchecked_dec Long/MIN_VALUE) (clojure.lang.Numbers/unchecked_add Long/MAX_VALUE 1) (clojure.lang.Numbers/unchecked_minus Long/MIN_VALUE 1) (clojure.lang.Numbers/unchecked_multiply Long/MAX_VALUE 2)]" :expected "[-9223372036854775808 9223372036854775807 -9223372036854775808 9223372036854775807 -2]"}
+  {:suite "javastatic / Numbers" :expr "[(clojure.lang.Numbers/lt 1 2) (clojure.lang.Numbers/gt 2.0 1) (clojure.lang.Numbers/lte 2 2) (clojure.lang.Numbers/gte 3/2 1) (clojure.lang.Numbers/equiv 3 3.0) (clojure.lang.Numbers/equiv 3 4)]" :expected "[true true true true true false]"}
   {:suite "javastatic" :expr "(pos? Long/MAX_VALUE)" :expected "true"}
   {:suite "javastatic" :expr "(String/valueOf 42)" :expected "\"42\""}
   {:suite "javastatic" :expr "(String/valueOf \"hi\")" :expected "\"hi\""}


### PR DESCRIPTION
## Summary

Add only the 19 `clojure.lang.Numbers` statics emitted by the pinned SCI
analyzer. Checked, unchecked, comparison, remainder, and numeric-equivalence
calls route through Jolt's existing numeric tower operations.

This does not claim complete `Numbers` parity.

## Tests

- Direct coverage for unary operations, predicates, arithmetic, remainder,
  mixed and large numbers, unchecked 64-bit wrapping, comparisons, and numeric
  equivalence.
- All six grouped cases fail on pristine upstream and pass with this change.
- `make unit`
- `make numeric` (124/124)
- `make oparity` (263/263)
- `make sci` (accepted source-loading floor)
- `make selfhost` (exact fixpoint)

All local Jolt commands used Chez 10.4.1.
