### PR TITLE
Expose Chez continuations as jolt.continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`jolt.continuations`: one-shot escape continuations (#736).** `call-cc` and
+  `letcc` expose the capability jolt's runtime already runs on — the fiber
+  park/resume switch, the throw site a backtrace is walked from — to jolt
+  programs. `(letcc [return] ...)` unwinds out of any depth, including out of a
+  callback a library invoked, where `reduced` cannot reach. JVM Clojure
+  cannot have this (the JVM cannot capture its stack), so
+  code using it is jolt-only by design, like `jolt.scheme`; it is purely
+  additive and no Clojure program is affected.
+
+  An escape is a real exit, so a `finally` between the capture and the escape
+  runs and a `binding` is restored — the opposite of a fiber park, which drops
+  those winders because a park is not an exit. A park between the capture and
+  the escape is fine within one fiber: the scheduler captures and restores the
+  fiber's whole stack segment.
+
+  Re-entrancy is not supported and never half-works. Invoking an escape twice,
+  invoking one after its `call-cc` returned, or invoking one from a thread or
+  fiber other than the one that captured it each raise
+  `IllegalStateException` naming the rule. The last of those is not pedantry:
+  the raw host primitive HANGS the process there, with no error at all.
 - **Digit separators in number literals (#389).** `1_000_000` reads as
   `1000000`. The rule is Java's, which is the one someone writing a grouped
   literal expects: an underscore must sit between two digits, never against the
@@ -25,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has none, and jolt's printer never emits one, so the only thing accepting
   them there would add is a hand-written config that reads on jolt and fails in
   every other edn reader.
-
 - **Atomic native-error capture for `jolt.ffi`.** `foreign-fn` and `defcfn`
   accept `{:capture-native-error true}` and return `[native-result error-code]`,
   capturing POSIX `errno` or Windows `GetLastError` in the foreign-call return

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ install: build
 # answers "is this working tree gated?" — which is not something to remember.
 
 CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke depscpcache depsunit \
-  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi ffidupsym stdlibfasl \
+  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi ffidupsym continuations stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
@@ -524,6 +524,15 @@ ffi:
 	@sh test/chez/ffi-aggregate-test.sh "$(CHEZ)"
 	@bin/jolt run test/chez/jolt-ffi-scoped-test.clj
 	@sh test/chez/ffi-native-error-test.sh "$(CHEZ)"
+
+# Escape continuations (jolt.continuations, issue #736): the one-shot contract
+# call-cc/letcc expose, what unwinds on an escape, that a park inside ONE fiber
+# is not an ownership boundary, and the four misuses. The cross-fiber rows are
+# why this gate exists — unguarded, invoking an escape captured on another
+# fiber hangs the process rather than raising, so each of those rows runs on a
+# watchdog thread and FAILS on a deadline instead of wedging the run.
+continuations:
+	@bin/jolt run test/chez/continuations-test.clj
 
 # Transients: mutable backing, snapshot on persistent!, and linear-time builds.
 transient:

--- a/host/chez/continuations.ss
+++ b/host/chez/continuations.ss
@@ -1,0 +1,173 @@
+;; continuations.ss — the jolt.continuations seam (issue #736).
+;;
+;; Chez has first-class continuations and the host already leans on them:
+;; call/1cc drives the fiber park/resume switch (fibers.ss), call/cc captures
+;; the throw site for a backtrace (rt.ss), and the state-image machinery walks
+;; them. None of that was reachable from a jolt program. This file exposes ONE
+;; thing — the one-shot ESCAPE continuation — as jolt.host/call-cc, which
+;; stdlib/jolt/continuations.clj presents as call-cc / letcc.
+;;
+;; WHY ONLY ESCAPE. The primitive underneath is the adapter's
+;; sa-call-with-escape-continuation, contracted to call/1cc's semantics: the
+;; captured procedure is valid at most once, and only while its capturing call
+;; is still on the stack. That is the shape the host itself uses, it is the
+;; shape a target can implement without a full multi-shot stack model, and it
+;; is the shape with a defensible story for fibers (below). Re-entrant
+;; continuations are deliberately NOT exposed.
+;;
+;; WHY THE GUARD IS NOT OPTIONAL. Handing the raw primitive to jolt gets two
+;; bad outcomes, both measured before this file existed:
+;;
+;;   * Re-invoking a spent continuation raises a Chez condition that reaches
+;;     jolt as class :object: with an EMPTY message — catchable in principle,
+;;     useless in practice, and nothing tells the caller which rule broke.
+;;
+;;   * Invoking a continuation captured on ANOTHER fiber HANGS the process.
+;;     Not an error, not a timeout: control transfers into a stack segment
+;;     belonging to a fiber this thread is not running, and never comes back.
+;;     A continuation captured on a dead fiber and invoked from the main thread
+;;     wedges the program with no diagnostic at all.
+;;
+;; So every escape this file hands out is a WRAPPER that answers three
+;; questions before it transfers control, and raises IllegalStateException
+;; naming the broken rule when the answer is no:
+;;
+;;   1. spent?  — has this escape already fired? ("already been invoked")
+;;   2. mine?   — am I on the thread AND the fiber that captured it?
+;;                ("captured on another")
+;;   3. live?   — has its call-cc already returned normally? ("no longer live")
+;;
+;; Only (2) prevents a hang; (1) and (3) would eventually reach the adapter's
+;; own raise, but they are checked here so the message names the rule instead
+;; of surfacing a host condition. All three are O(1) reads on the escape path.
+;; They are checked in that order because several can hold at once — see
+;; jolt-cc-check! for why the ownership answer outranks the lifetime one.
+;;
+;; WHAT ABOUT PARKING. A park is NOT an ownership boundary. A fiber that parks
+;; (yield, a channel op, a parked deref, jolt.socket IO) has its whole stack
+;; segment captured and later restored by the scheduler, so an escape captured
+;; before the park is still the same fiber's frame after it and the escape
+;; works — verified by the gate, and the reason the identity checked here is
+;; (thread, fiber) and not "the stack as it stood at capture". A fiber is bound
+;; to its carrier for life, so neither half of that pair drifts under a park.
+;;
+;; The identity is captured as a PAIR of cheap reads: the thread id (the
+;; contract's get-thread-id, a number distinct per live thread) and the current
+;; fiber record (the vreg fibers.ss owns; 0 off a fiber). Comparing the fiber
+;; by eq? is what separates two fibers on the SAME carrier thread, which a
+;; thread id alone cannot do.
+
+;; The fiber vreg, read the way fibers.ss reads it. Guarded because this file
+;; is loaded from rt.ss after fibers.ss, but the standalone gates load pieces
+;; of the runtime in other orders and a missing fiber layer must degrade to
+;; "not on a fiber" rather than break the capture.
+(define (jolt-cc-current-fiber)
+  (guard (e (#t #f))
+    (let ((r (virtual-register jolt-vreg-current-fiber)))
+      (if (eq? r 0) #f r))))
+
+(define (jolt-cc-thread-id)
+  (guard (e (#t 0)) (get-thread-id)))
+
+;; An escape's identity and state. Kept in a record rather than closed-over
+;; mutable variables so jolt-escape-fn? can recognise one by its wrapper (see
+;; jolt-cc-escapes below) and so the three checks read named fields.
+(define-record-type jolt-escape
+  (fields (immutable k jolt-escape-k)
+          (immutable thread jolt-escape-thread)
+          (immutable fiber jolt-escape-fiber)
+          (mutable spent jolt-escape-spent? jolt-escape-spent-set!)
+          (mutable live jolt-escape-live? jolt-escape-live-set!)))
+
+;; The wrapper procedures handed to jolt, keyed by the procedure itself, so
+;; jolt-escape-fn? can answer for a value that is otherwise an ordinary jolt
+;; callable. An eq?-keyed weak table: an escape that is collected takes its
+;; entry with it, and the table never keeps a spent capture (or its stack
+;; segment) alive. Per-process and not per-thread — escapes are compared by
+;; identity, and a wrapper may legitimately be ASKED about from another thread
+;; even though invoking it there is refused.
+;;
+;; UNDER THE MUTEX, BOTH DIRECTIONS. This is the same shape as hasheq.ss's
+;; proc-hasheq-tbl and takes the same lock for the same reason: a global weak
+;; table written by two threads at once faults in the collector, and a read
+;; racing a write is no safer than two writes. Captures happen on any thread,
+;; so neither side can be left unguarded.
+;;
+;; WHAT IT COSTS, measured (2M captures, this machine): the bare capture —
+;; call/1cc plus the case-lambda — is 8.5 ns. The weak-table write takes it to
+;; 61 ns, and the mutex to 86 ns. So escape-fn? is not free: it makes a capture
+;; about 10x its floor. It is still far below the exception-based early exit it
+;; replaces, and it is paid per CAPTURE, not per iteration of whatever loop the
+;; capture wraps — but "costs nothing" would be a lie, and the number is
+;; recorded here so the trade can be revisited rather than rediscovered.
+(define jolt-cc-escapes (make-weak-eq-hashtable))
+(define jolt-cc-escapes-mu (make-mutex))
+
+(define (jolt-cc-register! escape e)
+  (jolt-with-mutex jolt-cc-escapes-mu (hashtable-set! jolt-cc-escapes escape e)))
+
+(define (jolt-escape-fn? x)
+  (and (procedure? x)
+       (jolt-with-mutex jolt-cc-escapes-mu
+         (and (hashtable-ref jolt-cc-escapes x #f) #t))))
+
+;; The three rules. ORDER IS THE MESSAGE: more than one can be true at once,
+;; and the caller is told the most actionable of them.
+;;
+;;   spent first — an escape that fired is also no longer live and may also be
+;;   read from the wrong thread, but "you invoked it twice" is the whole bug.
+;;
+;;   owner before live — these two go together constantly: an escape saved out
+;;   of a fiber and invoked later from the main thread is BOTH dead and
+;;   foreign. "No longer live" is true there but reads as a lifetime problem,
+;;   and the caller's actual mistake is structural: they moved an escape across
+;;   a boundary it cannot cross. Reporting the boundary points at the fix.
+;;   Reversed, the cross-fiber case — the one that used to hang — would report
+;;   the least useful of its two true answers.
+(define (jolt-cc-check! e)
+  (cond
+    ((jolt-escape-spent? e)
+     (throw-jvm 'IllegalStateException
+                "jolt.continuations: this escape has already been invoked — an escape continuation is one-shot"))
+    ((not (and (eqv? (jolt-escape-thread e) (jolt-cc-thread-id))
+               (eq? (jolt-escape-fiber e) (jolt-cc-current-fiber))))
+     (throw-jvm 'IllegalStateException
+                (string-append
+                 "jolt.continuations: this escape was captured on another "
+                 (if (jolt-escape-fiber e) "fiber" "thread")
+                 " — an escape continuation may only be invoked from the thread and fiber that captured it")))
+    ((not (jolt-escape-live? e))
+     (throw-jvm 'IllegalStateException
+                "jolt.continuations: this escape is no longer live — its call-cc already returned"))
+    (else (void))))
+
+;; jolt.host/call-cc. f is a jolt fn of one argument; it receives the escape.
+;; The escape takes the value to return, or no argument for nil.
+;;
+;; live is cleared on the normal return, so a wrapper that outlives its frame
+;; answers the lifetime rule here rather than reaching the adapter's raise. An
+;; escape never reaches that clear — it transferred control out — which is why
+;; the escape path sets spent BEFORE transferring: after the transfer this code
+;; does not run again.
+(define (jolt-call-cc f)
+  (sa-call-with-escape-continuation
+   (lambda (k)
+     (let ((e (make-jolt-escape k (jolt-cc-thread-id) (jolt-cc-current-fiber) #f #t)))
+       (let ((escape
+              (case-lambda
+                (() (jolt-cc-check! e)
+                    (jolt-escape-spent-set! e #t)
+                    ((jolt-escape-k e) jolt-nil))
+                ((v) (jolt-cc-check! e)
+                     (jolt-escape-spent-set! e #t)
+                     ((jolt-escape-k e) v)))))
+         (jolt-cc-register! escape e)
+         ;; The normal return. An escape never reaches here (k transferred
+         ;; control out of this lambda), so clearing live here is exactly the
+         ;; "call-cc returned without you" case rule 2 reports.
+         (let ((v (jolt-invoke1 f escape)))
+           (jolt-escape-live-set! e #f)
+           v))))))
+
+(def-var! "jolt.host" "call-cc" jolt-call-cc)
+(def-var! "jolt.host" "escape-fn?" jolt-escape-fn?)

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -17,6 +17,7 @@ block-sigint
 build-binary
 build-library
 bytes-allocated
+call-cc
 call-on-main-thread
 call-on-main-thread-async
 callable-host?
@@ -39,6 +40,7 @@ delete-tree!
 directory?
 enable-trace!
 entry-at
+escape-fn?
 exact?
 extension-epoch
 extension-has?

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -1585,6 +1585,12 @@
 ;; runtime (it depends on async.ss).
 (load "host/chez/java/fibers-async.ss")
 
+;; Escape continuations as a jolt API (issue #736): jolt.host/call-cc, which
+;; stdlib/jolt/continuations.clj presents as call-cc / letcc. After fibers.ss —
+;; the guard that refuses an escape captured on another fiber reads the fiber
+;; vreg, and refusing is what keeps a cross-fiber invoke from hanging.
+(load "host/chez/continuations.ss")
+
 ;; The cheap park (R7, jolt-nvpr.9): __sm-spawn/__sm-take/__sm-put, the ops a
 ;; CPS'd go body (the pass in clojure.core.async) calls. A
 ;; lexically-parking body stores the rest of the computation as an ordinary

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -443,6 +443,29 @@
 ;; Degradation: none.
 (define (sa-foreign-callable-entry-point co) (foreign-callable-entry-point co))
 
+;; ---- continuations tier (capability: continuations) --------------------------
+
+;; (sa-call-with-escape-continuation proc) -> value
+;; Call PROC with a one-shot ESCAPE procedure k. Invoking (k v) returns v from
+;; this sa-call-with-escape-continuation call, unwinding the dynamic-wind chain
+;; between the two — an escape is a real exit, so a jolt `finally` in between
+;; RUNS (unlike a fiber park, which drops those winders first).
+;;
+;; The contract is call/1cc's, and a target must enforce it rather than merely
+;; offer it: k is valid AT MOST ONCE, and only while this call is still on the
+;; stack. Invoking it a second time, or after PROC has returned normally, must
+;; RAISE — never re-enter, and never hang. That is what lets the layer above
+;; (host/chez/continuations.ss) present a single one-shot escape semantic on
+;; every target instead of one per target's continuation model.
+;;
+;; Degradation: a target with no continuations at all must raise a
+;; message-carrying condition; jolt.continuations then fails honestly rather
+;; than silently doing nothing. Chez: call/1cc natively, so this is the whole
+;; implementation — zero wrappers, capture is O(1) and depth-independent.
+;; Gambit: call/cc plus the spent flag its adapter carries, because call/cc is
+;; multi-shot and would otherwise re-enter a dead frame.
+(define (sa-call-with-escape-continuation proc) (call/1cc proc))
+
 ;; ---- R8: eval/compile/AOT (capabilities: native-compile, image) --------------
 
 ;; (sa-baked-global sym) -> value | #f

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -43,6 +43,7 @@ grenadine.lock
 grenadine.repo
 grenadine.runtime
 grenadine.source
+jolt.continuations
 jolt.fibers
 jolt.fs
 jolt.image

--- a/host/gambit/gambitcheck.ss
+++ b/host/gambit/gambitcheck.ss
@@ -403,6 +403,55 @@
   (check-raise-message "sa-run-process" (lambda () (sa-run-process "echo hi" #f))
                        "subprocess support is unsupported on the gambit target"))
 
+;; ---- continuations tier — the one-shot escape primitive ---------------------
+;; The gambit target IMPLEMENTS this tier rather than degrading, so these rows
+;; assert real behaviour, not an honest-failure message. The two refusals are
+;; the whole reason the adapter wraps call/cc at all: call/cc is multi-shot and
+;; would happily graft control back into a frame that already finished.
+(define (test-continuations)
+  (printf "== continuations: one-shot escape (call/cc + spent flag) ==\n")
+  (check "escape returns its value"
+         (sa-call-with-escape-continuation (lambda (k) (k 'escaped) 'not-reached))
+         'escaped)
+  (check "falling through returns the body value"
+         (sa-call-with-escape-continuation (lambda (k) 'fell-through))
+         'fell-through)
+  (check "escape leaves a loop from depth"
+         (sa-call-with-escape-continuation
+          (lambda (k) (let loop ((i 0)) (if (= i 100) (k i) (loop (+ i 1))))))
+         100)
+  ;; An escape is a real exit: the dynamic-wind chain between the capture and
+  ;; the escape unwinds, which is what makes a jolt `finally` run.
+  (check "escape unwinds dynamic-wind"
+         (let ((log '()))
+           (sa-call-with-escape-continuation
+            (lambda (k)
+              (dynamic-wind
+                (lambda () (set! log (cons 'in log)))
+                (lambda () (k 'out))
+                (lambda () (set! log (cons 'out log))))))
+           (reverse log))
+         '(in out))
+  (check-raise-message "second invocation refused"
+                       (lambda ()
+                         (let ((saved #f))
+                           (sa-call-with-escape-continuation
+                            (lambda (k) (set! saved k) (k 'first)))
+                           (saved 'again)))
+                       "escape continuation is spent")
+  (check-raise-message "invocation after a normal return refused"
+                       (lambda ()
+                         (let ((saved #f))
+                           (sa-call-with-escape-continuation
+                            (lambda (k) (set! saved k) 'fell-through))
+                           (saved 'too-late)))
+                       "escape continuation is spent")
+  (check "a fresh capture after a spent one still escapes"
+         (let ((saved #f))
+           (sa-call-with-escape-continuation (lambda (k) (set! saved k) (k 'first)))
+           (sa-call-with-escape-continuation (lambda (k) (k 'second))))
+         'second))
+
 ;; ---- coroutines tier (fibers R1) — the call/cc-based fiber primitive --------
 ;; Mirrors the Chez gate's correctness set at small scale: round trip,
 ;; round-robin order, per-fiber raise isolation with a surviving scheduler,
@@ -482,6 +531,7 @@
 (test-threads)
 (test-hasheq-known-answers)
 (test-sa-surface)
+(test-continuations)
 (test-coroutines)
 
 (printf "\ngambitcheck: ~a failure(s)\n" failures)

--- a/host/gambit/scheme-adapter-runtime.ss
+++ b/host/gambit/scheme-adapter-runtime.ss
@@ -373,6 +373,39 @@
 (define (sa-fasl-read port . rest)
   (error 'sa-fasl-read "fasl serialization is unsupported on the gambit target"))
 
+;; ---- continuations tier (capability: continuations) -------------------------
+
+;; (sa-call-with-escape-continuation proc) -> value
+;; The one-shot ESCAPE continuation jolt.continuations is built on. Gambit's
+;; usable primitive is call/cc (the same R0(e) finding the fiber scheduler
+;; below rests on: ##continuation-capture/##continuation-graft SIGBUS gsi on
+;; same-stack re-entry), and call/cc is MULTI-SHOT — so the one-shot half of
+;; the contract is this adapter's job, not something the primitive gives.
+;;
+;; The spent flag is what supplies it. Chez's call/1cc refuses a second
+;; invocation and refuses one after the capturing call returned; both refusals
+;; are reproduced here, because without them a re-invocation would graft
+;; control back into a frame that already finished and silently re-run the
+;; caller's half-completed expression — the exact trap the fiber scheduler
+;; below avoids by construction rather than by checking.
+;;
+;; The flag is set on the normal return as well as on the escape: after PROC
+;; answers, this capture is no longer live, and a saved k invoked later must
+;; raise rather than re-enter. The layer above (host/chez/continuations.ss)
+;; adds the thread/fiber ownership rule and the jolt-level error; a target owes
+;; only the one-shot primitive.
+(define (sa-call-with-escape-continuation proc)
+  (call/cc
+   (lambda (k)
+     (let ((spent #f))
+       (let ((v (proc (lambda (val)
+                        (if spent
+                            (error 'sa-call-with-escape-continuation
+                                   "escape continuation is spent")
+                            (begin (set! spent #t) (k val)))))))
+         (set! spent #t)
+         v)))))
+
 ;; ---- fibers R1: coroutines tier (capability: coroutines) --------------------
 ;; Stackful green threads sharing one OS thread, per CONTRACT.txt's coroutines
 ;; tier. R0(e) pinned the primitive: ##continuation-capture/##continuation-graft

--- a/host/scheme-adapter/CONTRACT.txt
+++ b/host/scheme-adapter/CONTRACT.txt
@@ -191,6 +191,29 @@ sa-foreign-procedure
 sa-foreign-procedure-native-error
 sa-foreign-procedure-blocking
 #
+# tier: capability-continuations
+# OUR OWN definition in host/chez/scheme-adapter-runtime.ss — the one-shot
+# ESCAPE continuation, exposed to jolt programs as jolt.continuations
+# (call-cc / letcc) via host/chez/continuations.ss.
+#   (sa-call-with-escape-continuation proc) -> value: call PROC with a one-shot
+#     escape procedure k; (k v) returns v from THIS call, unwinding the
+#     dynamic-wind chain in between (so a jolt `finally` runs — an escape is a
+#     real exit, unlike a fiber park, which drops those winders first).
+# ENFORCED, NOT MERELY OFFERED: k is valid AT MOST ONCE and only while this
+# call is still on the stack. A second invocation, or one after PROC returned
+# normally, must RAISE — never re-enter a dead frame and never hang. A target
+# whose only continuation primitive is multi-shot (Gambit's call/cc) carries a
+# spent flag in its adapter to meet this; Chez's call/1cc is the contract
+# natively, so its adapter is a one-liner.
+# The layer above adds jolt policy the contract does not: which thread and
+# fiber may invoke a given escape, and the jolt-level error. Targets do not
+# implement that — they only owe the one-shot primitive.
+# Permitted degradation: a target with no usable continuations must raise a
+# message-carrying condition (never leave the name unbound); jolt.continuations
+# then fails honestly on that target, the same shape jolt.image takes when
+# fasl serialization is absent.
+sa-call-with-escape-continuation
+#
 # tier: eval
 # interaction-environment: R7RS (scheme repl), not Chez-only. The ONLY host
 # call shape is the standard (eval expr (interaction-environment)) — jolt's

--- a/host/scheme-adapter/TARGET-CONTRACT.md
+++ b/host/scheme-adapter/TARGET-CONTRACT.md
@@ -39,6 +39,15 @@ misbehavior, not a crash.
 - **`condition-wait` may wake spuriously.** Every wait site loops on its
   predicate; your implementation may wake threads freely but must not LOSE
   wakeups.
+- **An escape continuation is one-shot, and the target enforces it.**
+  `sa-call-with-escape-continuation` hands `proc` a procedure valid AT MOST
+  ONCE and only while that call is still on the stack. A second invocation, or
+  one after `proc` returned normally, must RAISE — a target whose only
+  primitive is multi-shot (`call/cc`) carries a spent flag rather than letting
+  control re-enter a finished frame. The escape must unwind the dynamic-wind
+  chain on its way out: jolt's `finally` runs on an escape, and a target that
+  skipped the unwind would silently drop cleanup. Ownership (which thread and
+  fiber may invoke a given escape) is the HOST's rule, not yours.
 - **Native error capture is part of the foreign call boundary.**
   `sa-foreign-procedure-native-error` must return the C result and the calling
   thread's errno/GetLastError-equivalent atomically; a later host call that reads

--- a/host/scheme-adapter/guile.ss
+++ b/host/scheme-adapter/guile.ss
@@ -100,6 +100,11 @@
 ;; ---------------------------------------------------------------------------
 ;; tier: capability-ffi
 ;; ---------------------------------------------------------------------------
+;;   sa-call-with-escape-continuation UNIMPLEMENTED Guile has call/cc; wrap it with a
+;;                                        spent flag so a second invocation (or one after
+;;                                        the capturing call returned) RAISES rather than
+;;                                        re-entering. The escape must unwind dynamic-wind
+;;                                        on the way out — jolt's `finally` rides that.
 ;;   sa-foreign-procedure   UNIMPLEMENTED  Guile: (pointer->procedure ret (dynamic-func name
 ;;                                        lib) args) — (system foreign). must verify call
 ;;                                        shape translation; SYNTAX on Chez (lowering).

--- a/stdlib/jolt/continuations.clj
+++ b/stdlib/jolt/continuations.clj
@@ -1,0 +1,85 @@
+;; jolt.continuations — one-shot escape continuations.
+;;
+;; Chez captures continuations natively and jolt's runtime already runs on
+;; them: the fiber park/resume switch, the throw site a backtrace is walked
+;; from, the state image. This namespace hands the capability to jolt programs.
+;; JVM Clojure has no equivalent and cannot have one — the JVM cannot capture
+;; its stack — so code here is JOLT-ONLY by design, like jolt.scheme. It is
+;; purely additive: no Clojure program is affected by its existence.
+;;
+;; What you get is an ESCAPE, not a re-entrant continuation:
+;;
+;;   (call-cc (fn [escape] ...))   ;; (escape v) makes call-cc answer v
+;;   (letcc [escape] ...)          ;; the same, macro-shaped
+;;
+;; ONE-SHOT, and only inward. An escape is valid at most once, and only while
+;; its own call-cc is still running. It is the `return` a Clojure program
+;; otherwise writes with reduced/some or an exception, and it unwinds from any
+;; depth — including out of a callback a library invoked, where reduced cannot
+;; reach. It is not free: a capture costs about 86ns (host/chez/
+;; continuations.ss records the breakdown), paid once per call-cc rather than
+;; per iteration of whatever the capture wraps.
+;;
+;; Re-entrancy (resuming a computation that already finished, generators built
+;; by re-invoking a saved continuation) is NOT supported and never silently half-works: every misuse
+;; raises IllegalStateException naming the rule it broke.
+;;
+;;   (escape v) twice                      -> \"already been invoked\"
+;;   (escape v) after call-cc returned     -> \"no longer live\"
+;;   (escape v) from another thread/fiber  -> \"captured on another ...\"
+;;
+;; The third is not pedantry. Invoking a continuation captured on another
+;; fiber transfers control into a stack segment this thread is not running;
+;; unguarded it HANGS the process with no error at all.
+;;
+;; UNWINDING. An escape is a real exit, so everything between the capture and
+;; the escape unwinds on the way out: a `finally` runs, innermost first, and a
+;; `binding` is restored. This is the opposite of a fiber park, which
+;; deliberately drops the `finally` winders because a park is not an exit.
+;;
+;; FIBERS. A park between the capture and the escape is fine — inside ONE
+;; fiber. Yield, a channel op, a parked deref, jolt.socket IO: the scheduler
+;; captures and restores the fiber's whole stack segment, so the escape is
+;; still the same frame when the fiber resumes. What is refused is crossing
+;; fibers or threads with an escape, which is the hang above.
+(ns jolt.continuations)
+
+(defn call-cc
+  "Call f with an escape continuation and return f's value, or the value the
+  escape was given.
+
+  (call-cc (fn [escape] body...)) runs body. If body calls (escape v), call-cc
+  answers v immediately, unwinding out of body — running any `finally` in
+  between and restoring any `binding`. (escape) with no argument answers nil.
+  If body returns normally instead, call-cc answers what body returned.
+
+  The escape is ONE-SHOT and scoped to this call: valid at most once, and only
+  while this call-cc is still running, only on the thread and fiber that
+  captured it. Every other use raises IllegalStateException — see the
+  namespace docs."
+  [f]
+  (jolt.host/call-cc f))
+
+(defmacro letcc
+  "(letcc [escape] body...) — call-cc with the escape bound by name.
+
+  Equivalent to (call-cc (fn [escape] body...)); body's last form is the value
+  when nothing escapes.
+
+      (letcc [return]
+        (doseq [x xs]
+          (when (pred x) (return x)))
+        nil)"
+  [binding & body]
+  (when-not (and (vector? binding) (= 1 (count binding)) (symbol? (first binding)))
+    (throw (ex-info "jolt.continuations/letcc requires a [escape] binding of one symbol"
+                    {:binding binding})))
+  (list 'jolt.host/call-cc (concat (list 'fn binding) body)))
+
+(defn escape-fn?
+  "True when x is an escape continuation handed out by call-cc or letcc.
+
+  Answers for an escape from any thread — asking about one is always allowed,
+  even where invoking it would be refused."
+  [x]
+  (jolt.host/escape-fn? x))

--- a/test/chez/continuations-test.clj
+++ b/test/chez/continuations-test.clj
@@ -1,0 +1,288 @@
+;; continuations-test.clj — the jolt.continuations gate (issue #736).
+;;
+;; Pins the ONE-SHOT ESCAPE contract call-cc/letcc expose over the host's
+;; call/1cc:
+;;   * an escape returns its value from the call-cc form, from any depth;
+;;   * falling through returns the body's value;
+;;   * a `finally` between the capture and the escape RUNS (an escape is a real
+;;     exit, unlike a fiber park, which drops those winders);
+;;   * a binding/parameterize between them is restored;
+;;   * a park between the capture and the escape is fine WITHIN one fiber — the
+;;     fiber's stack segment is captured and restored whole.
+;;
+;; And the four ways to misuse it, each of which must raise a catchable jolt
+;; error naming what happened. Two of them are why this file exists: before the
+;; guard, invoking a continuation captured on another fiber HUNG the process
+;; (no error, no timeout), and re-invoking one raised a Chez condition that
+;; reached jolt as class :object: with an empty message.
+;;
+;; Every row that invokes a continuation across an ownership boundary runs on a
+;; watchdog thread with a join deadline, so a regression that reinstates the
+;; hang FAILS this gate instead of wedging it.
+
+(ns continuations-test
+  (:require [jolt.continuations :as k]
+            [jolt.fibers :as fib]))
+
+(def failures (atom []))
+(defn check [label pred]
+  (when-not pred (swap! failures conj label)))
+
+;; Run (f) on its own thread and answer [:ok v] / [:threw class message], or
+;; :timeout when it does not finish inside ms. A guard that fails open shows up
+;; here as :timeout rather than hanging the gate.
+(defn within [ms f]
+  (let [box (atom :timeout)
+        t (Thread. (fn []
+                     (reset! box
+                             (try [:ok (f)]
+                                  (catch Throwable e
+                                    [:threw (.getName (class e)) (ex-message e)])))))]
+    (.start t)
+    (.join t ms)
+    @box))
+
+(defn illegal-state?
+  "The result of `within` is a raise of IllegalStateException whose message
+  mentions what the caller did wrong."
+  [result needle]
+  (and (vector? result)
+       (= :threw (nth result 0))
+       (= "java.lang.IllegalStateException" (nth result 1))
+       (string? (nth result 2))
+       (clojure.string/includes? (nth result 2) needle)))
+
+;; --- escaping ----------------------------------------------------------------
+
+(check "escape returns its value from call-cc"
+       (= :escaped (k/call-cc (fn [escape] (escape :escaped) :not-reached))))
+
+(check "falling through returns the body value"
+       (= :fell-through (k/call-cc (fn [_] :fell-through))))
+
+(check "escape from inside a loop"
+       (= 3 (k/call-cc (fn [escape]
+                         (doseq [x [1 2 3 4 5]]
+                           (when (= x 3) (escape x)))
+                         :not-reached))))
+
+(check "escape from inside a reduce"
+       (= :negative (k/call-cc (fn [escape]
+                                 (reduce (fn [acc x]
+                                           (if (neg? x) (escape :negative) (+ acc x)))
+                                         0 [1 2 -3 4])))))
+
+(check "escape from a deeply nested non-tail recursion"
+       (= :deep (k/call-cc (fn [escape]
+                             (letfn [(down [n] (if (zero? n) (escape :deep) (inc (down (dec n)))))]
+                               (down 200))))))
+
+(check "escape carries nil"
+       (nil? (k/call-cc (fn [escape] (escape nil) :not-reached))))
+
+(check "escape carries false"
+       (false? (k/call-cc (fn [escape] (escape false) :not-reached))))
+
+(check "zero-arity escape answers nil"
+       (nil? (k/call-cc (fn [escape] (escape) :not-reached))))
+
+;; --- letcc is call-cc ---------------------------------------------------------
+
+(check "letcc escapes"
+       (= 3 (k/letcc [escape]
+              (doseq [x [1 2 3 4 5]] (when (= x 3) (escape x)))
+              :not-reached)))
+
+(check "letcc falls through to its last form"
+       (= :fell-through (k/letcc [escape] :ignored :fell-through)))
+
+(check "letcc body sees the enclosing scope"
+       (= 42 (let [n 42] (k/letcc [escape] (escape n)))))
+
+;; --- nesting ------------------------------------------------------------------
+
+(check "an inner escape does not disturb the outer capture"
+       (= [:inner :outer-done]
+          (k/call-cc (fn [outer]
+                       [(k/call-cc (fn [inner] (inner :inner) :not-reached))
+                        :outer-done]))))
+
+(check "an inner body can escape the OUTER capture"
+       (= :straight-out
+          (k/call-cc (fn [outer]
+                       (k/call-cc (fn [_inner] (outer :straight-out)))
+                       :not-reached))))
+
+;; --- escape-fn? ---------------------------------------------------------------
+
+(check "escape-fn? is true for the captured escape"
+       (true? (k/call-cc (fn [escape] (k/escape-fn? escape)))))
+
+(check "escape-fn? is false for an ordinary fn"
+       (false? (k/escape-fn? (fn [_] nil))))
+
+(check "escape-fn? is false for a non-fn"
+       (and (false? (k/escape-fn? 1))
+            (false? (k/escape-fn? nil))
+            (false? (k/escape-fn? :escape))))
+
+;; --- unwinding: an escape is a real exit ---------------------------------------
+
+(check "finally runs when the escape leaves a try"
+       (= [:finally]
+          (let [log (atom [])]
+            (k/call-cc (fn [escape]
+                         (try (escape :out) (finally (swap! log conj :finally)))))
+            @log)))
+
+(check "nested finallys run innermost first"
+       (= [:inner :outer]
+          (let [log (atom [])]
+            (k/call-cc (fn [escape]
+                         (try (try (escape :out)
+                                   (finally (swap! log conj :inner)))
+                              (finally (swap! log conj :outer)))))
+            @log)))
+
+(check "the escape's value survives a finally that runs after it"
+       (= :out (let [log (atom [])]
+                 (k/call-cc (fn [escape]
+                              (try (escape :out)
+                                   (finally (swap! log conj :finally))))))))
+
+(check "a dynamic binding is restored by the escape"
+       (= [:inner :root]
+          (let [seen (atom nil)]
+            [(binding [*print-readably* :inner]
+               (k/call-cc (fn [escape] (escape *print-readably*))))
+             (do (reset! seen :root) @seen)])))
+
+(check "an escape does not run a finally it never entered"
+       (= [] (let [log (atom [])]
+               (k/call-cc (fn [escape] (escape :out)))
+               (try :untouched (finally nil))
+               @log)))
+
+;; --- fibers -------------------------------------------------------------------
+
+(check "capture and escape inside one fiber"
+       (= :fiber-escape
+          (fib/join (fib/spawn (fn [] (k/call-cc (fn [escape] (escape :fiber-escape))))))))
+
+(check "a park between the capture and the escape is fine within one fiber"
+       (= :after-park
+          (fib/join (fib/spawn (fn []
+                                 (k/call-cc (fn [escape]
+                                              (fib/yield)
+                                              (escape :after-park))))))))
+
+(check "a parked deref between the capture and the escape is fine within one fiber"
+       (= :after-deref
+          (fib/join (fib/spawn (fn []
+                                 (k/call-cc (fn [escape]
+                                              (let [p (promise)]
+                                                (fib/spawn (fn [] (deliver p :v)))
+                                                @p
+                                                (escape :after-deref)))))))))
+
+;; --- the four misuses ----------------------------------------------------------
+;; Each must RAISE, and each raise must say which rule was broken.
+
+(check "re-invoking an escape that already fired raises"
+       (illegal-state?
+        (within 5000
+                (fn []
+                  (let [saved (atom nil)]
+                    (k/call-cc (fn [escape] (reset! saved escape) (escape :first)))
+                    (@saved :again))))
+        "already"))
+
+(check "invoking an escape after its call-cc returned normally raises"
+       (illegal-state?
+        (within 5000
+                (fn []
+                  (let [saved (atom nil)]
+                    (k/call-cc (fn [escape] (reset! saved escape) :fell-through))
+                    (@saved :too-late))))
+        "no longer"))
+
+(check "invoking an escape from another thread raises rather than hanging"
+       (illegal-state?
+        (let [saved (atom nil)
+              ready (promise)]
+          (k/call-cc (fn [escape] (reset! saved escape) (deliver ready true) :captured))
+          @ready
+          (within 5000 (fn [] (@saved :cross-thread))))
+        "another"))
+
+(check "invoking an escape captured on a dead fiber raises rather than hanging"
+       (illegal-state?
+        (let [saved (atom nil)]
+          (fib/join (fib/spawn (fn [] (k/call-cc (fn [escape] (reset! saved escape) :done)))))
+          (within 5000 (fn [] (@saved :cross-fiber))))
+        "another"))
+
+(check "invoking an escape captured on a LIVE other fiber raises rather than hanging"
+       (illegal-state?
+        (let [saved (promise)
+              hold (promise)
+              f (fib/spawn (fn []
+                             (k/call-cc (fn [escape]
+                                          (deliver saved escape)
+                                          @hold
+                                          :done))))]
+          (let [escape @saved
+                result (within 5000 (fn [] (escape :cross-fiber)))]
+            (deliver hold true)
+            (fib/join f)
+            result))
+        "another"))
+
+;; --- the guard does not cost correctness on the happy path ---------------------
+
+(check "a fresh capture after a spent one still escapes"
+       (= [:first :second]
+          (let [saved (atom nil)]
+            [(k/call-cc (fn [escape] (reset! saved escape) (escape :first)))
+             (k/call-cc (fn [escape] (escape :second)))])))
+
+(check "many captures in a loop each escape independently"
+       (= (range 50)
+          (map (fn [n] (k/call-cc (fn [escape] (escape n)))) (range 50))))
+
+;; --- the escape registry under concurrency -------------------------------------
+;; escape-fn? is backed by a process-wide weak table, so captures on several
+;; threads WRITE it while escape-fn? READS it. Unguarded that is the
+;; writer-vs-writer collector fault, which shows up as a crash rather than a
+;; wrong answer — so this row is here to run the shape, not to assert a value.
+
+(check "concurrent captures and escape-fn? across threads"
+       (= (range 6)
+          (let [results (atom {})
+                ts (doall (for [t (range 6)]
+                            (Thread. (fn []
+                                       (dotimes [i 2000]
+                                         (k/call-cc (fn [escape]
+                                                      (k/escape-fn? escape)
+                                                      (escape i))))
+                                       (swap! results assoc t t)))))]
+            (doseq [t ts] (.start t))
+            (doseq [t ts] (.join t 60000))
+            (sort (vals @results)))))
+
+(check "concurrent captures across fibers sharing carriers"
+       (= [:ok]
+          (let [fs (doall (for [_ (range 16)]
+                            (fib/spawn (fn []
+                                         (dotimes [i 500]
+                                           (k/call-cc (fn [escape]
+                                                        (k/escape-fn? escape)
+                                                        (escape i))))
+                                         :ok))))]
+            (distinct (map fib/join fs)))))
+
+(if (empty? @failures)
+  (do (println "CONTINUATIONS-TEST OK") (flush) (System/exit 0))
+  (do (doseq [failure @failures] (println "FAIL:" failure))
+      (flush)
+      (System/exit 1)))


### PR DESCRIPTION
Closes #736.

`call-cc` and `letcc` hand jolt programs the one-shot escape continuation the runtime already runs on — the fiber park/resume switch, the throw site a backtrace is walked from. JVM Clojure cannot have this, so code using it is jolt-only by design, like `jolt.scheme`. Purely additive.

```clojure
(require '[jolt.continuations :as k])

(k/letcc [return]
  (doseq [x xs] (when (pred x) (return x)))
  nil)

(k/call-cc (fn [escape] ...))
(k/escape-fn? x)
```

Escape only, and one-shot. That is `call/1cc`'s shape, it is what the host itself uses, and it is what a target can implement without a multi-shot stack model. Re-entrancy is not exposed.

## The guard is most of the work

Handed the raw primitive, jolt gets two bad outcomes, both measured before writing any of this:

- re-invoking a spent continuation raises a Chez condition that arrives as class `:object:` with an empty message;
- invoking one captured on another fiber **hangs the process** — no error, no timeout, control transfers into a stack segment this thread is not running and never comes back.

So every escape is a wrapper that checks spent/owner/live and raises `IllegalStateException` naming the rule. Ownership is checked before lifetime: an escape saved out of a fiber is both dead and foreign, and the boundary is the half you can act on.

Two semantics worth calling out, both verified rather than assumed:

- **A park is not an ownership boundary.** I expected crossing one to invalidate an escape. It doesn't — the scheduler restores the fiber's whole segment, so capture -> `yield` -> escape works inside one fiber. That is why the identity is (thread, fiber) and not a stack snapshot.
- **An escape is a real exit**, so a `finally` between the capture and the escape runs and a `binding` is restored — the opposite of a park, which drops those winders precisely because it is not an exit.

## Architecture

New `capability-continuations` contract tier with one name, `sa-call-with-escape-continuation`. Chez's arm is a one-liner over native `call/1cc`. Gambit implements the tier over `call/cc` plus a spent flag, since `call/cc` is multi-shot and would otherwise graft control into a finished frame; `gambitcheck` asserts real behaviour, not a degradation message. Documented in `TARGET-CONTRACT.md` and `guile.ss`. Jolt policy (ownership, error conversion) lives in `host/chez/continuations.ss` — targets owe only the primitive.

## Cost

`escape-fn?` needs a process-wide weak table, mutex-guarded both ways like `hasheq.ss`'s `proc-hasheq-tbl`, since captures happen on any thread. Measured over 2M captures: bare capture 8.5ns, +weak table 61ns, +mutex 86ns. So it makes a capture roughly 10x its floor. Kept, because 86ns is still far below the exception-based early exit it replaces and it is paid per capture rather than per iteration — but the breakdown is recorded in the file header rather than glossed, and dropping `escape-fn?` is the lever if the floor matters more.

## Gates

New `continuations` target, in `CI-GATES` (84 -> 85). Covers the escape semantics, unwinding, the fiber/park cases, the four misuses, and concurrent captures across threads and fibers. Every row that invokes an escape across an ownership boundary runs on a watchdog thread with a join deadline, so a regression that reinstates the hang fails the gate instead of wedging it.

`make test` green.