### PR TITLE
Lower a nested syntax-quote inside-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A backtick nested inside a backtick is lowered inside-out.** Defining a
+  macro that defines a macro — `` `(defmacro f [x#] `(g ~x#)) `` — raised
+  "Unable to resolve symbol: x#" at the point the OUTER macro was defined,
+  where `x#` names a parameter of an inner macro that does not exist yet. It
+  was never gensym-specific: `` `(defmacro f [a b] `(vector ~a ~b)) `` failed
+  the same way with no `#` anywhere. jolt lowers syntax-quote in the analyzer
+  rather than the reader, and the compile path did not recognise a nested one
+  at all, so the outer walk claimed the inner template's `~unquotes` as its
+  own. It now lowers the inner backtick first, with its own auto-gensym scope,
+  and walks the construction code that produces — the order the JVM's reader
+  gets for free, and what makes the `x#` in the parameter vector and the `x#`
+  in the body the same gensym. `~'~x` carries the outer macro's argument into
+  the inner expansion again for the same reason. The reader's data path
+  (`read-string`) already did this; only the compile path was missing it.
+
+  One thing this makes visible for the first time: a nested backtick is the
+  only place a syntax-quote's construction code becomes a value rather than
+  being compiled, so it is the only place jolt's `__sqcat`/`__sq1` shows where
+  the JVM has `seq`/`concat`. Both evaluate to the same expansion; only a
+  program that prints or structurally walks the inner template can tell.
+  Recorded in `known-divergences.edn` as `:impl-detail`.
+
 - **A native library carrying its own static copy of another one is reported
   instead of going inert (#731).** A declared `:jolt/native` linked against
   another's static archive gets a private copy of that library's globals, so

--- a/host/chez/host-contract.ss
+++ b/host/chez/host-contract.ss
@@ -464,9 +464,40 @@
         out
         (jolt-list (hc-sym "with-meta") out (hc-sq-lower ctx m gsmap)))))
 
