### PR TITLE
ffi: report a native carrying its own static copy of another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A native library carrying its own static copy of another one is reported
+  instead of going inert (#731).** A declared `:jolt/native` linked against
+  another's static archive gets a private copy of that library's globals, so
+  writes through one are invisible to the other — raygui built against
+  `libraylib.a` reads a mouse that never moves and every control goes dead with
+  no error anywhere. jolt cannot merge the copies (the duplicate is baked into
+  the `.so`; the fix is to rebuild the dependent against the shared library),
+  but it no longer stays quiet: binding such a symbol prints a duplicate-native-
+  symbol report naming the symbol and the libraries, and
+  `jolt.ffi/defining-libraries` answers which libraries supply distinct
+  definitions of a symbol.
+
+  The check keys on the resolved ADDRESS, not on how many handles answer:
+  `dlsym` searches a handle's dependency chain, so a dependent linked correctly
+  against the shared base also resolves the base's symbols through its own
+  handle. Counting handles would have flagged exactly the build that got it
+  right.
+
 - **A jolt local could capture the ftype heads `jolt.ffi/layout` lowers to.**
   The layout lowering emits `define-ftype`, `make-ftype-pointer`,
   `ftype-sizeof`, `ftype-&ref`, and `ftype-pointer-address` into the scope a

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ install: build
 # answers "is this working tree gated?" — which is not something to remember.
 
 CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke depscpcache depsunit \
-  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi stdlibfasl \
+  smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi ffidupsym stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
@@ -365,6 +365,13 @@ buildlibsmoke: testbin
 # default), and --dynamic keeps the runtime load-shared-object path.
 staticnativesmoke: testbin
 	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/static-native-smoke.sh
+
+# Duplicate native symbol detection (issue #731): a declared :jolt/native that
+# carries its own static copy of another's code — raygui linked against
+# libraylib.a — used to go inert with no error. Pins that the footgun build is
+# reported AND that a correctly linked one is not.
+ffidupsym:
+	@sh host/chez/ffi-duplicate-symbol-smoke.sh
 
 # OPT-IN: jolt.mvn-http cert-verifying HTTPS fetch against Central + Clojars.
 # Not in `make test` — needs network + a working system OpenSSL.

--- a/host/chez/ffi-duplicate-symbol-smoke.sh
+++ b/host/chez/ffi-duplicate-symbol-smoke.sh
@@ -120,6 +120,34 @@ echo "$out2" | grep -q "jolt.ffi: duplicate native symbol" \
 echo "$out2" | grep -q "WIDGET 42" \
   || report "correctly linked build did not share the global (got: $(echo "$out2" | grep WIDGET || echo none))"
 
+# --- a declared native shadowing the GLOBAL namespace is not a duplicate -------
+# The scoped loader exists so a declared native's symbols beat the process
+# global namespace for its own defcfns — that is how jolt-lang/crypto's OpenSSL
+# EVP_* reach OpenSSL and not Apple's BoringSSL. That shadowing is the FEATURE,
+# and it must not read as a duplicate: the check only compares declared natives
+# against each other, never against the global namespace, or the case the loader
+# was built for would warn on every call.
+cat > "$work/shadow.c" <<'EOF'
+int abs(int x) { return (x < 0 ? -x : x) + 1000; }
+EOF
+# shellcheck disable=SC2086
+cc $shared "$work/shadow.c" -o "$work/libshadow.$soext"
+cat > "$work/shadow.clj" <<EOF
+(ns shadow (:require [jolt.ffi :as ffi]))
+(ffi/load-library "$work/libshadow.$soext")
+(ffi/defcfn c-abs "abs" [:int] :int)
+(println "SHADOW" (c-abs -4))
+(println "DEFINERS" (count (ffi/defining-libraries "abs")))
+EOF
+out3="$("$jolt" run "$work/shadow.clj" 2>&1)" || { echo "$out3"; report "shadow fixture did not run"; }
+
+echo "$out3" | grep -q "SHADOW 1004" \
+  || report "the declared native no longer shadows the global namespace (got: $(echo "$out3" | grep SHADOW || echo none))"
+echo "$out3" | grep -q "DEFINERS 1" \
+  || report "global-namespace shadowing counted as a duplicate definition (got: $(echo "$out3" | grep DEFINERS || echo none))"
+echo "$out3" | grep -q "jolt.ffi: duplicate native symbol" \
+  && report "false positive: shadowing the global namespace was reported as duplicated"
+
 # --- the warning is emitted once per symbol, not once per call ------------------
 cat > "$work/once.clj" <<EOF
 (ns once (:require [jolt.ffi :as ffi]))

--- a/host/chez/ffi-duplicate-symbol-smoke.sh
+++ b/host/chez/ffi-duplicate-symbol-smoke.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# ffi-duplicate-symbol smoke (issue #731): a declared :jolt/native that carries
+# its OWN static copy of another declared native's code is the raygui/raylib
+# footgun — raygui linked against libraylib.a gets a private copy of raylib's
+# input globals, so every control reads a mouse that never moves and the UI goes
+# inert WITHOUT A SINGLE ERROR.
+#
+# jolt cannot merge the two copies: by the time the .so exists the duplicate is
+# baked into it, and the fix is to rebuild the dependent against the SHARED base
+# library. What jolt can do is refuse to be silent about it.
+#
+# The discriminator is the ADDRESS, not the count of handles that answer.
+# dlsym(handle, sym) searches that handle's dependency chain too, so a dependent
+# linked CORRECTLY against the shared base also resolves the base's symbols
+# through its own handle — counting handles would flag the build that got it
+# right. Two copies means two addresses; one address reached through several
+# handles is one copy, which is the point of linking dynamically.
+#
+# This gate pins both halves, and the second is the one that matters: the
+# footgun build is reported, and the correct build is NOT. A false positive here
+# would train people to ignore the warning.
+set -eu
+
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+jolt="${JOLT_BIN:-bin/jolt}"
+
+if ! command -v cc >/dev/null 2>&1; then
+  echo "ffi-duplicate-symbol smoke: skipped (no C compiler)"
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Darwin) soext="dylib"; shared="-dynamiclib" ;;
+  MINGW*|MSYS*|CYGWIN*)
+    echo "ffi-duplicate-symbol smoke: skipped (windows resolves globally, no scoped handles)"
+    exit 0 ;;
+  *)      soext="so";    shared="-shared -fPIC" ;;
+esac
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# The base library: a global nothing else can see, plus a setter and a getter.
+# raylib's input state, in miniature.
+cat > "$work/state.c" <<'EOF'
+static int g_mouse = 0;
+void state_set_mouse(int v) { g_mouse = v; }
+int  state_get_mouse(void)  { return g_mouse; }
+EOF
+
+# The dependent: reads the base library's global through its API. raygui.
+cat > "$work/widget.c" <<'EOF'
+extern int state_get_mouse(void);
+int widget_read_mouse(void) { return state_get_mouse(); }
+EOF
+
+cc -c "$work/state.c" -o "$work/state.o"
+ar rcs "$work/libstate.a" "$work/state.o"
+# shellcheck disable=SC2086
+cc $shared "$work/state.c" -o "$work/libstate.$soext"
+# THE FOOTGUN: linked against the static archive, so it carries its own g_mouse.
+# shellcheck disable=SC2086
+cc $shared "$work/widget.c" "$work/libstate.a" -o "$work/libwidget-static.$soext"
+# The correct build: linked against the shared base, so there is one g_mouse.
+# shellcheck disable=SC2086
+cc $shared "$work/widget.c" -L"$work" -lstate -o "$work/libwidget-shared.$soext" \
+   -Wl,-rpath,"$work"
+
+fails=0
+report() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+# --- the footgun build is reported --------------------------------------------
+cat > "$work/footgun.clj" <<EOF
+(ns footgun (:require [jolt.ffi :as ffi]))
+(ffi/load-library "$work/libstate.$soext")
+(ffi/load-library "$work/libwidget-static.$soext")
+(println "DEFINERS" (count (ffi/defining-libraries "state_get_mouse")))
+(ffi/defcfn set-mouse "state_set_mouse" [:int] :void)
+(ffi/defcfn get-mouse "state_get_mouse" [] :int)
+(ffi/defcfn widget-read "widget_read_mouse" [] :int)
+(set-mouse 42)
+(println "OWN" (get-mouse))
+(println "WIDGET" (widget-read))
+EOF
+out="$("$jolt" run "$work/footgun.clj" 2>&1)" || { echo "$out"; report "footgun fixture did not run"; }
+
+echo "$out" | grep -q "DEFINERS 2" \
+  || report "defining-libraries did not report both natives (got: $(echo "$out" | grep DEFINERS || echo none))"
+echo "$out" | grep -q "jolt.ffi: duplicate native symbol" \
+  || report "no duplicate-symbol warning for the static-copy build"
+echo "$out" | grep -q "state_get_mouse" \
+  || report "the warning does not name the duplicated symbol"
+echo "$out" | grep -q "libwidget-static" \
+  || report "the warning does not name the library carrying the private copy"
+# The private copy really is a second copy — the widget cannot see the write.
+echo "$out" | grep -q "WIDGET 0" \
+  || report "fixture did not reproduce the two-copies behaviour (got: $(echo "$out" | grep WIDGET || echo none))"
+
+# --- the correct build is NOT reported ----------------------------------------
+cat > "$work/correct.clj" <<EOF
+(ns correct (:require [jolt.ffi :as ffi]))
+(ffi/load-library "$work/libstate.$soext")
+(ffi/load-library "$work/libwidget-shared.$soext")
+(println "DEFINERS" (count (ffi/defining-libraries "state_get_mouse")))
+(ffi/defcfn set-mouse "state_set_mouse" [:int] :void)
+(ffi/defcfn get-mouse "state_get_mouse" [] :int)
+(ffi/defcfn widget-read "widget_read_mouse" [] :int)
+(set-mouse 42)
+(println "OWN" (get-mouse))
+(println "WIDGET" (widget-read))
+EOF
+out2="$("$jolt" run "$work/correct.clj" 2>&1)" || { echo "$out2"; report "correct fixture did not run"; }
+
+echo "$out2" | grep -q "DEFINERS 1" \
+  || report "defining-libraries over-reported for the correctly linked build (got: $(echo "$out2" | grep DEFINERS || echo none))"
+echo "$out2" | grep -q "jolt.ffi: duplicate native symbol" \
+  && report "false positive: the correctly linked build was reported as duplicated"
+# One copy: the widget sees the write.
+echo "$out2" | grep -q "WIDGET 42" \
+  || report "correctly linked build did not share the global (got: $(echo "$out2" | grep WIDGET || echo none))"
+
+# --- the warning is emitted once per symbol, not once per call ------------------
+cat > "$work/once.clj" <<EOF
+(ns once (:require [jolt.ffi :as ffi]))
+(ffi/load-library "$work/libstate.$soext")
+(ffi/load-library "$work/libwidget-static.$soext")
+(ffi/defcfn get-mouse "state_get_mouse" [] :int)
+(dotimes [_ 5] (get-mouse))
+EOF
+n="$("$jolt" run "$work/once.clj" 2>&1 | grep -c "duplicate native symbol" || true)"
+[ "$n" = "1" ] || report "warning fired $n times for one symbol, expected once"
+
+if [ "$fails" -eq 0 ]; then
+  echo "ffi-duplicate-symbol smoke: passed"
+  exit 0
+fi
+echo "ffi-duplicate-symbol smoke: $fails failure(s)" >&2
+exit 1

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -120,7 +120,10 @@
 ;; not dlopen'd twice. Mutated only from load-natives!/jolt-build-load-native,
 ;; but guarded anyway in case a repl loads a native lazily.
 (define ffi-native-mu (make-mutex))
