### PR TITLE
certify: allowlist the 2-arity reduce-over-eduction row as :flaky

### DIFF
--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -776,6 +776,12 @@
    ;; Iterable, so allowlisting it as a plain divergence fails one of the two.
    {:suite "seq / lazy over infinite", :label "eduction reduces", :category :permissive, :flaky true}
 
+   ;; Same expression, same unspecified dispatch, reached from the other side:
+   ;; this row asserts the Iterable outcome ("stays on the seq path", :expected
+   ;; "9"), so it fails wherever find-protocol-impl happens to pick IReduceInit.
+   ;; Added in 36105184 without the :flaky its sibling above already carries.
+   {:suite "host-interop / reducible dispatch", :label "2-arity reduce over an eduction stays on the seq path", :category :permissive, :flaky true}
+
    ;; with-open closes anything carrying a :close fn; the JVM demands a member
    ;; named close and raises on a map. line-seq and file-seq are the same shape:
    ;; jolt duck-types the reader and takes a path string, where the JVM insists on


### PR DESCRIPTION
Fixes #758.

## The row

`test/chez/corpus.edn:1072`, added in `36105184`:

```clojure
{:suite "host-interop / reducible dispatch"
 :label "2-arity reduce over an eduction stays on the seq path"
 :expected "9"
 :actual "(reduce + (eduction (map inc) [1 2 3]))"
 :portability :jvm}
```

## Why it cannot be pinned

The allowlist already explains this, one row above, for the sibling case:

> `clojure.core.protocols/CollReduce` is extended to both `IReduceInit` and
> `Iterable`, and an Eduction implements both, so `find-protocol-impl` reduces
> `pref` over `(supers Eduction)` — a hash SET — and `pref` keeps whichever of
> two unrelated interfaces it sees first. Iterable wins and the row answers 9;
> IReduceInit wins and the 2-arity casts to `IReduce`, which an Eduction is
> not, and it raises ClassCastException.

`seq / lazy over infinite / eduction reduces` carries `:flaky true` for exactly
that. The new row is the same expression reached from the other side — it
asserts the Iterable outcome — and did not get the same treatment.

## The change

Six lines: one allowlist entry plus a comment saying which sibling it matches
and why.

## Measured

From a pristine `aafa0fc3`, macOS 15 / AArch64, JDK 25.0.2, Clojure 1.12.3:

| | exit | entries | known | NEW | stale |
|---|---|---|---|---|---|
| without | **1** | 106 (1 flaky) | 106/107 | **1** | 0 |
| with | **0** | 107 (2 flaky) | 107/107 | **0** | 0 |

`0 stale` both ways, so the entry masks nothing that was otherwise reported.

## It is an environment split, not a plain failure

This project's CI is **green** at `aafa0fc3` — I checked before writing this,
having got that exact claim wrong on the issue first time round and had to
correct it. It fails on a local `make certify` (8/8 runs here). Which is the
more awkward shape for a contributor: no clean local gate, and CI offering no
explanation.

For what it is worth, an ambient `deps.edn` changes the answer too — in a
project pulling `cnuernber/dtype-next`, a second `CollReduce` extender, the
same expression returns `9`. Consistent with the hash-order explanation, and a
good reason not to trust a casual one-liner check here.

## One thing worth a second opinion

The label asserts the **seq path** specifically, and `:expected "9"` encodes
only the Iterable outcome. If pinning that path is what the row is *for*, the
more honest fix may be the 3-arity form:

```clojure
(reduce + 0 (eduction (map inc) [1 2 3]))   ;; => 9, well defined via IReduceInit
```

which still exercises the dispatch the suite is testing, without a label that
is true only half the time. I do not know the intent behind `36105184` — happy
to switch this PR to that instead.
