### PR TITLE
ex-info with nil data reads back as {}, and gate the :documented divergences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ex-info` with nil data.** `(ex-data (ex-info "m" nil))` answered `nil` where
+  the JVM answers `{}` — `ExceptionInfo`'s constructor rejects a null map, so an
+  ExceptionInfo whose data is nil cannot exist. It flipped a
+  `(when (ex-data e) ...)` branch silently, and `Throwable->map` and `str` were
+  wrong with it. The coercion is in the constructor, which is what the emitter
+  lowers the `ex-info` native op to, so compiled call sites are covered too.
+  Fixes #771.
+
+- **Binding a non-dynamic var reports its real class.** `push-thread-bindings`
+  on a var that is not `^:dynamic`, and `set!` on a var with no thread binding,
+  raised an `ExceptionInfo`; the JVM raises `java.lang.IllegalStateException`
+  with the same message. Both are typed throwables now, so `ex-data` on them is
+  `nil` the way it is on the JVM.
+
+- **`resolve` no longer answers for classes that do not exist.**
+  `(resolve 'fake.pkg.String)` handed back a class token because the class-graph
+  lookup fell back to the last dotted segment, so any `a.b.String` matched
+  `java.lang.String`'s registration. Feature detection — which is what `resolve`
+  on a class name is for — read that as "this class is present" and took the
+  branch. Answers `nil` now, like the JVM.
+
+### Internal
+
+- The `:documented` half of `test/conformance/known-divergences.edn` is gated.
+  Those entries are prose about divergences that are not corpus rows, and
+  nothing ever ran them: an audit found entries claiming the JVM throws on
+  `(ex-info "m" nil)` and on `(resolve 'java.lang.module.ModuleFinder)`, neither
+  of which any JVM run reproduces, and two entries whose divergence had been
+  fixed years apart with no one noticing. Every entry now carries a `:check` —
+  either an expression with its recorded value on each runtime, or `:prose` with
+  a reason it cannot be one. `certify.clj` verifies the JVM side, `make
+  documented` the jolt side, and both reject an entry whose two sides agree.
+
+
 ## [0.7.28] - 2026-08-27
 
 Two things a namespace does constantly — name a class and read a form — were

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ install: build
 # naming the covered tree is written ONLY on a complete pass. `make gate-status`
 # answers "is this working tree gated?" — which is not something to remember.
 
-CI-GATES := submodules values corpus unit grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke taskssmoke depscpcache depsunit \
+CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke taskssmoke depscpcache depsunit \
   smoke tracesmoke buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi ffidupsym continuations stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq \
@@ -311,6 +311,19 @@ corpus:
 # Host-specific unit cases.
 unit:
 	@$(CHEZ) --script host/chez/run-unit.ss
+
+# The jolt half of the known-divergences :documented gate: every entry's :check
+# must render exactly its recorded :jolt value, its :jvm and :jolt must differ,
+# and an entry with no :check fails. certify.clj runs the JVM half against
+# reference Clojure; this half needs no JVM, so it lives in `ci`.
+# `make documented-record` prints what jolt currently answers, for recording a
+# new entry (the JVM side comes from
+# `clojure -M test/conformance/certify.clj --record-documented`).
+documented:
+	@$(CHEZ) --script host/chez/run-documented.ss
+
+documented-record:
+	@$(CHEZ) --script host/chez/run-documented.ss --record
 
 # Real-CLI smoke over bin/jolt.
 # The CLI and build gates spawn a jolt process per case; a prebuilt binary boots

--- a/host/chez/dyn-binding.ss
+++ b/host/chez/dyn-binding.ss
@@ -164,11 +164,12 @@
                    ;; set-var-meta!).
                    (let ((m (var-cell-meta cell)))
                      (when (not (and m (jolt-truthy? (jolt-get m (keyword #f "dynamic")))))
-                       (jolt-throw
-                        (jolt-ex-info
-                         (string-append "Can't dynamically bind non-dynamic var: "
-                                        (var-cell-ns cell) "/" (var-cell-name cell))
-                         jolt-nil))))
+                       ;; Var.pushThreadBindings raises IllegalStateException, not
+                       ;; an ExceptionInfo — so ex-data on it is nil, and only a
+                       ;; typed host throwable can say that.
+                       (throw-jvm (quote IllegalStateException)
+                                  (string-append "Can't dynamically bind non-dynamic var: "
+                                                 (var-cell-ns cell) "/" (var-cell-name cell)))))
                    (cons (cons cell v) acc))
                  '())))
     pairs))
