### PR TITLE
File permission checks ask access(2), not file-exists?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`File.canRead`/`canWrite`/`canExecute` and `Files.isReadable`/`isWritable`/
+  `isExecutable` answer permissions, not existence.** All six reported whether
+  the file exists, so a read-only file came back writable and every regular file
+  came back executable — code testing writability before a write took the wrong
+  branch and found out at the open. `babashka.fs/writable?` and its siblings
+  route to `Files/is*able` and inherited it. They now ask `access(2)` about the
+  effective user, through one shared predicate so the `java.io` and
+  `java.nio.file` spellings cannot drift apart.
+
 ### Added
 
 - **`jolt.host/extend-class!`: add to or replace the shim jolt already has for a

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -350,6 +350,31 @@
 ;; last-modified as epoch milliseconds (0 if the file is absent).
 (define (file-mtime-millis p)
   (if (file-exists? p) (sa-file-mtime-ms p) 0))
+
+;; access(2): may the EFFECTIVE user read / write / execute this path? This is
+;; the question File.canRead/canWrite/canExecute and Files.isReadable/isWritable/
+;; isExecutable ask on the JVM. All six used to answer (file-exists? p) instead,
+;; which reports a read-only file as writable and every regular file as
+;; executable — so a caller testing writability before a write took the wrong
+;; branch and found out at the open, and babashka.fs/writable? (which routes to
+;; Files/isWritable) inherited it. ONE predicate for all six: two hand-kept
+;; copies is how java.io and java.nio.file start disagreeing about a path.
+;;
+;; Resolved through jolt-foreign-proc-safe like utimes above — a literal
+;; foreign-procedure is a fasl relocation that aborts the boot where the symbol
+;; is absent. Windows' CRT spells it _access and has no X_OK: mode 1 is EINVAL
+;; there, so an execute test falls back to existence.
+(define c-access (or (jolt-foreign-proc-safe "access" '(string int) 'int)
+                     (jolt-foreign-proc-safe "_access" '(string int) 'int)))
+(define access-r-ok 4)
+(define access-w-ok 2)
+(define access-x-ok 1)
+(define (file-accessible? p mode)
+  (if (and c-access
+           (not (and (fx=? mode access-x-ok) (eq? (sa-os-family) 'windows))))
+      (= (c-access p mode) 0)
+      ;; no access(2) to ask (or X_OK on Windows): the old answer, existence.
+      (if (file-exists? p) #t #f)))
 ;; set atime+mtime from epoch milliseconds via utimes(2). struct timeval is
 ;; sec + usec, 16 bytes each on the 64-bit platforms Chez targets; usec fits
 ;; its field (< 1e6) so a signed 64-bit native-endian write covers the layout.
@@ -584,9 +609,9 @@
                  jolt-nil)))
       ((string=? name "length")         (list (->num (file-byte-size fp))))
       ((string=? name "lastModified")   (list (->num (file-mtime-millis fp))))
-      ((string=? name "canRead")        (list (if (file-exists? fp) #t #f)))
-      ((string=? name "canWrite")       (list (if (file-exists? fp) #t #f)))
-      ((string=? name "canExecute")     (list (if (file-exists? fp) #t #f)))
+      ((string=? name "canRead")        (list (file-accessible? fp access-r-ok)))
+      ((string=? name "canWrite")       (list (file-accessible? fp access-w-ok)))
+      ((string=? name "canExecute")     (list (file-accessible? fp access-x-ok)))
       ((string=? name "isHidden")       (list (let ((nm (path-last-segment p)))
                                                 (if (and (> (string-length nm) 0) (char=? (string-ref nm 0) #\.)) #t #f))))
       ((string=? name "mkdir")          (list (guard (e (#t #f)) (and (not (file-exists? fp)) (begin (mkdir fp) #t)))))

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -342,9 +342,12 @@
 (let ((files-statics
        (list
         (cons "notExists"     (lambda (p . _) (if (file-exists? (nfp p)) #f #t)))
-        (cons "isReadable"    (lambda (p . _) (if (file-exists? (nfp p)) #t #f)))
-        (cons "isWritable"    (lambda (p . _) (if (file-exists? (nfp p)) #t #f)))
-        (cons "isExecutable"  (lambda (p . _) (if (file-exists? (nfp p)) #t #f)))
+        ;; the effective user's permission, from the one predicate java.io.File's
+        ;; canRead/canWrite/canExecute uses (io.ss) — these are the same question
+        ;; and must not drift into two answers for one path.
+        (cons "isReadable"    (lambda (p . _) (file-accessible? (nfp p) access-r-ok)))
+        (cons "isWritable"    (lambda (p . _) (file-accessible? (nfp p) access-w-ok)))
+        (cons "isExecutable"  (lambda (p . _) (file-accessible? (nfp p) access-x-ok)))
         (cons "isHidden"      (lambda (p . _) (let ((nm (npath-string-of (npath-file-name (npath-string-of p)))))
                                                 (and (> (string-length nm) 0) (char=? (string-ref nm 0) #\.)))))
         (cons "size"          (lambda (p . _) (nio-size (nfp p))))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -350,6 +350,17 @@
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (.isFile (io/file \"stdlib\")))" :expected "false"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (.exists (io/file \"/no/such/path/xyz\")))" :expected "false"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (.exists (io/file \"README.md\")))" :expected "true"}
+  ;; canRead/canWrite/canExecute ask access(2) — whether the EFFECTIVE user may
+  ;; read/write/execute the path — not whether the file exists. Answering
+  ;; existence made a read-only file report writable and every regular file
+  ;; report executable, so a caller testing writability before a write took the
+  ;; wrong branch and found out at the open.
+  {:suite "io" :expr "(do (require (quote [babashka.fs :as fs])) (fs/delete-if-exists \"/tmp/jolt-access-ro.txt\") (spit \"/tmp/jolt-access-ro.txt\" \"x\") (fs/set-posix-file-permissions \"/tmp/jolt-access-ro.txt\" (fs/str->posix \"r--r--r--\")) (let [f (java.io.File. \"/tmp/jolt-access-ro.txt\")] [(.canRead f) (.canWrite f) (.canExecute f)]))" :expected "[true false false]"}
+  {:suite "io" :expr "(do (require (quote [babashka.fs :as fs])) (fs/delete-if-exists \"/tmp/jolt-access-rwx.txt\") (spit \"/tmp/jolt-access-rwx.txt\" \"x\") (fs/set-posix-file-permissions \"/tmp/jolt-access-rwx.txt\" (fs/str->posix \"rwxr-xr-x\")) (let [f (java.io.File. \"/tmp/jolt-access-rwx.txt\")] [(.canRead f) (.canWrite f) (.canExecute f)]))" :expected "[true true true]"}
+  {:suite "io" :expr "(let [f (java.io.File. \"/tmp/jolt-access-absent-xyz\")] [(.canRead f) (.canWrite f) (.canExecute f)])" :expected "[false false false]"}
+  ;; java.nio.file.Files/isReadable etc. (what babashka.fs/readable? routes to)
+  ;; answer from the same predicate, so the two spellings cannot disagree
+  {:suite "io" :expr "(do (require (quote [babashka.fs :as fs])) (fs/delete-if-exists \"/tmp/jolt-access-ro2.txt\") (spit \"/tmp/jolt-access-ro2.txt\" \"x\") (fs/set-posix-file-permissions \"/tmp/jolt-access-ro2.txt\" (fs/str->posix \"r--r--r--\")) [(fs/readable? \"/tmp/jolt-access-ro2.txt\") (fs/writable? \"/tmp/jolt-access-ro2.txt\") (fs/executable? \"/tmp/jolt-access-ro2.txt\")])" :expected "[true false false]"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (instance? java.io.File (io/file \"/a/b\")))" :expected "true"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (instance? java.io.File \"/a/b\"))" :expected "false"}
   {:suite "io" :expr "(do (require (quote [clojure.java.io :as io])) (str (type (io/file \"/a\"))))" :expected "\"class java.io.File\""}


### PR DESCRIPTION
Found while writing the docs for #748 — `(.canWrite f)` came back `true` on a file I'd just chmod'd to `r--r--r--`.

`File.canRead`/`canWrite`/`canExecute` were all this:

```scheme
((string=? name "canRead")    (list (if (file-exists? fp) #t #f)))
((string=? name "canWrite")   (list (if (file-exists? fp) #t #f)))
((string=? name "canExecute") (list (if (file-exists? fp) #t #f)))
```

and `nio-file.ss` had the same three lines again for `Files/isReadable`/`isWritable`/`isExecutable`. So a read-only file reports writable and every regular file reports executable — code testing writability before a write takes the wrong branch and finds out at the open. `babashka.fs/writable?`/`readable?`/`executable?` route to `Files/is*able` and inherited it.

One shared `file-accessible?` asking `access(2)` about the effective user now backs all six. Keeping it to one predicate is the point: two hand-kept copies is how the `java.io` and `java.nio.file` spellings start giving different answers for one path. It resolves through `jolt-foreign-proc-safe` like the neighbouring `utimes`, so a host that can't resolve the symbol keeps the old existence answer instead of aborting the boot at a fasl relocation. Windows' CRT spells it `_access` and has no `X_OK` (mode 1 is `EINVAL`), so an execute test falls back to existence there.

Nothing in jolt-core, stdlib or the vendored trees called these, so the blast radius is library and user code — which is where the wrong answer was landing.

### Testing

Four unit rows in the `io` suite: a `r--r--r--` file, a `rwxr-xr-x` file, an absent path, and the `babashka.fs` spelling of the first. The two read-only rows fail before the fix (`want [true false false] got [true true true]`) and pass after.

`make test` green — 86 CI targets + 3 test targets.

Note the rows assert real permission semantics, so they'd fail if the gate ever ran as root (root bypasses `W_OK`). `tests.yml` runs on `ubuntu-latest` with no container, as the non-root `runner` user. Failing loudly there beats silently passing.
