### PR TITLE
test(sci): exercise a real persistent SCI context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ install: build
 # answers "is this working tree gated?" — which is not something to remember.
 
 CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke depscpcache depsunit \
-  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci cts ffi stdlibfasl \
+  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
@@ -485,6 +485,12 @@ stdlibfasl: testbin
 # SCI conformance: load borkdude/sci's source through jolt (floor-gated).
 sci:
 	@$(CHEZ) --script host/chez/run-sci.ss
+
+# A complementary functional gate: load SCI through Jolt's ordinary dependency
+# path, then initialize and reuse real contexts. run-sci.ss remains the broad,
+# intentionally lenient source-loading compatibility gate.
+scifunctional: testbin
+	@JOLT_NO_USER_DEPS=1 target/release/jolt -Sdeps '{:deps {borkdude/sci {:local/root "vendor/sci"}}}' run test/chez/sci-functional-test.clj
 
 # clojure-test-suite conformance: run the vendored jank-lang/clojure-test-suite
 # per-namespace under jolt, gated on the per-namespace baseline

--- a/test/chez/sci-functional-test.clj
+++ b/test/chez/sci-functional-test.clj
@@ -1,0 +1,46 @@
+;; Functional SCI gate: the source-loading gate proves broad compatibility,
+;; while this file proves that the supported dependency path yields usable,
+;; persistent SCI contexts.
+(ns sci-functional-test
+  (:require [sci.core :as sci]))
+
+(defn- check= [label expected actual]
+  (when-not (= expected actual)
+    (throw (ex-info (str label ": expected " (pr-str expected)
+                         ", got " (pr-str actual))
+                    {:label label :expected expected :actual actual}))))
+
+(let [ctx (sci/init {})]
+  (check= "basic evaluation" 3
+          (sci/eval-string* ctx "(+ 1 2)"))
+
+  (sci/eval-string* ctx "(def x 41)")
+  (check= "definitions persist" 42
+          (sci/eval-string* ctx "(+ x 1)"))
+
+  (sci/eval-string* ctx "(defn twice [n] (* n 2))")
+  (check= "defined functions persist" 42
+          (sci/eval-string* ctx "(twice 21)"))
+  (check= "closures evaluate" 42
+          (sci/eval-string* ctx "((let [n 40] (fn [x] (+ n x))) 2)"))
+  (check= "collection operations evaluate" {:a 2 :b 3}
+          (sci/eval-string* ctx "(update {:a 1 :b 3} :a inc)"))
+  (check= "lazy sequences realize with vec" [1 2 3 4]
+          (sci/eval-string* ctx "(vec (map inc (range 4)))"))
+
+  (sci/eval-string* ctx "(def y (twice x))")
+  (check= "successive evaluations share context state" 82
+          (sci/eval-string* ctx "y")))
+
+(let [a (sci/init {})
+      b (sci/init {})]
+  (sci/eval-string* a "(def isolated 7)")
+  (check= "first independent context retains its definition" 7
+          (sci/eval-string* a "isolated"))
+  (check= "independent contexts do not share definitions" :missing
+          (try
+            (sci/eval-string* b "isolated")
+            :shared
+            (catch Throwable _ :missing))))
+
+(println "SCI-FUNCTIONAL-TEST OK")


### PR DESCRIPTION
## Summary

This adds a functional SCI integration gate alongside the existing
source-loading compatibility gate.

It demonstrates real `sci.core/init` and repeated `sci.core/eval-string*`
evaluation on Jolt, including persistent context state.

It does not claim that the complete upstream SCI test suite passes on Jolt,
and it does not require the source-loading compatibility gate to reach 424/424.

## Coverage

- basic evaluation
- persistent `def` and `defn`
- closure evaluation
- collection operation
- lazy sequence realized with `vec`
- multiple successive evaluations
- independent Context state

## Tests

- `make scifunctional` through the ordinary `-Sdeps` local/root dependency path
  on a built Jolt binary (`SCI-FUNCTIONAL-TEST OK`)
- `make sci` (417/424)
- `make unit`
- `make selfhost` (exact fixpoint)

All local Jolt commands used Chez 10.4.1.