@@ -251,11 +252,10 @@
       (let ((p (dyn-find-binding v)))
         (if p
             (begin (set-cdr! p val) val)
-            (jolt-throw
-             (jolt-ex-info
-              (string-append "Can't change/establish root binding of: "
-                             (var-cell-name v) " with set")
-              jolt-nil))))
+            ;; Var.set raises IllegalStateException — see the push path above.
+            (throw-jvm (quote IllegalStateException)
+                       (string-append "Can't change/establish root binding of: "
+                                      (var-cell-name v) " with set"))))
       (throw-jvm (quote ClassCastException) "set!: not a var")))
 
 ;; alter-var-root: apply f to the current root plus args, atomically.

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -199,6 +199,14 @@
     (or (hashtable-ref t wanted #f)
         (hashtable-ref t (jch-last-segment wanted) #f))))
 
+;; Exact membership, no last-segment fallback. The fallback above is there so a
+;; SIMPLE name answers (chez-condition-exc-class hands over "ArityException"),
+;; but it also makes every dotted name whose last segment happens to be modeled —
+;; fake.pkg.String, no.such.Class — read as known. A caller asking "does the host
+;; back THIS class" rather than "have I seen this name" wants this one.
+(define (jch-known-exact? wanted)
+  (and (hashtable-ref (jch-known-table) wanted #f) #t))
+
 ;; simple last-segment -> canonical FQN for a modeled class (first registered
 ;; wins). Lets a simple exception name (from chez-condition-exc-class) resolve to
 ;; its graph key so the exception hierarchy answers through the one graph.

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -2626,8 +2626,12 @@
   ;; A bare name needs no arm here: every one a namespace maps and jolt models is
   ;; a cell — an :import, a deftype, or the clojure.core token the class model
   ;; registers for each auto-import it knows — so jolt-resolve already found it.
+  ;; jch-known-exact?, not jch-known?: the latter falls back to the last dotted
+  ;; segment, so fake.pkg.String answered java.lang.String's registration and
+  ;; resolve handed back a token for a class that exists nowhere — the opposite
+  ;; of the feature-detection answer this is here to give.
   (and (hc-fq-class-name? nm)
-       (or (jch-known? nm) (host-class-registered? nm))
+       (or (jch-known-exact? nm) (host-class-registered? nm))
        (jolt-class-for nm)))
 (define (rsv-through v sym ns)
   (cond ((jolt-nil? v)

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -584,10 +584,22 @@
 ;; /associative?/counted? are naturally false). Arity 2 (msg data) or 3 (msg data cause).
 ;; No :jolt/class field on plain ex-info — class defaults to clojure.lang.ExceptionInfo
 ;; via ex-info-class in records-interop.ss.
+;;
+;; nil data reads back as {}, not nil: ExceptionInfo's constructor rejects a null
+;; map, so an ExceptionInfo whose data is nil cannot exist and (ex-data (ex-info
+;; "m" nil)) is {}. Coercing HERE covers every caller — the emitter lowers the
+;; ex-info native op to a direct call to this procedure, so a wrapper around the
+;; clojure.core/ex-info var root would miss every compiled call site. It is also
+;; what makes (some? (ex-data e)) a sound "is this an ExceptionInfo" test, which
+;; is how the analyzer's throw-message tells one from a host throwable.
+;;
+;; A throwable that genuinely has NO data is a different construction:
+;; jolt-host-throwable / throw-jvm, which is what the JVM raises wherever
+;; ex-data is nil.
 (define (jolt-ex-info msg data . more)
   (make-jolt-ex-info-record "clojure.lang.ExceptionInfo" msg
                              (if (null? more) jolt-nil (car more))
-                             data 0))
+                             (if (jolt-nil? data) empty-pmap data) 0))
 ;; A host-constructed throwable (RuntimeException. etc.): a jolt-ex-info-record
 ;; carrying its canonical JVM class-name, so (class …) / instance? / .getMessage /
 ;; ex-message all reflect the real type.

--- a/host/chez/run-case-isolation.ss
+++ b/host/chez/run-case-isolation.ss
@@ -1,0 +1,58 @@
+;; run-case-isolation.ss — snapshot the world once, restore it between cases.
+;;
+;; A gate that evaluates many independent jolt expressions in one process needs
+;; each one to start from the same world: a row that defs a var, requires a
+;; namespace, derives into the global hierarchy or extends a host class must not
+;; decide what the next row sees. Loaded AFTER the gate has done its own setup
+;; (source roots, any preloaded namespace) — the snapshot is taken here, so
+;; whatever the gate established beforehand is part of the stable base.
+;;
+;; Shared by run-unit.ss and run-documented.ss. run-corpus.ss keeps its own,
+;; narrower copy: it deliberately does not roll back the loader dedup.
+;; --- per-case isolation (snapshot the world after setup, restore each case) -------
+(define zj-base (let ((h (make-hashtable string-hash string=?)))
+  (vector-for-each (lambda (k) (hashtable-set! h k #t)) (hashtable-keys var-table)) h))
+(define zj-roots '())
+(vector-for-each (lambda (k) (let ((c (hashtable-ref var-table k #f)))
+                   (when c (set! zj-roots (cons (cons c (var-cell-root c)) zj-roots)))))
+                 (hashtable-keys var-table))
+(define (zj-snap ht) (let ((h (make-hashtable string-hash string=?)))
+  (vector-for-each (lambda (k) (hashtable-set! h k #t)) (hashtable-keys ht)) h))
+(define (zj-prune! ht base) (vector-for-each
+  (lambda (k) (unless (hashtable-ref base k #f) (hashtable-delete! ht k))) (hashtable-keys ht)))
+(define zj-ns-base (zj-snap ns-registry))
+(define zj-type-base (zj-snap type-registry))
+(define zj-loaded-base (zj-snap loaded-ns))
+(define zj-ghier (var-cell-lookup "clojure.core" "global-hierarchy"))
+(define (zj-reset!)
+  ;; a var-table mutation, so it takes var-table-mu like every other one (rt.ss).
+  ;; This harness is single-threaded, but the invariant is easier to keep if it
+  ;; has no exceptions.
+  (jolt-with-mutex var-table-mu
+    (vector-for-each (lambda (k) (unless (hashtable-ref zj-base k #f) (hashtable-delete! var-table k)))
+                     (hashtable-keys var-table)))
+  (rebuild-ns-cells-index!)   ; the prune bypassed the ns->cells buckets (rt.ss)
+  (for-each (lambda (cr) (unless (eq? (var-cell-root (car cr)) (cdr cr))
+                           (var-cell-root-set! (car cr) (cdr cr)))) zj-roots)
+  (jolt-with-mutex ns-registry-mu (zj-prune! ns-registry zj-ns-base))  ; same rule as var-table (ns.ss)
+  ; the protocol tree AND its by-method index, through the one entry
+  ; point that keeps them in step (protocols.ss)
+  (prune-type-registry! (lambda (k) (hashtable-ref zj-type-base k #f)))
+  ;; roll back the loader dedup — a row's require must reload for the next row,
+  ;; since the vars it defined were just pruned from var-table
+  (vector-for-each (lambda (k) (unless (hashtable-ref zj-loaded-base k #f)
+                                 (ldr-unmark-loaded! k)))
+                   (hashtable-keys loaded-ns))
+  (hashtable-clear! ns-alias-table)
+  (hashtable-clear! ns-refer-table)
+  (hashtable-clear! ns-refer-all-table)
+  (hashtable-clear! ns-refer-all-exclude-table)
+  (hashtable-clear! ns-core-exclude-table)
+  ;; class extensions are process-wide by design (java/class-extensions.ss), so a
+  ;; row that overrides java.io.File/getPath would otherwise decide what every
+  ;; later row sees.
+  (class-ext-reset!)
+  (clear-thread-interrupt!)   ; a case that set the runner thread's interrupt flag mustn't leak
+  (when zj-ghier (jolt-invoke (var-deref "clojure.core" "reset!")
+                   (var-cell-root zj-ghier) (jolt-invoke (var-deref "clojure.core" "make-hierarchy"))))
+  (set-chez-ns! "user"))

--- a/host/chez/run-documented.ss
+++ b/host/chez/run-documented.ss
@@ -1,0 +1,139 @@
+;; run-documented.ss — the jolt half of the known-divergences gate.
+;;
+;; test/conformance/known-divergences.edn has two lists. :entries names corpus
+;; rows and certify.clj already gates it for NEW and STALE. :documented is prose
+;; about divergences that are NOT corpus rows, and nothing ever ran it. Making the
+;; 33 checkable entries checkable found two whose divergence no longer existed at
+;; all and five whose recorded JVM or jolt answer no run reproduces — including one
+;; claiming resolve throws ClassNotFoundException, which it never does.
+;;
+;; So every :documented entry now carries a :check. Either
+;;   :check {:expr "<expr>" :jvm "<rendered>" :jolt "<rendered>"}   machine-verified
+;;   :check :prose  :why "<reason>"                                 deliberately not
+;; and a missing :check fails the gate, so a new entry cannot arrive unverified.
+;;
+;; This runner owns the JOLT half: evaluate :expr here and require it to render
+;; exactly :jolt. certify.clj owns the JVM half against reference Clojure, and
+;; both ends additionally require :jvm and :jolt to DIFFER — an entry whose two
+;; sides have converged documents a divergence that no longer exists.
+;;
+;;   chez --script host/chez/run-documented.ss            gate
+;;   chez --script host/chez/run-documented.ss --record   print measured :jolt values
+(import (chezscheme))
+
+(load "host/chez/run-gate-harness.ss")
+(load "host/chez/loader.ss")
+(set-source-roots! ldr-install-roots)
+(load-namespace "jolt.time.base")
+(load "host/chez/run-case-isolation.ss")
+
+(define record-mode?
+  (let loop ((a (command-line-arguments)))
+    (cond ((null? a) #f)
+          ((string=? (car a) "--record") #t)
+          (else (loop (cdr a))))))
+
+(define (slurp path)
+  (call-with-input-file path
+    (lambda (p)
+      (let loop ((cs '()) (c (read-char p)))
+        (if (eof-object? c) (list->string (reverse cs))
+            (loop (cons c cs) (read-char p)))))))
+
+(define registry
+  (jolt-read-string (slurp "test/conformance/known-divergences.edn")))
+(define (kw s) (keyword #f s))
+(define entries (jolt-get registry (kw "documented")))
+
+;; Render exactly as certify.clj's JVM half does: the readable printer for a
+;; value, "throws <SimpleName>" for a raise. The simple name is the last dotted
+;; segment of the class jolt reports, so the two halves name the same thing.
+(define (kd-simple-name v)
+  (let ((n (guard (e (#t jolt-nil)) (jolt-class-name (jolt-unwrap-throw v)))))
+    (if (string? n) (jch-last-segment n) "Object")))
+
+(define (kd-render expr)
+  (let ((sink (open-output-string)))
+    (guard (e (#t (string-append "throws " (kd-simple-name e))))
+      ;; jolt-pr-str1 is pr-str: readable, and "nil" for nil. NOT jolt-repl-str
+      ;; (the -e printer), which renders nil as the empty string and would make
+      ;; every nil-valued entry disagree with the JVM half for no real reason.
+      (jolt-pr-str1
+        (parameterize ((current-output-port sink))
+          (jolt-compile-eval (string-append "(do " expr ")") "user"))))))
+
+;; Every :category in use must have a :legend line. A category is how a reader
+;; decides whether a divergence is deliberate, and one with no legend entry says
+;; nothing — :restrictive was in use with no line until this check went in.
+(define (kd-check-legend!)
+  (let ((legend (jolt-get registry (kw "legend")))
+        (seen (make-hashtable string-hash string=?)))
+    (for-each
+      (lambda (lst)
+        (let loop ((i 0))
+          (when (< i (pvec-count lst))
+            (let ((c (jolt-get (pvec-nth-d lst i jolt-nil) (kw "category"))))
+              (when (and (keyword? c) (jolt-nil? (jolt-get legend c))
+                         (not (hashtable-ref seen (keyword-t-name c) #f)))
+                (hashtable-set! seen (keyword-t-name c) #t)
+                (fail! ":legend" (string-append "category :" (keyword-t-name c)
+                                                " is used but has no :legend entry"))))
+            (loop (+ i 1)))))
+      (list entries (jolt-get registry (kw "entries"))))))
+
+(define pass 0)
+(define fails '())
+(define checked 0)
+(define prose 0)
+(define (fail! what msg) (set! fails (cons (cons what msg) fails)))
+
+(kd-check-legend!)
+
+(let loop ((i 0))
+  (when (< i (pvec-count entries))
+    (let* ((e (pvec-nth-d entries i jolt-nil))
+           (behavior (jolt-get e (kw "behavior")))
+           (label (if (string? behavior) behavior "<no :behavior>"))
+           (check (jolt-get e (kw "check"))))
+      (cond
+        ((jolt-nil? check)
+         (fail! label "no :check — add {:expr .. :jvm .. :jolt ..} or :prose with a :why"))
+        ((eq? check (kw "prose"))
+         (if (jolt-nil? (jolt-get e (kw "why")))
+             (fail! label ":check :prose needs a :why saying why it is not machine-checkable")
+             (set! prose (+ prose 1))))
+        ((jolt-map? check)
+         (let ((expr (jolt-get check (kw "expr")))
+               (jvm  (jolt-get check (kw "jvm")))
+               (jolt (jolt-get check (kw "jolt"))))
+           (cond
+             ((not (and (string? expr) (string? jvm) (string? jolt)))
+              (fail! label ":check needs string :expr, :jvm and :jolt"))
+             ((string=? jvm jolt)
+              (fail! label (string-append "STALE — :jvm and :jolt agree (" jvm
+                                          "), so this is no longer a divergence")))
+             (else
+              (set! checked (+ checked 1))
+              (let ((got (kd-render expr)))
+                (if record-mode?
+                    (printf "  :expr ~s\n  :jolt ~s\n\n" expr got)
+                    (if (string=? got jolt)
+                        (set! pass (+ pass 1))
+                        (fail! label (string-append "jolt side: want `" jolt "` got `" got
+                                                    "`\n      expr: " expr)))))))))
+        (else (fail! label ":check must be a map or :prose")))
+      (zj-reset!))
+    (loop (+ i 1))))
+
+(if record-mode?
+    (printf "\nrecorded ~a checkable entries\n" checked)
+    (begin
+      (printf "\ndocumented-divergence gate (jolt half): ~a/~a machine-checked entries pass"
+              pass checked)
+      (printf ", ~a prose\n" prose)
+      (when (> (length fails) 0)
+        (printf "\n~a FAIL(s):\n" (length fails))
+        (for-each (lambda (f) (printf "  [~a]\n      ~a\n" (car f) (cdr f)))
+                  (reverse fails)))))
+(flush-output-port)
+(exit (if (and (not record-mode?) (> (length fails) 0)) 1 0))

--- a/host/chez/run-unit.ss
+++ b/host/chez/run-unit.ss
@@ -41,53 +41,7 @@
 (define kw-expected (keyword #f "expected"))
 (define kw-throws   (keyword #f "throws"))
 
-;; --- per-case isolation (snapshot the world after setup, restore each case) -------
-(define zj-base (let ((h (make-hashtable string-hash string=?)))
-  (vector-for-each (lambda (k) (hashtable-set! h k #t)) (hashtable-keys var-table)) h))
-(define zj-roots '())
-(vector-for-each (lambda (k) (let ((c (hashtable-ref var-table k #f)))
-                   (when c (set! zj-roots (cons (cons c (var-cell-root c)) zj-roots)))))
-                 (hashtable-keys var-table))
-(define (zj-snap ht) (let ((h (make-hashtable string-hash string=?)))
-  (vector-for-each (lambda (k) (hashtable-set! h k #t)) (hashtable-keys ht)) h))
-(define (zj-prune! ht base) (vector-for-each
-  (lambda (k) (unless (hashtable-ref base k #f) (hashtable-delete! ht k))) (hashtable-keys ht)))
-(define zj-ns-base (zj-snap ns-registry))
-(define zj-type-base (zj-snap type-registry))
-(define zj-loaded-base (zj-snap loaded-ns))
-(define zj-ghier (var-cell-lookup "clojure.core" "global-hierarchy"))
-(define (zj-reset!)
-  ;; a var-table mutation, so it takes var-table-mu like every other one (rt.ss).
-  ;; This harness is single-threaded, but the invariant is easier to keep if it
-  ;; has no exceptions.
-  (jolt-with-mutex var-table-mu
-    (vector-for-each (lambda (k) (unless (hashtable-ref zj-base k #f) (hashtable-delete! var-table k)))
-                     (hashtable-keys var-table)))
-  (rebuild-ns-cells-index!)   ; the prune bypassed the ns->cells buckets (rt.ss)
-  (for-each (lambda (cr) (unless (eq? (var-cell-root (car cr)) (cdr cr))
-                           (var-cell-root-set! (car cr) (cdr cr)))) zj-roots)
-  (jolt-with-mutex ns-registry-mu (zj-prune! ns-registry zj-ns-base))  ; same rule as var-table (ns.ss)
-  ; the protocol tree AND its by-method index, through the one entry
-  ; point that keeps them in step (protocols.ss)
-  (prune-type-registry! (lambda (k) (hashtable-ref zj-type-base k #f)))
-  ;; roll back the loader dedup — a row's require must reload for the next row,
-  ;; since the vars it defined were just pruned from var-table
-  (vector-for-each (lambda (k) (unless (hashtable-ref zj-loaded-base k #f)
-                                 (ldr-unmark-loaded! k)))
-                   (hashtable-keys loaded-ns))
-  (hashtable-clear! ns-alias-table)
-  (hashtable-clear! ns-refer-table)
-  (hashtable-clear! ns-refer-all-table)
-  (hashtable-clear! ns-refer-all-exclude-table)
-  (hashtable-clear! ns-core-exclude-table)
-  ;; class extensions are process-wide by design (java/class-extensions.ss), so a
-  ;; row that overrides java.io.File/getPath would otherwise decide what every
-  ;; later row sees.
-  (class-ext-reset!)
-  (clear-thread-interrupt!)   ; a case that set the runner thread's interrupt flag mustn't leak
-  (when zj-ghier (jolt-invoke (var-deref "clojure.core" "reset!")
-                   (var-cell-root zj-ghier) (jolt-invoke (var-deref "clojure.core" "make-hierarchy"))))
-  (set-chez-ns! "user"))
+(load "host/chez/run-case-isolation.ss")
 
 ;; --- run ------------------------------------------------------------------------
 (define pass 0)

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -253,17 +253,17 @@
            (jolt-throw (jolt-ex-info
                          (string-append "image: no var " (cadr d) "/" (caddr d)
                                         " in this build to restore a function reference")
-                         jolt-nil)))))
+                         empty-pmap)))))
     ((handler)
      (let loop ((hs image-handlers))
        (if (null? hs)
-           (jolt-throw (jolt-ex-info "image: no handler registered to restore a resource" jolt-nil))
+           (jolt-throw (jolt-ex-info "image: no handler registered to restore a resource" empty-pmap))
            ;; restore fns are tried in registration order; the first that accepts wins
            (let ((r (call/cc (lambda (k)
                       (with-exception-handler (lambda (e) (k 'image-no))
                         (lambda () (jolt-invoke (caddr (car hs)) (cadr d))))))))
              (if (eq? r 'image-no) (loop (cdr hs)) r)))))
-    (else (jolt-throw (jolt-ex-info "image: unknown external descriptor" jolt-nil)))))
+    (else (jolt-throw (jolt-ex-info "image: unknown external descriptor" empty-pmap)))))
 
 ;; --- R2: substitution pre-pass --------------------------------------------------
 ;; A var root a handler claimed, replaced by the handler's plain-data payload.
@@ -559,12 +559,12 @@
                                           "' was optimized into the compiled code, so its value"
                                           " cannot be recovered from the live closure —"
                                           " store a named fn, or the data to rebuild one")
-                           jolt-nil))))
+                           empty-pmap))))
         (else
          (jolt-throw (jolt-ex-info
                        (string-append "image: cannot write " (image-describe-obj x)
                                       " at " (image-path->string path))
-                       jolt-nil)))))))
+                       empty-pmap)))))))
 
 ;; A condition's human text, best effort — jolt ex-info and raw Chez
 ;; conditions both pass through here on the restore failure path.
@@ -596,7 +596,7 @@
                                    (image-fnsrc-name x) " from source"
                                    " (a tree-shaken build that dropped the compiler"
                                    " cannot restore images holding anonymous fns)")
-                    jolt-nil)))
+                    empty-pmap)))
     (let* ((frees (image-fnsrc-free-names x))
            (params (let loop ((s (jolt-seq frees)) (acc '()))
                      (if (jolt-nil? s)
@@ -610,7 +610,7 @@
                                                            (image-fnsrc-name x) " in ns "
                                                            (image-fnsrc-ns x) ": "
                                                            (image-condition-text e))
-                                            jolt-nil))))
+                                            empty-pmap))))
                   (ce wrapper (image-fnsrc-ns x)))))
       (apply jolt-invoke wfn tfvs))))
 
@@ -619,7 +619,7 @@
 (define (image-restore-handler payload)
   (let loop ((hs image-handlers))
     (if (null? hs)
-        (jolt-throw (jolt-ex-info "image: no handler registered to restore a resource" jolt-nil))
+        (jolt-throw (jolt-ex-info "image: no handler registered to restore a resource" empty-pmap))
         (let ((r (call/cc (lambda (k)
                    (with-exception-handler (lambda (e) (k 'image-no))
                      (lambda () (jolt-invoke (caddr (car hs)) payload)))))))
@@ -729,7 +729,7 @@
                                                        (number->string (image-stub-id x))
                                                        " (" (image-stub-kind x) "): "
                                                        (image-condition-text e))
-                                        jolt-nil))))
+                                        empty-pmap))))
                                        (jolt-invoke r (image-stub-info x)))))
                               (hashtable-set! memo x v)
                               v)
@@ -764,7 +764,7 @@
                                 (jolt-ex-info
                                   (string-append "image: cannot write " (image-describe-obj x)
                                                  " at " (image-path->string path))
-                                  jolt-nil)))
+                                  empty-pmap)))
                              (else
                               (hashtable-set! memo x #t)
                               (report! x path (image-report-disposition mode)))))
@@ -1223,7 +1223,7 @@
                                                  (image-fnsrc-name x) ": " (number->string n)
                                                  " free values for " (number->string (pvec-count frees))
                                                  " free names")
-                                  jolt-nil)))
+                                  empty-pmap)))
                   (let ((tfvs (map (lambda (v)
                                      (walk v (cons (string-append "free:" (image-fnsrc-name x)) path)))
                                    (vector->list fvs))))
@@ -1335,12 +1335,12 @@
 
 (define (image-check-header! h path)
   (unless (and (vector? h) (fx=? (vector-length h) 4) (eq? (vector-ref h 0) 'jolt-image))
-    (jolt-throw (jolt-ex-info (string-append "image: " path " is not a jolt image") jolt-nil)))
+    (jolt-throw (jolt-ex-info (string-append "image: " path " is not a jolt image") empty-pmap)))
   (unless (member (vector-ref h 1) jolt-image-read-versions)
     (jolt-throw (jolt-ex-info
                   (string-append "image: " path " has format version "
                                  (jolt-str-one (vector-ref h 1)) ", this build reads versions 2 to 5")
-                  jolt-nil)))
+                  empty-pmap)))
   ;; The fasl version moves with Chez, and a mismatch otherwise surfaces as an
   ;; opaque fasl-read error, so name it here instead.
   (unless (equal? (vector-ref h 2) (jolt-image-runtime-version))
@@ -1348,7 +1348,7 @@
                   (string-append "image: " path " was written by runtime "
                                  (jolt-str-one (vector-ref h 2)) ", this is "
                                  (jolt-image-runtime-version))
-                  jolt-nil)))
+                  empty-pmap)))
   #t)
 
 ;; Runtime identity an image is pinned to. The fasl format moves with the Chez
@@ -1458,7 +1458,7 @@
                                               (string-append "image: cannot write "
                                                              (image-describe-obj x)
                                                              " at " where)
-                                              jolt-nil)))))
+                                              empty-pmap)))))
                         externals)))
         ;; Descriptors are written WITHOUT an externals-pred, so a handler that
         ;; returns something non-data would fail here with a raw Chez error.
@@ -1470,7 +1470,7 @@
                     (lambda (e)
                       (k (jolt-throw (jolt-ex-info
                                        "image: a resource handler returned a value that is not plain data"
-                                       jolt-nil))))
+                                       empty-pmap))))
                     (lambda () (call-with-bytevector-output-port
                                  (lambda (p) (sa-fasl-write descs p)))))))))
           (let ((port (open-file-output-port path (file-options no-fail))))
@@ -1485,7 +1485,7 @@
 
 (define (jolt-image-read path)
   (unless (file-exists? path)
-    (jolt-throw (jolt-ex-info (string-append "image: no such file: " path) jolt-nil)))
+    (jolt-throw (jolt-ex-info (string-append "image: no such file: " path) empty-pmap)))
   (let ((port (open-file-input-port path)))
     (let* ((h (sa-fasl-read port))
            (_ (image-check-header! h path))
@@ -1494,7 +1494,7 @@
            (b (sa-fasl-read port 'load exts)))
       (close-port port)
       (unless (and (vector? b) (fx=? (vector-length b) 2))
-        (jolt-throw (jolt-ex-info (string-append "image: malformed body in " path) jolt-nil)))
+        (jolt-throw (jolt-ex-info (string-append "image: malformed body in " path) empty-pmap)))
       (image-reattach-meta! (vector-ref b 1))
       ;; R3: rebuild what the write side substituted — fn source records become
       ;; live closures, handler payloads go back through their restore fns.
@@ -1598,7 +1598,7 @@
       (jolt-throw (jolt-ex-info
                     (string-append "image: " path
                                    " is a value image, not a world image — read it with read-image")
-                    jolt-nil)))
+                    empty-pmap)))
     (let ((n 0))
       (for-each
         (lambda (p)
@@ -1735,7 +1735,7 @@
       (jolt-throw (jolt-ex-info
                     (string-append "image: no unresolved stub #"
                                    (jolt-str-one id) " from the last world restore")
-                    jolt-nil)))
+                    empty-pmap)))
     (let* ((k (cdr e))
            (slash (let scan ((i 0))
                     (cond ((fx>=? i (string-length k)) #f)

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -355,10 +355,22 @@
 ;; /associative?/counted? are naturally false). Arity 2 (msg data) or 3 (msg data cause).
 ;; No :jolt/class field on plain ex-info — class defaults to clojure.lang.ExceptionInfo
 ;; via ex-info-class in records-interop.ss.
+;;
+;; nil data reads back as {}, not nil: ExceptionInfo's constructor rejects a null
+;; map, so an ExceptionInfo whose data is nil cannot exist and (ex-data (ex-info
+;; "m" nil)) is {}. Coercing HERE covers every caller — the emitter lowers the
+;; ex-info native op to a direct call to this procedure, so a wrapper around the
+;; clojure.core/ex-info var root would miss every compiled call site. It is also
+;; what makes (some? (ex-data e)) a sound "is this an ExceptionInfo" test, which
+;; is how the analyzer's throw-message tells one from a host throwable.
+;;
+;; A throwable that genuinely has NO data is a different construction:
+;; jolt-host-throwable / throw-jvm, which is what the JVM raises wherever
+;; ex-data is nil.
 (define (jolt-ex-info msg data . more)
   (make-jolt-ex-info-record "clojure.lang.ExceptionInfo" msg
                              (if (null? more) jolt-nil (car more))
-                             data 0))
+                             (if (jolt-nil? data) empty-pmap data) 0))
 ;; A host-constructed throwable (RuntimeException. etc.): a jolt-ex-info-record
 ;; carrying its canonical JVM class-name, so (class …) / instance? / .getMessage /
 ;; ex-message all reflect the real type.

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -603,6 +603,16 @@
   {:suite "exceptions / ex-info" :label "ex-data on non-ex" :expected "nil" :actual "(ex-data 42)" :portability :common}
   {:suite "exceptions / ex-info" :label "ex-cause on non-ex" :expected "nil" :actual "(ex-cause {:k 1})" :portability :common}
   {:suite "exceptions / ex-info" :label "ex-message of string" :expected "nil" :actual "(ex-message \"hi\")" :portability :common}
+  {:suite "exceptions / ex-info" :label "nil data reads back as {}" :expected "{}" :actual "(ex-data (ex-info \"m\" nil))" :portability :common}
+  {:suite "exceptions / ex-info" :label "nil data is indistinguishable from {}" :expected "true" :actual "(= (ex-data (ex-info \"m\" nil)) (ex-data (ex-info \"m\" {})))" :portability :common}
+  {:suite "exceptions / ex-info" :label "nil data survives a catch as {}" :expected "{}" :actual "(try (throw (ex-info \"m\" nil)) (catch clojure.lang.ExceptionInfo e (ex-data e)))" :portability :common}
+  {:suite "exceptions / ex-info" :label "nil data with a cause still reads {}" :expected "{}" :actual "(ex-data (ex-info \"m\" nil (RuntimeException. \"c\")))" :portability :jvm}
+  {:suite "core / Throwable->map" :label "nil ex-info data maps as {}" :expected "{}" :actual "(:data (Throwable->map (ex-info \"m\" nil)))" :portability :common}
+  {:suite "exceptions / ex-info" :label "str renders the data map even when nil was passed" :expected "\"clojure.lang.ExceptionInfo: m {}\"" :actual "(str (ex-info \"m\" nil))" :portability :jvm}
+  {:suite "exceptions / typed throw" :label "binding a non-dynamic var is an IllegalStateException with no ex-data" :expected "[\"java.lang.IllegalStateException\" nil]" :actual "(do (def ndv 1) (try (push-thread-bindings {(var ndv) 2}) (catch Throwable e [(.getName (class e)) (ex-data e)])))" :portability :jvm}
+  {:suite "host-interop / resolve" :label "a dotted name whose last segment is modeled but whose package is not resolves to nil" :expected "[nil nil nil]" :actual "[(resolve 'fake.pkg.String) (resolve 'no.such.Class) (resolve 'x.y.Object)]" :portability :jvm}
+  {:suite "host-interop / resolve" :label "a fully-qualified modeled class still resolves" :expected "\"java.lang.String\"" :actual "(pr-str (resolve 'java.lang.String))" :portability :jvm}
+  {:suite "host-interop / resolve" :label "a class the host models under an import resolves" :expected "true" :actual "(some? (resolve 'java.io.StringReader))" :portability :jvm}
   {:suite "forms / case" :label "bool" :expected ":yes" :actual "(case true true :yes false :no :default)" :portability :common}
   {:suite "forms / case" :label "keyword match" :expected ":b" :actual "(case :a :x :wrong :a :b :default)" :portability :common}
   {:suite "forms / case" :label "number match" :expected ":two" :actual "(case 2 1 :one 2 :two :default)" :portability :common}

--- a/test/conformance/certify.clj
+++ b/test/conformance/certify.clj
@@ -223,6 +223,88 @@
               (re-find #"Unable to resolve classname|Unable to resolve var|Unable to find static field|No such namespace|No such var" m) :unresolved-name)))
         (causes t)))
 
+;; --- the :documented half of known-divergences.edn ---------------------------
+;; :entries names corpus rows, and everything above gates them. :documented is
+;; prose about divergences that are NOT corpus rows, and until now nothing ever
+;; ran it. Prose with no oracle behind it decays silently: of the 33 entries that
+;; could be made checkable, two documented a divergence that no longer existed and
+;; five recorded a JVM or jolt answer no run reproduces — one claiming the JVM
+;; throws on (ex-info "m" nil), which returns {}, and one claiming resolve throws
+;; ClassNotFoundException, which it never does.
+;;
+;; So every :documented entry now declares how it is verified:
+;;   :check {:expr "<expr>" :jvm "<rendered>" :jolt "<rendered>"}
+;;   :check :prose  :why "<reason it cannot be an expression>"
+;; and an entry with neither fails the gate, so a new one cannot arrive unchecked.
+;;
+;; This half evaluates :expr on reference Clojure and requires it to render
+;; exactly :jvm. host/chez/run-documented.ss does the same for :jolt. Both halves
+;; also require :jvm and :jolt to DIFFER — an entry whose sides have converged is
+;; documenting a divergence that no longer exists, and belongs deleted.
+(def registry
+  (if (.exists (java.io.File. allowlist-path))
+    (edn/read-string (slurp allowlist-path))
+    {}))
+(def documented-entries (:documented registry))
+
+;; Render as host/chez/run-documented.ss does: pr-str for a value, "throws
+;; <SimpleName>" for a raise. The name is the ROOT cause's — the Compiler wraps a
+;; macroexpansion-time throw, and jolt has no such wrapper to match.
+(defn render-documented [src]
+  (let [r (eval-safe src)]
+    (case (first r)
+      :ok (pr-str (second r))
+      :timeout "timeout"
+      (str "throws " (.getSimpleName (class (last (causes (second r)))))))))
+
+;; Every :category in use must have a :legend line explaining it. A category is
+;; how a reader decides whether a divergence is deliberate, and one with no legend
+;; entry says nothing — :restrictive was in use with no legend line until this
+;; check went in.
+(defn check-legend []
+  (let [legend (set (keys (:legend registry)))
+        used (into (sorted-set) (map :category (concat (:documented registry)
+                                                       (:entries registry))))]
+    (for [c used :when (not (legend c))]
+      (str "  [:legend] category " c " is used but has no :legend entry"))))
+
+(defn check-documented
+  "Problems with the :documented list, as printable lines. Empty means it holds."
+  []
+  (for [e documented-entries
+        :let [label (or (:behavior e) "<no :behavior>")
+              {:keys [expr jvm jolt]} (when (map? (:check e)) (:check e))]
+        msg (cond
+              (nil? (:check e))
+              ["no :check — add {:expr .. :jvm .. :jolt ..}, or :prose with a :why"]
+
+              (= :prose (:check e))
+              (when-not (string? (:why e))
+                [":check :prose needs a :why saying why it is not machine-checkable"])
+
+              (not (map? (:check e)))
+              [":check must be a map or :prose"]
+
+              (not (every? string? [expr jvm jolt]))
+              [":check needs string :expr, :jvm and :jolt"]
+
+              (= jvm jolt)
+              [(str "STALE — :jvm and :jolt agree (" jvm "), so this is no longer a divergence")]
+
+              :else
+              (let [got (render-documented expr)]
+                (when-not (= got jvm)
+                  [(str "JVM side: want `" jvm "` got `" got "`\n      expr: " expr)])))]
+    (str "  [" label "]\n      " msg)))
+
+(defn record-documented []
+  (doseq [e documented-entries
+          :when (map? (:check e))]
+    (println (format "  :expr %s\n  :jvm %s\n"
+                     (pr-str (:expr (:check e)))
+                     (pr-str (render-documented (:expr (:check e)))))))
+  (System/exit 0))
+
 (defn classify [row]
   (let [{:keys [expected actual]} row
         throws? (= expected :throws)
@@ -338,6 +420,7 @@
   [[[] nil]
    [["c.edn"] "c.edn"]
    [["--self-test"] nil]
+   [["--record-documented"] nil]
    [["--edn" "out.edn"] nil]
    [["--profile" "p.edn"] nil]
    [["c.edn" "--profile" "p.edn"] "c.edn"]
@@ -365,7 +448,12 @@
 
 (defn -main [& _]
   (when (some #{"--self-test"} *command-line-args*) (self-test))
-  (let [corpus (edn/read-string (slurp corpus-path))
+  (when (some #{"--record-documented"} *command-line-args*) (record-documented))
+  (let [;; forced here, not left lazy: these evaluate programs, and a gate should
+        ;; run its checks where it says it does rather than wherever the seq is
+        ;; first realized.
+        documented-problems (vec (concat (check-legend) (check-documented)))
+        corpus (edn/read-string (slurp corpus-path))
         results (mapv (fn [row] (assoc (classify row) :row row)) corpus)
         by (group-by :bucket results)
         n (count results)
@@ -491,6 +579,17 @@
     ;; intentional (classified in the allowlist) or a tracked bug — so a clean run
     ;; means the corpus matches reference Clojure everywhere it claims to, modulo the
     ;; documented jolt-specific deltas.
-    (System/exit (if (or (seq new-divergences) (seq stale-entries) (pos? (cnt :expected-error))) 1 0))))
+    ;; The :documented list is gated too: its entries are prose about divergences
+    ;; that are not corpus rows, so nothing above would notice one going stale.
+    (println (format "\ndocumented-divergence gate (JVM half): %d machine-checked, %d prose"
+                     (count (filter #(map? (:check %)) documented-entries))
+                     (count (filter #(= :prose (:check %)) documented-entries))))
+    (when (seq documented-problems)
+      (println (format "\n%d DOCUMENTED-DIVERGENCE FAILURE(S):" (count documented-problems)))
+      (doseq [m documented-problems] (println m)))
+
+    (System/exit (if (or (seq new-divergences) (seq stale-entries)
+                         (seq documented-problems) (pos? (cnt :expected-error)))
+                   1 0))))
 
 (apply -main *command-line-args*)

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -23,6 +23,8 @@
   "jolt strings are Chez strings: codepoint-indexed, no UTF-16 surrogate pairs. count/seq/subs/nth index codepoints, so an astral character counts 1 where the JVM counts 2 surrogate units. Substrate-inherent.",
   :concurrency-model
   "compare-and-set! compares with value equality (jolt=), not JVM reference identity — Chez immediates and reconstructed values have no stable identity to compare. Deliberate (atoms.ss).",
+  :restrictive
+  "the JVM supports something jolt does not: mark/reset replay over a non-seekable stream. The narrow direction, so it is NOT a superset — code relying on the JVM capability has no counterpart here",
   :permissive
   "jolt succeeds where the JVM throws, on operations with one reasonable meaning: count works on eduction, keys on a vector of pairs, (empty MapEntry) => []. A superset: portable JVM code behaves identically.",
   :namespace-model
@@ -30,8 +32,26 @@
   :deps-model
   "jolt resolves deps.edn itself (grenadine, no JVM toolchain) and jolt IS Clojure, so a host-supplied coordinate is TERMINAL: it contributes neither an artifact nor children. Not a superset — the JVM's org.clojure/clojure carries dependencies of its own, and those do not arrive here."},
  :documented
- [;; Deliberate/tracked divergences that are NOT corpus rows, so they live here (not in
-  ;; :entries, which certify.clj gates for staleness against the corpus).
+ [;; Deliberate/tracked divergences that are NOT corpus rows, so they live here (not
+  ;; in :entries, which certify.clj gates for staleness against the corpus).
+  ;;
+  ;; EVERY entry here declares how it is verified, because prose with no oracle
+  ;; behind it rots: an audit in 2026-08 found entries claiming the JVM throws on
+  ;; (ex-info "m" nil) and on (resolve 'java.lang.module.ModuleFinder), neither of
+  ;; which any JVM run reproduces. Each entry carries one of
+  ;;
+  ;;   :check {:expr "<expr>" :jvm "<rendered>" :jolt "<rendered>"}
+  ;;   :check :prose  :why "<why it cannot be one expression>"
+  ;;
+  ;; test/conformance/certify.clj evaluates :expr on reference Clojure and requires
+  ;; it to render exactly :jvm; host/chez/run-documented.ss (make documented) does
+  ;; the same for :jolt. Both require :jvm and :jolt to DIFFER — an entry whose two
+  ;; sides have converged documents a divergence that no longer exists and should
+  ;; be deleted, which is how the 2^60 loop-overflow and quoted-syntax-quote
+  ;; entries left. An entry with no :check fails both halves, so a new one cannot
+  ;; arrive unverified. Rendering is pr-str for a value, "throws <SimpleName>" for
+  ;; a raise (the ROOT cause's simple name). :jvm/:jolt outside :check are prose
+  ;; for a reader; the :check pair is what the gate holds to.
   ;; (NumberFormat/getCurrencyInstance) with no argument resolves the JVM's DEFAULT
   ;; locale, which is a property of the machine — en_CA gives "$123.45", en_US
   ;; "$123.45", de_DE "123,45 €". jolt core has no notion of a default locale (it does
@@ -43,6 +63,8 @@
    :behavior "(.format (java.text.NumberFormat/getCurrencyInstance) 123.45)"
    :jvm "the default locale's currency format, e.g. \"$123.45\" under en_US"
    :jolt "\"\\u00a4\\u00a0123.45\" — the Locale.ROOT format"
+   :check :prose
+   :why "the JVM's answer is the machine's default locale, so there is no fixed value to record"
    :note "Core has no default locale. Explicit locales are :strict: an unregistered one raises rather than formatting with root separators."}
   ;; (java.text.SimpleDateFormat. pattern) with no Locale resolves the JVM's
   ;; DEFAULT locale, a property of the machine — en gives "March"/"Saturday",
@@ -57,6 +79,8 @@
    :behavior "(.format (java.text.SimpleDateFormat. \"MMMM\") some-date)"
    :jvm "the default locale's month name, e.g. \"March\" under en"
    :jolt "\"Mar\" — the Locale.ROOT name"
+   :check :prose
+   :why "the JVM's answer is the machine's default locale, so there is no fixed value to record"
    :note "Core has no default locale. Explicit locale ids resolve through the :date-names extension point (:fallback :default): an unregistered id falls back to ROOT rather than throwing."}
   ;; java.text.SimpleDateFormat formats in UTC on jolt; the JVM's formats in the
   ;; machine's DEFAULT time zone. So a fixed epoch renders "2014-03-01 00:00" here
@@ -68,6 +92,8 @@
    :behavior "(.format (java.text.SimpleDateFormat. \"yyyy-MM-dd HH:mm\") (java.util.Date. 1393632000000))"
    :jvm "the default zone's rendering, e.g. \"2014-02-28 19:00\" under EST"
    :jolt "\"2014-03-01 00:00\" — UTC"
+   :check :prose
+   :why "the JVM's answer is the machine's default time zone"
    :note "format-ms is UTC by design; .setTimeZone is accepted but not honored."}
   ;; (str lazy-seq) renders the realized seq "(2 3)" rather than the JVM's opaque
   ;; "clojure.lang.LazySeq@<hash>". Deliberately friendlier; left as is.
@@ -75,6 +101,9 @@
    :behavior "(str (map inc [1 2])) => \"(2 3)\""
    :jvm "\"clojure.lang.LazySeq@<hash>\""
    :jolt "\"(2 3)\""
+   :check {:expr "(clojure.string/starts-with? (str (map inc [1 2])) \"clojure.lang.LazySeq@\")"
+           :jvm "true"
+           :jolt "false"}
    :note "Deliberately friendlier rendering; intentionally left as is."}
   ;; .equals does not respect numeric category: (.equals {:a 1} {:a 1N}) is true on
   ;; jolt, false on the JVM (Long vs BigInt category). The root is jolt's numeric
@@ -85,36 +114,35 @@
    :behavior "(.equals {:a 1} {:a 1N})"
    :jvm "false"
    :jolt "true"
+   :check {:expr "(.equals {:a 1} {:a 1N})"
+           :jvm "false"
+           :jolt "true"}
    :note "Numeric-category-blind value equality; a deep = property, not a cheap fix. Verified against Clojure 1.12.5."}
-  ;; ex-info with explicit nil data. Both runtimes ACCEPT it — the JVM does not
-  ;; throw, which the legend used to imply — but they disagree on what ex-data
-  ;; then reports, and that flips a (when (ex-data e) ...) branch. jolt models
-  ;; every throwable as one record whose data field is nil unless given, and 25
-  ;; internal throw sites rely on that reading back as nil the way a plain
-  ;; RuntimeException's does on the JVM; separating the user-facing constructor
-  ;; from the internal one is the fix, and it is bigger than the divergence.
-  {:category :impl-detail
-   :behavior "(ex-data (ex-info \"m\" nil))"
-   :jvm "{}"
-   :jolt "nil"
-   :note "Both accept nil data; they differ in what ex-data reports. Verified against Clojure 1.12.5."}
-  ;; A ^long-typed or (now) literal-init loop var is a Chez 61-bit fixnum, so its
-  ;; fixed-width arithmetic raises at 2^60 where a JVM long raises/wraps at 2^63.
-  ;; jolt matches JVM loop semantics (a literal-init loop var is a primitive long and
-  ;; overflows rather than promoting to bignum) modulo this width difference.
-  {:category :numeric-model
-   :behavior "(loop [i 1152921504606846974 k 0] (if (= k 2) i (recur (inc i) (inc k))))"
-   :jvm "returns 1152921504606846976 (long arithmetic, overflow at 2^63)"
-   :jolt "raises (61-bit fixnum overflow at 2^60)"
-   :note "^long / literal-init loop vars are Chez 61-bit fixnums; overflow point is 2^60 vs the JVM long's 2^63."}
-  ;; Adjacent to but DISTINCT from the width divergence above. There a literal-init loop
-  ;; var IS :long and jolt raises at its 2^60 boundary. Here a bignum-literal operand
-  ;; (9223372036854775807 = Long/MAX_VALUE, past jolt's 2^60-1 fixnum ceiling) BLOCKS
-  ;; :long specialization, so the loop var stays generic and jolt computes the EXACT
-  ;; bignum sum — where the JVM keeps `i` a primitive long and the add overflows. This
-  ;; IS a corpus row (3754, "literal-init loop var + bignum-literal stays generic
-  ;; (exact)"): the :actual throws on the JVM, so certify buckets it :jvm-raises, which
-  ;; IS gated — the row is classified in :entries and the prose stays here.
+  ;; ex-info's data map is unchecked here. ExceptionInfo's constructor takes an
+  ;; IPersistentMap, so a non-map is a ClassCastException on the JVM; jolt stores
+  ;; whatever it is handed and ex-data reads it back. A superset: portable code
+  ;; passing a map behaves identically. (nil data DOES match — it reads back as
+  ;; {} on both, as of the fix for #771.)
+  {:category :permissive
+   :behavior "(ex-data (ex-info \"m\" 5))"
+   :jvm "throws ClassCastException"
+   :jolt "5"
+   :check {:expr "(ex-data (ex-info \"m\" 5))"
+           :jvm "throws ClassCastException"
+           :jolt "5"}
+   :note "Unchecked data argument; a map behaves identically. Verified against Clojure 1.12.5."}
+  ;; A bignum-literal operand (9223372036854775807 = Long/MAX_VALUE, past jolt's
+  ;; 2^60-1 fixnum ceiling) BLOCKS :long specialization, so the loop var stays
+  ;; generic and jolt computes the EXACT bignum sum — where the JVM keeps `i` a
+  ;; primitive long and the add overflows. This IS a corpus row (3754,
+  ;; "literal-init loop var + bignum-literal stays generic (exact)"): the :actual
+  ;; throws on the JVM, so certify buckets it :jvm-raises, which IS gated — the row
+  ;; is classified in :entries and the prose stays here.
+  ;;
+  ;; A companion entry used to claim a literal-init or ^long loop var RAISES on
+  ;; crossing jolt's own 2^60 fixnum boundary. It does not: every shape promotes to
+  ;; a bignum, exactly as this entry describes, so the two sides had converged and
+  ;; the :check pair removed it.
   ;; jolt's dot form reads a plain map as an object: (. m member) calls a stored fn
   ;; with the map as self and otherwise reads the key, and (.-member m) reads the
   ;; key (dot-forms.ss's precedence note). The JVM has no fields on a
@@ -131,6 +159,9 @@
    :behavior "(.-value {:value 41}) and (. {:value 41} value)"
    :jvm "throws IllegalArgumentException — a map has no fields"
    :jolt "41 — the map-as-object read"
+   :check {:expr "(.-value {:value 41})"
+           :jvm "throws IllegalArgumentException"
+           :jolt "41"}
    :note "A key the map does not have throws on both. jolt's own values (deftype/defrecord slots) follow the JVM exactly: an undeclared slot is an error, not nil."}
   ;; A char reaches the reference's INTEGER casts through RT.intCast/longCast's
   ;; char overload — (int \\a) and (long \\a) are 97 on both — but `double` and
@@ -159,11 +190,16 @@
    :behavior "(.markSupported (BufferedInputStream. <non-seekable>)) / System/in"
    :jvm "true — BufferedInputStream buffers and replays on reset"
    :jolt "false — no replay layer; mark/reset honoured only where the port seeks"
+   :check :prose
+   :why "needs a non-seekable stream (process stdin), which the gate does not control"
    :note "Corpus rows cover the agreeing cases (file, ByteArrayInputStream, PipedInputStream, FileInputStream); unit rows pin System/in answering false without crashing."}
   {:category :permissive
    :behavior "(double \\a) / (float \\a)"
    :jvm "throws ClassCastException — double/float are declared ^Number"
    :jolt "97.0 — the char's code point, as the integer casts already give"
+   :check {:expr "(double \\a)"
+           :jvm "throws ClassCastException"
+           :jolt "97.0"}
    :note "(int \\a) / (long \\a) / (short \\a) / (byte \\a) are 97 on BOTH runtimes; only the float widths differ."}
   ;; jolt's strings are indexed by Unicode CODE POINT where the JVM's are indexed
   ;; by UTF-16 code unit, and (char n) follows the string model rather than the
@@ -181,6 +217,9 @@
    :behavior "(char 128515), the code point (first \"<astral>\") yields"
    :jvm "throws IllegalArgumentException — a JVM char is 16 bits"
    :jolt "returns that character; (int (first (str (char 128515)))) is 128515 again"
+   :check {:expr "(int (first (str (char 128515))))"
+           :jvm "throws IllegalArgumentException"
+           :jolt "128515"}
    :note "Deliberate superset of the JVM, following jolt's code-point string model."}
   ;; The same model the other way round: half of a surrogate pair is not a value
   ;; jolt can hold, so no operation can produce or match one. A parser asked to
@@ -193,6 +232,9 @@
    :behavior "indexing into a string holding an astral character"
    :jvm "(count \"<astral>\") is 2 and (first …) is the high surrogate \\uD83D"
    :jolt "(count …) is 1, (first …) is the whole character, (second …) is nil"
+   :check {:expr "(count \"😀\")"
+           :jvm "2"
+           :jolt "1"}
    :note "Inherent to code-point strings: a surrogate half is not a scalar value."}
   ;; proxy over a concrete class EXTENDS BY DELEGATION: jolt generates no classes,
   ;; so the proxy holds a real base instance, answers what its body declares and
@@ -208,6 +250,8 @@
    :behavior "a base method calling a method the proxy overrides"
    :jvm "re-enters the override (virtual dispatch)"
    :jolt "runs the base's own version"
+   :check :prose
+   :why "needs a shimmed base class whose own method calls the one the proxy overrides; the shim set has none"
    :note "Delegation, not subclassing. Overriding a leaf method is unaffected."}
   ;; A proxy method returns its body's value; the JVM coerces to the declared
   ;; return type, so a void method yields nil there. jolt has no signatures — the
@@ -216,11 +260,17 @@
    :behavior "(.flush (proxy [java.io.ByteArrayOutputStream] [] (flush [] :x)))"
    :jvm "nil — flush() is declared void"
    :jolt ":x — the body's value"
+   :check {:expr "(.flush (proxy [java.io.ByteArrayOutputStream] [] (flush [] :x)))"
+           :jvm "nil"
+           :jolt ":x"}
    :note "No method signatures; reify has always behaved this way."}
   {:category :numeric-model
    :behavior "(loop [i 5] (+ i 9223372036854775807))"
    :jvm "throws ArithmeticException (primitive long add overflows at 2^63)"
    :jolt "returns 9223372036854775812 (bignum-literal operand demotes the loop var to generic; exact result)"
+   :check {:expr "(loop [i 5] (+ i 9223372036854775807))"
+           :jvm "throws ArithmeticException"
+           :jolt "9223372036854775812N"}
    :note "Corpus row 3754. The bignum literal (2^63-1) exceeds jolt's 2^60-1 fixnum max, so it blocks :long and jolt stays exact; the JVM keeps primitive-long arithmetic and throws."}
   ;; *allow-unresolved-vars* true. Both sides stop throwing "Unable to resolve
   ;; symbol" at resolve time; what they build from the unresolved name differs.
@@ -235,6 +285,8 @@
    :behavior "(binding [*allow-unresolved-vars* true] (eval '(defn f [] later))) then (def later 42), (f)"
    :jvm "VerifyError at the defn (UnresolvedVarExpr emits nothing)"
    :jolt "42 — the unresolved name compiles to a late-bound var-ref"
+   :check :prose
+   :why "*allow-unresolved-vars* is a jolt-only var, so the JVM cannot evaluate the form at all"
    :note "Deliberate. The JVM's UnresolvedVarExpr is unusable in every position; jolt implements the flag's intent."}
   ;; a def/defn carries source position (:line/:column/:file) in its var meta, like
   ;; the JVM Compiler, for user code and loaded files. A clojure.core var built
@@ -245,6 +297,9 @@
    :behavior "(:line (meta #'clojure.core/reduce))"
    :jvm "an int (source line in clojure/core.clj)"
    :jolt "nil"
+   :check {:expr "(integer? (:line (meta #'clojure.core/reduce)))"
+           :jvm "true"
+           :jolt "false"}
    :note "core vars are minted without reader positions; user + loaded-file defns carry :line/:column/:file."}
   ;; resolve/ns-resolve ignore a :refer-clojure :exclude/:only — clojure.core always
   ;; resolves. The filter still governs syntax-quote qualification. jolt-ox7c.27
@@ -252,12 +307,18 @@
    :behavior "(ns x (:refer-clojure :exclude [map])) then (resolve 'map)"
    :jvm "nil"
    :jolt "#'clojure.core/map"
+   :check {:expr "(do (ns kd-refer-excl (:refer-clojure :exclude [map])) (pr-str (resolve 'map)))"
+           :jvm "\"nil\""
+           :jolt "\"#'clojure.core/map\""}
    :note "clojure.core always resolves; :exclude/:only affect syntax-quote, not resolve. Permissive."}
   ;; a :private var is readable from another namespace (privacy is not enforced).
   {:category :namespace-model
    :behavior "reading a ^:private var from another namespace"
    :jvm "throws (var is not public)"
    :jolt "returns the value"
+   :check {:expr "(do (ns kd-priv-a) (def ^:private secret 42) (ns kd-priv-b) (eval 'kd-priv-a/secret))"
+           :jvm "throws IllegalStateException"
+           :jolt "42"}
    :note "Var privacy is not enforced across namespaces; ns-publics still filters privates out."}
   ;; (ns-resolve / ns-unmap / alias on a missing namespace now throw like the JVM —
   ;;  jolt-ox7c.33 — so that divergence is gone.)
@@ -266,36 +327,56 @@
    :behavior "(read-string \"#foo/bar 5\") with no reader for foo/bar"
    :jvm "throws: No reader function for tag foo/bar"
    :jolt "#foo/bar 5 (a tagged literal)"
+   :check {:expr "(pr-str (read-string \"#foo/bar 5\"))"
+           :jvm "throws RuntimeException"
+           :jolt "\"#foo/bar 5\""}
    :note "The default data-reader tags rather than throwing. clojure.edn still throws on an unknown tag."}
-  ;; resolve of a class name jolt does not model answers nil, not a throw.
+  ;; resolve of a class name jolt does not model answers nil. The JVM answers the
+  ;; CLASS — resolve never throws for an absent class there either, it answers nil
+  ;; (this entry used to claim ClassNotFoundException, which no run ever produced).
   {:category :host-model
    :behavior "(resolve 'java.lang.module.ModuleFinder)"
-   :jvm "throws ClassNotFoundException"
-   :jolt "nil"
+   :jvm "the class — java.lang.module.ModuleFinder is on the module path"
+   :jolt "nil — jolt does not model it"
+   :check {:expr "(pr-str (resolve 'java.lang.module.ModuleFinder))"
+           :jvm "\"java.lang.module.ModuleFinder\""
+           :jolt "\"nil\""}
    :note "resolve answers the narrower \"does this class exist here\" for feature detection (compliment gates its JDK9 scanner on it); a class the host models resolves to the class. The bare symbol still evaluates through the syntactic class model."}
   ;; reader conditionals match :bb, ahead of :clj when the clause is listed first.
   {:category :reader-model
    :behavior "#?(:bb 1 :clj 2)"
    :jvm "2 (:bb is not a JVM feature)"
    :jolt "1"
+   :check {:expr "(pr-str (read-string {:read-cond :allow} \"#?(:bb 1 :clj 2)\"))"
+           :jvm "\"2\""
+           :jolt "\"1\""}
    :note "jolt's feature set is {:jolt :bb :clj :default}, like babashka's {:bb :clj}. A library's :bb branch solves the same non-JVM problems jolt has (no reflection, no JVM-only classes) and is listed ahead of :clj precisely so a bb-like host takes it."}
   ;; read-string of an empty string returns nil (JVM throws EOF).
   {:category :permissive
    :behavior "(read-string \"\")"
    :jvm "throws (EOF while reading)"
    :jolt "nil"
+   :check {:expr "(read-string \"\")"
+           :jvm "throws RuntimeException"
+           :jolt "nil"}
    :note "Permissive."}
   ;; unchecked-add/-subtract/-multiply accept any arity (the JVM's take exactly 2).
   {:category :permissive
    :behavior "(unchecked-add x) or (unchecked-add a b c), e.g. through apply"
    :jvm "throws ArityException — these are arity-2 only"
    :jolt "folds like +: no args => 0, one => the operand, N => a left fold"
+   :check {:expr "(unchecked-add)"
+           :jvm "throws ArityException"
+           :jolt "0"}
    :note "The overlay is variadic where the JVM's is fixed-arity. At arity 2 — every arity the JVM accepts — the wrapping result is identical, 64-bit edges included, so portable code is unaffected. Costs nothing on the hot path either: proven-long operands lower straight to jolt-uncadd2 (a left fold past 2 operands) and never reach the variadic overlay, which only serves value position."}
   ;; distinct accepts any seqable, not just what nth can index.
   {:category :permissive
    :behavior "(distinct #{1 2 3}) or (distinct {:a 1}) — a coll that seqs but has no nth"
    :jvm "throws UnsupportedOperationException: nth not supported on this type: PersistentHashSet"
    :jolt "(1 3 2) — the set's own seq order, deduped"
+   :check {:expr "(pr-str (distinct #{1 2 3}))"
+           :jvm "throws UnsupportedOperationException"
+           :jolt "\"(1 3 2)\""}
    :note "The reference implementation reads the head twice: f as (nth coll 0 nil) through its [[f :as xs]] destructure, s as (seq coll). Only the nth read refuses a set or a map, and for every coll the JVM does accept the two reads are the same value — so taking f off the seq widens the domain and moves nothing else. Widening only; portable JVM code behaves identically. jolt's nth is NOT lenient here (it raises for an unsupported type exactly as RT.nth does, message included) — distinct simply no longer asks it."}
 
   ;; keys/vals accept a plain 2-element vector where the JVM casts to Map.Entry.
@@ -303,18 +384,27 @@
    :behavior "(keys [[:a 1] [:b 2]]) — a vector of pairs rather than of map entries"
    :jvm "throws ClassCastException — PersistentVector is not a java.util.Map$Entry"
    :jolt "(:a :b)"
+   :check {:expr "(pr-str (keys [[:a 1] [:b 2]]))"
+           :jvm "throws ClassCastException"
+           :jolt "\"(:a :b)\""}
    :note "jolt reads any 2-element vector as an entry, so a vector of pairs walks like a seq of map entries. Anything else — a string, a number, a longer vector — is the same ClassCastException the JVM throws, naming the same class; keys never returns a nil or an index into a non-entry."}
   ;; auto-gensym suffix differs by a trailing "__".
   {:category :reader-model
    :behavior "an auto-gensym x# expands to a symbol named"
    :jvm "x__N__auto__"
    :jolt "x__N__auto"
+   :check {:expr "(boolean (re-find #\"__auto__$\" (name `x#)))"
+           :jvm "true"
+           :jolt "false"}
    :note "Cosmetic; each x# in a syntax-quote is still consistently renamed. Only string comparison of gensym names would see it."}
   ;; #?(...) reader conditionals are read by default (JVM requires {:read-cond :allow}).
   {:category :reader-model
    :behavior "read-string of a #?(...) reader conditional"
    :jvm "throws unless {:read-cond :allow}"
    :jolt "reads the matching branch by default"
+   :check {:expr "(read-string \"#?(:clj 1)\")"
+           :jvm "throws RuntimeException"
+           :jolt "1"}
    :note "jolt is single-platform-ish; conditionals always resolve. Deliberate."}
   ;; read-line is (.readLine *in*) on the JVM, so a reader without that method —
   ;; a plain java.io.PushbackReader, which extends FilterReader — is a cast error
@@ -326,6 +416,9 @@
    :behavior "(binding [*in* (java.io.PushbackReader. …)] (read-line))"
    :jvm "throws ClassCastException — PushbackReader is not a BufferedReader"
    :jolt "the next line"
+   :check {:expr "(binding [*in* (java.io.PushbackReader. (java.io.StringReader. \"hi\\n\"))] (read-line))"
+           :jvm "throws ClassCastException"
+           :jolt "\"hi\""}
    :note "Widening only. Anything that works on the JVM works here."}
   ;; the JVM records a read form's position only when the reader is a
   ;; LineNumberingPushbackReader; jolt has one reader path, which is always
@@ -336,6 +429,9 @@
    :behavior "(meta (read a-plain-java.io.PushbackReader)) on a list form"
    :jvm "nil"
    :jolt "{:line N :column M}"
+   :check {:expr "(pr-str (into (sorted-map) (select-keys (meta (read (java.io.PushbackReader. (java.io.StringReader. \"(foo)\")))) [:line :column])))"
+           :jvm "\"{}\""
+           :jolt "\"{:column 1, :line 1}\""}
    :note "No unpositioned reader variant exists here to fall back to."}
   ;; a read stops at the end of the FORM; the JVM's LispReader consumes the
   ;; character that terminated a bare token as part of scanning it. Only visible
@@ -346,6 +442,8 @@
    :behavior "(.getLineNumber lnpbr) after reading the bare token on line 1 of \"1\\n2\\n\""
    :jvm "2 — the newline that ended the token was consumed with it"
    :jolt "1 — the reader stopped at the end of the token"
+   :check :prose
+   :why "LineNumberingPushbackReader is a JVM-only class; there is nothing for jolt to evaluate"
    :note "Extent of a token read, not a counting error: the next read still returns the next form, and a delimited form counts identically."}
   ;; io/reader hands back an in-memory java.io.StringReader here (the full Reader
   ;; contract, mark/reset and pushback included) where the JVM hands back a
@@ -358,6 +456,9 @@
    :behavior "(instance? java.io.BufferedReader (java.io.StringReader. \"x\"))"
    :jvm "false"
    :jolt "true"
+   :check {:expr "(instance? java.io.BufferedReader (java.io.StringReader. \"x\"))"
+           :jvm "false"
+           :jolt "true"}
    :note "io/reader's result and a bare StringReader are one jhost tag; the BufferedReader answer belongs to the former. Widening only, and only for readers."}
   ;; On the JVM syntax-quote is purely a reader macro, so nothing of it survives a
   ;; read. jolt's compile-path reader emits (clojure.core/syntax-quote form) and
@@ -366,12 +467,7 @@
   ;; agrees with the JVM. The marker is qualified precisely so it reserves nothing:
   ;; a bare `syntax-quote` is an ordinary name a program may define (corpus,
   ;; "reader / syntax-quote is not a reserved name").
-  {:category :reader-model
-   :behavior "'`foo/bar in source — a quoted syntax-quote"
-   :jvm "(quote foo/bar) — the reader has already expanded it"
-   :jolt "(clojure.core/syntax-quote foo/bar) — the analyzer expands it"
-   :note "(read-string \"`foo/bar\") agrees with the JVM; only a syntax-quote quoted in compiled source differs. Surfaces in clojure.tools.reader's read-syntax-quote suite."}
-  ;; the reader stamps a position on list forms for error reporting, and quote takes
+    ;; the reader stamps a position on list forms for error reporting, and quote takes
   ;; it back off so a quoted list literal stays a constant rather than an allocating
   ;; (with-meta …). The JVM keeps it, and cannot tell it from a position the program
   ;; wrote — jolt drops both. Vectors, maps, sets and symbols are never stamped, so
@@ -380,6 +476,9 @@
    :behavior "(meta '(foo)) read from a file, and (meta '^{:line 99} (foo))"
    :jvm "{:line N :column M} / {:line 99 :column M}"
    :jolt "nil / nil"
+   :check {:expr "(:line (meta '^{:line 99} (foo)))"
+           :jvm "99"
+           :jolt "nil"}
    :note "Only :line/:column/:file, only on a quoted LIST. Keeps quoted list literals constant instead of reallocating a with-meta wrapper per evaluation."}
   ;; Integer/toHexString of a byte read out of a byte[]. Unlike format's %x (which
   ;; infers the width and is handled in :entries), these statics name their width.
@@ -387,6 +486,8 @@
    :behavior "(Integer/toHexString (aget (byte-array [255]) 0))"
    :jvm "\"ff\" (the byte widens to int -1 … so also \"ffffffff\"; the two-digit form needs Byte/toUnsignedInt)"
    :jolt "\"ffffffff\" — the same, since the static's width is 32 by name"
+   :check :prose
+   :why "both runtimes agree here: the entry is guidance about which form to use, not a divergence"
    :note "Both agree here: Integer/toHexString is 32 bits wide on both, so a signed byte gives eight digits on both. Listed only to point at the portable forms — Byte/toUnsignedInt or (bit-and b 0xff) — since format's %x DOES infer its width and is the case that diverges (see the :entries row for numbers / unsigned string conversions)."}
   ;; The same collapse on the float side: one flonum type reported as Double, and
   ;; instance? answers to both Float and Double so either check written against the
@@ -395,6 +496,9 @@
    :behavior "(class (float 1.5)), (instance? Float 1.5)"
    :jvm "java.lang.Float, false"
    :jolt "java.lang.Double, true"
+   :check {:expr "[(.getName (class (float 1.5))) (instance? Float 1.5)]"
+           :jvm "[\"java.lang.Float\" false]"
+           :jolt "[\"java.lang.Double\" true]"}
    :note "Chez has one flonum. instance? is deliberately permissive for Float/Double and Integer/Long — a value answers to both spellings of its collapsed class — while Short and Byte stay false. Since #627 the big classes are value-sensitive: BigInt/BigInteger answer only for bignums (which also class as clojure.lang.BigInt), Long/Integer only for fixnums, matching the JVM. A bignum still answers BigInteger (one big representation serves both classes; the JVM says false) — the remaining superset."}
   ;; (.getStackTrace (Thread/currentThread)) is empty. jolt does proper tail calls,
   ;; so the frames a caller-naming API wants are the ones TCO has already erased —
@@ -405,6 +509,9 @@
    :behavior "(.getStackTrace (Thread/currentThread)), and clojure.spec.test.alpha's ::caller derived from it"
    :jvm "the caller's frames; ::caller {:var-scope the-calling-var}"
    :jolt "an empty StackTraceElement[]; no ::caller key"
+   :check {:expr "(zero? (count (.getStackTrace (Thread/currentThread))))"
+           :jvm "false"
+           :jolt "true"}
    :note "Inherent to tail calls, not a missing shim. spec's instrument still throws the same conform ExceptionInfo with the same explain-data — only the ::caller annotation is absent. Surfaces in spec.alpha's clojure.test-clojure.instr suite."}
   ;; clojure.instant's third reader. jolt has one millisecond instant type, so
   ;; java.sql.Timestamp is java.util.Date and the sub-millisecond digits are gone.
@@ -413,13 +520,19 @@
   {:category :host-model
    :behavior "(.getNanos (clojure.instant/read-instant-timestamp \"...T13:14:15.123456789Z\"))"
    :jvm "123456789 — Timestamp keeps nanoseconds"
-   :jolt "the instant is millisecond-precise; the remaining digits truncate"
+   :jolt "no .getNanos at all (\"No matching field found: getNanos for class java.util.Date\") — the reader itself parses fine and drops the sub-millisecond digits, which is what the :check measures"
+   :check {:expr "(do (require 'clojure.instant) (pr-str (clojure.instant/read-instant-timestamp \"2020-01-01T13:14:15.123Z\")))"
+           :jvm "\"#inst \\\"2020-01-01T13:14:15.123000000-00:00\\\"\""
+           :jolt "\"#inst \\\"2020-01-01T13:14:15.123-00:00\\\"\""}
    :note "One instant type, millisecond-based. read-instant-date and read-instant-calendar are exact."}
   ;; ByteBuffer.slice() copies where the JVM shares the backing array.
   {:category :host-model
    :behavior "(.array (.slice buf)) after (.position buf 1)"
    :jvm "the WHOLE shared backing array (slice is a view; .array ignores the offset)"
    :jolt "just the sliced bytes (slice copies)"
+   :check {:expr "(let [b (java.nio.ByteBuffer/wrap (byte-array [1 2 3 4]))] (.position b 1) (count (.array (.slice b))))"
+           :jvm "4"
+           :jolt "3"}
    :note "jolt's byte-buffer state is #(backing position limit) with no array offset, so a slice cannot express \"0-based view into a shared backing\". Read paths — hexdumps, decoders — are unaffected; a write through a slice does not propagate back. Tracked as jolt-93c9."}
   ;; No classloaders. This is not a shim gap that could be filled — a classloader
   ;; is a JVM linkage concept, and jolt compiles ahead of time to native code with
@@ -429,7 +542,10 @@
   {:category :host-model
    :behavior "java.net.URLClassLoader and the classloader API generally"
    :jvm "present — dynapath/pomegranate manipulate the runtime classpath through it"
-   :jolt "absent; a reference raises \"Unable to resolve symbol: URLClassLoader\""
+   :jolt "absent; resolve answers nil and construction raises \"No matching ctor found for class java.net.URLClassLoader\""
+   :check {:expr "(pr-str (resolve 'java.net.URLClassLoader))"
+           :jvm "\"java.net.URLClassLoader\""
+           :jolt "\"nil\""}
    :note "Substrate-inherent, like the reflection API. Affects kaocha (via dynapath), which blocks it as a test harness for rewrite-clj / malli / ordered / tick — each of those has another upstream runner that does work."}
   ;; No JMX / java.lang.management. Runtime's own memory API is present and maps
   ;; onto Chez's heap accounting (totalMemory/freeMemory/maxMemory/gc), which is
@@ -439,7 +555,10 @@
   {:category :host-model
    :behavior "java.lang.management.ManagementFactory/getMemoryMXBean and the MXBean API"
    :jvm "returns a MemoryMXBean reporting heap/non-heap usage, GC counts, and more"
-   :jolt "absent; the call raises \"No matching method getMemoryMXBean\""
+   :jolt "absent; resolve answers nil and the call raises \"Unknown class java.lang.management.ManagementFactory\""
+   :check {:expr "(pr-str (resolve 'java.lang.management.ManagementFactory))"
+           :jvm "\"java.lang.management.ManagementFactory\""
+           :jolt "\"nil\""}
    :note "Runtime.totalMemory/freeMemory/maxMemory ARE present over Chez's collector accounting. What is missing is JMX itself. Affects criterium's benchmark reporting, not its timing."}
   ;; A recv error reads as EOF: errno is not reachable through the FFI, so
   ;; ECONNRESET (Java: SocketException) cannot be told from EINTR (Java: retry).
@@ -447,6 +566,8 @@
    :behavior "(.read (.getInputStream socket)) on a reset connection — requires (require 'jolt.socket)"
    :jvm "throws java.net.SocketException (\"Connection reset\")"
    :jolt "-1 (EOF)"
+   :check :prose
+   :why "needs a live TCP peer that resets the connection"
    :note "No errno through the FFI, so error and orderly shutdown collapse to EOF. Writes DO throw (send's return distinguishes); only the read side is permissive."}
   ;; connect's timeout argument is accepted and ignored — the underlying
   ;; connect(2) is always blocking (equivalent to Java's timeout 0).
@@ -454,6 +575,8 @@
    :behavior "(.connect socket endpoint 5000) — requires (require 'jolt.socket)"
    :jvm "aborts with SocketTimeoutException after 5000 ms"
    :jolt "blocks until the OS-level connect resolves"
+   :check :prose
+   :why "needs an unroutable address to time out against"
    :note "A timed connect needs non-blocking mode + poll; not modeled. The no-timeout arity behaves identically on both."}
   ;; getHostName does no reverse lookup. The JVM reverse-resolves a
   ;; literal-address InetSocketAddress ("127.0.0.1" answers "localhost" when
@@ -464,6 +587,8 @@
    :behavior "(.getHostName (java.net.InetSocketAddress. \"127.0.0.1\" 80)) — requires (require 'jolt.socket)"
    :jvm "\"localhost\" — reverse lookup through the nameservice (machine-dependent)"
    :jolt "\"127.0.0.1\" — the literal; no reverse lookup"
+   :check :prose
+   :why "the JVM answer is a reverse DNS lookup, so it is machine-dependent"
    :note "Reverse DNS would need getnameinfo and makes the answer environment-dependent; the JVM's own javadoc flags the lookup. Use .getHostString for the literal on both. Caught certifying test/chez/socket-test.clj against the JVM."}
   ;; Interruption now reaches a PARKED thread as well as the flag: promise/future
   ;; deref, agent await, Thread.sleep/join, CountDownLatch.await, a task Future's
