### PR TITLE
getSimpleName and getCanonicalName honour class nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`getSimpleName` and `getCanonicalName` ignored class nesting.**
+  `(.getSimpleName java.util.Map$Entry)` answered `"Map$Entry"` where the JVM
+  answers `"Entry"`, and `getCanonicalName` kept the `$` where the JVM spells
+  nesting with a dot. Splitting on `$` is not the rule: the JVM reads nesting
+  off the class file, and a Clojure fn class merely contains one and is
+  top-level, so `(.getSimpleName (class inc))` is `"core$inc"`, not `"inc"`.
+  Both now ask the class model whether the name before a `$` is itself a class,
+  which is the same distinction. Surfaced by the auto-import work above, which
+  made `Thread$State` resolvable for the first time.
+
 - **A built binary could intern a stdlib var and leave it unbound.** `jolt build`
   skips any namespace already loaded in the build process as "already in the
   image", which is right for the runtime image every app shares and wrong for

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1624,6 +1624,32 @@
     (cond ((< i 0) s)
           ((char=? (string-ref s i) #\.) (substring s (+ i 1) (string-length s)))
           (else (loop (- i 1))))))
+;; Where a class name's nesting boundary is, or #f if it names a top-level class.
+;; The JVM reads nesting off the class file's enclosing-class attribute, never off
+;; the name, so a `$` does not by itself mean nested: java.util.Map$Entry is Map's
+;; member class, while clojure.core$inc is a TOP-LEVEL class whose name merely
+;; contains one — which is why the JVM answers "Entry" for the first and
+;; "core$inc", not "inc", for the second. Derive that from the class model: a `$`
+;; is a nesting boundary only when the name before it is itself a class jolt
+;; knows. Scanning stops at the last dot, since a `$` can only appear in the
+;; final segment.
+(define (hsc-nesting-dollar cn)
+  (let loop ((i (- (string-length cn) 1)))
+    (cond ((fx<? i 0) #f)
+          ((char=? (string-ref cn i) #\.) #f)
+          ((and (char=? (string-ref cn i) #\$) (jch-known? (substring cn 0 i))) i)
+          (else (loop (fx- i 1))))))
+;; Class.getSimpleName drops the package and, for a nested class, the enclosing
+;; class too. Class.getCanonicalName spells nesting with a dot instead of a `$`.
+(define (hsc-simple-name cn)
+  (let ((i (hsc-nesting-dollar cn)))
+    (if i (substring cn (fx+ i 1) (string-length cn)) (hsc-last-segment cn))))
+(define (hsc-canonical-name cn)
+  (let ((i (hsc-nesting-dollar cn)))
+    (if i
+        (string-append (hsc-canonical-name (substring cn 0 i))
+                       "." (substring cn (fx+ i 1) (string-length cn)))
+        cn)))
 ;; values that carry metadata (mirrors jolt-with-meta's set in natives-meta.ss).
 (define (hsc-imeta? x)
   (or (pvec? x) (pmap? x) (pset? x) (cseq? x) (empty-list-t? x)
@@ -1740,8 +1766,8 @@
     (lambda (x) (if (jclass? x) (jclass-name x) (jolt-invoke1 prev x)))))
 (register-host-methods! "class"
   (list (cons "getName" (lambda (self) (jclass-name self)))
-        (cons "getCanonicalName" (lambda (self) (jclass-name self)))
-        (cons "getSimpleName" (lambda (self) (hsc-last-segment (jclass-name self))))
+        (cons "getCanonicalName" (lambda (self) (hsc-canonical-name (jclass-name self))))
+        (cons "getSimpleName" (lambda (self) (hsc-simple-name (jclass-name self))))
         (cons "toString" (lambda (self) (string-append "class " (jclass-name self))))
         (cons "isArray" (lambda (self) (let ((n (jclass-name self)))
                                          (and (fx>? (string-length n) 0) (char=? (string-ref n 0) #\[)))))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1095,6 +1095,11 @@
   {:suite "host-interop / class tokens & readers" :label "Class str is class-prefixed" :expected "\"class java.lang.String\"" :actual "(str (class \"\"))" :portability :common}
   {:suite "host-interop / class tokens & readers" :label "Class getName" :expected "\"java.lang.String\"" :actual "(.getName (class \"\"))" :portability :jvm}
   {:suite "host-interop / class tokens & readers" :label "Class getSimpleName" :expected "\"Long\"" :actual "(.getSimpleName (class 5))" :portability :jvm}
+  {:suite "host-interop / class tokens & readers" :label "getSimpleName drops a nested class's enclosing class" :expected "\"Entry\"" :actual "(.getSimpleName java.util.Map$Entry)" :portability :jvm}
+  {:suite "host-interop / class tokens & readers" :label "getSimpleName on a nested enum" :expected "\"State\"" :actual "(.getSimpleName java.lang.Thread$State)" :portability :jvm}
+  {:suite "host-interop / class tokens & readers" :label "getCanonicalName spells nesting with a dot" :expected "\"java.util.Map.Entry\"" :actual "(.getCanonicalName java.util.Map$Entry)" :portability :jvm}
+  {:suite "host-interop / class tokens & readers" :label "getSimpleName keeps a fn class's $" :expected "\"core$inc\"" :actual "(.getSimpleName (class inc))" :portability :jvm}
+  {:suite "host-interop / class tokens & readers" :label "getCanonicalName of a fn class is its name" :expected "\"clojure.core$inc\"" :actual "(.getCanonicalName (class inc))" :portability :jvm}
   {:suite "host-interop / class tokens & readers" :label "Class of equal-typed values is =" :expected "true" :actual "(= (class 5) (class 6))" :portability :common}
   {:suite "host-interop / class tokens & readers" :label "Class in a thrown message" :expected "\"of class java.lang.String\"" :actual "(try (throw (Exception. (str \"of \" (class \"\")))) (catch Exception e (.getMessage e)))" :portability :jvm}
   {:suite "host-interop / class tokens & readers" :label "ctor sugar still constructs" :expected "\"x\"" :actual "(.toString (StringBuilder. \"x\"))" :portability :jvm}


### PR DESCRIPTION
`(.getSimpleName java.util.Map$Entry)` answered `"Map$Entry"` where the JVM answers `"Entry"`, and `getCanonicalName` kept the `$` where the JVM spells nesting with a dot.

Splitting on `$` is not the rule, and that is the whole subtlety. The JVM reads nesting off the class file's enclosing-class attribute, never off the name, so a Clojure fn class — which merely *contains* a `$` while being top-level — keeps it: `(.getSimpleName (class inc))` is `"core$inc"`, not `"inc"`. jolt already got that half right, and a naive `$` split would have broken it.

So ask the class model the same question the class file answers: a `$` is a nesting boundary only when the name before it is itself a class jolt knows. `java.util.Map` is; `clojure.core` is not.

| | jolt before | jolt after | Clojure 1.12.5 |
|---|---|---|---|
| `(.getSimpleName java.util.Map$Entry)` | `"Map$Entry"` | `"Entry"` | `"Entry"` |
| `(.getCanonicalName java.util.Map$Entry)` | `"java.util.Map$Entry"` | `"java.util.Map.Entry"` | `"java.util.Map.Entry"` |
| `(.getSimpleName java.lang.Thread$State)` | `"Thread$State"` | `"State"` | `"State"` |
| `(.getSimpleName (class inc))` | `"core$inc"` | `"core$inc"` | `"core$inc"` |
| `(.getCanonicalName (class inc))` | `"clojure.core$inc"` | `"clojure.core$inc"` | `"clojure.core$inc"` |

Five corpus rows, one per line above — the fn rows are there because they are what a naive fix breaks.

Pre-existing, found while reviewing #763/#765: #765 made `Thread$State` resolvable for the first time, so `.getSimpleName` on it is newly reachable. Bead jolt-jp15.

`getName` is untouched, so the placeholder-class rows in `unit.edn` (`clojure.lang.IObj$reify__0` and friends) are unaffected. Their *simple* names do change, from `X$Y` to `Y` — nothing pins them, and jolt's spelling for an anonymous fn class already diverges from the JVM's per-eval `user$evalNNN$fn__NNN` either way.

Import names are deliberately not touched: a nested class is imported under `Map$Entry`, so `rsv-registration-class` / `hsc-ns-import-class` keep the dot-only split. Each question now has its own helper saying which it is.

Gates: `make test` green, `make certify` 0 NEW / 0 stale, `make libconformance` 47 ok / 0 regressed.