### PR TITLE
fix(concurrency): restore outer polling after nested run-interruptible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscali
   inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck shelloutcheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
-  certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer threadsafety
+  certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety
 TEST-GATES := submodules selfhost ci
 
 GATE-RECEIPT := target/gate-receipt
@@ -272,6 +272,12 @@ fibers:
 # cleared before an idle wait forked a second immortal timer per call.
 asynctimer:
 	@$(CHEZ) --script test/chez/async-timer-test.ss
+
+# A nested run-interruptible extent restores the enclosing polling timer after
+# normal return, exception, or interruption, without sharing ownership between
+# application threads.
+interruptnest:
+	@$(CHEZ) --script test/chez/interrupt-nesting-test.ss
 
 # The dynamic-var binding stack (jolt-3bo): lookup cost against binding DEPTH and
 # against the number of vars in one frame, push/pop throughput, and the two

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1180,12 +1180,23 @@
 (define (jolt-make-interrupt) (box #f))
 (define (jolt-interrupt! token) (when (box? token) (set-box! token #t)) jolt-nil)
 (define (jolt-interrupted? token) (and (box? token) (unbox token) #t))
+;; Active timer borrows form a dynamic stack per application thread. Chez child
+;; threads inherit thread-parameter values, so owner-tag it: an inherited stack
+;; is empty in the child and cannot make the child poll a parent's token.
+(define interrupt-poll-stack (make-thread-parameter (cons #f '())))
+(define (current-interrupt-poll-stack)
+  (let ((state (interrupt-poll-stack)) (owner (get-thread-id)))
+    (if (and (pair? state) (eqv? (car state) owner)) (cdr state) '())))
 (define (jolt-run-interruptible token thunk)
   ;; Captured ONCE, outside the wind: a before-thunk that re-read it would, on a
   ;; resume, save the handler the SCHEDULER had put back and restore that on the
   ;; real exit — the borrow would hand the carrier its own handler a second time
   ;; and lose whatever an enclosing borrow had installed.
   (let* ((prev-handler (timer-interrupt-handler))
+         ;; Captured once, like prev-handler. On a real off-fiber exit from a
+         ;; nested borrow the restored outer handler needs a fresh poll tick.
+         (owner (get-thread-id))
+         (outer-stack (current-interrupt-poll-stack))
          ;; --- handing the quantum back DURING the borrow (jolt-449m) -----------
          ;; jolt-ly62 stopped the borrow outliving itself. What was still open is
          ;; the extent of the borrow: the handler below answered a quantum by
@@ -1220,8 +1231,8 @@
                 (dynamic-wind
                   (lambda ()
                     (set! borrowed 0)
-                    (timer-interrupt-handler
-                      (lambda ()
+                    (let ((handler
+                           (lambda ()
                         (cond
                           ((and (box? token) (unbox token)) (k interrupt-sentinel))
                           (else
@@ -1243,12 +1254,15 @@
                              ;; nothing AND does not re-arm, so calling it there
                              ;; would leave the borrow with no timer and stop the
                              ;; interrupt from ever being noticed.
-                             ((and (jolt-current-fiber)
-                                   (fx>=? borrowed (jolt-fiber-preempt-ticks)))
-                              (set! borrowed 0)
-                              (jolt-fiber-preempt-handler))
-                             (else (arm!) (void)))))))
-                    (arm!))
+                              ((and (jolt-current-fiber)
+                                    (fx>=? borrowed (jolt-fiber-preempt-ticks)))
+                               (set! borrowed 0)
+                               (jolt-fiber-preempt-handler))
+                              (else (arm!) (void))))))))
+                      ;; Push is the timer-frame ownership linearization point.
+                      (interrupt-poll-stack (cons owner (cons handler outer-stack)))
+                      (timer-interrupt-handler handler)
+                      (arm!)))
                   (lambda () (thunk))
                   ;; Runs on every way out of the body, the park included. Disarm
                   ;; BEFORE restoring the handler: the other order leaves a window
@@ -1256,12 +1270,21 @@
                   ;; handler, which answers it by preempting.
                   (lambda ()
                     (set-timer 0)
+                    ;; Pop before restoring the enclosing handler. Every terminal
+                    ;; path (return, throw, interrupt, and park unwind) comes here.
+                    (interrupt-poll-stack (cons owner outer-stack))
                     (timer-interrupt-handler prev-handler)
                     ;; Off a fiber, and on a park (the current-fiber vreg is
                     ;; already cleared by then), this is a plain disarm — which is
                     ;; what the scheduler wants for the carrier it is about to take
                     ;; back. On a real exit from a fiber it re-arms the quantum.
-                    (jolt-fiber-rearm-preempt!)))))))
+                    ;; On a park, enclosing winds immediately disarm this tick;
+                    ;; on a real off-fiber nested exit it keeps the outer token
+                    ;; polling. Fiber exits retain the scheduler rearm behavior.
+                    (cond
+                      ((jolt-current-fiber) (jolt-fiber-rearm-preempt!))
+                      ((pair? outer-stack) (set-timer interrupt-check-ticks))
+                      (else (jolt-fiber-rearm-preempt!)))))))))
     (if (eq? r interrupt-sentinel)
         (jolt-throw (jolt-ex-info "Evaluation interrupted" (jolt-hash-map jolt-kw-interrupted #t)))
         r)))

--- a/test/chez/interrupt-nesting-test.ss
+++ b/test/chez/interrupt-nesting-test.ss
@@ -1,0 +1,161 @@
+;; Nested run-interruptible timer restoration regression. Run from repo root:
+;;   chez --script test/chez/interrupt-nesting-test.ss
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define total 0)
+(define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred
+    (set! fails (+ fails 1))
+    (printf "FAIL: ~a~n" name)))
+
+(define (interrupted-condition? e)
+  (let ((v (jolt-unwrap-throw e)))
+    (and (jolt-ex-info-record? v)
+         (string=? "Evaluation interrupted" (jolt-ex-info-record-message v))
+         (eq? #t (jolt-get (jolt-ex-info-record-data v)
+                           jolt-kw-interrupted #f)))))
+
+;; #(ready? done? result mutex condition). Ready is published only after the
+;; inner extent exits, so an outer interrupt then requires restored polling.
+(define (make-probe-state)
+  (vector #f #f #f (make-mutex) (make-condition)))
+(define (probe-signal-ready! state)
+  (with-mutex (vector-ref state 3)
+    (vector-set! state 0 #t)
+    (condition-broadcast (vector-ref state 4))))
+(define (probe-finish! state result)
+  (with-mutex (vector-ref state 3)
+    (vector-set! state 2 result)
+    (vector-set! state 1 #t)
+    (condition-broadcast (vector-ref state 4))))
+(define (probe-wait state index ms)
+  (let ((deadline (ms->deadline ms)))
+    (with-mutex (vector-ref state 3)
+      (let loop ()
+        (cond ((vector-ref state index) #t)
+              ((condition-wait (vector-ref state 4)
+                               (vector-ref state 3) deadline)
+               (loop))
+              (else (and (vector-ref state index) #t)))))))
+(define (probe-done? state)
+  (with-mutex (vector-ref state 3) (and (vector-ref state 1) #t)))
+
+(define inner-throw-sentinel (list 'inner-throw-sentinel))
+(define (spin-forever) (let loop () (loop)))
+
+(define (start-probe mode)
+  (let ((outer-token (jolt-make-interrupt))
+        (inner-token (jolt-make-interrupt))
+        (state (make-probe-state)))
+    (let ((thread
+           (fork-thread
+            (lambda ()
+              (let ((result
+                     (guard (e (#t e))
+                       (jolt-run-interruptible
+                        outer-token
+                        (lambda ()
+                          (case mode
+                            ((normal)
+                             (unless (eq? 'inner-value
+                                          (jolt-run-interruptible
+                                           inner-token
+                                           (lambda () 'inner-value)))
+                               (error 'interrupt-nesting-test
+                                      "normal inner result changed")))
+                            ((throw)
+                             (unless
+                                 (guard (e (#t (eq? e inner-throw-sentinel)))
+                                   (jolt-run-interruptible
+                                    inner-token
+                                    (lambda () (raise inner-throw-sentinel)))
+                                   #f)
+                               (error 'interrupt-nesting-test
+                                      "inner throw did not propagate unchanged")))
+                            ((interrupt)
+                             (jolt-interrupt! inner-token)
+                             (unless
+                                 (guard (e (#t (interrupted-condition? e)))
+                                   (jolt-run-interruptible inner-token spin-forever)
+                                   #f)
+                               (error 'interrupt-nesting-test
+                                      "inner interrupt marker missing")))
+                            (else
+                             (error 'interrupt-nesting-test
+                                    "unknown probe mode" mode)))
+                          (probe-signal-ready! state)
+                          (spin-forever)))
+                       'outer-returned-without-interrupt)))
+                (probe-finish! state result))))))
+      (vector outer-token state thread))))
+
+(define (probe-token probe) (vector-ref probe 0))
+(define (probe-state probe) (vector-ref probe 1))
+(define (probe-thread probe) (vector-ref probe 2))
+
+(define (require-ready! label probe)
+  (unless (probe-wait (probe-state probe) 0 5000)
+    (printf "FAIL: ~a did not reach its post-inner outer extent~n" label)
+    ;; Chez has no safe force-stop for a failed spinning worker.
+    (exit 1)))
+(define (interrupt-and-require-done! label probe)
+  (jolt-interrupt! (probe-token probe))
+  (unless (probe-wait (probe-state probe) 1 5000)
+    (printf "FAIL: ~a outer token was not polled after inner exit~n" label)
+    (exit 1))
+  (thread-join (probe-thread probe))
+  (ok (string-append label " restores outer token polling")
+      (interrupted-condition? (vector-ref (probe-state probe) 2))))
+
+;; Every terminal path through an inner dynamic extent restores the outer frame.
+(for-each
+ (lambda (entry)
+   (let* ((mode (car entry)) (label (cdr entry)) (probe (start-probe mode)))
+     (require-ready! label probe)
+     (interrupt-and-require-done! label probe)))
+ '((normal . "normal inner return")
+   (throw . "inner throw")
+   (interrupt . "inner interruption")))
+
+;; Workers own disjoint timer stacks and tokens. No scheduling fairness beyond
+;; each forked OS thread eventually running is assumed.
+(let ((a (start-probe 'normal)) (b (start-probe 'normal)))
+  (require-ready! "concurrent worker A" a)
+  (require-ready! "concurrent worker B" b)
+  (jolt-interrupt! (probe-token a))
+  (unless (probe-wait (probe-state a) 1 5000)
+    (printf "FAIL: concurrent worker A did not observe its token~n")
+    (exit 1))
+  (thread-join (probe-thread a))
+  (sleep (ms->duration 50))
+  (ok "interrupting worker A does not interrupt worker B"
+      (not (probe-done? (probe-state b))))
+  (ok "concurrent worker A reports interruption"
+      (interrupted-condition? (vector-ref (probe-state a) 2)))
+  (interrupt-and-require-done! "concurrent worker B" b))
+
+;; Thread parameters are inherited. A child can see the raw stack value, but it
+;; must not treat the parent's active polling extent as its own.
+(let ((child-effective-stack #f))
+  (jolt-run-interruptible
+   (jolt-make-interrupt)
+   (lambda ()
+     (let ((child (fork-thread
+                   (lambda ()
+                     (set! child-effective-stack
+                           (current-interrupt-poll-stack))))))
+       (thread-join child))))
+  (ok "child thread does not inherit effective polling ownership"
+      (null? child-effective-stack)))
+
+;; No handler/token state leaks into later work on the test thread.
+(ok "normal run-interruptible remains healthy"
+    (= 42 (jolt-run-interruptible (jolt-make-interrupt) (lambda () 42))))
+(ok "runtime compile/eval remains healthy"
+    (= 42 (jnum->exact (jolt-compile-eval "(+ 20 22)" "user"))))
+
+(printf "~a/~a interrupt nesting assertions passed~n" (- total fails) total)
+(exit (if (zero? fails) 0 1))


### PR DESCRIPTION
## Summary

Track active interrupt polling extents in an owner-tagged per-thread stack.
When a nested off-fiber extent exits, rearm the restored outer handler;
inherited thread-parameter state does not give a child thread ownership of its
parent's extent.

This is an independent Jolt concurrency correctness fix discovered while
exercising SCI.

## Tests

- New `interruptnest` gate covers normal inner return, inner exception, inner
  interruption, outer interruption after inner exit, concurrent tokens, and
  child-thread ownership.
- Pristine upstream fails the outer-after-inner case; the fix passes 9/9.
- `make fibers`
- `make gosm` (116/116)
- `make asynctimer` (16/16)
- `make threadsafety` (42 checks)
- `make unit`
- `make selfhost` (exact fixpoint)

All local Jolt commands used Chez 10.4.1.