@@ -482,6 +607,8 @@
    :behavior "(.interrupt t) for a dispatch thread t while several go blocks are parked in blocking derefs that ran on it"
    :jvm "a parked go block holds no thread; only whatever is running on t at that moment can be interrupted"
    :jolt "the parked fibers registered against t's interrupt box are all woken and one of them consumes the interrupt and throws"
+   :check :prose
+   :why "needs several go blocks parked on one dispatch thread with an interrupt landing mid-park"
    :note "jolt has no per-fiber interrupt flag to key on and .interrupt is handed a box and nothing else. The check CLEARS, so one interrupt still produces exactly one InterruptedException — but which fiber gets it is not determined. Pinned by the \"interrupt / blocking fibers\" rows in test/chez/unit.edn, which bind *go-backend* :fiber — go defaults to :thread, so an unbound (go ...) runs on an OS thread and tests nothing about fibers. The reasoning is at jolt-cv-wait-interruptibly in host/chez/locks.ss."}
   ;; A fiber's Thread/sleep gets the ALREADY-SET half of the rule but not the other
   ;; half. Chez's sleep has no wakeup, and Thread/sleep on a fiber deliberately
@@ -493,12 +620,16 @@
    :behavior "(.interrupt carrier) while a fiber on it is inside (Thread/sleep n) — under (binding [*go-backend* :fiber] ...)"
    :jvm "a go block's Thread/sleep runs on a pool thread and throws InterruptedException at once"
    :jolt "the sleep runs to its full duration; the flag is set and readable the moment it returns"
