### PR TITLE
ns: set-chez-ns! must write where chez-current-ns reads

### DIFF
--- a/host/chez/multimethods.ss
+++ b/host/chez/multimethods.ss
@@ -37,7 +37,27 @@
             (jns-name bv)
             (chez-current-ns-param)))
       (chez-current-ns-param)))
-(define (set-chez-ns! ns) (chez-current-ns-param ns))
+;; The WRITE half of the same seam, and it has to target whatever the read half
+;; would consult or the two disagree: chez-current-ns prefers a live (binding
+;; [*ns* ..]) over the parameter, so writing only the parameter under such a
+;; binding is a write that no read can see. JVM parity too — (set! *ns* ..) is
+;; Var.set, which writes the innermost thread binding and leaves the root alone,
+;; so the binding frame popping still restores the ns that was current before it.
+;;
+;; What the asymmetry cost: ldr-load-body saves the current ns and restores it on
+;; the way out so a loaded file's ns form cannot leak past its own load. Under a
+;; *ns* binding that restore silently did nothing, so a nested require left *ns*
+;; pointing at the LAST file it finished — every def after the require in the
+;; requiring file interned into the wrong namespace.
+;;
+;; Bootstrap-safe by the same star-ns-cell test chez-current-ns uses: it is #f
+;; until dyn-binding.ss captures the cell, and the boot writes just set the
+;; parameter.
+(define (set-chez-ns! ns)
+  (let ((p (and star-ns-cell (dyn-find-binding star-ns-cell))))
+    (if p
+        (set-cdr! p (intern-ns! ns))
+        (chez-current-ns-param ns))))
 
 (define-record-type jolt-multifn
   (fields name dispatch-fn methods default hierarchy prefers

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1292,7 +1292,9 @@ fi
 
 # Loader: require :reload / :reload-all, failed-load rollback, a data-reader fn
 # whose var resolves surfaces a throw (not silently degraded), the LIST-libspec
-# superset (use '(ns :only [x])), and the prefix-list form ((require '(pfx [c :as s]))).
+# superset (use '(ns :only [x])), the prefix-list form ((require '(pfx [c :as s])))
+# and that a require fired under a (binding [*ns* ..]) still interns each loaded
+# file's defs into its own namespace.
 # The fixture writes its own scratch ns files under a temp dir and requires them.
 loader_out="$($jolt run test/chez/loader-test.clj 2>/dev/null)"
 if printf '%s' "$loader_out" | grep -q 'LOADER OK'; then

--- a/test/chez/loader-test.clj
+++ b/test/chez/loader-test.clj
@@ -91,6 +91,28 @@
   (chk "missing-ns: error names the missing file"
        (and msg (re-find #"no/such/namespace/xyz" msg) (re-find #"Could not locate" msg))))
 
+;; --- (8) a nested require under (binding [*ns* ..]) interns into its own ns ----
+;; chez-current-ns prefers a live (binding [*ns* ..]) over the thread parameter,
+;; but set-chez-ns! used to write only the parameter — so ldr-load-body's restore
+;; of the current ns on the way out of a load did nothing under such a binding,
+;; and *ns* stayed pointing at the LAST file the require finished. Every def
+;; after the :require in the requiring file then interned into the wrong
+;; namespace. typedclojure's ann* macroexpands under exactly such a binding, so
+;; its whole dependency tree loaded wrong.
+;; Every answer below probed against JVM Clojure 1.12 first.
+(spit (str root "/nfx.clj") "(ns nfx) (defn nfx-fn [] :ok)")
+(spit (str root "/nfy.clj") "(ns nfy (:require [nfx :as d])) (defn nfy-fn [] (d/nfx-fn))")
+(set-roots!)
+(binding [*ns* (the-ns 'loader-test)]
+  (require 'nfy)
+  (chk "ns-binding: the load restores *ns* to the bound one" (= "loader-test" (str *ns*))))
+(chk "ns-binding: nested require's ns exists" (some? (find-ns 'nfx)))
+(chk "ns-binding: nested def interns in its own ns" (some? (ns-resolve 'nfx 'nfx-fn)))
+(chk "ns-binding: def did not leak into the bound ns" (nil? (ns-resolve 'loader-test 'nfx-fn)))
+(chk "ns-binding: requiring ns's def interns in its own ns" (some? (ns-resolve 'nfy 'nfy-fn)))
+(chk "ns-binding: cross-ns call works"
+     (= :ok (when-let [v (ns-resolve 'nfy 'nfy-fn)] ((deref v)))))
+
 (if (empty? @failures)
   (println "LOADER OK")
   (doseq [f @failures] (println "FAIL:" f)))


### PR DESCRIPTION
chez-current-ns prefers a live (binding [*ns* ..]) over the thread-local
current-ns parameter, but set-chez-ns! only ever wrote the parameter. Under such
a binding the write was one no read could see.

ldr-load-body is what that cost. It saves the current ns and restores it on the
way out precisely so a loaded file's ns form cannot leak past its own load —
and under a *ns* binding the restore did nothing, so *ns* stayed pointing at the
LAST file the require finished. Every def after the :require in the requiring
file interned into that namespace instead of its own, silently, until a call
somewhere else could not resolve.

  (binding [*ns* (the-ns 'x)] (require 'nfy))
  nfy.clj: (ns nfy (:require [nfx :as d])) (defn nfy-fn [] (d/nfx-fn))

  before   nfy-fn interned in nfx
  after    nfy-fn interned in nfy

Macroexpansion is where a require lands inside someone else's *ns* binding in
practice; typedclojure's ann* expands under exactly one, so its dependency tree
loaded wrong.

Fixed at the seam rather than in jolt-in-ns, which is only the loudest caller:
the reader/writer pair has to agree or any of the six runtime set-chez-ns! sites
can lose a write. Writing the binding and NOT the parameter is also what the JVM
does — (set! *ns* ..) is Var.set, which writes the innermost thread binding and
leaves the root alone, so the frame popping still restores the ns from before
it. Bootstrap-safe by the star-ns-cell test chez-current-ns already uses.

Gates in loader-test.clj, the loader's own fixture, wired into the smoke
comment. Four of the six checks are discriminating, verified by reverting only
multimethods.ss. The other two are guards: the required ns existing at all
passes both ways, and *ns* reading back as the bound one after the require
guards the restore this fix newly makes reachable. Every expected answer probed
against JVM Clojure 1.12 first, including that *ns* is the bound ns afterwards.