### PR TITLE
Preserve dialect use forms on stdin

### DIFF
--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -149,10 +149,17 @@
 ;; throws wherever it appears — top level or nested body — matching JVM. A forward
 ;; reference needs a declare, as it does on the JVM.
 ;;
-;; The CLI auto-quotes require vector/list args (but NOT symbols, so a plain
+;; The CLI auto-quotes require/use vector/list args (but NOT symbols — a plain
 ;; (require sym) evaluates sym normally) so `(require [my.lib :as m])` works
 ;; without an explicit quote, matching the convenience of JVM Clojure's ns macro.
-;; A dialect may define its own `use` macro and own the quoting of its arguments.
+;;
+;; The convenience belongs to clojure.core's require/use, not to the SPELLING of
+;; the head symbol. Forms are read and evaluated one at a time, so a dialect that
+;; defines its own `use` (or `require`) macro earlier in the same stdin program
+;; has already interned it by the time the next form is rewritten — and it owns
+;; the quoting of its own arguments. So the head is resolved the way the compiler
+;; will resolve it (a locally defined var, then a :refer, then clojure.core) and
+;; auto-quoting applies only when that lands on clojure.core's own var.
 (define (jolt-run-expr-string expr app-args print?)
   (let ((cla (if (null? app-args) jolt-nil (list->cseq app-args)))
         (end (string-length expr))
@@ -162,13 +169,36 @@
            (let ((ah (car (seq->list a))))
              (and (symbol-t? ah)
                   (string=? (symbol-t-name ah) "quote")))))
+    ;; Does HEAD name clojure.core's require/use? Resolved to the (ns . name) pair
+    ;; the compiler would reach — a locally DEFINED var shadows, then a :refer
+    ;; (which carries the name it was renamed FROM), else the implicit core refer.
+    ;; Deliberately compares the resolved pair rather than dereferencing
+    ;; clojure.core/require by name: a literal (var-cell-lookup "clojure.core"
+    ;; "require") here would be a runtime shim reference that has to be pinned as
+    ;; a dce-runtime-core-roots entry, which would keep require/use (and the whole
+    ;; loader behind them) unshakeable in every tree-shaken app.
+    (define (core-require-head? h)
+      (and (symbol-t? h)
+           (let* ((nm (symbol-t-name h))
+                  (sns (symbol-t-ns h))
+                  (qualified (and sns (not (jolt-nil? sns)) (not (null? sns)) sns))
+                  (here (chez-current-ns))
+                  (target
+                    (if qualified
+                        ;; a qualified ns may be a require :as alias
+                        (cons (or (chez-resolve-alias here qualified) qualified) nm)
+                        (cond ((let ((c (var-cell-lookup here nm)))
+                                 (and c (var-cell-defined? c)))
+                               (cons here nm))
+                              ((chez-resolve-refer here nm) => values)
+                              (else (cons "clojure.core" nm))))))
+             (and (string=? (car target) "clojure.core")
+                  (or (string=? (cdr target) "require")
+                      (string=? (cdr target) "use"))))))
     (define (maybe-quote-require-args form)
       (if (and (cseq? form)
                (let ((items (seq->list form)))
-                 (and (pair? items)
-                      (let ((h (car items)))
-                        (and (symbol-t? h)
-                             (string=? (symbol-t-name h) "require"))))))
+                 (and (pair? items) (core-require-head? (car items)))))
           (let ((items (seq->list form)))
             (list->cseq
               (cons (car items)

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -149,9 +149,10 @@
 ;; throws wherever it appears — top level or nested body — matching JVM. A forward
 ;; reference needs a declare, as it does on the JVM.
 ;;
-;; The CLI auto-quotes require/use vector/list args (but NOT symbols — a plain
+;; The CLI auto-quotes require vector/list args (but NOT symbols, so a plain
 ;; (require sym) evaluates sym normally) so `(require [my.lib :as m])` works
 ;; without an explicit quote, matching the convenience of JVM Clojure's ns macro.
+;; A dialect may define its own `use` macro and own the quoting of its arguments.
 (define (jolt-run-expr-string expr app-args print?)
   (let ((cla (if (null? app-args) jolt-nil (list->cseq app-args)))
         (end (string-length expr))
@@ -167,9 +168,7 @@
                  (and (pair? items)
                       (let ((h (car items)))
                         (and (symbol-t? h)
-                             (let ((hn (symbol-t-name h)))
-                               (or (string=? hn "require")
-                                   (string=? hn "use"))))))))
+                             (string=? (symbol-t-name h) "require"))))))
           (let ((items (seq->list form)))
             (list->cseq
               (cons (car items)

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -472,6 +472,18 @@ printf '%s\n' \
   '(defmacro use [& specs] `(println (quote ~specs)))' \
   '(use (demo :as d))' > "$use_prog"
 cla_check "$jolt - < \"$use_prog\"" '((demo :as d))'
+# ... and the same for a dialect-defined require, which shadows core's just as
+# a use macro does.
+printf '%s\n' \
+  '(defmacro require [& specs] `(println (quote ~specs)))' \
+  '(require (demo :as d))' > "$use_prog"
+cla_check "$jolt - < \"$use_prog\"" '((demo :as d))'
+# Shadowing is what turns the convenience off, not the name: an UNshadowed
+# top-level use still gets its args auto-quoted, the way require does.
+printf '%s\n' \
+  '(use [clojure.set :only [union]])' \
+  '(prn (union #{1} #{2}))' > "$use_prog"
+cla_check "$jolt - < \"$use_prog\"" '#{1 2}'
 rm -rf "$use_dir"
 
 # help prints usage (bare `help` and --help/-h are synonyms) and lists the

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -2,8 +2,8 @@
 # CLI smoke: exercise the real jolt process end to end — core eval, runtime
 # eval/load-string, runtime defmacro, futures, and the numeric tower. The in-process
 # corpus/unit gates cover semantics in depth; this confirms the CLI entry itself.
-root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
-cd "$root"
+root="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root" || exit 1
 
 # JOLT_BIN overrides the jolt under test (make test points it at the freshly
 # built target/release/jolt — 10x faster boot than script mode; the explicit
@@ -464,6 +464,15 @@ ns_dir="$(mktemp -d)"; ns_prog="$ns_dir/p.clj"
 printf "(intern (create-ns 'aux) 'AAA 42)\n(ns main)\n(refer 'aux :only '[AAA])\n(println AAA)\n" > "$ns_prog"
 cla_check "$jolt - < \"$ns_prog\"" '42'
 rm -rf "$ns_dir"
+
+# A dialect-defined use macro owns the quoting of its arguments. The stdin
+# evaluator must not quote them first and turn one module spec into (quote ...).
+use_dir="$(mktemp -d)"; use_prog="$use_dir/p.clj"
+printf '%s\n' \
+  '(defmacro use [& specs] `(println (quote ~specs)))' \
+  '(use (demo :as d))' > "$use_prog"
+cla_check "$jolt - < \"$use_prog\"" '((demo :as d))'
+rm -rf "$use_dir"
 
 # help prints usage (bare `help` and --help/-h are synonyms) and lists the
 # nREPL server as a bare command.


### PR DESCRIPTION
Limit the CLI argument auto-quoting convenience to require forms. 
This lets dialect-defined use macros retain ownership of their arguments.

Add a real-CLI stdin regression and keep the smoke script clean under shellcheck.