+   :check :prose
+   :why "timing-dependent: asserts when a sleep returns relative to an interrupt"
    :note "Entering the sleep with the flag ALREADY set does throw, so the pre-set half matches. Only mid-sleep delivery is missing. Pinned by the last \"interrupt / blocking fibers\" row in test/chez/unit.edn, which also shows the flag surviving the nap. A fiber that must be interruptible mid-wait should park on a promise or channel rather than sleep."}
   ;; The piped streams are the one blocking read left outside the interruptible set.
   {:category :concurrency-model
    :behavior "(.interrupt t) while t is blocked in (.read a-PipedInputStream)"
    :jvm "the read throws java.io.InterruptedIOException"
    :jolt "the read blocks until the writer writes or closes; the flag is set and readable afterwards"
+   :check :prose
+   :why "needs a thread blocked in a PipedInputStream read with an interrupt landing during it"
    :note "PipedInputStream signals interruption with an IOException subclass rather than InterruptedException, so it is a different contract from the ops jolt-cv-wait-interruptibly covers. Bound the read with a timeout or close the write end to release a reader."}
   ;; NOT a divergence, and recorded so it does not read as an oversight: jolt has no
   ;; Object.wait / .notify / .notifyAll on any object — they are in no host method
@@ -521,6 +652,8 @@
    :behavior "(System/getProperty \"line.separator\") / \"file.separator\" / \"path.separator\", and clojure.core/system-newline, ON WINDOWS"
    :jvm "\"\\r\\n\", \"\\\\\" and \";\" — the platform's own conventions"
    :jolt "\"\\n\", \"/\" and \":\" on every platform"
