### PR TITLE
Model every java.lang auto-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **38 of the 96 java.lang auto-imports did not resolve.**
+  `(resolve 'ExceptionInInitializerError)`, `'StringBuffer`, `'Process`,
+  `'ThreadLocal` and 34 others answered nil where the JVM answers the class —
+  they had no row in the class model, so no class token. They have one now:
+  a name and an ancestry, not an implementation, so `(StringBuffer. "a")` still
+  has no constructor. Four of the 96 are not java.lang, and `ns-imports` named
+  them wrongly: `BigDecimal` and `BigInteger` are `java.math`, `Callable` is
+  `java.util.concurrent`, `Compiler` is `clojure.lang`.
+
+- **A nested class was mapped under its innermost name.** The name a namespace
+  maps a class under is the part after the last dot, `$` and all —
+  `java.util.Map$Entry` is `Map$Entry`. jolt read the innermost segment instead,
+  which minted `clojure.core` mappings for `Entry`, `Seq`, `RSeq`, `SubVector`
+  and friends that the JVM has no mapping for, and left `Thread$State` and
+  `Thread$UncaughtExceptionHandler` with no mapping at all.
+
 - **A backtick was still there when a macro read its own argument.** Clojure's
   `` ` `` is a reader macro, so a form is past its backticks before anything can
   look at it. jolt reads one to a `(clojure.core/syntax-quote FORM)` marker and

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -120,6 +120,16 @@
           ((char=? (string-ref s i) #\$) (substring s (+ i 1) (string-length s)))
           (else (loop (- i 1))))))
 
+;; The name a NAMESPACE maps a class under — the part after the last dot, $ and
+;; all: the JVM imports java.util.Map$Entry as Map$Entry, not as Entry. Distinct
+;; from jch-last-segment above, which goes on past the $ because its job is the
+;; alternative SPELLING a protocol extension may use for a tag.
+(define (jch-import-name s)
+  (let loop ((i (- (string-length s) 1)))
+    (cond ((< i 0) s)
+          ((char=? (string-ref s i) #\.) (substring s (+ i 1) (string-length s)))
+          (else (loop (- i 1))))))
+
 ;; The protocol-dispatch / instance? tag list for a value of class NAME: the class
 ;; and its whole ancestry, each in BOTH canonical and simple spelling (extend-protocol
 ;; and instance? accept either "Associative" or "clojure.lang.Associative"), plus
@@ -586,6 +596,76 @@
 (jch-register-supers! "java.util.Hashtable" '("java.util.Map"))
 (jch-register-supers! "java.util.Properties" '("java.util.Hashtable"))
 (jch-register-supers! "java.util.HashSet" '("java.util.Set"))
+;; --- the java.lang auto-imports ---------------------------------------------
+;; clojure.core maps 96 class names into every namespace, so on the JVM every one
+;; of them resolves, always. 38 had no row here, which meant no class token, which
+;; meant (resolve 'ExceptionInInitializerError) answered nil where the JVM answers
+;; the class (jolt-9my7). A row is what backs the name: it mints the clojure.core
+;; token (class-token-alist, host-class.ss) so the bare symbol evaluates to the
+;; class, which is the half resolve's answer promises — the instance? macro reads
+;; a class from resolve as "this symbol evaluates to that class" and emits it
+;; unquoted.
+;;
+;; A row is the class's NAME and ancestry, not an implementation: (StringBuffer.
+;; "a") still has no constructor here, exactly as before. That is safe in a way it
+;; would not be for an arbitrary class — resolve is how tooling feature-DETECTS a
+;; class, and these 96 are present on every JVM, so no program can be using one as
+;; a capability test.
+;;
+;; Direct supers are the JVM's wherever jolt models the parent. Where it does not
+;; — StringBuffer's package-private AbstractStringBuilder, Package's NamedPackage,
+;; RuntimePermission's java.security.BasicPermission — the row roots at Object and
+;; keeps the interfaces jolt does model, so .getSuperclass is the one thing that
+;; differs. Process's java.io.Closeable is left off deliberately: it is JDK-version
+;; dependent, and claiming it would let with-open take a Process.
+(jch-register-supers! "java.lang.ArrayStoreException" '("java.lang.RuntimeException"))
+(jch-register-supers! "java.lang.EnumConstantNotPresentException" '("java.lang.RuntimeException"))
+(jch-register-supers! "java.lang.IllegalMonitorStateException" '("java.lang.RuntimeException"))
+(jch-register-supers! "java.lang.NegativeArraySizeException" '("java.lang.RuntimeException"))
+(jch-register-supers! "java.lang.SecurityException" '("java.lang.RuntimeException"))
+(jch-register-supers! "java.lang.TypeNotPresentException" '("java.lang.RuntimeException"))
+(jch-register-supers! "java.lang.IllegalThreadStateException" '("java.lang.IllegalArgumentException"))
+(jch-register-supers! "java.lang.InstantiationException" '("java.lang.ReflectiveOperationException"))
+(jch-register-supers! "java.lang.ClassFormatError" '("java.lang.LinkageError"))
+(jch-register-supers! "java.lang.ExceptionInInitializerError" '("java.lang.LinkageError"))
+(jch-register-supers! "java.lang.VerifyError" '("java.lang.LinkageError"))
+(jch-register-supers! "java.lang.UnsupportedClassVersionError" '("java.lang.ClassFormatError"))
+(jch-register-supers! "java.lang.InstantiationError" '("java.lang.IncompatibleClassChangeError"))
+(jch-register-supers! "java.lang.NoSuchFieldError" '("java.lang.IncompatibleClassChangeError"))
+(jch-register-supers! "java.lang.NoSuchMethodError" '("java.lang.IncompatibleClassChangeError"))
+(jch-register-supers! "java.lang.UnknownError" '("java.lang.VirtualMachineError"))
+(jch-register-supers! "java.lang.ClassLoader" '())
+(jch-register-supers! "java.lang.Enum" '("java.lang.Comparable"))
+(jch-register-supers! "java.lang.Package" '())
+(jch-register-supers! "java.lang.Process" '())
+(jch-register-supers! "java.lang.ProcessBuilder" '())
+(jch-register-supers! "java.lang.Runtime" '())
+(jch-register-supers! "java.lang.RuntimePermission" '())
+(jch-register-supers! "java.lang.SecurityManager" '())
+(jch-register-supers! "java.lang.StackTraceElement" '())
+(jch-register-supers! "java.lang.StrictMath" '())
+(jch-register-supers! "java.lang.StringBuffer" '("java.lang.CharSequence" "java.lang.Appendable" "java.lang.Comparable"))
+(jch-register-supers! "java.lang.ThreadLocal" '())
+(jch-register-supers! "java.lang.InheritableThreadLocal" '("java.lang.ThreadLocal"))
+(jch-register-supers! "java.lang.ThreadGroup" '("java.lang.Thread$UncaughtExceptionHandler"))
+(jch-register-supers! "java.lang.Thread$State" '("java.lang.Enum"))
+(jch-register-supers! "java.lang.Void" '())
+(jch-register-supers! "clojure.lang.Compiler" '())
+;; interfaces, including the three annotations — an annotation type IS an
+;; interface on the JVM, and extends java.lang.annotation.Annotation.
+(jch-register-supers! "java.lang.Cloneable" '())
+(jch-mark-interface! "java.lang.Cloneable")
+(jch-register-supers! "java.lang.Thread$UncaughtExceptionHandler" '())
+(jch-mark-interface! "java.lang.Thread$UncaughtExceptionHandler")
+(jch-register-supers! "java.lang.annotation.Annotation" '())
+(jch-mark-interface! "java.lang.annotation.Annotation")
+(jch-register-supers! "java.lang.Deprecated" '("java.lang.annotation.Annotation"))
+(jch-mark-interface! "java.lang.Deprecated")
+(jch-register-supers! "java.lang.Override" '("java.lang.annotation.Annotation"))
+(jch-mark-interface! "java.lang.Override")
+(jch-register-supers! "java.lang.SuppressWarnings" '("java.lang.annotation.Annotation"))
+(jch-mark-interface! "java.lang.SuppressWarnings")
+
 ;; base interfaces used as super targets — need keys for simple-name resolution
 (jch-register-supers! "java.lang.Number" '())
 (jch-register-supers! "java.lang.Iterable" '())

--- a/host/chez/java/host-class.ss
+++ b/host/chez/java/host-class.ss
@@ -197,12 +197,20 @@
 ;; bare class-name tokens -> canonical JVM class-name strings, derived from the
 ;; modeled class graph (jvm-class-parents) so this list stays current with any
 ;; additions to class-hierarchy.ss.
+;;
+;; Keyed by the name a namespace would MAP the class under — the part after the
+;; last dot, $ and all (java.util.Map$Entry -> Map$Entry, java.lang.Thread$State
+;; -> Thread$State), which is what the JVM imports. jch-last-segment goes on past
+;; the $ because its job is the alternative spelling a protocol extension may use;
+;; taking that as an import name minted a clojure.core/Entry and a
+;; clojure.core/Seq the JVM has no mapping for, and left the two nested auto-
+;; imports with no token at all.
 (define class-token-alist
   (let-values (((keys vals) (hashtable-entries jvm-class-parents)))
     (let ((result '()) (seen (make-hashtable string-hash string=?)))
       (vector-for-each
         (lambda (k _)
-          (let ((s (jch-last-segment k)))
+          (let ((s (jch-import-name k)))
             (when (not (hashtable-ref seen s #f))
               (hashtable-set! seen s #t)
               (set! result (cons (cons s k) result)))))

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -2528,6 +2528,16 @@
 (for-each
   (lambda (nm) (def-var! "clojure.core" nm (jolt-class-for nm)))
   class-fqn-list)
+;; ...and the 96 auto-imports get theirs pinned to the canonical name, last, so
+;; the mapping every namespace has cannot be decided by which class the graph
+;; happened to enumerate first: class-token-alist is first-simple-name-wins over
+;; an unordered hashtable walk, so a same-named class anywhere else in the graph
+;; could otherwise take `Process` or `Package` from java.lang.
+(for-each
+  (lambda (n)
+    (let ((fqn (jolt-default-import-canonical n)))
+      (when (jch-known? fqn) (def-var! "clojure.core" n (jolt-class-for fqn)))))
+  jolt-default-import-names)
 
 ;; --- resolve/ns-resolve return the Class for a class mapping ------------------
 ;; A JVM ns mapping is a var or a Class, and resolve hands back whichever the

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -375,18 +375,29 @@
     "Thread$UncaughtExceptionHandler" "ThreadDeath" "ThreadGroup" "ThreadLocal" "Throwable"
     "TypeNotPresentException" "UnknownError" "UnsatisfiedLinkError" "UnsupportedClassVersionError"
     "UnsupportedOperationException" "VerifyError" "VirtualMachineError" "Void"))
+;; Four of the 96 are not java.lang, so the canonical name is not derivable from
+;; the short one for all of them.
+(define jolt-default-import-overrides
+  '(("BigDecimal" . "java.math.BigDecimal")
+    ("BigInteger" . "java.math.BigInteger")
+    ("Callable"   . "java.util.concurrent.Callable")
+    ("Compiler"   . "clojure.lang.Compiler")))
+(define (jolt-default-import-canonical n)
+  (let ((o (assoc n jolt-default-import-overrides)))
+    (if o (cdr o) (string-append "java.lang." n))))
 (define jolt-default-imports
   (let loop ((ns jolt-default-import-names) (m (jolt-hash-map)))
     (if (null? ns) m
         (loop (cdr ns)
-              (jolt-assoc m (jolt-symbol #f (car ns)) (string-append "java.lang." (car ns)))))))
+              (jolt-assoc m (jolt-symbol #f (car ns))
+                          (jolt-default-import-canonical (car ns)))))))
 ;; The same set as a name lookup. A bare class name is a namespace MAPPING, not a
 ;; global fact — (:import ...) and deftype map one into a single namespace, and
 ;; these are the only ones mapped everywhere — so resolve asks this before it
 ;; answers a bare capitalized symbol (host-static-classes.ss rsv-mapping-visible?).
 (define jolt-default-import-tbl
   (let ((t (make-hashtable string-hash string=?)))
-    (for-each (lambda (n) (hashtable-set! t n (string-append "java.lang." n)))
+    (for-each (lambda (n) (hashtable-set! t n (jolt-default-import-canonical n)))
               jolt-default-import-names)
     t))
 (define (jolt-default-import-fqn nm) (hashtable-ref jolt-default-import-tbl nm #f))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -5284,10 +5284,24 @@
   {:suite "ns / resolve-class" :label "a macro guarding on (resolve name) still emits its deftype" :expected "true" :actual "(do (ns rzc.i) (clojure.core/defmacro rzc-defty [n] (clojure.core/when-not (clojure.core/resolve n) (clojure.core/list 'clojure.core/deftype n '[a]))) (rzc.i/rzc-defty Path) (clojure.core/some? (clojure.core/resolve 'rzc.i/->Path)))" :portability :jvm}
   ;; The other edge of that: resolve answers a CLASS only for one jolt models, and
   ;; the instance? macro reads a class answer as "this symbol evaluates to that
-  ;; class" and emits it unquoted. Some java.lang auto-imports have no backing
-  ;; here at all, so widening resolve to the auto-import LIST turns fipp's
-  ;; (catch ExceptionInInitializerError _) into an unresolved symbol.
-  {:suite "ns / resolve-class" :label "an auto-import jolt does not model still works in catch and instance?" :expected "[:ex false false]" :actual "[(try (throw (Exception. \"x\")) (catch ExceptionInInitializerError e :eiie) (catch Exception e :ex)) (instance? ExceptionInInitializerError 1) (instance? UnsupportedClassVersionError 1)]" :portability :jvm}
+  ;; class" and emits it UNQUOTED. So the two have to move together — the row
+  ;; below pins that for every auto-import at once, and these two pin the shape it
+  ;; broke while they did not (fipp's (catch ExceptionInInitializerError _) became
+  ;; an unresolved symbol, and 7 malli namespaces with it).
+  {:suite "ns / resolve-class" :label "a java.lang auto-import works in catch and instance?" :expected "[:ex false false]" :actual "[(try (throw (Exception. \"x\")) (catch ExceptionInInitializerError e :eiie) (catch Exception e :ex)) (instance? ExceptionInInitializerError 1) (instance? UnsupportedClassVersionError 1)]" :portability :jvm}
+  {:suite "ns / resolve-class" :label "what resolve answers as a class, the symbol also evaluates to" :expected "true" :actual "(every? (fn [s] (= (resolve s) (eval s))) (keys (ns-imports 'user)))" :portability :jvm}
+  ;; Every one of the 96 auto-imports is mapped in every namespace on the JVM, so
+  ;; every one has to resolve — and to the class the mapping names, which for four
+  ;; of them is not java.lang.
+  {:suite "ns / resolve-class" :label "every auto-import resolves" :expected "0" :actual "(count (remove (fn [s] (some? (resolve s))) (keys (ns-imports 'user))))" :portability :jvm}
+  {:suite "ns / resolve-class" :label "and to the class the namespace maps it to" :expected "true" :actual "(every? (fn [e] (= (val e) (resolve (key e)))) (ns-imports 'user))" :portability :jvm}
+  {:suite "ns / resolve-class" :label "the four that are not java.lang" :expected "[java.math.BigDecimal clojure.lang.Compiler java.util.concurrent.Callable java.math.BigInteger]" :actual "[(resolve 'BigDecimal) (resolve 'Compiler) (resolve 'Callable) (resolve 'BigInteger)]" :portability :jvm}
+  {:suite "ns / resolve-class" :label "their ancestry is the JVM's" :expected "[true true true]" :actual "[(isa? ExceptionInInitializerError LinkageError) (isa? Thread$State Enum) (isa? UnsupportedClassVersionError Error)]" :portability :jvm}
+  ;; A class is mapped under the name after the last DOT, $ and all — the JVM
+  ;; imports java.util.Map$Entry as Map$Entry. Reading the innermost segment as
+  ;; the import name instead minted clojure.core mappings for Entry, Seq and
+  ;; friends, which the JVM has no mapping for at all.
+  {:suite "ns / resolve-class" :label "an inner class is not mapped under its innermost name" :expected "[nil nil nil]" :actual "[(resolve 'Entry) (resolve 'Seq) (resolve 'State)]" :portability :jvm}
   ;; ns-imports is the same question made observable — what class names does THIS
   ;; namespace map. It used to be the fixed 96 auto-imports for every ns, so an
   ;; :import and a deftype were both invisible in it.


### PR DESCRIPTION
Stacked on #764, which is stacked on #763 — this branch's base is `fix/syntax-quote-before-macroexpand`.

`clojure.core` maps 96 class names into every namespace, so on the JVM every one of them resolves, always. 38 had no row in jolt's class model, which meant no class token, which meant `(resolve 'ExceptionInInitializerError)` — and `'StringBuffer`, `'Process`, `'ThreadLocal`, 34 others — answered nil (jolt-9my7).

A row is what backs the name: it mints the `clojure.core` token so the bare symbol evaluates to the class, which is the half `resolve`'s answer promises — the `instance?` macro reads a class from `resolve` as "this symbol evaluates to that class" and emits it unquoted. A row is a name and an ancestry, not an implementation: `(StringBuffer. "a")` still has no constructor. Answering for these is safe in a way it would not be for an arbitrary class, since `resolve` is how tooling feature-detects one and these 96 are on every JVM, so nothing can be using one as a capability test. Direct supers are the JVM's wherever jolt models the parent; where it does not (`AbstractStringBuilder`, `NamedPackage`, `BasicPermission`) the row roots at Object, so `.getSuperclass` is the one thing that differs.

Four of the 96 are not java.lang and `ns-imports` named them wrongly: `BigDecimal` and `BigInteger` are `java.math`, `Callable` is `java.util.concurrent`, `Compiler` is `clojure.lang`.

Separately, the name a namespace maps a class under is the part after the last **dot**, `$` and all — the JVM imports `java.util.Map$Entry` as `Map$Entry`. The token table read the innermost segment instead, which minted `clojure.core` mappings for `Entry`, `Seq`, `RSeq`, `SubVector` and friends that the JVM has no mapping for, and left the two nested auto-imports with none at all. `jch-last-segment` keeps going past the `$` because its job is the alternative spelling a protocol extension may use; import names get their own `jch-import-name`. The 96 are then pinned to their canonical names last, so which class the graph happened to enumerate first cannot decide the mapping every namespace has.

7 new corpus rows certified against JVM Clojure, including the coupling as an invariant over all 96 at once: `(every? (fn [s] (= (resolve s) (eval s))) (keys (ns-imports 'user)))`.

Gates: `make test` green, `make certify` 0 new / 0 stale, `make libconformance` 47 ok / 0 regressed.