### PR TITLE
Resolve a bare class name only where the namespace maps it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`resolve` answered a bare class name the namespace never imported.** A class
+  name is a per-namespace mapping on the JVM — the java.lang auto-imports
+  everywhere, an `(:import ...)` in the namespace that asked, a
+  `deftype`/`defrecord` in the namespace that defines it — and `resolve` answers
+  only what the namespace maps. jolt keeps a `clojure.core` class token for every
+  class it models so a bare `Pattern` self-evaluates, and `resolve` was reading
+  those as mappings: `(resolve 'Path)` answered `java.nio.file.Path` in a
+  namespace with no import of it. A macro that guards on `(resolve Name)` before
+  defining a type therefore skipped the definition — typedclojure's
+  `(u/def-object Path ...)` emitted neither the deftype nor the `Path-maker` fn
+  it also emits, and the checker failed to load.
+
+- **`ns-imports` was the same 96 auto-imports for every namespace.** An
+  `(:import ...)` and a `deftype`'s own class are namespace mappings and now
+  show up in it, mapped to classes rather than class-name strings. The other half
+  of that line: a class mapping is an import, never an intern, so `ns-interns`,
+  `ns-publics` and the refers built from `clojure.core`'s publics no longer
+  report one — which is what made `(ns-map 'user)` answer a var for `String`
+  where the JVM answers the class.
+
 - **`compare` ignored a deftype's declared `Comparable`.** `(.compareTo a b)`
   reached the type's own method, but `compare` did not, so it raised "cannot be
   compared to" for values that carry an ordering — and `sort`, `sorted-set` and

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -2539,49 +2539,113 @@
 ;;     merely holds a class ((def MyCls String)) keeps resolving to the var,
 ;;     which is what the JVM's def would produce. The name must match the class
 ;;     (FQN or simple), so ->Rec ctor vars stay vars.
