### PR TITLE
Stop exporting the kernel's ncurses symbols from the executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ call. Memoizing the probe by `(zone, instant)` undoes it: a repeated
 `jolt.host/tz-offset-seconds` lookup drops from ~1.7ms to ~100ns, and
 `jolt-lang/time`'s zone-aware `now` speeds up by roughly 100x.
 
+Also here: a binary no longer exports the Chez kernel's own ncurses, which was
+enough to stop any FFI binding of a real ncurses from opening a terminal.
+
 ### Fixed
 
 - **`jolt.ffi` `:string` carries NULL in both directions.** Chez's `string`
@@ -43,6 +46,32 @@ call. Memoizing the probe by `(zone, instant)` undoes it: a repeated
   Until this a callback could neither model a nullable string argument nor
   decline to answer one, which is ordinary in any C API that hands a callback an
   optional path, name or error.
+
+- **The kernel's ncurses is no longer exported from the executable.** Chez's
+  expression editor links ncurses and terminfo, and `-rdynamic` — which a built
+  binary needs, so a statically linked native resolves through
+  `(load-shared-object #f)` — put all of it in the dynamic symbol table: 77
+  `_nc_*` internals plus `setupterm`, `tigetnum`, `raw`, `cbreak`, `curs_set`,
+  `keypad`, `notimeout`, `wtimeout`, and globals including `cur_term`. The
+  executable is searched before any `dlopen`'d library, so a program that bound
+  a real ncurses through the FFI had that library's own internal calls bound
+  back into the kernel's copy:
+
+  ```
+  binding file /lib/x86_64-linux-gnu/libncursesw.so.6 [0] to jolt [0]:
+      normal symbol `_nc_setupterm' [NCURSES6_TINFO_5.5.20051010]
+  ```
+
+  The kernel's copy predates ncurses 6.1, so it reads a terminfo entry with a
+  4096-byte buffer and cannot parse the 32-bit number format that any entry
+  carrying a value above 32767 is stored in — `xterm-256color`, whose
+  `max_pairs` is 65536, for one. `initscr` then failed with "Error opening
+  terminal" on a terminal that works everywhere else; where the entry was in the
+  legacy format the old code parsed it instead and filled `cur_term` with a
+  pre-6.1 `TERMINAL` layout that the newer library then read with its own, which
+  segfaults. Linking with `--exclude-libs` marks those archives' symbols local,
+  which is enough: Chez calls them internally, and internal linkage does not go
+  through the dynamic symbol table, so the expression editor is unaffected.
 
 ### Performance
 

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -252,7 +252,21 @@
      "-static -llz4 -lz -lws2_32 -lrpcrt4 -lole32 -luuid -ladvapi32 -luser32 -lshell32 -lm")
     ;; Linux: the Chez kernel pulls in compression (lz4/z), the expression
     ;; editor (ncurses + terminfo), threads, dlopen, libuuid, and clock_gettime.
-    (else "-llz4 -lz -lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt")))
+    ;;
+    ;; --exclude-libs keeps the terminal libraries OUT of the executable's
+    ;; dynamic symbol table. -rdynamic puts everything else in, which is what
+    ;; lets a statically linked native resolve through (load-shared-object #f) —
+    ;; but exporting ncurses is actively harmful. The executable is searched
+    ;; before any dlopen'd library, so a jolt program that binds a real ncurses
+    ;; through the FFI has that library's own calls (_nc_setupterm and the rest)
+    ;; bound back into the kernel's copy, which is a different build with a
+    ;; different TERMINAL layout: the terminfo entry fails to parse, or initscr
+    ;; segfaults on the mismatch. Naming the archives costs nothing when they
+    ;; resolve to shared libraries instead — ld ignores an --exclude-libs name
+    ;; it did not link.
+    (else (string-append
+            "-Wl,--exclude-libs,libncurses.a:libncursesw.a:libtinfo.a "
+            "-llz4 -lz -lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt"))))
 
 ;; --- optional built-binary startup profile ----------------------------------
 ;; JOLT_STARTUP_PROFILE=1 reports wall time, process CPU, collections,


### PR DESCRIPTION
A jolt program that binds ncurses through the FFI cannot start a screen: `initscr`
either fails with `Error opening terminal` on a terminal that works everywhere else,
or segfaults. Found while debugging
[glimmer-tui](https://github.com/jolt-lang/glimmer-tui), which binds `libncursesw`.

## Cause

Chez's expression editor links `-lncurses -ltinfo`, and `-rdynamic` exports every
symbol the executable defines. In a release build those resolve to static archives
(`STATIC_DEPS=1` in `ci/glibc-floor-build.sh`), so the binary ends up exporting 77
`_nc_*` internals plus `setupterm`, `tigetnum`, `raw`, `cbreak`, `curs_set`,
`keypad`, `notimeout`, `wtimeout`, and globals including `cur_term` and
`_nc_globals`.

The executable is searched before any `dlopen`'d library, so the ncurses a program
loads has its *own* internal calls bound back into the kernel's copy:

```
binding file /lib/x86_64-linux-gnu/libncursesw.so.6 [0] to jolt [0]:
    normal symbol `_nc_setupterm' [NCURSES6_TINFO_5.5.20051010]
```

The kernel's copy predates ncurses 6.1 — it has `_nc_read_entry` and
`_nc_copy_termtype` but none of the 6.1 `*2` variants. Two consequences, depending
on the terminfo entry:

- **32-bit format** (magic `0x021e`, used for any entry with a number above 32767 —
  `xterm-256color` has `max_pairs#0x10000`): the old parser reads it with a
  4096-byte buffer and rejects it, `newterm` returns NULL → `Error opening terminal`.
  Observable as the same file being read twice in one process with different buffer
  sizes: 32768 by the system library, 4096 by the kernel's.
- **Legacy 16-bit format**: the old code parses it and fills `cur_term` with a
  pre-6.1 `TERMINAL` layout, which the 6.3 library then reads with its own →
  `invalid memory reference` inside `initscr`.

Python's `curses` works in the same terminal, which is what ruled out the
environment.

## Fix

`-Wl,--exclude-libs,libncurses.a:libncursesw.a:libtinfo.a` on the Linux link line
marks those archives' symbols local. Chez calls them internally and internal
linkage does not go through the dynamic symbol table, so the editor is unaffected.
`ld` ignores an `--exclude-libs` name it did not link, so a build against the shared
libraries is unchanged.

## Verified

Built in the shipping configuration (ncurses statically linked, as `ldd` confirms):

| | before | after |
|---|---|---|
| `_nc_*` in `.dynsym` | 77 | **0** |
| `setupterm` / `tigetnum` | exported | **not exported** |

- `jolt repl` — the expression editor still echoes and evaluates on a pty.
- `jolt -M:test` in glimmer-tui — 95 tests, 301 assertions, green.
- `jolt -M:smoke` in glimmer-tui on a real pty — `SMOKE OK ticks: 1 presses: 2 timer: 24`,
  where it previously died in `initscr`.
- The glimmer-tui example app runs, animates and quits cleanly.
- `grep` over the stdlib: nothing binds a terminal symbol through the FFI, so
  nothing depended on the export.

macOS is untouched: ncurses comes from the SDK as a dylib there, so the executable
never defines these symbols. `--exclude-libs` is GNU ld only; ld64's equivalent
would be `-hidden-l`, not needed here.