+   :check :prose
+   :why "Windows-only; the gate runs on whichever host invoked it"
    :note "Consistent with the rest of jolt on Windows, which reads and writes LF and joins paths with \"/\". Code that must produce native line endings on Windows should not read them from these properties on jolt. On POSIX the two agree exactly."}
   ;; ThreadLocal under thread-parameter fork-inheritance: a proxy'd
   ;; ThreadLocal's value is a Chez thread parameter, and a forked thread
@@ -533,6 +666,9 @@
    :behavior "(.get tl) on a thread forked AFTER (.set tl v) on the parent"
    :jvm "the initialValue result — ThreadLocal state never crosses threads"
    :jolt "v — the parent's current value at fork time (thread-parameter inheritance)"
+   :check {:expr "(let [tl (proxy [ThreadLocal] [] (initialValue [] :init))] (.set tl :parent) (let [p (promise)] (.start (Thread. (fn [] (deliver p (.get tl))))) (deref p 2000 :timeout)))"
+           :jvm ":init"
+           :jolt ":parent"}
    :note "A .set before any fork is indistinguishable from a fresh init on both. Code needing JVM-exact isolation calls .remove in the child. A fresh-default-per-thread target reproduces the JVM exactly; fixing it on Chez means wrapping every ThreadLocal in an owner check — deferred until a real consumer needs it."}
   ;; An agent that FAILS while an await is parked on it: the JVM's latch
   ;; count-down action sits in the failed agent's halted queue and never runs,