-;;   - an unresolved symbol classifies exactly as the analyzer's
-;;     hc-resolve-global :class branches do, through the same jolt-class-for
-;;     interner, so (= (resolve 'X) X) holds for every class form: dotted names
-;;     (java.util.Map), registered short names (an :import), deftype simple names.
+;;   - an unresolved symbol classifies as a class the same way, through the same
+;;     jolt-class-for interner, so (= (resolve 'X) X) holds for every class form
+;;     the asking namespace maps: dotted names (java.util.Map) and the java.lang
+;;     auto-imports.
+;;
+;; Both layers answer the JVM's question, which is per-NAMESPACE: "does this ns
+;; map this name to a class", not "does this class exist". The distinction is not
+;; academic — jolt keeps a class-token var in clojure.core for EVERY class it
+;; models (above) so a bare `Pattern` self-evaluates, and reading those as
+;; mappings made (resolve 'Path) answer in a namespace that never imported
+;; java.nio.file.Path. typedclojure's (u/def-object Path ...) guards on exactly
+;; that resolve before emitting its deftype, so the guard fired, the deftype was
+;; skipped, and the Path-maker it also emits never existed (jolt-17w2).
+(define (rsv-registration-class-name c)
+  (let ((root (var-cell-root c)))
+    (cond ((jclass? root) (jclass-name root))
+          ;; a deftype/defrecord NAME var holds its ctor, which carries the tag
+          ((procedure? root) (deftype-ctor-tag root))
+          (else #f))))
 (define (rsv-registration-class c)
-  (let* ((root (var-cell-root c))
-         (cn (cond ((jclass? root) (jclass-name root))
-                   ((procedure? root) (deftype-ctor-tag root))
-                   (else #f))))
+  (let ((cn (rsv-registration-class-name c)))
     (and cn
          (let ((nm (var-cell-name c)))
            (and (or (string=? nm cn) (string=? nm (hsc-last-segment cn)))
-                root)))))
+                (var-cell-root c))))))
+;; Is that registration a mapping the asking namespace HAS? jolt holds a ns's own
+;; class mappings as cells in that ns — (:import ...) binds the short name there
+;; (natives-str.ss), deftype/defrecord binds its own name there (protocols.ss) —
+;; so a cell found in the asking ns is one by construction. Beyond that only the
+;; two kinds the JVM makes visible everywhere answer: a fully-qualified name, and
+;; the java.lang auto-imports. The clojure.core class tokens for everything else
+;; are the class MODEL and stay invisible to resolve.
+(define (rsv-mapping-visible? c ns)
+  (let ((nm (var-cell-name c)))
+    (or (string=? (var-cell-ns c) ns)
+        (hc-fq-class-name? nm)
+        (and (jolt-default-import-fqn nm) #t))))
 (define (rsv-class-for-name nm)
-  ;; only classes the host actually MODELS answer — the class graph, a
-  ;; statics/ctor registration, or a deftype. The syntactic dotted-name shape
-  ;; is deliberately not enough: resolve is how tooling feature-detects a class
-  ;; (compliment gates its JDK9 module scanner on resolving
+  ;; Only a class the host actually MODELS answers, and the syntactic dotted-name
+  ;; shape is deliberately not enough: resolve is how tooling feature-detects a
+  ;; class (compliment gates its JDK9 module scanner on resolving
   ;; java.lang.module.ModuleFinder), and a token for a class jolt cannot back
-  ;; sends such code down paths that then die on the missing pieces. A symbol
-  ;; in code keeps the syntactic model (hc-resolve-global); resolve answers
-  ;; the narrower "does this class exist here".
-  (cond ((and (hc-fq-class-name? nm)
-              (or (jch-known? nm) (host-class-registered? nm)))
-         (jolt-class-for nm))
-        ((and (fx>? (string-length nm) 0) (char-upper-case? (string-ref nm 0)))
-         (cond ((host-class-has-statics? nm) (jolt-class-for nm))
-               ((chez-deftype-simple->tag nm) => jolt-class-for)
-               (else #f)))
-        (else #f)))
-(define (rsv-through v sym)
+  ;; sends such code down paths that then die on the missing pieces — the
+  ;; instance? macro reads a class answer here as "the symbol evaluates to that
+  ;; class" and emits it unquoted, so answering for an unbacked java.lang name
+  ;; (ExceptionInInitializerError, which nothing registers) turns fipp's
+  ;; (catch ExceptionInInitializerError _) into an unresolved symbol.
+  ;; A symbol in CODE keeps the wider syntactic model (hc-resolve-global).
+  ;; A bare name needs no arm here: every one a namespace maps and jolt models is
+  ;; a cell — an :import, a deftype, or the clojure.core token the class model
+  ;; registers for each auto-import it knows — so jolt-resolve already found it.
+  (and (hc-fq-class-name? nm)
+       (or (jch-known? nm) (host-class-registered? nm))
+       (jolt-class-for nm)))
+(define (rsv-through v sym ns)
   (cond ((jolt-nil? v)
          (or (and (symbol-t? sym) (not (string? (symbol-t-ns sym)))
                   (rsv-class-for-name (symbol-t-name sym)))
              jolt-nil))
-        ((rsv-registration-class v))
+        ;; a class registration the ns does not map is NOT the var either — the
+        ;; JVM has no such var to hand back, so the answer is nil.
+        ((rsv-registration-class v)
+         => (lambda (root) (if (rsv-mapping-visible? v ns) root jolt-nil)))
         (else v)))
 (def-var! "clojure.core" "resolve"
   (case-lambda
-    ((sym) (rsv-through (jolt-resolve sym) sym))
+    ((sym) (rsv-through (jolt-resolve sym) sym (chez-current-ns)))
     ;; the &env arity: a local named sym answers nil, never a class
     ((env sym) (if (and (pmap? env) (pmap-contains? env sym))
                    jolt-nil
-                   (rsv-through (jolt-resolve env sym) sym)))))
+                   (rsv-through (jolt-resolve env sym) sym (chez-current-ns))))))
 (def-var! "clojure.core" "ns-resolve"
-  (lambda (ns-desig sym) (rsv-through (jolt-ns-resolve ns-desig sym) sym)))
+  (lambda (ns-desig sym)
+    (rsv-through (jolt-ns-resolve ns-desig sym) sym
+                 (jns-name (jolt-the-ns ns-desig)))))
+
+;; --- ns-imports reports the namespace's own class mappings --------------------
+;; A JVM namespace maps class names as well as vars: the java.lang auto-imports
+;; everywhere, an (:import ...) into the ns that asked for it, a deftype/defrecord
+;; into the ns that defines it. ns.ss returns the auto-imports alone because the
+;; class model does not exist yet where it is defined; this reads the other two
+;; back off the namespace itself rather than keeping a second table that could
+;; drift out of step with the cells resolve answers from.
+(define hsc-default-imports
+  (pmap-fold jolt-default-imports
+             (lambda (k v acc) (jolt-assoc acc k (jolt-class-for v)))
+             (jolt-hash-map)))
+(define (hsc-ns-import-class c)
+  ;; the cell is the ns's mapping FOR a class only when it is bound under that
+  ;; class's own simple name, so Foo counts and ->Foo / map->Foo do not.
+  (and (var-cell-defined? c)
+       (let ((cn (rsv-registration-class-name c)))
+         (and cn (string=? (var-cell-name c) (hsc-last-segment cn))
+              (jolt-class-for cn)))))
+(define (hsc-ns-imports . desig)
+  (let ((cns (if (pair? desig) (ns-desig->name (car desig)) (chez-current-ns))))
+    (fold-left (lambda (m c)
+                 (let ((cls (hsc-ns-import-class c)))
+                   (if cls (jolt-assoc m (jolt-symbol #f (var-cell-name c)) cls) m)))
+               hsc-default-imports
+               (ns-cells-list cns))))
+(set! jolt-ns-imports hsc-ns-imports)   ; so ns-map (ns.ss) sees them too
+(def-var! "clojure.core" "ns-imports" hsc-ns-imports)
+;; ...and the other half of that: a cell that IS a class mapping is an import, so
+;; ns-interns / ns-publics / the refers built from clojure.core's publics must not
+;; report it as a var. Without this the class tokens above are public vars of
+;; clojure.core, every namespace refers them, and the refer shadows the very
+;; ns-imports entry this section just built ((ns-map 'user) answered the token var
+;; for String where the JVM answers the class).
+(set! ns-cell-class-mapping? (lambda (c) (and (hsc-ns-import-class c) #t)))

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -270,13 +270,22 @@
 (define (var-private? c)
   (let ((m (var-cell-meta c)))
     (and m (jolt-truthy? (jolt-get m (keyword #f "private"))))))
+;; A namespace maps class names as well as vars, and the JVM keeps the two apart:
+;; a class mapping is an IMPORT, never an intern, so ns-interns / ns-publics /
+;; ns-map's intern layer must skip it. jolt holds a class mapping as a cell —
+;; (:import ...) binds the short name, deftype/defrecord binds its own name, and
+;; the class model registers a token for every class it knows in clojure.core —
+;; so without this the tokens leak into every namespace as refers and shadow
+;; ns-imports' entry for the same name. That model is not loaded where this file
+;; is, so it starts as "no cell is one" and host-static-classes.ss replaces it.
+(define ns-cell-class-mapping? (lambda (c) #f))
 (define (ns-vars-pmap-when nm keep?)
   ;; the namespace's own bucket (rt.ss ns-cells-index): O(vars in nm), where a
   ;; var-table-cells scan cost O(every var in the image) per call
   (let ((m (jolt-hash-map)))
     (for-each
       (lambda (c)
-        (when (and (var-cell-defined? c) (keep? c))
+        (when (and (var-cell-defined? c) (keep? c) (not (ns-cell-class-mapping? c)))
           (set! m (jolt-assoc m (jolt-symbol #f (var-cell-name c)) c))))
       (ns-cells-list nm))
     m))
@@ -371,6 +380,20 @@
     (if (null? ns) m
         (loop (cdr ns)
               (jolt-assoc m (jolt-symbol #f (car ns)) (string-append "java.lang." (car ns)))))))
+;; The same set as a name lookup. A bare class name is a namespace MAPPING, not a
+;; global fact — (:import ...) and deftype map one into a single namespace, and
+;; these are the only ones mapped everywhere — so resolve asks this before it
+;; answers a bare capitalized symbol (host-static-classes.ss rsv-mapping-visible?).
+(define jolt-default-import-tbl
+  (let ((t (make-hashtable string-hash string=?)))
+    (for-each (lambda (n) (hashtable-set! t n (string-append "java.lang." n)))
+              jolt-default-import-names)
+    t))
+(define (jolt-default-import-fqn nm) (hashtable-ref jolt-default-import-tbl nm #f))
+;; The base is the auto-imports alone; host-static-classes.ss extends it with the
+;; namespace's OWN class mappings (its :imports and deftypes) once the class model
+;; it reads them out of exists. jolt-ns-map below goes through this variable, so
+;; that extension reaches ns-map too.
 (define (jolt-ns-imports . _) jolt-default-imports)
 
 ;; ns-map: every mapping visible in the ns — the java.lang imports, the refers

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -5254,6 +5254,42 @@
   {:suite "ns / resolve-class" :label "an unknown bare capitalized name is nil" :expected "true" :actual "(nil? (resolve 'NoSuchClassXyz))" :portability :jvm}
   {:suite "ns / resolve-class" :label "a var merely holding a class stays a var" :expected "true" :actual "(do (def rzc-corpus-alias String) (var? (resolve 'rzc-corpus-alias)))" :portability :jvm}
   {:suite "ns / resolve-class" :label "resolve of a deftype name is its class" :expected "true" :actual "(do (deftype RzCorpT [a]) (class? (resolve 'RzCorpT)))" :portability :jvm}
+  ;; A bare class name is a per-NAMESPACE mapping, not a global fact: the JVM maps
+  ;; the java.lang auto-imports into every ns, an (:import ...) into the ns that
+  ;; asked, a deftype into the ns that defines it — and resolve answers only what
+  ;; the ns maps. jolt keeps a clojure.core class-token var for every class it
+  ;; models so a bare `Pattern` self-evaluates, and reading those as mappings made
+  ;; resolve answer for classes the ns never imported. typedclojure's
+  ;; (u/def-object Path ...) guards on that resolve before emitting its deftype,
+  ;; so the guard fired and the Path-maker it also emits never existed (jolt-17w2).
+  {:suite "ns / resolve-class" :label "a class the namespace never imported does not resolve" :expected "[nil nil nil]" :actual "(do (ns rzc.a) [(clojure.core/resolve 'Pattern) (clojure.core/resolve 'ArrayList) (clojure.core/resolve 'Path)])" :portability :jvm}
+  {:suite "ns / resolve-class" :label "the java.lang auto-imports resolve with no import at all" :expected "[true true true true true true]" :actual "(mapv (fn [s] (some? (resolve s))) '[String Integer Thread Object Exception Math])" :portability :jvm}
+  {:suite "ns / resolve-class" :label "an :import maps the short name in that namespace" :expected "true" :actual "(do (ns rzc.b (:import [java.nio.file Path])) (clojure.core/= java.nio.file.Path (clojure.core/resolve 'Path)))" :portability :jvm}
+  {:suite "ns / resolve-class" :label "and not in a namespace that did not import it" :expected "nil" :actual "(do (ns rzc.c (:import [java.nio.file Path])) (ns rzc.d) (clojure.core/resolve 'Path))" :portability :jvm}
+  {:suite "ns / resolve-class" :label "a deftype's class maps only where it is defined" :expected "[true false]" :actual "(do (ns rzc.e) (clojure.core/deftype RzcT [a]) (ns rzc.f) [(clojure.core/some? (clojure.core/ns-resolve 'rzc.e 'RzcT)) (clojure.core/some? (clojure.core/ns-resolve 'rzc.f 'RzcT))])" :portability :common}
+  {:suite "ns / resolve-class" :label "a macro guarding on (resolve name) still emits its deftype" :expected "true" :actual "(do (ns rzc.i) (clojure.core/defmacro rzc-defty [n] (clojure.core/when-not (clojure.core/resolve n) (clojure.core/list 'clojure.core/deftype n '[a]))) (rzc.i/rzc-defty Path) (clojure.core/some? (clojure.core/resolve 'rzc.i/->Path)))" :portability :jvm}
+  ;; The other edge of that: resolve answers a CLASS only for one jolt models, and
+  ;; the instance? macro reads a class answer as "this symbol evaluates to that
+  ;; class" and emits it unquoted. Some java.lang auto-imports have no backing
+  ;; here at all, so widening resolve to the auto-import LIST turns fipp's
+  ;; (catch ExceptionInInitializerError _) into an unresolved symbol.
+  {:suite "ns / resolve-class" :label "an auto-import jolt does not model still works in catch and instance?" :expected "[:ex false false]" :actual "[(try (throw (Exception. \"x\")) (catch ExceptionInInitializerError e :eiie) (catch Exception e :ex)) (instance? ExceptionInInitializerError 1) (instance? UnsupportedClassVersionError 1)]" :portability :jvm}
+  ;; ns-imports is the same question made observable — what class names does THIS
+  ;; namespace map. It used to be the fixed 96 auto-imports for every ns, so an
+  ;; :import and a deftype were both invisible in it.
+  {:suite "ns / ns-imports" :label "the auto-imports are mapped to classes, not name strings" :expected "[true true]" :actual "[(class? (get (ns-imports 'user) 'String)) (= (get (ns-imports 'user) 'String) String)]" :portability :jvm}
+  {:suite "ns / ns-imports" :label "an :import shows up in that namespace's imports only" :expected "[true false]" :actual "(do (ns rzc.g (:import [java.nio.file Path])) [(clojure.core/contains? (clojure.core/ns-imports 'rzc.g) 'Path) (clojure.core/contains? (clojure.core/ns-imports 'user) 'Path)])" :portability :jvm}
+  {:suite "ns / ns-imports" :label "a runtime import shows up too" :expected "[true true]" :actual "(do (ns rzc.k) (clojure.core/import '[java.util ArrayList]) [(clojure.core/some? (clojure.core/resolve 'ArrayList)) (clojure.core/contains? (clojure.core/ns-imports 'rzc.k) 'ArrayList)])" :portability :jvm}
+  {:suite "ns / ns-imports" :label "a deftype adds its own class and nothing else" :expected "[true 97]" :actual "(do (ns rzc.h) (clojure.core/deftype RzcU [a]) [(clojure.core/contains? (clojure.core/ns-imports 'rzc.h) 'RzcU) (clojure.core/count (clojure.core/ns-imports 'rzc.h))])" :portability :jvm}
+  {:suite "ns / ns-imports" :label "a defrecord maps its class, not its factory fns" :expected "[true true false]" :actual "(do (ns rzc.j) (clojure.core/defrecord RzcR [a]) [(clojure.core/some? (clojure.core/resolve 'RzcR)) (clojure.core/contains? (clojure.core/ns-imports 'rzc.j) 'RzcR) (clojure.core/contains? (clojure.core/ns-imports 'rzc.j) 'clojure.core/->RzcR)])" :portability :jvm}
+  ;; ...and the other side of the same line: a class mapping is an IMPORT, never an
+  ;; intern. jolt holds one as a cell like a var, so without the split the class
+  ;; tokens are clojure.core publics, every ns refers them, and the refer shadows
+  ;; the ns-imports entry for the same name.
+  {:suite "ns / ns-imports" :label "an imported class is not an intern" :expected "[false true]" :actual "(do (ns rzc.m (:import [java.nio.file Path])) [(clojure.core/contains? (clojure.core/ns-interns 'rzc.m) 'Path) (clojure.core/contains? (clojure.core/ns-map 'rzc.m) 'Path)])" :portability :jvm}
+  {:suite "ns / ns-imports" :label "a deftype's class is not an intern, its factory fn is" :expected "[false true true]" :actual "(do (ns rzc.n) (clojure.core/deftype RzcV [a]) [(clojure.core/contains? (clojure.core/ns-interns 'rzc.n) 'RzcV) (clojure.core/contains? (clojure.core/ns-interns 'rzc.n) '->RzcV) (clojure.core/contains? (clojure.core/ns-map 'rzc.n) 'RzcV)])" :portability :common}
+  {:suite "ns / ns-imports" :label "ns-map answers the class for an auto-import, not a var" :expected "[true true false]" :actual "[(= (get (ns-map 'user) 'String) String) (class? (get (ns-map 'user) 'String)) (contains? (ns-publics 'clojure.core) 'String)]" :portability :jvm}
+  {:suite "ns / ns-imports" :label "ordinary vars are still in ns-map" :expected "true" :actual "(some? (get (ns-map 'user) 'map))" :portability :common}
   ;; A rest param can duplicate a positional (both _, typically). Chez rejects
   ;; duplicate formals, so every earlier occurrence renames — including against
   ;; the rest binder, which is the last occurrence and keeps the name (jolt-n6o4).


### PR DESCRIPTION
A class name is a per-namespace mapping on the JVM: the java.lang auto-imports everywhere, an `(:import ...)` in the namespace that asked, a `deftype`/`defrecord` in the namespace that defines it. `resolve` answers what the namespace maps, not what classes exist.

jolt keeps a `clojure.core` class token for every class it models so a bare `Pattern` self-evaluates, and `resolve` was reading those as mappings — `(resolve 'Path)` answered `java.nio.file.Path` in a namespace with no import of it. A macro that guards on `(resolve Name)` before defining a type then skipped the definition: typedclojure's `(u/def-object Path ...)` emitted neither the deftype nor the `Path-maker` fn it also emits, and `typed.clj.checker` failed to load on that (jolt-17w2).

`resolve`/`ns-resolve` now take the asking namespace and answer a class registration only when that namespace has it — its own cell (an import, a deftype), a fully-qualified name, or an auto-import. The bare-name fallback for any registered short name or any session deftype is gone; those were the "does this class exist" answer.

Alongside, `ns-imports` was the same 96 auto-imports for every namespace. It reports the namespace's own class mappings now, as classes rather than name strings, read off the namespace's cells rather than from a second table that could drift. The other half of that line: a class mapping is an import, never an intern, so `ns-interns`/`ns-publics` and the refers built from `clojure.core`'s publics skip one — which is what made `(ns-map 'user)` answer a var for `String` where the JVM answers the class.

`resolve` still refuses a class jolt does not model, including the handful of java.lang auto-imports nothing backs (jolt-9my7). That is load-bearing: the `instance?` macro reads a class answer as "this symbol evaluates to that class" and emits it unquoted, so answering for an unbacked name turns fipp's `(catch ExceptionInInitializerError _)` into an unresolved symbol — it cost 7 malli namespaces when tried. Pinned by a corpus row.

15 new corpus rows, all certified against JVM Clojure.

Gates: `make test` green, `make certify` 0 new / 0 stale, `make libconformance` 47 ok / 0 regressed.

The typedclojure ladder moves past this wall; the next one is jolt-024c (a backtick reaches a macro as jolt's `(clojure.core/syntax-quote x)` marker).