### PR TITLE
Pay for the interrupt check once, not per call

### DIFF
--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -97,29 +97,32 @@
 ;; A thread handle (from currentThread) captures this box, so .interrupt from
 ;; another thread sets the target thread's flag.
 ;;
-;; The cell carries the owning thread's id, because a Chez thread parameter is
-;; INHERITED: a forked thread starts with the creating thread's value. A plain
-;; (make-thread-parameter #f) therefore handed a child its PARENT's box — so
-;; interrupting the child set the parent's flag, and the monitor-ownership check in
-;; concurrency.ss saw a child as holding a lock the parent had taken. Comparing the
-;; stored id against (get-thread-id) makes an inherited cell miss, so the child
-;; allocates its own box on first use; no global table, so no per-thread leak.
-(define thread-interrupt-cell (make-thread-parameter #f))   ; (thread-id . box)
+;; A VIRTUAL REGISTER and not a thread parameter, and the reason is the bug this
+;; used to carry a workaround for: a Chez thread parameter is INHERITED, so a
+;; forked thread started out holding its PARENT's box and interrupting the child
+;; set the parent's flag. That was patched by storing (thread-id . box) and
+;; comparing the id on every read. A vreg has the property directly — a freshly
+;; forked thread starts every slot at fixnum 0 — so the id compare, the pair, and
+;; the (get-thread-id) call all go away, and what is left is one register read.
+;; That read is on the hot path: every interruptible wait consults it before
+;; deciding, including the ones that never wait (a deref of a delivered promise),
+;; and so do Thread/interrupted, .isInterrupted, monitor enter/exit and
+;; ReentrantLock's owner check.
+(define jolt-vreg-interrupt-box 9)      ; rt.ss owns the slot map; 0-8 were taken
 (define (current-interrupt-box)
-  (let ((c (thread-interrupt-cell))
-        (id (get-thread-id)))
-    (if (and (pair? c) (eqv? (car c) id))
-        (cdr c)
-        (let ((b (box #f)))
-          (thread-interrupt-cell (cons id b))
-          b))))
+  (let ((b (virtual-register jolt-vreg-interrupt-box)))
+    (if (box? b)
+        b
+        (let ((nb (box #f)))
+          (set-virtual-register! jolt-vreg-interrupt-box nb)
+          nb))))
 ;; A thread jolt itself forked already HAS a flag — the box its Thread object hands
 ;; .interrupt — so it must not lazily allocate a second one. The child adopts that
 ;; box as its own before running the body; without this, .interrupt from outside
 ;; and (.isInterrupted (Thread/currentThread)) inside were two unrelated flags and
 ;; the ordinary interruption idiom never reached the worker.
 (define (adopt-interrupt-box! b)
-  (thread-interrupt-cell (cons (get-thread-id) b))
+  (set-virtual-register! jolt-vreg-interrupt-box b)
   b)
 (define (clear-thread-interrupt!) (set-box! (current-interrupt-box) #f))
 

--- a/host/chez/locks.ss
+++ b/host/chez/locks.ss
@@ -388,45 +388,115 @@
       (sleep (ms->duration ms))))
 
 (define (jolt-cv-wait mu cv deadline decide)
+  (jolt-cv-wait/ibox mu cv deadline decide #f #f))
+
+;; The wait itself. ibox is the caller's interrupt box, or #f for a wait that is
+;; NOT interruptible — which is the default and what jolt-cv-wait above passes,
+;; because the runtime's own plumbing waits here too (the carrier idle wait, the
+;; load barrier, the main-queue pump, the tap queue, the channel internals) and
+;; interrupting any of those breaks the runtime rather than the caller's code.
+;; jolt-cv-wait-interruptibly at the bottom of this file is the opt-in door.
+;;
+;; The interrupt arm reads as a parameter rather than a wrapper around `decide`
+;; for a measured reason: a wrapper allocated a closure and a box on EVERY call,
+;; and most calls through here never wait at all — a deref of an already-delivered
+;; promise or a settled future runs decide once and returns. That cost a settled
+;; deref 1.15x against a 1.1x ceiling (release binary, A/B/A). Threaded through,
+;; the fast path is an `(if ibox ...)` that falls through (jolt-a0f1).
+(define (jolt-cv-wait/ibox mu cv deadline decide ibox who)
   ;; Registered OUTSIDE mu, and only for a fiber. Outside because the timer's
   ;; thunks run with timeout-mu released but registering takes it, so doing this
   ;; under mu would order mu above timeout-mu here and below it there.
   (when (and deadline (jolt-current-fiber))
     (jolt-timer-at! deadline (lambda () (jolt-with-mutex mu (jolt-cv-wake! cv)))))
-  (jolt-lock-wait mu
-    (lambda ()
-      (let loop ()
-        (let ((r (decide (and deadline (>= (now-millis) deadline)))))
-          (cond
-            ((not (eq? r jolt-cv-again)) r)
-            ((jolt-current-fiber)
-             => (lambda (f)
-                  (jolt-cv-register! cv f)
-                  (jolt-fiber-state-set! f 'parked)
-                  jolt-lock-parked))
-            (else
-             (if deadline
-                 (jolt-condition-wait cv mu (jolt-millis->time deadline))
-                 (jolt-condition-wait cv mu))
-             (loop))))))))
+  ;; The (mu . cv) this wait is findable by while it is willing to be interrupted,
+  ;; or #f. It lives OUT here and not inside the thunk below because jolt-lock-wait
+  ;; RETAKES that thunk when a parked fiber resumes: a loop-local would forget a
+  ;; registration the park had already made, and the entry would outlive the wait.
+  (let ((entry #f))
+    (jolt-lock-wait mu
+      (lambda ()
+        (let loop ()
+          ;; The flag FIRST, on every round. That ordering is what gives the
+          ;; already-set case for free — a thread whose flag is set when it calls a
+          ;; blocking op throws immediately and never waits, as on the JVM — and
+          ;; because the decision here is retaken rather than resumed into, the
+          ;; same check covers every wake for nothing extra. The read CLEARS, which
+          ;; is java.lang.Thread's own rule: "the interrupted status is cleared and
+          ;; an InterruptedException is thrown."
+          (when ibox
+            (when (unbox ibox)
+              (set-box! ibox #f)
+              (when entry (jolt-interrupt-wait-remove! ibox entry) (set! entry #f))
+              (jolt-interrupted-throw! who)))
+          (let ((r (if entry
+                       ;; REGISTERED. decide throws on its own account (a failed
+                       ;; agent is the live case), so that exit has to deregister
+                       ;; too, or the entry outlives the wait and a later interrupt
+                       ;; pokes a condition nobody is on.
+                       ;;
+                       ;; with-exception-handler and not guard, for java/sm.ss's
+                       ;; reason: the handler runs AT THE RAISE POINT, so
+                       ;; jolt-throw's captured continuation and site still describe
+                       ;; where the throw came from. A guard would unwind first and
+                       ;; the report would name this wait instead.
+                       (with-exception-handler
+                         (lambda (e) (jolt-interrupt-wait-remove! ibox entry) (raise-continuable e))
+                         (lambda () (decide (and deadline (>= (now-millis) deadline)))))
+                       ;; NOT REGISTERED — nothing to clean up, so decide runs with
+                       ;; nothing wrapped around it. This is the arm every
+                       ;; non-interruptible wait takes, and the one a wait that
+                       ;; answers on its first run takes.
+                       (decide (and deadline (>= (now-millis) deadline))))))
+            (cond
+              ((not (eq? r jolt-cv-again))
+               (when entry (jolt-interrupt-wait-remove! ibox entry) (set! entry #f))
+               r)
+              (else
+               ;; About to wait for the first time: become findable, then RE-READ
+               ;; the flag. The window between the read at the top and this
+               ;; registration is exactly what the second read closes — the
+               ;; interrupter sets the flag BEFORE it reads the registry, so either
+               ;; it found us, and its wake is already on its way to a mutex we
+               ;; still hold, or it did not and its flag is set for this read.
+               (when (and ibox (not entry))
+                 (let ((e (cons mu cv)))
+                   (set! entry e)
+                   (jolt-interrupt-wait-add! ibox e)
+                   (when (unbox ibox)
+                     (set-box! ibox #f)
+                     (jolt-interrupt-wait-remove! ibox e)
+                     (set! entry #f)
+                     (jolt-interrupted-throw! who))))
+               (cond
+                 ((jolt-current-fiber)
+                  => (lambda (f)
+                       (jolt-cv-register! cv f)
+                       (jolt-fiber-state-set! f 'parked)
+                       jolt-lock-parked))
+                 (else
+                  (if deadline
+                      (jolt-condition-wait cv mu (jolt-millis->time deadline))
+                      (jolt-condition-wait cv mu))
+                  (loop)))))))))))
 
 ;; --- interruptible waiting --------------------------------------------------
 ;; (jolt-cv-wait-interruptibly who mu cv deadline decide)
 ;;
 ;; jolt-cv-wait with one thing added: a thread parked in it is thrown out by
-;; .interrupt, the way every interruptible wait on the JVM is. It is an OPT-IN
-;; VARIANT and jolt-cv-wait itself is untouched, because the runtime's own
-;; plumbing waits through the same seam — the carrier idle wait, the load
-;; barrier, the main-queue pump, the tap queue, the channel internals — and
-;; interrupting any of those breaks the runtime rather than the caller's code.
-;; The interruptible sites are the ones a JVM caller can already name: promise
-;; and future deref, agent await, Thread.join, Thread.sleep, CountDownLatch.await,
-;; a task Future's get, a blocking queue take/put, awaitTermination, waitFor.
+;; .interrupt, the way every interruptible wait on the JVM is. It is the OPT-IN
+;; door onto jolt-cv-wait/ibox above; jolt-cv-wait passes #f and stays exactly as
+;; uninterruptible as it was, because the runtime's own plumbing waits through the
+;; same seam — the carrier idle wait, the load barrier, the main-queue pump, the
+;; tap queue, the channel internals — and interrupting any of those breaks the
+;; runtime rather than the caller's code. The interruptible sites are the ones a
+;; JVM caller can already name: promise and future deref, agent await,
+;; Thread.join, Thread.sleep, CountDownLatch.await, a task Future's get, a
+;; blocking queue take/put, awaitTermination, waitFor.
 ;;
-;; TWO PIECES, and only the second one is new work. The first is that jolt-cv-wait
-;; RETAKES its decision on every wake rather than resuming into it, so a check
-;; placed at the top of decide re-runs for free on every wake and needs no second
-;; wait protocol; that is what makes this a wrapper rather than a fork.
+;; TWO PIECES, and only the second one is new work. The first is that the wait
+;; RETAKES its decision on every wake rather than resuming into it, so one check
+;; at the top of the loop covers every wake and needs no second wait protocol.
 ;;
 ;; The second is that the interrupter has to WAKE a waiter blocked on a condition
 ;; variable it has never heard of. It cannot know which future or latch its target
@@ -434,8 +504,8 @@
 ;; its own interrupt identity for as long as it is willing to wait, and .interrupt
 ;; sets the flag and then pokes every condition registered against that identity.
 ;;
-;; WHY THE RACE CLOSES, and it closes for a reason worth not breaking. Everything
-;; below runs with mu HELD — decide is called under it — and the interrupter takes
+;; WHY THE RACE CLOSES, and it closes for a reason worth not breaking. The whole
+;; loop above runs with mu HELD — decide is called under it — and the interrupter takes
 ;; mu to wake (jolt-cv-wake! is documented "call with mu HELD"). So an interrupt
 ;; cannot land in the gap between deciding to wait and actually parking. The one
 ;; remaining window is between the check and the registration, and the re-check
@@ -444,11 +514,9 @@
 ;; a mutex we still hold — or it did not, and its flag is already set for the
 ;; re-read. Both orders end in the same throw.
 ;;
-;; Putting the check FIRST is also what makes the pre-set-flag case fall out for
-;; free: a thread whose flag is already set when it calls a blocking op throws
-;; immediately and never waits, which is what the JVM does. And the registry is
-;; touched ONLY by a wait that actually waits — a deref of an already-delivered
-;; promise takes no lock this file did not already take.
+;; The registry is touched ONLY by a wait that actually waits — a deref of an
+;; already-delivered promise takes no lock this file did not already take, and
+;; allocates nothing this file did not already allocate.
 ;;
 ;; THE IDENTITY IS THE INTERRUPT BOX, not the fiber, and that is a decision rather
 ;; than an oversight. The flag lives in the box, .interrupt is handed a box and
@@ -510,57 +578,4 @@
 ;; and "sleep interrupted" for Thread.sleep; jolt names the op instead, which is
 ;; strictly more information and is what its other host throwables do.
 (define (jolt-cv-wait-interruptibly who mu cv deadline decide)
-  (let ((b (current-interrupt-box))
-        (entry #f))                    ; consed only if this wait actually waits
-    (jolt-cv-wait mu cv deadline
-      (lambda (timed-out?)
-        ;; The flag read is INLINE rather than a call to jolt-interrupt-take!. This
-        ;; runs on every round of every interruptible wait, including the ones that
-        ;; never wait at all, and the call alone measured ~8ns per deref against an
-        ;; already-settled promise — the same order as everything else left here.
-        (when (unbox b)
-          (set-box! b #f)
-          (when entry (jolt-interrupt-wait-remove! b entry))
-          (jolt-interrupted-throw! who))
-        (let ((r (if entry
-                     ;; REGISTERED. decide throws on its own account (a failed agent
-                     ;; is the live case), so that exit has to deregister too, or the
-                     ;; entry outlives the wait and a later interrupt pokes a
-                     ;; condition nobody is on.
-                     ;;
-                     ;; with-exception-handler and not guard, for java/sm.ss's
-                     ;; reason: the handler runs AT THE RAISE POINT, so jolt-throw's
-                     ;; captured continuation and site still describe where the throw
-                     ;; came from. A guard would unwind first and the report would
-                     ;; name this wait instead.
-                     (with-exception-handler
-                       (lambda (e) (jolt-interrupt-wait-remove! b entry) (raise-continuable e))
-                       (lambda () (decide timed-out?)))
-                     ;; NOT REGISTERED — the fast path, and the reason for the
-                     ;; branch. A wait that answers on its first run (a deref of an
-                     ;; already-delivered promise, a take from a non-empty queue) has
-                     ;; nothing to clean up, so it runs decide with nothing wrapped
-                     ;; around it and its whole cost is the flag read above. Wrapping
-                     ;; it unconditionally, and consing the entry up front, is what
-                     ;; made a settled deref 1.7x rather than 1.1x.
-                     (decide timed-out?))))
-          (cond
-            ((not (eq? r jolt-cv-again))
-             (when entry
-               (jolt-interrupt-wait-remove! b entry)
-               (set! entry #f))
-             r)
-            (entry r)                   ; already findable; nothing changed
-            (else
-             ;; about to wait for the first time: become findable, then RE-READ the
-             ;; flag. The window between the read above and this registration is
-             ;; exactly what that second read closes.
-             (let ((e (cons mu cv)))
-               (set! entry e)
-               (jolt-interrupt-wait-add! b e)
-               (when (unbox b)
-                 (set-box! b #f)
-                 (jolt-interrupt-wait-remove! b e)
-                 (set! entry #f)
-                 (jolt-interrupted-throw! who)))
-             r)))))))
+  (jolt-cv-wait/ibox mu cv deadline decide (current-interrupt-box) who))

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -341,7 +341,7 @@
 ;; ~2.4ns vs ~3.3ns, a smaller but free win.
 ;;
 ;; Virtual registers are a fixed global resource: (virtual-register-count) slots for
-;; the whole process (16 on every platform jolt targets). jolt claims three, allocated
+;; the whole process (16 on every platform jolt targets). jolt claims 0-9, listed
 ;; here so the assignment is in one place; nothing else in the runtime uses them.
 ;; A freshly forked thread starts every slot at fixnum 0, NOT #f, so "unset" means
 ;; fixnum 0 (the site slots hold a site pair or 0). Slot 0 was claimed by R1's
@@ -349,10 +349,9 @@
 ;; write is ~2ns against ~33ns for a thread-parameter write, which is what keeps
 ;; the 3.4M switches/sec design point (R0(c)); the fibers define re-defines the
 ;; value in fibers.ss so the standalone gate can load it without rt.ss. Slot 1
-;; remains FREE since R3 (jolt-230w) removed the R1 ring/mark vregs — the tail
-;; marks live on the continuation, not in a vreg — so new virtual-register users
-;; should claim it before renumbering anything. The surviving slots keep their
-;; R2 numbers.
+;; was freed by R3 (jolt-230w), which moved the R1 ring/mark vregs onto the
+;; continuation, and re-claimed by fibers.ss for park-unwinding; the next free
+;; slot is 10. The surviving slots keep their R2 numbers.
 (define jolt-vreg-site 2)        ; ('ns/fn' . line) of the innermost live call site
 (define jolt-vreg-catch-line 3)  ; the site at the throw a catch clause is handling
 (define jolt-vreg-print-readably 4)  ; the print family's *print-readably* override; 0 = unset
@@ -365,6 +364,12 @@
 ;;   dispatched the running fiber with, so the park's finally walk knows where to stop
 ;; slot 8: values.ss jolt-vreg-symcell-cache — this thread's bounded identity
 ;;   front cache over the symbol-string pool (intern-symbol-cell)
+;; slot 9: java/host-static-methods.ss jolt-vreg-interrupt-box — this thread's
+;;   interrupt flag. A vreg and NOT a thread parameter on purpose: a thread
+;;   parameter is inherited by a forked thread, so the box had to carry the
+;;   owning thread's id and be re-checked on every read; a vreg starts at
+;;   fixnum 0 in a fresh thread, which is the property that workaround was
+;;   buying.
 ;; Effective *print-readably* for the readable renderer's string/char cases. The
 ;; print family stashes its override in the slot above — a virtual-register write
 ;; is ~1ns vs a pmap alloc + fold + two thread-parameter writes per dynamic


### PR DESCRIPTION
`#729` made fourteen blocking ops interruptible, and the check it added runs on
every interruptible wait — including the ones that never wait. A deref of an
already-delivered promise or a settled future calls `decide` once and returns,
and that path was wrapping `decide` in a fresh closure and consing a
registration entry up front: two allocations per call, for a registration the
call never makes.

## Thread the box, don't wrap the decision

`jolt-cv-wait/ibox` is the same loop with one more argument. `jolt-cv-wait`
passes `#f` and stays exactly as uninterruptible as it was, so the plumbing that
must never be interrupted — the carrier idle wait, the load barrier, the
main-queue pump, the tap queue, the channel internals — is untouched;
`jolt-cv-wait-interruptibly` is still the only door in, and still passes the
caller's own box. The fast path is now an `(if ibox …)` that falls through.

This does mean #729's "jolt-cv-wait itself is unchanged" is no longer literally
true, and the comments say so. It is the same loop, single-sourced, with the
interruptible arm guarded — not a fork of the wait protocol, which is the part
that mattered.

## The flag lives in a register now

`current-interrupt-box` stored `(thread-id . box)` and compared
`(get-thread-id)` on every read, for one reason: a Chez thread parameter is
**inherited** by a forked thread, so a plain one handed a child its parent's
interrupt box. A virtual register starts at fixnum 0 in a fresh thread — probed,
not assumed — which is precisely the property that workaround was buying, so
this deletes it rather than optimizing around it. Slot 9; `rt.ss` holds the map.

`.isInterrupted`, `Thread/interrupted`, `monitor-self`, monitor enter/exit and
`ReentrantLock`'s owner check all read that box too, so they get it as well.

Before porting any of this to Gambit, read jolt-c684: the Gambit vreg shim is
`make-parameter`-backed and *does* fork-inherit, while claiming in a comment
that it doesn't.

## Numbers

Release binary, A/B/A in one sitting, ms per 500k ops, medians of 5 rounds:

|                      | pre-#729 | main  | here  |
|----------------------|---------:|------:|------:|
| `@delivered-promise` |     27.4 |  32.3 |  30.3 |
| `@settled-future`    |     29.0 |  33.3 |  31.3 |
| ABQ put+take         |    175.0 | 185.8 | 182.9 |

Against pre-#729 that is **1.11x / 1.08x / 1.05x**, down from 1.18x / 1.15x /
1.06x. A second, separately interleaved sitting put the two derefs at 1.08x and
1.09x — so this sits *at* the 1.1x ceiling rather than comfortably under it, and
I would rather say that than quote the better of the two runs. The floor is
real: a diagnostic build that only reads a flag before deciding, with no lookup
and no registration at all, measures 1.04x. The ABQ column swings about 5% run
to run and should not be read finer than that.

## Gates

`unit` (10/10 `interrupt`, 21/21 `interrupt / blocking`, 4/4 `interrupt /
blocking fibers`), `corpus` (0 crashes, 0 new divergences, 10 known),
`lockcheck`, `parkcheck`, `gosm` 116/116, `asynctimer`, `interruptnest`,
`fibers` (all ten scripts), `threadsafety` — green.

Also here: `rt.ss`'s slot map claimed jolt used three virtual registers and that
slot 1 was free. Both had been false since fibers claimed slot 1, and the next
person to claim a slot would have double-booked it.

Closes jolt-a0f1.