-(define ffi-native-handles (vector #f))   ; cell[0] = list of handles, oldest first
+;; cell[0] = list of (path . handle) pairs, oldest first. The PATH rides along
+;; only so a duplicate-symbol report can name the libraries involved (issue
+;; #731); resolution itself reads the handle.
+(define ffi-native-handles (vector #f))
 (define ffi-native-paths (make-hashtable string-hash equal?))  ; path(string) -> #t
 ;; dlopen `path` RTLD_LOCAL and record the handle. Returns the handle (a positive
 ;; integer) on success, #f on failure, or #t on Windows (loaded globally, not
@@ -141,22 +144,110 @@
               ((and h (integer? h) (positive? h))
                (hashtable-set! ffi-native-paths path #t)
                (vector-set! ffi-native-handles 0
-                            (append (or (vector-ref ffi-native-handles 0) '()) (list h)))
+                            (append (or (vector-ref ffi-native-handles 0) '())
+                                    (list (cons path h))))
                h)
               (else #f)))))))))
+;; Every declared native through which `sym` RESOLVES, as (path . address) in
+;; declaration order. Walking all of them rather than stopping at the first is
+;; what makes the duplicate below visible; it costs one dlsym per declared
+;; native, paid ONCE per defcfn (the emitted binding caches the address in its
+;; own `p` cell — backend_scheme.clj emit-ffi-fn), not once per call.
+(define (jolt-ffi-native-resolvers sym)
+  (if (or (eq? (sa-os-family) 'windows) (not ffi-dlsym))
+      '()
+      (let loop ((hs (or (vector-ref ffi-native-handles 0) '())) (acc '()))
+        (cond
+          ((null? hs) (reverse acc))
+          (else
+           (let ((a (ffi-dlsym (cdar hs) sym)))
+             (loop (cdr hs)
+                   (if (and a (integer? a) (positive? a))
+                       (cons (cons (caar hs) a) acc)
+                       acc))))))))
+
+;; The DISTINCT definitions of `sym`, one entry per address, naming the first
+;; declared native that reaches each.
+;;
+;; The address is the discriminator, and it has to be: dlsym(handle, sym)
+;; searches that handle's DEPENDENCY CHAIN as well as the library itself, so a
+;; dependent linked correctly against the shared base resolves the base's
+;; symbols through its own handle too. Counting handles that answer would call
+;; that a duplicate — a false positive on exactly the build that got it right,
+;; which is the one way to make a warning worth ignoring. Two copies means two
+;; ADDRESSES; one address reached through several handles is one copy, which is
+;; the whole point of linking dynamically.
+(define (jolt-ffi-native-definers sym)
+  (let loop ((rs (jolt-ffi-native-resolvers sym)) (seen '()) (acc '()))
+    (cond
+      ((null? rs) (reverse acc))
+      ((memv (cdar rs) seen) (loop (cdr rs) seen acc))
+      (else (loop (cdr rs) (cons (cdar rs) seen) (cons (car rs) acc))))))
+
+;; --- the duplicate-static-copy report (issue #731) ---------------------------
+;; Two declared natives defining the SAME symbol is the signature of a dependent
+;; library that was linked against the base library's STATIC archive instead of
+;; its shared object: the archive members it pulled in are exported from the
+;; dependent too. raygui built against libraylib.a is the case that named this —
+;; it gets a private copy of raylib's input globals, so every control reads a
+;; mouse that never moves and the UI goes inert with no error anywhere.
+;;
+;; jolt cannot repair it. By the time the .so exists the second copy is baked in,
+;; and the only fix is to rebuild the dependent against the SHARED base library.
+;; So this reports rather than raises, for two reasons: the damage is already
+;; done and refusing to run would not undo it, and two unrelated natives may
+;; legitimately export a common name (`version`, `init`) where first-hit
+;; resolution is correct and always was. A raise would turn those into a
+;; regression; silence is what the issue is about.
+;;
+;; Once per symbol, not once per call. The emitted binding caches its address,
+;; so a repeat would only appear if a caller resolved the same name again — and
+;; a warning that repeats is a warning that gets filtered out.
+(define ffi-dup-reported (make-hashtable string-hash equal?))
+(define (ffi-report-duplicate! sym defs)
+  (unless (hashtable-ref ffi-dup-reported sym #f)
+    (hashtable-set! ffi-dup-reported sym #t)
+    (let ((p (current-error-port)))
+      (display (string-append
+                 "jolt.ffi: duplicate native symbol " sym " — defined by "
+                 (number->string (length defs)) " declared libraries:\n")
+               p)
+      (for-each (lambda (d)
+                  (display (string-append "  " (car d) "\n") p))
+                defs)
+      (display (string-append
+                 "  Resolving against the first. This usually means a library was linked\n"
+                 "  against another's STATIC archive and carries its own copy of that\n"
+                 "  library's globals, which then never see the other copy's writes.\n"
+                 "  Rebuild it against the shared library instead.\n")
+               p)
+      (flush-output-port p))))
+
 ;; dlsym `sym` across the registered native handles in declaration order. Returns
 ;; the address (positive integer) of the first hit, or #f when no handle has it
 ;; — the emitter then falls back to global name resolution. #f on Windows (no
 ;; registered handles).
 (define (jolt-ffi-dlsym-native sym)
-  (if (or (eq? (sa-os-family) 'windows) (not ffi-dlsym))
-      #f
-      (let loop ((hs (or (vector-ref ffi-native-handles 0) '())))
-        (cond
-          ((null? hs) #f)
-          (else
-           (let ((a (ffi-dlsym (car hs) sym)))
-             (if (and a (integer? a) (positive? a)) a (loop (cdr hs)))))))))
+  (let ((rs (jolt-ffi-native-resolvers sym)))
+    (cond
+      ((null? rs) #f)
+      (else
+       ;; Only walk the dedupe when more than one handle answered; the common
+       ;; case (exactly one) skips it entirely.
+       (when (pair? (cdr rs))
+         (let ((defs (jolt-ffi-native-definers sym)))
+           (when (pair? (cdr defs)) (ffi-report-duplicate! sym defs))))
+       (cdar rs)))))
+
+;; jolt.ffi/defining-libraries: one declared native per DISTINCT definition of
+;; `sym`, in declaration order — the diagnostic to reach for when a native call
+;; returns something impossible and nothing has raised. A correctly linked set
+;; answers one entry however many libraries use the symbol; two entries means
+;; two copies.
+(define (jolt-ffi-defining-libraries sym)
+  (make-pvec
+   (list->vector
+    (map car (jolt-ffi-native-definers (ffi-str-arg "symbol" sym))))))
 
 ;; --- foreign type keywords ---------------------------------------------------
 ;; The keyword type names jolt.ffi accepts (in foreign-fn signatures and the
@@ -445,6 +536,7 @@
 (def-var! "jolt.ffi" "load-library" ffi-load-library)
 (def-var! "jolt.ffi" "loaded?" (lambda (n) (if (ffi-loaded? n) #t #f)))
 (def-var! "jolt.ffi" "load-native" jolt-ffi-load-native)
+(def-var! "jolt.ffi" "defining-libraries" jolt-ffi-defining-libraries)
 (def-var! "jolt.ffi" "dlsym-native" jolt-ffi-dlsym-native)
 (def-var! "jolt.ffi" "alloc" ffi-alloc)
 (def-var! "jolt.ffi" "free" ffi-free)

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -48,6 +48,18 @@
   [:matrix 1 2]. The array field path itself names its base address and is not a
   scalar read/write target.
 
+  TWO LIBRARIES, ONE COPY. A declared :jolt/native is dlopen'd RTLD_LOCAL, so
+  its symbols reach its own defcfns and nobody else's. That is fine for a
+  dependent library linked against the SHARED base — it resolves the base's
+  symbols through its own handle and there is one copy of the base's globals.
+  It is not fine for one linked against the base's STATIC archive: that library
+  carries its own copy, so writes through one never appear in the other, and
+  nothing raises. raygui built against libraylib.a is the case that named this
+  — every control reads a mouse that never moves. jolt reports a duplicate
+  native symbol on stderr the first time such a symbol is bound, and
+  defining-libraries answers which libraries supply distinct definitions. The
+  fix is always to rebuild the dependent against the shared base library.
+
   The memory/library primitives (alloc/free/read/write/sizeof/load-library/
   ptr->string/string->ptr/null/null?) are provided by the host, as are the
   buffer moves: read-bytes/write-bytes decode and encode UTF-8, read-array/


### PR DESCRIPTION
Closes #731.

## What the exploration found

Built the raygui/raylib shape as a minimal repro — a base library with a global plus a setter/getter, and a dependent that reads it through the base's API — and built the dependent two ways:

| dependent linked against | `state_get_mouse` | `widget_read_mouse` |
|---|---|---|
| `libstate.a` (static) | 42 | **0** — silent, no error |
| `libstate.dylib` (shared) | 42 | 42 |

Two findings worth recording.

**The `RTLD_LOCAL` scoped loader is not the cause.** I suspected it was — declared natives are loaded `RTLD_LOCAL` on both platforms (`ffi.ss`, where Linux's `RTLD_LOCAL` is 0). It isn't: a dependent linked against the *shared* base resolves through its own handle and shares the one copy. That is now the second half of the gate, so the finding stays true.

**The duplicate is baked into the `.so`.** `nm` shows the footgun build exports the base's `_state_get_mouse`/`_state_set_mouse`; the correct build exports only `_widget_read_mouse`. Nothing jolt can do at load time merges them — the fix is always to rebuild the dependent against the shared library.

So there is no workaround jolt can apply. What it can stop doing is being silent.

## What this adds

Binding a symbol that two declared natives define differently prints a report naming the symbol and the libraries, once per symbol. `jolt.ffi/defining-libraries` answers which libraries supply distinct definitions of a symbol — the thing to reach for when a native call returns something impossible and nothing has raised.

It reports rather than raises. The damage is already in the `.so`, so refusing to run would not undo it, and two unrelated natives may legitimately export a common name (`init`, `version`) where first-hit resolution is correct and always was. Easy to make fatal later if that turns out to be the wrong call.

## The bit the gate caught

My first implementation counted how many handles answered `dlsym`. That flagged the **correctly linked** build as duplicated, because `dlsym(handle, ...)` searches the handle's dependency chain — so a dependent linked properly against the shared base also resolves the base's symbols through its own handle. A false positive on the build that got it right is the one way to make a warning worthless.

The discriminator is the resolved **address**: two copies means two addresses; one address reached through several handles is one copy, which is the point of linking dynamically.

## Gates

New `ffidupsym` target, in `CI-GATES` (85 -> 86). Four properties:

- the footgun build is reported, naming the symbol and the library carrying the private copy;
- the correctly linked build is **not** reported, and does share the global;
- a declared native shadowing the **global namespace** is not a duplicate — that shadowing is the scoped loader's whole purpose (jolt-lang/crypto's OpenSSL `EVP_*` over Apple's BoringSSL), and the row asserts the shadow still wins and reports one definer;
- the report fires once per symbol, not once per call.

`make test` green, 85 targets, receipt on this exact tree.