@@ -545,6 +681,8 @@
    :behavior "(await a) while a fails mid-wait"
    :jvm "blocks forever (the failed agent never runs the latch action)"
    :jolt "throws RuntimeException \"Agent is failed, needs restart\""
+   :check :prose
+   :why "the JVM half blocks forever by design, so a gate cannot evaluate it"
    :note "await entered on an ALREADY-failed agent throws identically on both. jolt returning normally (pre-R4) was the silent-success worst case."}
   ;; Ref history exists on the JVM to serve a transaction that started before a
   ;; writer committed: rather than retry, the reader is handed an older value
@@ -555,9 +693,12 @@
   ;; setter returns the ref) so tuning code keeps working and reads back what it
   ;; set; only the count differs.
   {:category :concurrency-model
-   :behavior "(ref-history-count r) after a transaction has written r"
-   :jvm "the history chain's length (1 after one committing txn)"
+   :behavior "(ref-history-count r) after (ref-min-history r 3) and several committing transactions"
+   :jvm "3 — the chain grows to the minimum the ref was told to keep"
    :jolt "0 — always, since serialized transactions keep no history"
+   :check {:expr "(let [r (ref 0)] (ref-min-history r 3) (dotimes [_ 5] (dosync (alter r inc))) (ref-history-count r))"
+           :jvm "3"
+           :jolt "0"}
    :note "0 is also the JVM's answer for a fresh ref. Closing this means adding MVCC, which the single-lock design deliberately does not have (see refs.ss stm-lock)."}
   ;; *in* is a Reader over System/in on both, but the JVM's InputStreamReader
   ;; decodes into 8K of its own, so the first (read-line) pulls the whole of a
