### PR TITLE
reader: digit separators in number literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Digit separators in number literals (#389).** `1_000_000` reads as
+  `1000000`. The rule is Java's, which is the one someone writing a grouped
+  literal expects: an underscore must sit between two digits, never against the
+  sign, the `0x` / `NrDDD` radix marker, the decimal point, the exponent
+  marker, the ratio slash, or the `N`/`M` suffix. So `0xFF_FF`, `0_52`,
+  `36rR_Z`, `1_0.5_5`, `1_0e1_0` and `3_000N` all read, while `1_`, `0x_52` and
+  `1e_5` raise `Invalid number` exactly as before. A run of underscores counts
+  as one separator (`5_______2` is `52`), and a leading underscore is still an
+  ordinary symbol — `_1` is the symbol `_1`, unchanged.
+
+  A jolt superset: the JVM raises `Invalid number` on every literal this adds,
+  so nothing that reads today changes meaning. `clojure.edn` deliberately does
+  NOT accept separators — edn is an interchange format whose integer grammar
+  has none, and jolt's printer never emits one, so the only thing accepting
+  them there would add is a hand-written config that reads on jolt and fails in
+  every other edn reader.
+
 - **Atomic native-error capture for `jolt.ffi`.** `foreign-fn` and `defcfn`
   accept `{:capture-native-error true}` and return `[native-result error-code]`,
   capturing POSIX `errno` or Windows `GetLastError` in the foreign-call return

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ divergences:
   portable Clojure. It resolves first, so a library can ship a portable
   `foo.cljc` next to a `foo.jolt` that wins on jolt, the way `.clj` wins over
   `.cljc` on the JVM. `data_readers.jolt` works like `data_readers.clj` too.
+- **Digit separators in numbers.** `1_000_000`, `0xFF_FF` and `36rR_Z` read as
+  numbers; the JVM raises `Invalid number` on all three. The rule is Java's — an
+  underscore must sit between two digits, never against a sign, radix marker,
+  decimal point, exponent marker or `N`/`M` suffix — so `1_` and `0x_52` still
+  raise. A leading underscore is still an ordinary symbol. `clojure.edn` refuses
+  separators: edn's grammar has none, and a config that read only here would
+  fail in every other edn reader. Additive — nothing that reads on the JVM
+  changes meaning.
 - **Clojure is a terminal dependency.** jolt *is* Clojure, so
   `org.clojure/clojure` in a `deps.edn` contributes neither an artifact nor
   children. On the JVM that artifact pulls in `org.clojure/spec.alpha`, so a

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -99,6 +99,132 @@
 ;; Numeric tower (JVM parity): integer literals read as exact integers (= Long/
 ;; BigInt, arbitrary precision), a/b ratios as exact rationals (= Ratio), and
 ;; decimal/exponent literals as flonums (= double).
+;; --- digit separators: 1_000_000 (issue #389) --------------------------------
+;; A jolt superset: the JVM reader raises "Invalid number" on every token below,
+;; so nothing that reads today changes meaning. Only a token that ALREADY starts
+;; like a number is affected — a leading underscore is still an ordinary symbol
+;; (_1 reads as the symbol _1 here exactly as on the JVM), because that decision
+;; is made before this runs.
+;;
+;; The rule is Java's, which is the one someone writing 1_000_000 expects: an
+;; underscore must sit BETWEEN TWO DIGITS of the literal. Never at either end,
+;; never against the sign, the 0x / NrDDD radix marker, the decimal point, the
+;; exponent marker, the ratio slash, or the N/M suffix. Being looser would be
+;; easier — strip every underscore and let the parse decide — but that accepts
+;; 0x_FF, 1e_5 and 2r_10, which reads as a second, stranger divergence to
+;; explain. One rule, matching the language jolt models, is cheaper to document
+;; than three special cases.
+;;
+;; "Digit" is per literal kind, so the marker characters are located FIRST and
+;; excluded by position rather than by character class: r IS a digit in base 36
+;; (36rR_Z is legal) and e IS a hex digit (0x1e_5 is legal), so a rule phrased
+;; over characters alone gets both wrong.
+(define (rdr-digit-sep-marker-positions body blen)
+  ;; Positions in BODY that are structural markers, not digits: the x of a 0x
+  ;; prefix, the r of a radix literal, and a trailing N/M suffix. The decimal
+  ;; point, exponent marker, sign and slash are handled by the alphanumeric
+  ;; test itself — none of them is alphanumeric except e/E, which is only a
+  ;; marker when the token has no hex or radix prefix.
+  (let* ((hex? (and (>= blen 2) (char=? (string-ref body 0) #\0)
+                    (let ((c (string-ref body 1)))
+                      (or (char=? c #\x) (char=? c #\X)))))
+         (ri (and (not hex?)
+                  (let loop ((i 0))
+                    (cond ((>= i blen) #f)
+                          ((let ((c (string-ref body i)))
+                             (or (char=? c #\r) (char=? c #\R)))
+                           i)
+                          (else (loop (+ i 1)))))))
+         (acc '()))
+    (when hex? (set! acc (cons 1 acc)))
+    (when (and ri (> ri 0)) (set! acc (cons ri acc)))
+    ;; A trailing N (bigint) or M (bigdecimal) is a suffix, not a digit.
+    (when (> blen 0)
+      (let ((c (string-ref body (- blen 1))))
+        (when (or (char=? c #\N) (char=? c #\M))
+          (set! acc (cons (- blen 1) acc)))))
+    ;; e/E is the exponent marker only in a plain decimal literal; in hex and in
+    ;; base>14 radix literals it is a digit.
+    (when (and (not hex?) (not ri))
+      (let loop ((i 0))
+        (when (< i blen)
+          (let ((c (string-ref body i)))
+            (when (or (char=? c #\e) (char=? c #\E)) (set! acc (cons i acc))))
+          (loop (+ i 1)))))
+    acc))
+
+(define (rdr-digit-sep-alnum? c)
+  (or (and (char>=? c #\0) (char<=? c #\9))
+      (and (char>=? c #\a) (char<=? c #\z))
+      (and (char>=? c #\A) (char<=? c #\Z))))
+
+;; TOK with its underscores removed, or #f when any of them is misplaced. #f
+;; reaches the caller's "starts like a number but does not parse" arm, which
+;; raises NumberFormatException naming the original token — the same answer the
+;; JVM gives, which is what a misplaced separator deserves.
+(define (rdr-strip-digit-separators tok)
+  (let* ((len (string-length tok))
+         (c0 (string-ref tok 0))
+         (start (if (or (char=? c0 #\+) (char=? c0 #\-)) 1 0))
+         (body (substring tok start len))
+         (blen (string-length body))
+         (markers (rdr-digit-sep-marker-positions body blen)))
+    (let loop ((i 0) (acc '()))
+      (cond
+        ((>= i blen)
+         (string-append (substring tok 0 start)
+                        (list->string (reverse acc))))
+        ((char=? (string-ref body i) #\_)
+         ;; The RUN of underscores starting here must be between two digits —
+         ;; 5_______2 is legal, the same as 5_2 (JLS 3.10.1). So look past the
+         ;; rest of the run for the right-hand neighbour rather than requiring
+         ;; the very next character to be a digit.
+         (let scan ((j i))
+           (cond
+             ((and (< j blen) (char=? (string-ref body j) #\_)) (scan (+ j 1)))
+             (else
+              ;; Both neighbours must exist, be alphanumeric, and not be one of
+              ;; this literal's structural markers.
+              (and (> i 0) (< j blen)
+                   (rdr-digit-sep-alnum? (string-ref body (- i 1)))
+                   (rdr-digit-sep-alnum? (string-ref body j))
+                   (not (memv (- i 1) markers))
+                   (not (memv j markers))
+                   (loop j acc))))))
+        (else (loop (+ i 1) (cons (string-ref body i) acc)))))))
+
+(define (rdr-has-digit-separator? tok)
+  (let ((n (string-length tok)))
+    (let loop ((i 0))
+      (cond ((>= i n) #f)
+            ((char=? (string-ref tok i) #\_) #t)
+            (else (loop (+ i 1)))))))
+
+;; NOT in EDN. edn is an interchange format with a published grammar, and its
+;; integers are [+-]?(0|[1-9][0-9]*)N? — no separators. jolt's PRINTER never
+;; emits one (numbers print canonically), so jolt-written edn stays portable
+;; either way; what accepting them would add is the other direction, a
+;; hand-written deps.edn or config that reads here and fails in tools.deps or
+;; any other edn reader. That is the trap edn strict mode already exists to
+;; prevent — it is why #(), #= and auto-resolved keywords are refused too — so
+;; a separator is refused with it, and the divergence stays confined to source
+;; jolt reads for itself.
+;; The separator retry, for a token that ALREADY failed to parse and already
+;; looks like a number. It is deliberately NOT part of rdr-try-number: that runs
+;; on every token in every source file, and a symbol fails the ordinary parse
+;; too, so hanging the retry off failure alone made every symbol in the file pay
+;; a parameter read and a scan of its own name to discover it is not a number.
+;; Measured on a 2593-line file: 7.06 ms/read became 7.22.
+;;
+;; rdr-token->value already knows which failures are numeric-looking, so the
+;; retry sits in that arm — on the path whose only other outcome is raising
+;; "Invalid number". Nothing that reads today reaches it.
+(define (rdr-try-separated-number tok)
+  (and (not (rdr-edn-mode))
+       (rdr-has-digit-separator? tok)
+       (let ((stripped (rdr-strip-digit-separators tok)))
+         (and stripped (rdr-try-number-raw stripped)))))
+
 (define (rdr-try-number tok)
   (rdr-try-number-raw tok))
 
@@ -344,9 +470,13 @@
       (n n)
       ;; a token that starts like a number but doesn't parse as one is an
       ;; invalid number (1a, 08, 0x2g, 2r2), never a symbol — like the JVM.
+      ;; Except that a digit separator (1_000_000) lands here too, so the
+      ;; retry goes in front of the raise: this is the only arm it can help,
+      ;; and putting it anywhere earlier taxes tokens that can never benefit.
       ((rdr-numeric-lead? tok)
-       (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
-                                        (string-append "Invalid number: " tok))))
+       (or (rdr-try-separated-number tok)
+           (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                                            (string-append "Invalid number: " tok)))))
       ((string=? tok "nil") jolt-nil)
       ((string=? tok "true") #t)
       ((string=? tok "false") #f)

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1132,6 +1132,22 @@
   {:suite "inst / value semantics & printing" :label "unequal instants" :expected "false" :actual "(= #inst \"2020-01-01T00:00:00Z\" #inst \"2020-01-01T00:00:01Z\")" :portability :common}
   {:suite "inst / value semantics & printing" :label "works as map key" :expected ":v" :actual "(get {#inst \"2020-01-01T00:00:00Z\" :v} #inst \"2020-01-01T00:00:00.000Z\")" :portability :common}
   {:suite "inst / value semantics & printing" :label "pr-str round-trips" :expected "\"#inst \\\"2020-01-01T00:00:00.000-00:00\\\"\"" :actual "(pr-str #inst \"2020-01-01T00:00:00Z\")" :portability :common}
+  {:suite "reader / digit separators" :label "underscores group a long decimal" :expected "1000000" :actual "1_000_000" :portability :common}
+  {:suite "reader / digit separators" :label "a run of underscores is one separator" :expected "52" :actual "5_______2" :portability :common}
+  {:suite "reader / digit separators" :label "a separator survives a leading sign" :expected "[-1000 1000]" :actual "[-1_000 +1_000]" :portability :common}
+  {:suite "reader / digit separators" :label "hex groups by nibble" :expected "65535" :actual "0xFF_FF" :portability :common}
+  {:suite "reader / digit separators" :label "octal keeps its leading zero" :expected "42" :actual "0_52" :portability :common}
+  {:suite "reader / digit separators" :label "a radix literal groups its digits" :expected "1007" :actual "36rR_Z" :portability :common}
+  {:suite "reader / digit separators" :label "both sides of a decimal point group" :expected "10.55" :actual "1_0.5_5" :portability :common}
+  {:suite "reader / digit separators" :label "mantissa and exponent group independently" :expected "1.0E11" :actual "1_0e1_0" :portability :common}
+  {:suite "reader / digit separators" :label "a bigint suffix follows a grouped literal" :expected "3000N" :actual "3_000N" :portability :common}
+  {:suite "reader / digit separators" :label "a ratio groups either side" :expected "10/3" :actual "1_0/3" :portability :common}
+  {:suite "reader / digit separators" :label "a trailing separator is an invalid number" :expected "\"Invalid number: 1_\"" :actual "(try (read-string \"1_\") (catch Exception e (.getMessage e)))" :portability :common}
+  {:suite "reader / digit separators" :label "a separator against the hex marker is an invalid number" :expected "\"Invalid number: 0x_52\"" :actual "(try (read-string \"0x_52\") (catch Exception e (.getMessage e)))" :portability :common}
+  {:suite "reader / digit separators" :label "a separator against the exponent marker is an invalid number" :expected "\"Invalid number: 1e_5\"" :actual "(try (read-string \"1e_5\") (catch Exception e (.getMessage e)))" :portability :common}
+  {:suite "reader / digit separators" :label "a separator against the decimal point is an invalid number" :expected "\"Invalid number: 1_.5\"" :actual "(try (read-string \"1_.5\") (catch Exception e (.getMessage e)))" :portability :common}
+  {:suite "reader / digit separators" :label "a leading underscore is still an ordinary symbol" :expected "\"_1\"" :actual "(pr-str (read-string \"_1\"))" :portability :common}
+  {:suite "reader / digit separators" :label "edn refuses a separator the source reader accepts" :expected "true" :actual "(try (clojure.edn/read-string \"1_000\") false (catch Exception _ true))" :portability :common}
   {:suite "reader / delimiters" :label "a mismatched close reports, it does not hang" :expected "\"Unmatched delimiter: )\"" :actual "(try (read-string \"(def m {:a 1)\") (catch Exception e (.getMessage e)))" :portability :common}
   {:suite "reader / delimiters" :label "mismatched bracket" :expected "\"Unmatched delimiter: }\"" :actual "(try (read-string \"[1 2}\") (catch Exception e (.getMessage e)))" :portability :common}
   {:suite "io / java.net.URL" :label "str renders the spec" :expected "\"https://e.com/x\"" :actual "(str (java.net.URL. \"https://e.com/x\"))" :portability :jvm}


### PR DESCRIPTION
Closes #389.

`1_000_000` reads as `1000000`.

The rule is Java's, which is the one someone writing a grouped literal expects: an underscore sits **between two digits**, never against the sign, the `0x` / `NrDDD` radix marker, the decimal point, the exponent marker, the ratio slash, or the `N`/`M` suffix.

| reads | still raises `Invalid number` |
|---|---|
| `1_000_000` `5_______2` `-1_000` `+1_000` | `1_` `0x_52` `0x52_` `052_` |
| `0xFF_FF` `0x5_2` `0_52` `05_2` | `1_.5` `1._5` `1e_5` `1_e5` |
| `1_0.5_5` `1_0e1_0` `3_000N` `1_0M` | `2r_10` `1_N` `1_M` `1_/3` |
| `1_0/3` `10/3_0` `2r1_0` `36rR_Z` `0x1e_5` | |

A run of underscores counts as one separator (`5_______2` is `52`, per JLS 3.10.1), and a leading underscore is still an ordinary symbol — `_1` is the symbol `_1`, unchanged.

## Cost

Read time only. The separator is gone by emit:

```
(def a 1_000_000)  ->  (def-var-with-meta! "user" "a" 1000000 ...)
(def b 1000000)    ->  (def-var-with-meta! "user" "b" 1000000 ...)   ; byte-identical
(defn f [] (+ 1_000 2_000))  ->  (lambda () 3000)                    ; const-folded
```

The read path is at parity, but only after moving the retry. `rdr-token->value` runs the number parser on EVERY token, and a symbol fails the ordinary parse exactly like a bad number does — so hanging the retry off parse failure alone made every symbol in every file pay a parameter read and a scan of its own name to learn it is not a number: **7.06 -> 7.22 ms** per read of a 2593-line file, ~2%, consistent across runs.

It now sits in the `rdr-numeric-lead?` arm, immediately in front of the `Invalid number` throw. That arm's only other outcome is raising, so nothing that reads today reaches it. A/B/A/B/A after the move:

| | 1 | 2 | 3 | mean |
|---|---|---|---|---|
| A (feature) | 7.32 | 7.41 | 7.37 | 7.37 |
| B (baseline) | 7.59 | 7.12 | — | 7.36 |

Indistinguishable — the baseline's own spread (0.47 ms) dwarfs the 0.01 ms mean difference. `target/dev/flat.so` was rebuilt before every measurement and between each swap; absolute numbers drifted between sessions, so only within-session comparisons are quoted.

## Two judgement calls

**Markers are located by position, not character class.** Being looser would be less code — strip every underscore and let the parse decide — but that accepts `0x_FF`, `1e_5` and `2r_10`, a second and stranger divergence to explain. And a rule phrased over characters alone gets `36rR_Z` and `0x1e_5` *wrong*, because `r` is a digit in base 36 and `e` is a hex digit.

**Not in `clojure.edn`.** edn's integer grammar has no separator and jolt's printer never emits one, so accepting them there adds only the bad direction: a hand-written `deps.edn` that reads on jolt and fails in tools.deps or any other edn reader. That is what edn strict mode already exists for (`#()`, `#=` and auto-resolved keywords are refused the same way).

## Divergence

A superset — the JVM raises `Invalid number` on every literal this adds, so nothing that reads today changes meaning. Recorded in the README divergence list (11628/12000 bytes, under `readmecheck`'s ceiling).

Certified against JVM Clojure 1.12.5, not assumed: of the 16 new corpus rows, 10 land in `read-error` (the JVM reader refuses them — certify's `:reader/jolt` category) and **6 certify**, including the exact message text of each rejection and the edn refusal. 0 divergent, 0 jvm-raises, 0 NEW.

`make test` green, 84 targets, `gate-status` receipt on this exact tree.