### PR TITLE
java: a Thread handle answers about the thread it stands for

### DIFF
--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1297,13 +1297,39 @@
 ;; Real OS threads over Chez fork-thread (shared heap — a captured atom/var is
 ;; shared). A Thread runs its Runnable thunk; start forks, join waits on a
 ;; condition latched at completion. CountDownLatch is a counting barrier.
-(define (make-jthread thunk) (make-jhost "user-thread" (vector thunk #f (make-mutex) (make-condition) (box #f) #f)))
+;; Slot 6 is the thread's NAME, in a box so .setName after .start reaches the
+;; running thread through the same box the start published. Unnamed threads get
+;; the JVM's construction-order default rather than nothing, so .getName has an
+;; answer before the thread has an id to be named after.
+(define jthread-name-counter 0)
+(define jthread-name-mutex (make-mutex))
+(define (next-jthread-name)
+  (jolt-with-mutex jthread-name-mutex
+    (let ((n jthread-name-counter))
+      (set! jthread-name-counter (+ n 1))
+      (string-append "Thread-" (number->string n)))))
+(define (make-jthread thunk name)
+  (make-jhost "user-thread"
+              (vector thunk #f (make-mutex) (make-condition) (box #f) #f
+                      (box (or name (next-jthread-name))) #f)))
+;; slot 7: the id of the thread the start forked, #f until then. A rename needs
+;; it to reach the id-keyed name table the handles read.
+(define (jthread-id st) (vector-ref st 7))
 ;; alive = started and not yet completed. join waits on exactly this, so a thread
 ;; that was never started is not waited for at all (JVM: isAlive is false before
 ;; .start, so join returns at once).
 (define (jthread-alive? st) (and (vector-ref st 5) (not (vector-ref st 1))))
 ;; JVM Thread() is legal: the target is null and run/start are no-ops.
-(for-each (lambda (nm) (register-class-ctor! nm (lambda args (make-jthread (if (null? args) #f (car args))))))
+;; Thread(), Thread(runnable) and Thread(runnable, name) — the name argument used
+;; to be accepted and dropped, so a thread the caller had named answered with a
+;; generated one.
+(for-each (lambda (nm)
+            (register-class-ctor! nm
+              (lambda args
+                (make-jthread (if (null? args) #f (car args))
+                              (if (or (null? args) (null? (cdr args)) (jolt-nil? (cadr args)))
+                                  #f
+                                  (jolt-final-str (cadr args)))))))
           '("Thread" "java.lang.Thread"))
 (register-host-methods! "user-thread"
   (list (cons "start" (lambda (self)
@@ -1311,6 +1337,17 @@
             (vector-set! st 5 #t)  ; mark started before forking
             (fork-thread (lambda ()
                (*txn* #f)                          ; child thread must not inherit parent's txn
+               ;; Adopt the Thread object's own interrupt flag, so .interrupt from
+               ;; outside and this thread's Thread/currentThread view are ONE flag.
+               (adopt-interrupt-box! (vector-ref st 4))
+               ;; publish the name under this thread's id, so .getName agrees
+               ;; whether it is asked of the Thread object or of the handle
+               ;; Thread/currentThread (and getAllStackTraces) hands out
+               (vector-set! st 7 (get-thread-id))
+               (jolt-thread-name-set! (get-thread-id) (unbox (vector-ref st 6)))
+               ;; and register that handle now, so a handle someone else takes for
+               ;; this thread before it first asks who it is is the live one
+               (current-thread-handle)
                (dyn-binding-stack snap)
                ;; surface a thread body's throw like the JVM's default uncaught-
               ;; exception handler; the thread still completes (isAlive/join
@@ -1351,6 +1388,14 @@
         (cons "isAlive" (lambda (self) (jthread-alive? (jhost-state self))))
         (cons "interrupt" (lambda (self . _) (set-box! (vector-ref (jhost-state self) 4) #t) jolt-nil))
         (cons "isInterrupted" (lambda (self) (and (unbox (vector-ref (jhost-state self) 4)) #t)))
+        (cons "getName" (lambda (self) (unbox (vector-ref (jhost-state self) 6))))
+        ;; A rename after .start has to reach the running thread too, or the two
+        ;; spellings of the same thread's name disagree.
+        (cons "setName" (lambda (self nm)
+          (let* ((st (jhost-state self)) (s (jolt-final-str nm)))
+            (set-box! (vector-ref st 6) s)
+            (when (jthread-id st) (jolt-thread-name-set! (jthread-id st) s)))
+          jolt-nil))
         (cons "setDaemon" (lambda (self . _) jolt-nil))))
 
 (define (make-jlatch n) (make-jhost "count-down-latch" (vector n (make-mutex) (make-condition))))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -113,6 +113,14 @@
         (let ((b (box #f)))
           (thread-interrupt-cell (cons id b))
           b))))
+;; A thread jolt itself forked already HAS a flag — the box its Thread object hands
+;; .interrupt — so it must not lazily allocate a second one. The child adopts that
+;; box as its own before running the body; without this, .interrupt from outside
+;; and (.isInterrupted (Thread/currentThread)) inside were two unrelated flags and
+;; the ordinary interruption idiom never reached the worker.
+(define (adopt-interrupt-box! b)
+  (thread-interrupt-cell (cons (get-thread-id) b))
+  b)
 (define (clear-thread-interrupt!) (set-box! (current-interrupt-box) #f))
 
 ;; libc sched_yield, resolved once; fall back to a zero-length park if the symbol

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1265,20 +1265,45 @@
 ;; any thread sets the target thread's flag and .isInterrupted reads it without
 ;; clearing (instance semantics; the static Thread/interrupted reads-and-clears).
 ;; getContextClassLoader hands back the loader.
+;; A handle STANDS FOR one thread, and every question asked through it is about
+;; that thread — including when some other thread is holding it, which is the
+;; only shape Thread/getAllStackTraces hands back. So the id travels IN the
+;; handle: reading (get-thread-id) here answered about whoever was asking, so
+;; every entry in that map reported the caller's id and its name was the constant
+;; "main". State is (interrupt-box . thread-id).
+(define (thread-handle-box h) (car (jhost-state h)))
+(define (thread-handle-id h) (cdr (jhost-state h)))
+;; Names live in an id-keyed table for the same reason, under the handle mutex:
+;; a thread parameter is only readable by its own thread. A thread nobody named
+;; answers the JVM's default shape — the boot thread is "main", anything else
+;; "Thread-<id>".
+(define thread-names-by-id (make-eqv-hashtable))
+(define (jolt-thread-name-set! id nm)
+  (jolt-with-mutex thread-handles-mutex (hashtable-set! thread-names-by-id id nm)))
+(define (jolt-thread-name id)
+  (or (jolt-with-mutex thread-handles-mutex (hashtable-ref thread-names-by-id id #f))
+      (if (eqv? id jolt-boot-thread-id)
+          "main"
+          (string-append "Thread-" (number->string id)))))
 (register-host-methods! "thread"
   (list (cons "getContextClassLoader" (lambda (self) the-classloader))
-        (cons "getName" (lambda (self) "main"))
-        (cons "getId" (lambda (self) (get-thread-id)))
+        (cons "getName" (lambda (self) (jolt-thread-name (thread-handle-id self))))
+        (cons "setName" (lambda (self nm)
+                          (jolt-thread-name-set! (thread-handle-id self) (jolt-final-str nm))
+                          jolt-nil))
+        (cons "getId" (lambda (self) (thread-handle-id self)))
         ;; no reified call stack (jolt does TCO, so caller frames are erased) — an
         ;; empty StackTraceElement[]. clojure.spec.test.alpha's instrument reads it
         ;; to name the caller var; it degrades to no ::caller, the conform error
         ;; (the ExceptionInfo) is still thrown.
         (cons "getStackTrace" (lambda (self) (jolt-vector)))
         (cons "interrupt" (lambda (self)
-                            (when (box? (jhost-state self)) (set-box! (jhost-state self) #t))
+                            (let ((b (thread-handle-box self)))
+                              (when (box? b) (set-box! b #t)))
                             jolt-nil))
         (cons "isInterrupted" (lambda (self)
-                                (and (box? (jhost-state self)) (unbox (jhost-state self)) #t)))))
+                                (let ((b (thread-handle-box self)))
+                                  (and (box? b) (unbox b) #t))))))
 ;; ONE handle per thread, cached in a thread parameter. The JVM's
 ;; Thread/currentThread is identity-stable, and code relies on it: keying a map by
 ;; the current thread, or comparing two calls with identical?/=. Allocating a fresh
@@ -1298,7 +1323,7 @@
         (id (get-thread-id)))
     (if (and (pair? c) (eqv? (car c) id))
         (cdr c)
-        (let ((h (make-jhost "thread" (current-interrupt-box))))
+        (let ((h (make-jhost "thread" (cons (current-interrupt-box) id))))
           (thread-handle-cell (cons id h))
           (jolt-with-mutex thread-handles-mutex (hashtable-set! thread-handles-by-id id h))
           h))))
@@ -1309,7 +1334,7 @@
   (if (eqv? id (get-thread-id))
       (current-thread-handle)              ; the caller must find ITSELF in the map
       (or (jolt-with-mutex thread-handles-mutex (hashtable-ref thread-handles-by-id id #f))
-          (let ((h (make-jhost "thread" (box #f))))
+          (let ((h (make-jhost "thread" (cons (box #f) id))))
             (jolt-with-mutex thread-handles-mutex (hashtable-set! thread-handles-by-id id h))
             h))))
 ;; Thread/getAllStackTraces: the live threads mapped to EMPTY stack traces. jolt

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -164,6 +164,30 @@
   {:suite "interrupt" :expr "(nil? (Thread/yield))" :expected "true"}
   {:suite "threads / id" :expr "(let [t (Thread/currentThread) a (.getId t) b (.getId t)] (and (integer? a) (= a b)))" :expected "true"}
   {:suite "threads / id" :expr "(let [current-id (.getId (Thread/currentThread)) ready (java.util.concurrent.CountDownLatch. 1) release (java.util.concurrent.CountDownLatch. 1) f (future (let [id (.getId (Thread/currentThread))] (.countDown ready) (.await release 5 java.util.concurrent.TimeUnit/SECONDS) id))] (.await ready 5 java.util.concurrent.TimeUnit/SECONDS) (.countDown release) (let [child-id (deref f)] (and (integer? child-id) (not= current-id child-id))))" :expected "true"}
+  ;; A handle asks about the thread it STANDS FOR, not the thread doing the
+  ;; asking — the distinction only shows through a handle for someone else, which
+  ;; is what Thread/getAllStackTraces hands back.
+  {:suite "threads / id" :expr "(let [ready (java.util.concurrent.CountDownLatch. 1) release (java.util.concurrent.CountDownLatch. 1) seen (atom nil) t (Thread. (fn [] (reset! seen (.getId (Thread/currentThread))) (.countDown ready) (.await release 5 java.util.concurrent.TimeUnit/SECONDS)))] (.start t) (.await ready 5 java.util.concurrent.TimeUnit/SECONDS) (let [ids (into #{} (map #(.getId %) (keys (Thread/getAllStackTraces))))] (.countDown release) (contains? ids @seen)))" :expected "true"}
+  {:suite "threads / id" :expr "(let [ready (java.util.concurrent.CountDownLatch. 1) release (java.util.concurrent.CountDownLatch. 1) t (Thread. (fn [] (.countDown ready) (.await release 5 java.util.concurrent.TimeUnit/SECONDS)))] (.start t) (.await ready 5 java.util.concurrent.TimeUnit/SECONDS) (let [ths (keys (Thread/getAllStackTraces)) ids (map #(.getId %) ths)] (.countDown release) (= (count ths) (count (set ids)))))" :expected "true"}
+  {:suite "threads / name" :expr "(.getName (Thread/currentThread))" :expected "\"main\""}
+  {:suite "threads / name" :expr "(let [p (promise)] (.start (Thread. (fn [] (deliver p (.getName (Thread/currentThread)))))) (not= \"main\" (deref p 5000 :timeout)))" :expected "true"}
+  {:suite "threads / name" :expr "(let [p (promise) t (Thread. (fn [] (deliver p (.getName (Thread/currentThread)))) \"worker-x\")] (.start t) [(.getName t) (deref p 5000 :timeout)])" :expected "[\"worker-x\" \"worker-x\"]"}
+  {:suite "threads / name" :expr "(let [t (Thread. (fn []) \"a\")] (.setName t \"b\") (.getName t))" :expected "\"b\""}
+  ;; renaming through the currentThread handle, done inside a worker so the row
+  ;; cannot rename the thread the rest of the suite runs on
+  {:suite "threads / name" :expr "(let [p (promise)] (.start (Thread. (fn [] (let [t (Thread/currentThread)] (.setName t \"renamed\") (deliver p (.getName t)))))) (deref p 5000 :timeout))" :expected "\"renamed\""}
+  ;; .interrupt from outside and the thread's own view of its flag are ONE flag on
+  ;; the JVM — the whole interruption idiom is an outside caller setting it and the
+  ;; worker polling Thread/currentThread or Thread/interrupted. All three answers
+  ;; certified against JVM Clojure 1.12. The worker SPINS rather than parking on a
+  ;; latch: on the JVM an interrupt out of an interruptible wait throws
+  ;; InterruptedException instead, which would test something else.
+  {:suite "threads / interrupt" :expr "(let [ready (promise) release (atom false) done (promise) t (Thread. (fn [] (deliver ready true) (loop [] (when-not @release (Thread/yield) (recur))) (deliver done (.isInterrupted (Thread/currentThread)))))] (.start t) (deref ready 5000 :timeout) (.interrupt t) (reset! release true) [(.isInterrupted t) (deref done 5000 :timeout)])" :expected "[true true]"}
+  {:suite "threads / interrupt" :expr "(let [ready (promise) release (atom false) done (promise) t (Thread. (fn [] (deliver ready true) (loop [] (when-not @release (Thread/yield) (recur))) (deliver done [(Thread/interrupted) (Thread/interrupted)])))] (.start t) (deref ready 5000 :timeout) (.interrupt t) (reset! release true) (deref done 5000 :timeout))" :expected "[true false]"}
+  ;; a handle taken for the thread by SOMEONE ELSE reaches the same flag
+  {:suite "threads / interrupt" :expr "(let [ready (promise) release (atom false) done (promise) t (Thread. (fn [] (deliver ready true) (loop [] (when-not @release (Thread/yield) (recur))) (deliver done (.isInterrupted (Thread/currentThread)))) \"interruptee\")] (.start t) (deref ready 5000 :timeout) (doseq [h (keys (Thread/getAllStackTraces))] (when (= \"interruptee\" (.getName h)) (.interrupt h))) (reset! release true) (deref done 5000 :timeout))" :expected "true"}
+  ;; the name a handle answers is the name of the thread it stands for
+  {:suite "threads / name" :expr "(let [ready (java.util.concurrent.CountDownLatch. 1) release (java.util.concurrent.CountDownLatch. 1) t (Thread. (fn [] (.countDown ready) (.await release 5 java.util.concurrent.TimeUnit/SECONDS)) \"named-worker\")] (.start t) (.await ready 5 java.util.concurrent.TimeUnit/SECONDS) (let [names (into #{} (map #(.getName %) (keys (Thread/getAllStackTraces))))] (.countDown release) (contains? names \"named-worker\")))" :expected "true"}
   {:suite "interrupt" :expr "(.isInterrupted (Thread/currentThread))" :expected "false"}
   {:suite "interrupt" :expr "(let [t (Thread/currentThread)] (.interrupt t) (.isInterrupted t))" :expected "true"}
   {:suite "interrupt" :expr "(let [t (Thread/currentThread)] (.interrupt t) [(.isInterrupted t) (.isInterrupted t)])" :expected "[true true]"}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -458,6 +458,29 @@
    :jvm "\"localhost\" — reverse lookup through the nameservice (machine-dependent)"
    :jolt "\"127.0.0.1\" — the literal; no reverse lookup"
    :note "Reverse DNS would need getnameinfo and makes the answer environment-dependent; the JVM's own javadoc flags the lookup. Use .getHostString for the literal on both. Caught certifying test/chez/socket-test.clj against the JVM."}
+  ;; Interruption reaches the FLAG but not a thread already parked. .interrupt sets
+  ;; the target's flag and the target sees it (jolt#727 made that one flag rather
+  ;; than two), so the polling idiom — (while (not (.isInterrupted
+  ;; (Thread/currentThread))) ...) — behaves as on the JVM. What does NOT happen is
+  ;; the JVM's second half: a thread blocked in an interruptible wait is not thrown
+  ;; out of it. Every jolt park runs to its own completion or timeout instead.
+  {:category :concurrency-model
+   :behavior "(.interrupt t) while t is parked in CountDownLatch.await / Thread.sleep / Thread.join / a blocking queue take"
+   :jvm "the wait throws InterruptedException at once and clears the flag"
+   :jolt "the wait runs to completion or its timeout and returns normally; the flag is set and readable afterwards"
+   :note "jolt.host/run-interruptible is the interruptible-blocking primitive that does exist, and ReentrantLock.lockInterruptibly does throw. Making every park interruptible means threading the interrupt box through each jolt-cv-wait site — bead jolt-qdi8. Code that must be interruptible on jolt should poll .isInterrupted or bound its waits with a timeout."}
+  ;; The three separator system properties are POSIX on every platform, Windows
+  ;; included. This is deliberate and consistent rather than an oversight: jolt's
+  ;; own IO layer writes LF and joins with "/" everywhere (java.io.File, the
+  ;; classpath, `newline`), so answering "\r\n" and "\\" on Windows would make the
+  ;; properties disagree with what the runtime beside them actually does. Windows
+  ;; accepts "/" in paths. Found reviewing clojure.core/system-newline, which is
+  ;; "\n" for the same reason.
+  {:category :host-model
+   :behavior "(System/getProperty \"line.separator\") / \"file.separator\" / \"path.separator\", and clojure.core/system-newline, ON WINDOWS"
+   :jvm "\"\\r\\n\", \"\\\\\" and \";\" — the platform's own conventions"
+   :jolt "\"\\n\", \"/\" and \":\" on every platform"
+   :note "Consistent with the rest of jolt on Windows, which reads and writes LF and joins paths with \"/\". Code that must produce native line endings on Windows should not read them from these properties on jolt. On POSIX the two agree exactly."}
   ;; ThreadLocal under thread-parameter fork-inheritance: a proxy'd
   ;; ThreadLocal's value is a Chez thread parameter, and a forked thread
   ;; starts with the CREATING thread's current value — so a child observes


### PR DESCRIPTION
Three questions asked through a java.lang.Thread answered about the wrong
thread, and #722 adding .getId beside them is what made the first one visible.

  - .getId read (get-thread-id), the id of whoever was ASKING. A thread asking
    about itself got the right answer, which is all the existing rows did — but
    every handle Thread/getAllStackTraces hands back is a handle for someone
    else, and all of them reported the caller's id. Four live threads, four
    entries, one id.

  - .getName was the constant "main". Every thread, always.

  - a forked thread lazily allocated its OWN interrupt box on first use, so the
    box .interrupt sets through the Thread object and the box the thread's own
    Thread/currentThread reads were unrelated. The ordinary interruption idiom —
    outside calls .interrupt, the worker polls .isInterrupted — never saw it.

    (let [t (Thread. body)] (.start t) ... (.interrupt t))
    before   outside sees true, the worker sees false, forever
    after    one flag

A handle stands for one thread, so it carries that thread's id: state is
(interrupt-box . id) rather than a bare box. Names are id-keyed under the
handle mutex for the same reason a handle cannot read another thread's
parameters; unnamed threads answer the JVM's shape, "main" for the boot thread
and "Thread-<id>" otherwise. A forked thread adopts its Thread object's box
before running the body, and registers its handle then too, so a handle taken
for it before it first asks who it is is the live one.

While in here: Thread(runnable, name) accepted the name and dropped it, and
neither .getName nor .setName existed on a constructed Thread. The name lives
in a box so a rename after .start reaches the running thread.

10 unit rows, every expected value certified against JVM Clojure 1.12 first —
including that an unnamed thread is "Thread-0" and that Thread/interrupted
reads-and-clears. 9 are discriminating; (.getName (Thread/currentThread)) =
"main" passes both ways and guards the default. The interrupt rows spin rather
than parking on a latch, because on the JVM interrupting a parked thread throws
InterruptedException out of the wait instead, which is a different question --
and one jolt still answers differently: no jolt park is interruptible. That is
the remaining half of jolt-qdi8, now documented in known-divergences.edn along
with the POSIX separator properties, which are "\n" / "/" / ":" on Windows too.