@@ -568,6 +709,8 @@
    :behavior "(.read System/in) after a (read-line)"
    :jvm "-1 — the reader on top of System.in has already buffered the rest"
    :jolt "the next byte of the input"
+   :check :prose
+   :why "needs process stdin, which the gate does not control"
    :note "A superset: mixing the two loses input on the JVM. jolt's only buffer for standard input is the one port on fd 0, which is the layer the JVM's BufferedInputStream is; what it does not add is the reader's second buffer."}
   ;; RT.in is built over whatever System.in was at class-init, so the JVM's
   ;; read-line cannot be redirected after startup. jolt reads the static every
@@ -576,12 +719,16 @@
    :behavior "(System/setIn s) followed by (read-line)"
    :jvm "reads the ORIGINAL stdin — *in* was bound over System.in at RT class-init"
    :jolt "reads s"
+   :check :prose
+   :why "needs process stdin, which the gate does not control"
    :note "A superset: on the JVM with-in-str is the only way to feed read-line. Reading the static per line costs one vector-ref."}
   ;; InetSocketAddress.toString is host:port; the JVM renders hostname/ip:port.
   {:category :host-model
    :behavior "(str (java.net.InetSocketAddress. \"127.0.0.1\" 80)) — requires (require 'jolt.socket)"
    :jvm "\"/127.0.0.1:80\" (hostname null for a literal; \"localhost/127.0.0.1:80\" for a name)"
    :jolt "\"127.0.0.1:80\""
+   :check :prose
+   :why "needs (require 'jolt.socket), and the JVM rendering embeds a reverse-lookup hostname"
    :note "jolt does not resolve in the InetSocketAddress constructor (the JVM does), so the hostname/ip split doesn't exist to render. Socket/ServerSocket toString follow the JVM shape."}
   ;; Process lifetime is Chez's, not the JVM's. A java.lang.Thread is a real OS
   ;; thread over fork-thread, but Chez exits when the main thread returns and does