+;; Is this the raw (clojure.core/syntax-quote x) form the reader emits for a `?
+;; The qualification is the point, exactly as in rdr-syntax-quote-form?: a BARE
+;; (syntax-quote x) is an ordinary call to whatever the program means by that
+;; name, not a marker. hc-head-is? accepts either spelling, so it cannot be used
+;; here.
+(define (hc-syntax-quote-form? x)
+  (and (hc-list? x)
+       (let ((s (jolt-seq x)))
+         (and (not (jolt-nil? s))
+              (let ((h (seq-first s)))
+                (and (symbol-t? h) (string=? (symbol-t-name h) "syntax-quote")
+                     (let ((ns (hc-sym-ns h)))
+                       (and (string? ns) (string=? ns "clojure.core")))))))))
+
 (define (hc-sq-lower-bare ctx form gsmap)
   (cond
     ((hc-head-is? form "unquote") (hc-second form))
+    ;; A NESTED backquote, lowered INSIDE-OUT — the order the JVM gets for free
+    ;; by resolving syntax-quote in the reader, where the inner ` has already
+    ;; become construction code before the outer one walks it. Two things follow
+    ;; from doing it in that order, and neither works without it:
+    ;;
+    ;;   * the inner template's ~unquotes belong to the INNER `. Lowering the
+    ;;     nested form as an ordinary list let the outer walk claim them, so
+    ;;     `(defmacro f [x#] `(g ~x#)) tried to resolve x# as a variable while
+    ;;     merely DEFINING the outer macro — the parameter it names does not
+    ;;     exist until the outer macro is called.
+    ;;   * a bare symbol left in the inner's construction code (what an inner
+    ;;     ~x# lowers to) is then walked by the OUTER gsmap, so the x# in the
+    ;;     parameter vector and the x# in the body get the same gensym.
+    ;;
+    ;; Fresh gsmap for the inner: each ` has its own auto-gensym scope.
+    ((hc-syntax-quote-form? form)
+     (hc-sq-lower ctx (hc-syntax-quote-lower ctx (hc-second form)) gsmap))
     ((hc-head-is? form "unquote-splicing")
      (jolt-throw (jolt-ex-info "~@ used outside of a list or vector in syntax-quote"
                                (jolt-hash-map))))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -269,6 +269,28 @@
   ;; available to programs. It used to be reserved, and a var or local named
   ;; syntax-quote was silently miscompiled into a syntax-quote of its first
   ;; argument (edamame names its own resolver that, and :refers it).
+  ;; A backtick nested inside a backtick — the macro-defining macro. The JVM's
+  ;; reader resolves these inside-out: the inner ` is already construction code
+  ;; by the time the outer ` walks it, so the outer's auto-gensym env rewrites
+  ;; the bare x# sitting in that code and it matches the parameter. jolt lowers
+  ;; syntax-quote in the analyzer instead, and the compile path did not
+  ;; recognize a nested one at all: the outer walk consumed the INNER template's
+  ;; ~unquotes as its own, so merely DEFINING the outer macro tried to resolve
+  ;; x# as a variable (jolt#a-nested-gensym).
+  {:suite "reader / nested syntax-quote" :label "defining a macro-defining macro does not resolve the inner macro's auto-gensym params" :expected ":defined" :actual "(do (defmacro sqb-outer [n] `(defmacro ~(symbol (str \"sqb-\" n)) [x# y#] `(vector ~x# ~y#))) :defined)" :portability :common}
+  {:suite "reader / nested syntax-quote" :label "the generated macro's auto-gensym params reach its template" :expected "[1 2]" :actual "(do (defmacro sqa-outer [n] `(defmacro ~(symbol (str \"sqa-\" n)) [x# y#] `(vector ~x# ~y#))) (sqa-outer one) (sqa-one 1 2))" :portability :common}
+  {:suite "reader / nested syntax-quote" :label "params are distinct gensyms, and one may be used twice" :expected "[:b :a :a]" :actual "(do (defmacro sqf-outer [n] `(defmacro ~(symbol (str \"sqf-\" n)) [x# y#] `(vector ~y# ~x# ~x#))) (sqf-outer one) (sqf-one :a :b))" :portability :common}
+  ;; The DATA a nested backtick yields is jolt's own construction code
+  ;; (__sqcat/__sq1), where the JVM's is seq/concat — the two evaluate to the
+  ;; same thing, but a program that prints or structurally walks that data sees
+  ;; a different shape. This is only observable for a NESTED backtick, because
+  ;; that is the one case where construction code becomes a value instead of
+  ;; being compiled. Recorded in known-divergences.edn (:impl-detail); the row
+  ;; is here so the shape cannot change without the gate saying so.
+  {:suite "reader / nested syntax-quote" :label "the inner template is jolt's construction code, not the JVM's seq/concat" :expected "\"(user/a (clojure.core/__sqcat (clojure.core/__sq1 (quote user/b)) (clojure.core/__sq1 (clojure.core/+ 1 2))))\"" :actual "(do (in-ns (quote user)) (pr-str `(a `(b ~(+ 1 2)))))" :portability :common}
+  ;; ~'~x interpolates the OUTER macro's argument into the inner expansion —
+  ;; the outer walk reaches the (unquote nm) the inner left behind.
+  {:suite "reader / nested syntax-quote" :label "~'~x carries the outer macro's argument into the inner template" :expected "(quote (9 1 2))" :actual "(do (defmacro sqe-outer [nm] `(defmacro ~(symbol (str \"sqe-\" nm)) [x# y#] `(list ~'~nm ~x# ~y#))) (sqe-outer 9) (sqe-9 1 2))" :portability :common}
   {:suite "reader / syntax-quote is not a reserved name" :label "a local named syntax-quote is an ordinary local" :expected "[:local 1 2]" :actual "(let [syntax-quote (fn [a b] [:local a b])] (syntax-quote 1 2))" :portability :common}
   {:suite "reader / syntax-quote is not a reserved name" :label "a var named syntax-quote is an ordinary var" :expected "[:fn 1 2 3]" :actual "(do (ns sqg.ns) (clojure.core/defn syntax-quote [a b c] [:fn a b c]) (syntax-quote 1 2 3))" :portability :common}
   {:suite "reader / syntax-quote is not a reserved name" :label "and it can be referred into another namespace" :expected "[:fn 1 2]" :actual "(do (ns sqa.ns) (clojure.core/defn syntax-quote [a b] [:fn a b]) (ns sqb.ns) (clojure.core/refer (quote sqa.ns)) (syntax-quote 1 2))" :portability :common}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -626,7 +626,16 @@
    :jolt "raises \"Could not locate clojure/spec/alpha.jolt (or .clj/.cljc) on the source roots\""
    :note "Declare org.clojure/spec.alpha and org.clojure/core.specs.alpha explicitly; declared that way they resolve as ordinary Maven dependencies. Affects any library that requires spec without declaring it."}]
  :entries
- [;; SimpleDateFormat with no Locale answers for ROOT in jolt but the machine's
+ [;; A nested backtick is the one place a syntax-quote's CONSTRUCTION CODE
+  ;; becomes a value rather than being compiled, so it is the one place jolt's
+  ;; lowering is visible. jolt's compile path emits __sqcat/__sq1 (which the
+  ;; analyzer builds at compile time, the point of the design); the JVM's reader
+  ;; emits seq/concat. Both evaluate to the same expansion — a program only
+  ;; notices if it prints or structurally walks the inner template.
+  {:suite "reader / nested syntax-quote",
+   :label "the inner template is jolt's construction code, not the JVM's seq/concat",
+   :category :impl-detail}
+  ;; SimpleDateFormat with no Locale answers for ROOT in jolt but the machine's
   ;; DEFAULT locale on the JVM ("March|Mar|Saturday|Sat" under en), so this row's
   ;; :expected is jolt's ROOT rendering, not the JVM's. See the :documented entry.
   {:suite "time / sdf locale names",


### PR DESCRIPTION
Fixes the nested auto-gensym report: `` `(defmacro f [x#] `(g ~x#)) `` raised `Unable to resolve symbol: x#` at the point the **outer** macro was defined, where `x#` names a parameter of an inner macro that doesn't exist yet.

### It isn't gensym-specific

The same form with no `#` anywhere fails identically:

```clojure
(defmacro outer2 [nm]
  `(defmacro ~(symbol (str "f-" nm)) [a b] `(vector ~'~nm ~a ~b)))
;; Unable to resolve symbol: a in this context
```

Nested syntax-quote was broken outright. The outer lowering walked the inner template as an ordinary list and claimed its `~unquotes` as its own, so `~a` became code to evaluate at *outer* expansion time. Auto-gensyms were just the loudest symptom, because a `#` parameter has no chance of accidentally resolving to something.

### Cause

The JVM resolves nested backticks **inside-out** for free: its reader processes the inner `` ` `` first, so by the time the outer walk runs, the inner is already construction code and the `x#` sitting in it is a plain symbol — which the outer's gensym env rewrites, giving the parameter vector and the body the same gensym.

jolt lowers syntax-quote in the analyzer instead, outside-in, and the compile path had no case for a nested one. The reader's data path *did*, with a comment saying exactly why:

```scheme
;; nested backquote: lower it first (with a fresh gsmap — auto-gensyms in
;; the nested backquote are independent), then reprocess the result through
;; the outer lowering.
```

Two copies of one rule; one missing a case. `host-contract.ss` now does the same thing, with a strict `hc-syntax-quote-form?` mirroring `rdr-syntax-quote-form?` — the marker only counts when `clojure.core`-qualified, so a bare `(syntax-quote x)` stays an ordinary call (#722's rule).

The reported repro now matches reference Clojure 1.12 byte for byte:

```
:nested-defined
(gensymrepro.nested/g two 1 2)
```

### Testing

Four corpus rows (`:portability :common`), expecteds sourced by running Clojure 1.12: defining a macro-defining macro, calling the generated macro, two params as distinct gensyms with one used twice, and `~'~x` carrying the outer argument inward.

Two cases I tried to cover turn out to fail on the JVM too — an inner `` `(let [y# …]) `` gets ns-qualified by the outer walk and `let` rejects it, and a three-level nest hits the same on the generated name. That's Clojure behaviour, so they aren't rows.

### One divergence this makes visible

A nested backtick is the only place a syntax-quote's construction code becomes a *value* instead of being compiled, so it's the only place jolt's lowering shows:

```clojure
(pr-str `(a `(b ~(+ 1 2))))
;; JVM:  "(user/a (clojure.core/seq (clojure.core/concat (clojure.core/list (quote user/b)) …)))"
;; jolt: "(user/a (clojure.core/__sqcat (clojure.core/__sq1 (quote user/b)) …))"
```

Both evaluate to the same expansion; only a program that prints or structurally walks the inner template can tell. Pinned with a fifth corpus row and recorded in `known-divergences.edn` as `:impl-detail` rather than changed — matching the JVM's shape means the generated macro expanding through real `seq`/`concat` instead of jolt's compile-time `__sqcat`, which is a perf trade and a design call, not a bug fix.

`make test` green — 86 CI targets + 3 test targets, corpus 4664/4674 with 0 new divergences and 0 crashes.
