### PR TITLE
fix(build): app images must not inherit the CLI's AOT closure as preloaded

### DIFF
--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -686,7 +686,10 @@
                   ;; defines above already installed every var. Without this the
                   ;; loader sees an unmarked ns and recompiles it from source on the
                   ;; first command that enters jolt.main/-main (run/build/version).
-                  (put-string out (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n")))))
+                  (put-string out (string-append "(ldr-mark-loaded! " (ei-str-lit name) ")\n"))
+                  ;; ...and record that this ns is preloaded only because the CLI
+                  ;; image defines it, so an app build does not inherit the claim.
+                  (put-string out (string-append "(ldr-mark-cli-aot! " (ei-str-lit name) ")\n")))))
             ordered))
         (lambda ()
           (set-optimize! #f)
@@ -990,7 +993,9 @@
             (let ((file (find-ns-file name)))
               (when (and file
                          (or (not (ldr-install-file? file))
-                             (not (hashtable-ref bld-boot-loaded name #f))))
+                             (not (hashtable-ref bld-boot-loaded name #f))
+                             ;; preloaded only in the CLI image, not in an app's
+                             (ldr-cli-aot? name)))
                 (dfs (append (bld-ns-class-providers file) (bld-ns-requires file)))
                 (set! order (cons (cons name file) order)))))
           (dfs (cdr ns)))))

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -1059,6 +1059,19 @@
     (else (parameterize ((aot-dep-sink #f) (io-file-read-sink #f)) (load-jolt-file file)))))
 
 ;; Mark a namespace as loaded in both the host hashtable and the *loaded-libs* ref.
+;; Namespaces defined by the CLI's OWN AOT closure (bld-emit-cli-aot bakes
+;; jolt.main, jolt.deps and their on-demand requires into the CLI boot image and
+;; marks each loaded). They really are preloaded in the jolt process — but an app
+;; image written by `jolt build` is a DIFFERENT image and carries none of them,
+;; so the app build must not skip them as "already in the image". Without this,
+;; a ns that is in the CLI closure and neither in the runtime image nor the
+;; stdlib-fasl manifest — jolt.ffi, jolt.mvn-http — has every var it defines
+;; interned but UNBOUND in a built binary, while `jolt run` masks it by
+;; compiling the source at require time.
+(define ldr-cli-aot-ns (make-hashtable string-hash string=?))
+(define (ldr-mark-cli-aot! name) (hashtable-set! ldr-cli-aot-ns name #t))
+(define (ldr-cli-aot? name) (hashtable-ref ldr-cli-aot-ns name #f))
+
 (define (ldr-mark-loaded! name)
   (jolt-with-mutex ldr-tbl-mu (hashtable-set! loaded-ns name #t))
   (ldr-libs-update! (lambda (s) (pset-conj s (jolt-symbol #f name)))))


### PR DESCRIPTION
## The problem

A namespace that jolt's own CLI closure defines, and that is neither in the
runtime image nor in `host/chez/stdlib-fasl-manifest.txt`, ends up with every
var it defines **interned but unbound** in a binary written by `jolt build`.

Two namespaces are in that position today:

| namespace | affected vars |
|---|---|
| `jolt.ffi` | `layout-size`, `layout-alignment`, `field-offset`, `read-field`, `write-field`, `errno`, `errno-message` |
| `jolt.mvn-http` | `fetch`, `fetch*` |

`jolt.ffi`'s host-provided primitives (`alloc`, `free`, `read`, `write`,
`sizeof`, `null`, `ptr->string`) are fine — they come from
`host/chez/java/ffi.ss`. It is exactly the `stdlib/jolt/ffi.clj` half that goes
missing.

`jolt run` masks it completely, because there the source is on disk and gets
compiled at require time. Only a built binary fails, and it fails at the
**call**, not the build.

```clojure
(ns repro (:require [jolt.ffi :as ffi]))
(def L (ffi/layout [:struct [[:x :float] [:y :float]]]))
(defn -main [& _]
  (println (:size L))            ; 8    — fine, map key
  (println (ffi/sizeof :float))  ; 4    — fine, host primitive
  (println (ffi/layout-size L))) ; unbound in a built binary
```

```
$ jolt run -m repro          →  8 / 4 / 8
$ jolt build -m repro -o r && ./r
8
4
Unhandled exception: Attempting to call unbound fn: #'jolt.ffi/layout-size
```

## Why

`bld-emit-cli-aot` bakes `jolt.main`, `jolt.deps` and their on-demand require
closure into the CLI boot image, emitting `(ldr-mark-loaded! …)` for each. Its
own comment names that closure:

> `jolt.main + jolt.deps and their on-demand Clojure require closure
> (clojure.string, clojure.edn, jolt.mvn-http, jolt.ffi, grenadine.*)`

At app-build time `bld-boot-loaded` snapshots `loaded-ns`, and
`bld-require-closure` skips anything in it as already-in-the-image. That is
right for the **runtime** image, which every app shares. It is wrong for the
**CLI's own** AOT closure, because an app image is a different image and
carries none of it.

`clojure.string` and `clojure.edn` sit in that same closure and survive only
because they are independently in the runtime image. That is the whole
discriminator, and it is why the fasl manifest is not the lever — adding
`jolt.ffi` there changes nothing for app builds (I tried it first).

## The change

Record *why* a namespace is preloaded, not merely that it is.

- `loader.ss` gains `ldr-cli-aot-ns` plus `ldr-mark-cli-aot!` / `ldr-cli-aot?`.
- `bld-emit-cli-aot` emits `(ldr-mark-cli-aot! …)` alongside its existing
  `(ldr-mark-loaded! …)`.
- `bld-require-closure` no longer treats a CLI-AOT-only namespace as preloaded,
  so it is emitted into the app image like any other lazy stdlib.

20 lines across two files. `make-devboot.ss` shares `bld-emit-cli-aot`, so the
dev boot cache gets the same treatment.

## Verification

macOS 15 / AArch64, Chez from Homebrew, baseline built from a pristine detached
`aafa0fc3` (confirmed 0 diff, 0 fix markers) so the before/after is real:

```
before  jolt.ffi/layout-size      unbound in a built binary
        jolt.mvn-http/fetch       unbound in a built binary
after   both bound and callable; layout-size / field-offset / read-field /
        write-field all round-trip in AOT
```

Neighbours unchanged before and after — `clojure.test`, `jolt.fs`,
`jolt.process`, `jolt.time.base`, `clojure.string`, `clojure.edn` stay bound.

```
make ffi             green — 45/45 layout, 18/18 aggregate, 39/39 scoped
stdlib-fasl smoke    11 passed, 0 failed
app binary           +128 KB (the cost of actually carrying the two namespaces)
```

Also exercised end to end by a real consumer: a 600-function generated raylib
binding built with `jolt build` and run, with 35/35 struct sizes and 167/167
field offsets agreeing with clang.

## One thing that is not mine

`make certify` fails on this branch — and identically on an unmodified
`aafa0fc3` build, with one NEW divergence:

```
[host-interop / reducible dispatch] 2-arity reduce over an eduction stays on the seq path
  (reduce + (eduction (map inc) [1 2 3]))
  jolt-expected="9"  JVM raised ClassCastException
```

Pre-existing and unrelated, but it means `make test` is currently red on main.
Happy to split that into its own issue.

## Related

#290 — same works-under-`run` / fails-in-AOT shape, different cause.