@@ -599,6 +746,8 @@
    :behavior "(.start (Thread. f)) as the last act of a program, without a join"
    :jvm "the process stays up until f returns — a non-daemon thread holds it open"
    :jolt "the process exits when the main thread returns; f may never finish"
+   :check :prose
+   :why "process-level: asserts whether the process outlives its main thread"
    :note "Inherent to Chez's thread model. .setDaemon is a no-op because every thread is already a daemon. Explicit .join / a latch / a deref of a promise all work."}
   ;; jolt IS Clojure, so org.clojure/clojure is TERMINAL during deps.edn expansion:
   ;; the coordinate contributes no artifact (its source on the roots would shadow
@@ -624,6 +773,8 @@
    :behavior "a deps.edn whose only :deps entry is org.clojure/clojure, then (require '[clojure.spec.alpha :as s])"
    :jvm "loads — spec.alpha and core.specs.alpha arrive transitively with the Clojure artifact"
    :jolt "raises \"Could not locate clojure/spec/alpha.jolt (or .clj/.cljc) on the source roots\""
+   :check :prose
+   :why "project-level: needs a deps.edn resolution rather than an expression"
    :note "Declare org.clojure/spec.alpha and org.clojure/core.specs.alpha explicitly; declared that way they resolve as ordinary Maven dependencies. Affects any library that requires spec without declaring it."}]
  :entries
  [;; Wherever a syntax-quote's CONSTRUCTION CODE becomes a value rather than


### PR DESCRIPTION
`(ex-data (ex-info "m" nil))` answered `nil`; the JVM answers `{}`. `ExceptionInfo`'s
constructor rejects a null map, so an ExceptionInfo whose data is nil cannot exist —
`Throwable->map` and `str` were wrong along with `ex-data`, and the difference flips a
`(when (ex-data e) ...)` branch with no error to point at it. Fixes #771.

The coercion goes in `jolt-ex-info`, which is what the emitter lowers the `ex-info`
native op to, so compiled call sites are covered — wrapping the `clojure.core/ex-info`
var root would only have caught reflective ones. 22 internal sites passed `jolt-nil`
deliberately. Two of them, in `dyn-binding.ss`, are `IllegalStateException` on the JVM
(`push-thread-bindings` on a non-dynamic var, `set!` with no thread binding) and now
throw that, which is a class-parity fix in its own right; the 20 in `state-image.ss`
were already ExceptionInfo and now say `empty-pmap`, which is what the rest of the host
uses for "no data".

### resolve answered for classes that do not exist

`(resolve 'fake.pkg.String)` handed back a class token. `jch-known?` falls back to the
last dotted segment — that fallback exists so a bare `ArityException` resolves — so any
`a.b.String` matched `java.lang.String`'s registration. `resolve` on a class name is
feature detection, and this told every caller the class was present. Six of the names I
probed answered where the JVM says `nil`. `rsv-class-for-name` uses an exact lookup now.

### Gating the :documented divergences

`known-divergences.edn` has two lists. `certify.clj` gated `:entries` and never read
`:documented` — 56 prose entries with no oracle behind them. Making the 33 checkable
ones checkable found:

- two divergences that no longer exist (the 2^60 loop-overflow raise, and
  ``'`foo/bar`` reading differently), removed
- five entries recording a JVM or jolt answer no run reproduces, including one claiming
  `resolve` throws `ClassNotFoundException` — it never does — and one claiming
  `.getNanos` truncates on jolt, where the method does not exist at all
- one `:category` (`:restrictive`) in use with no `:legend` line

Every entry now carries a `:check`: either `{:expr :jvm :jolt}` or `:prose` with a
`:why`. `certify.clj` verifies the JVM side against reference Clojure, `make documented`
the jolt side, and both reject an entry whose two sides agree or that has no `:check` at
all. Red-proven: corrupting either recorded value, converging the two, dropping the
`:check`, dropping a `:prose` entry's `:why`, and using an unlisted `:category` each fail
both halves, and re-introducing the original #771 claim fails them too.

`run-unit.ss`'s per-case isolation moved to `run-case-isolation.ss` so the new runner
shares it rather than a third copy.

### Not fixed

`(var-set #'v x)` with no thread binding writes v's root where the JVM raises
`IllegalStateException` (jolt-498p). `jolt-set-var!` — the `set!` backend — already gets
this right; `var-set` has a root-write fallback that `with-redefs-fn`, `with-local-vars`
and the REPL history vars all lean on, so the strict version needs those three moved
first and a seed remint. Separate change.
