### PR TITLE
Stop synchronisation primitives travelling into state images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Synchronisation primitives travelled into state images as dead objects.** A
+  record carrying a mutex or condition variable had no image walker of its own,
+  so the generic record copy serialised the primitive itself. What came back was
+  a fasl copy, not a live kernel object — and an *uncontended* acquire on one
+  succeeds, so a promise, future or agent read out of an image looked perfectly
+  healthy right up until something actually waited on it, and then it was
+  `Exception in mutex-acquire: failed: Invalid argument` from whichever thread
+  got there first, with no path and no name. `jolt.image/scan` reported nothing.
+
+  Affected `promise`, `future`, `agent`, the per-node lock a lazy sequence and a
+  seq cell take once the process is multi-threaded, `core.async` channels, and
+  the tap and fibers queues — `atom` and `ref` were already right, because they
+  rebuild through their own constructors, which is the shape this generalises. A
+  primitive is now written as an inert marker and a fresh live one is minted on
+  read. Done at the walk rather than per bearing type, so a record that gains a
+  mutex later is carried correctly without anyone rediscovering this; restoring
+  an image written before the fix mints a live primitive over the raw one, so
+  old files are healed rather than merely readable.
+
+  Image format version 6. Versions 2 through 6 still read; a version 6 image is
+  refused by an older build with the version in the message, as before.
+
+- **A restored `future` or `agent` could come back silently wedged.** Both carry
+  state that says a thread is mid-flight, and both used to travel with it. A
+  future written while still running restored as one that nothing would ever
+  complete, so `deref` hung forever; an agent written while an action was in
+  flight restored believing it had a busy worker, so every later `send` queued
+  behind nothing and its state never moved again. Neither said anything.
+
+  A state image carries state, not execution. A running future is refused now,
+  with a message that says so and points at `deref`-ing it first (and stubs
+  under `{:unwritable :stub}` like any other unwritable object); a completed one
+  is just its value and still travels. An agent's state, validator and error
+  handling travel, while its queue and in-flight flag do not, so a restored
+  agent accepts work immediately.
+
 - **A var defined twice froze the first definition into callers compiled between
   the two.** With splicing on by default, this legal Clojure gave one binary two
   answers:

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -34,8 +34,8 @@
 ;;
 ;; This build still READS versions 2 and 3: everything they can contain
 ;; (including raw jolt-ref-v1 records) restores here via the legacy arms.
-(define jolt-image-format-version 5)
-(define jolt-image-read-versions '(2 3 4 5))
+(define jolt-image-format-version 6)
+(define jolt-image-read-versions '(2 3 4 5 6))
 
 ;; --- classification -----------------------------------------------------------
 ;; An eq hashtable is the ONE hashtable kind Chez can fasl; eqv/equal/string-hash
@@ -345,6 +345,23 @@
 (define-record-type image-ref
   (fields (mutable val))
   (nongenerative image-ref-v1))
+
+;; A mutex or condition variable, standing in for one in the written graph. Chez
+;; fasls a mutex without complaint and the copy is NOT a live primitive -- but an
+;; uncontended acquire on the copy SUCCEEDS, so nothing goes wrong until
+;; something actually waits, and then it is "mutex-acquire: failed: Invalid
+;; argument" from whichever thread reached it first, with no path and no name.
+;;
+;; kind is 'mutex or 'condition; restore mints a fresh live one. Substituting at
+;; the WALK rather than through a walker arm per bearing type makes it total:
+;; jolt-promise, jolt-future, jolt-agent, the per-node lock on a lazy cell and on
+;; a seq, async channels, the tap queue and the fibers queues all carry one, and
+;; a record added later carries it correctly without anyone reading this file.
+;; jolt-atom and jolt-ref rebuild through their own constructors and so were
+;; always right; they are the shape this generalizes (jolt-ojoh).
+(define-record-type image-sync
+  (fields kind)
+  (nongenerative image-sync-v1))
 
 ;; A raw jolt-ref record in a format-2 image (v0.6.5/v0.6.6). The live runtime
 ;; type is jolt-ref-v2, so the fasl's nongenerative jolt-ref-v1 rtd (fields:
@@ -740,6 +757,8 @@
                      ;; a ref descriptor re-mints a live ref; a raw jolt-ref-v1
                      ;; record from a format-2 image re-mints through the
                      ;; legacy arm (same construction, val read via its own rtd)
+                     ((and (eq? mode 'restore) (image-sync? x))
+                      (if (eq? (image-sync-kind x) 'condition) (make-condition) (make-mutex)))
                      ((and (eq? mode 'restore) (image-ref? x))
                       (walk-ref-restore (image-ref-val x) x path))
                      ((and (eq? mode 'restore) (image-legacy-ref? x))
@@ -843,6 +862,97 @@
                              ((vector? x) (walk-vector x path))
                              ((and (hashtable? x) (hashtable-mutable? x))
                               (walk-hashtable x path))
+                             ;; A mutex or condition variable is per-process
+                             ;; kernel state. fasl copies one happily and the
+                             ;; copy is NOT a live primitive -- but an
+                             ;; uncontended acquire on it succeeds, so nothing
+                             ;; goes wrong until something actually waits, and
+                             ;; then it is "mutex-acquire: failed: Invalid
+                             ;; argument" from whichever thread got there first.
+                             ;;
+                             ;; Handled here rather than by a walker arm per
+                             ;; bearing type, so it is TOTAL: jolt-promise,
+                             ;; jolt-future, jolt-agent, the per-node locks on a
+                             ;; lazy cell and a seq, async channels, the tap
+                             ;; queue and the fibers queues all carry one, and a
+                             ;; record added later carries it correctly without
+                             ;; anyone remembering this file. jolt-atom and
+                             ;; jolt-ref predate it and rebuild through their own
+                             ;; constructors, which is why they were already
+                             ;; right. A FRESH primitive, not #f: a lock field
+                             ;; that is created on demand tolerates one either
+                             ;; way, and a promise's mu is dereferenced
+                             ;; unconditionally (jolt-ojoh).
+                             ;; Execution does not travel, and these two are the
+                             ;; cases where a record's own state says so.
+                             ;;
+                             ;; A future that has not completed is waiting on a
+                             ;; thread the image cannot carry: restored, nothing
+                             ;; will ever finish it, so `deref` hangs forever.
+                             ;; Refuse it, the way any other unwritable object is
+                             ;; refused -- naming it, and stubbing under stub
+                             ;; mode. A completed one is just its value and
+                             ;; travels.
+                             ((and (jolt-future? x) (not (jolt-future-done? x)))
+                              (cond
+                                ((eq? mode 'rebuild-stub)
+                                 (let ((st (make-stub x path "a future that has not completed")))
+                                   (hashtable-set! memo x st) st))
+                                ((image-rebuild-mode? mode)
+                                 (jolt-throw
+                                   (jolt-ex-info
+                                     (string-append
+                                       "image: cannot write a running future at "
+                                       (image-path->string path)
+                                       ": it is waiting on a thread, and a state image"
+                                       " carries state, not execution. Deref it first,"
+                                       " or store what it computes.")
+                                     empty-pmap)))
+                                (else (hashtable-set! memo x #t)
+                                      (report! x path (image-report-disposition mode)))))
+                             ;; An agent's QUEUE is pending execution too. Its
+                             ;; state travels; the actions behind it do not, and
+                             ;; carrying `running?` across would leave the
+                             ;; restored agent believing a worker it does not
+                             ;; have is mid-action, so every later send would
+                             ;; queue behind nothing and never run -- silently
+                             ;; wedged, which is worse than dropping them.
+                             ((jolt-agent? x)
+                              (if (image-rebuild-mode? mode)
+                                  ;; mu/cv go through the walk like any other
+                                  ;; field, so the marker/mint rule below covers
+                                  ;; this arm in both directions rather than
+                                  ;; being restated here (they are immutable
+                                  ;; fields, hence walked before construction).
+                                  (let ((nx (make-jolt-agent jolt-nil jolt-nil jolt-nil
+                                                             (vector '() '()) #f
+                                                             (walk (jolt-agent-mu x) (cons "@mu" path))
+                                                             (walk (jolt-agent-cv x) (cons "@cv" path))
+                                                             (jolt-agent-err-mode x) jolt-nil)))
+                                    (hashtable-set! memo x nx)
+                                    (image-meta-copy! x nx)
+                                    (jolt-agent-state-set! nx (walk (jolt-agent-state x) (cons "@" path)))
+                                    (jolt-agent-err-set! nx (walk (jolt-agent-err x) (cons "@err" path)))
+                                    (jolt-agent-validator-set! nx
+                                      (walk (jolt-agent-validator x) (cons "@validator" path)))
+                                    (jolt-agent-err-handler-set! nx
+                                      (walk (jolt-agent-err-handler x) (cons "@error-handler" path)))
+                                    nx)
+                                  (begin
+                                    (hashtable-set! memo x #t)
+                                    (walk (jolt-agent-state x) (cons "@" path))
+                                    (walk (jolt-agent-err x) (cons "@err" path))
+                                    (walk (jolt-agent-validator x) (cons "@validator" path))
+                                    (walk (jolt-agent-err-handler x) (cons "@error-handler" path))
+                                    #t)))
+                             ((mutex? x)
+                              (cond ((eq? mode 'restore) (make-mutex))
+                                    ((image-rebuild-mode? mode) (make-image-sync 'mutex))
+                                    (else #t)))
+                             ((thread-condition? x)
+                              (cond ((eq? mode 'restore) (make-condition))
+                                    ((image-rebuild-mode? mode) (make-image-sync 'condition))
+                                    (else #t)))
                              ((and (record? x) (record-rtd x))
                               (walk-record x path))
                              (else (if (image-rebuild-mode? mode) x #t)))))))))))
@@ -1368,7 +1478,7 @@
   (unless (member (vector-ref h 1) jolt-image-read-versions)
     (jolt-throw (jolt-ex-info
                   (string-append "image: " path " has format version "
-                                 (jolt-str-one (vector-ref h 1)) ", this build reads versions 2 to 5")
+                                 (jolt-str-one (vector-ref h 1)) ", this build reads versions 2 to 6")
                   empty-pmap)))
   ;; The fasl version moves with Chez, and a mismatch otherwise surfaces as an
   ;; opaque fasl-read error, so name it here instead.

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -93,6 +93,80 @@
 (rt "empty colls" "[[] {} #{} ()]"                 "[[] {} #{} ()]")
 (rt "record"      "(do (defrecord P [x y]) (->P 1 2))" "#user.P{:x 1, :y 2}")
 
+;; --- the value-kind matrix: restored values must still WORK ---------------------
+;; `rt` above compares printed forms, which settles a value type. It settles
+;; nothing for a value whose identity IS its meaning: = is identity for an atom, a
+;; delay, a regex, an array and a StringBuilder, so a restored one can print
+;; correctly and be dead. These rows bind the restored value and USE it.
+;;
+;; Every kind here round-trips today and none of it was pinned; probing the
+;; language kind by kind is what found the gaps the rest of this epic closes
+;; (jolt-1vfl).
+(define (rtu name expr probe expect)
+  (cleanup!)
+  (ev (string-append "(jolt.host/image-write! \"" tmp "\" " expr ")"))
+  (def-var! "user" "$rt"
+    (jolt-compile-eval (string-append "(jolt.host/image-read \"" tmp "\")") "user"))
+  (is name (string-append "(pr-str " probe ")") expect))
+
+;; reference types — restored, they must still deref, mutate and settle
+(rtu "atom"        "(atom {:a 1})"
+     "[(deref $rt) (do (swap! $rt assoc :b 2) (deref $rt))]" "[{:a 1} {:a 1, :b 2}]")
+(rtu "volatile"    "(volatile! 1)"
+     "[(deref $rt) (do (vreset! $rt 9) (deref $rt))]"        "[1 9]")
+(rtu "delay unforced" "(delay (+ 1 2))"
+     "[(realized? $rt) (deref $rt) (realized? $rt)]"         "[false 3 true]")
+(rtu "delay forced"   "(let [d (delay (+ 1 2))] @d d)"
+     "[(realized? $rt) (deref $rt)]"                         "[true 3]")
+
+;; NOT here: promise, future, agent, and a realized lazy seq. Each carries OS
+;; synchronisation state that the image copies as data, so what comes back holds
+;; dead primitives (jolt-ojoh). They get pinned with that fix, not before —
+;; a passing row here would enshrine the bug.
+
+;; seq kinds
+
+;; literals whose printed form is not the whole story
+(rtu "regex"       "#\"a+b\""
+     "[(str $rt) (re-find $rt \"xaabz\")]"                   "[\"a+b\" \"aab\"]")
+(rtu "class token" "String"     "[(str $rt) (instance? $rt \"x\")]"
+     "[\"class java.lang.String\" true]")
+(rtu "File"        "(java.io.File. \"/tmp\")"
+     "[(.getPath $rt) (.isDirectory $rt)]"                   "[\"/tmp\" true]")
+
+;; arrays and StringBuilder are mutable host objects: contents, and still writable
+(rtu "byte-array"   "(byte-array [1 2 3])"      "(vec $rt)"  "[1 2 3]")
+(rtu "double-array" "(double-array [1.0 2.5])"  "(vec $rt)"  "[1.0 2.5]")
+(rtu "object-array" "(object-array [1 :a])"     "(vec $rt)"  "[1 :a]")
+(rtu "StringBuilder" "(StringBuilder. \"ab\")"
+     "(do (.append $rt \"c\") (str $rt))"                    "\"abc\"")
+
+(rtu "cons onto vec" "(cons 1 [2 3])"          "(vec $rt)"   "[1 2 3]")
+(rtu "PersistentQueue"
+     "(conj clojure.lang.PersistentQueue/EMPTY 1 2)"
+     "[(vec $rt) (peek $rt)]"                                "[[1 2] 1]")
+(rtu "subvec"      "(subvec [1 2 3 4] 1 3)"    "(vec $rt)"   "[2 3]")
+(rtu "sorted-set-by" "(sorted-set-by > 1 3 2)"
+     "[(vec $rt) (vec (conj $rt 4))]"                        "[[3 2 1] [4 3 2 1]]")
+
+;; scalars and literals the printed-form rows above do not reach
+(rtu "bigdec"      "1.5M"        "[(pr-str $rt) (decimal? $rt)]" "[\"1.5M\" true]")
+(rtu "NaN and Inf" "[##NaN ##Inf ##-Inf]"
+     "[(Double/isNaN (nth $rt 0)) (nth $rt 1) (nth $rt 2)]"  "[true ##Inf ##-Inf]")
+(rtu "inst"        "#inst \"2020-01-01T00:00:00.000-00:00\""
+     "[(inst? $rt) (inst-ms $rt)]"                           "[true 1577836800000]")
+(rtu "uuid"        "#uuid \"00000000-0000-0000-0000-000000000001\""
+     "[(uuid? $rt) (str $rt)]"
+     "[true \"00000000-0000-0000-0000-000000000001\"]")
+(rtu "tagged-literal" "(tagged-literal 'x 1)"
+     "[(:tag $rt) (:form $rt)]"                              "[x 1]")
+(rtu "qualified symbol" "'foo.bar/baz"
+     "[(namespace $rt) (name $rt)]"                          "[\"foo.bar\" \"baz\"]")
+
+;; a var travels by NAME and comes back as the live var, not a copy
+(rtu "var"         "(do (def rt-data-var {:a 1}) #'rt-data-var)"
+     "[(deref $rt) (= $rt #'rt-data-var)]"                   "[{:a 1} true]")
+
 ;; --- R4: sorted maps and sets travel -------------------------------------------
 ;; The wrapper's internal comparator machinery (a wrapped comparator closure + an
 ;; :ops table of closures in a string-keyed hashtable) never reaches the externals
@@ -511,6 +585,123 @@
   (ok "handler payload rides in the body"
       (= 7 (jolt-get (image-handled-payload (car handled)) (keyword #f "claimed") jolt-nil))))
 
+
+;; --- no synchronisation primitive may travel (jolt-ojoh) -----------------------
+;; A record carrying a mutex or condition variable has to be rebuilt through the
+;; LIVE constructor on the way out, the way walk-atom and walk-ref already are.
+;; Copying one as data produces an object whose primitives are not live kernel
+;; objects: an uncontended acquire on the copy happens to succeed, so the damage
+;; does not show until something actually waits, and then it is
+;;
+;;   Exception in mutex-acquire: failed: Invalid argument
+;;
+;; which names nothing and takes the process with it. That is why this is
+;; asserted STRUCTURALLY, on the written file, and not by using the restored
+;; object: a probe that acquires the copy passes, and a probe that contends for
+;; it is a race. The contract is simply that no such primitive is in the image.
+(define (sync-prims-in path)
+  (let ((acc '()))
+    (image-walk (image-graph path)
+                (lambda (x p) (when (mutex? x) (set! acc (cons (image-path->string p) acc)))))
+    acc))
+
+;; These run AFTER a thread has been forked, because that is what populates the
+;; per-node locks on a lazy cell and a lazily-tailed seq -- single-threaded, the
+;; lock field stays #f and the bug is invisible.
+(ev "(deref (future 1))")
+(ok "the runtime is on its multi-threaded path" jolt-mt?)
+
+(define (no-sync name expr)
+  (cleanup!)
+  (ev (string-append "(jolt.host/image-write! \"" tmp "\" " expr ")"))
+  (let ((found (sync-prims-in tmp)))
+    (set! total (+ total 1))
+    (unless (null? found)
+      (set! fails (+ fails 1))
+      (printf "FAIL: ~a wrote ~a mutex(es), at: ~a\n" name (length found) found))))
+
+(no-sync "an undelivered promise"  "(promise)")
+(no-sync "a delivered promise"     "(let [p (promise)] (deliver p 5) p)")
+(no-sync "a completed future"      "(let [f (future 5)] @f f)")
+(no-sync "an agent"                "(agent 1)")
+(no-sync "a lazy seq forced multi-threaded" "(doall (map inc [1 2 3]))")
+(no-sync "a lazily-tailed seq"     "(doall (take 2 (iterate inc 0)))")
+(no-sync "a promise inside app state" "{:pending (promise) :xs [1 2]}")
+
+;; An image written BEFORE this fix (format 5 and older) has a raw mutex in it,
+;; and there is nothing to be done about the file -- but the restore walk can
+;; hand back a live primitive instead of the dead copy. Driven through the walk
+;; directly, since the checked-in old-format fixtures predate agents/promises.
+;; --- execution does not travel (jolt-ojoh) --------------------------------------
+;; The two records whose own state says a thread is mid-flight. Both used to
+;; restore SILENTLY WEDGED, which is worse than the dead-primitive bug above: a
+;; restored running future never completes, so deref hangs forever, and a
+;; restored agent that believes it has a busy worker queues every later send
+;; behind nothing.
+(define (str-has? s sub)
+  (let ((n (string-length s)) (m (string-length sub)))
+    (let loop ((i 0))
+      (cond ((fx>? (fx+ i m) n) #f)
+            ((string=? (substring s i (fx+ i m)) sub) #t)
+            (else (loop (fx+ i 1)))))))
+(define (refusal-of expr)
+  (cleanup!)
+  (call/cc (lambda (k)
+    (with-exception-handler
+      (lambda (e) (k (if (jolt-ex-info-record? e)
+                         (jolt-ex-info-record-message e)
+                         (call/cc (lambda (k2)
+                           (with-exception-handler (lambda (_) (k2 "?"))
+                             (lambda () (condition->message-string e))))))))
+      (lambda ()
+        (ev (string-append "(jolt.host/image-write! \"" tmp "\" " expr ")"))
+        "WROTE")))))
+
+;; sleeps far longer than the gate takes, so it is still running when written --
+;; no window to get wrong, since the row only needs "not done yet"
+(ok "a running future is refused, and the message says why"
+    (str-has? (refusal-of "(future (Thread/sleep 300000))") "carries state, not execution"))
+(is "a running future scans as unwritable"
+    "(count (jolt.host/image-scan (future (Thread/sleep 300000))))" "1")
+(is "a completed future still travels"
+    "(count (jolt.host/image-scan (let [f (future 5)] @f f)))" "0")
+
+;; the wedged agent state is built directly rather than by racing a real send:
+;; the row is about the invariant, not about how fast this machine runs an action
+(let ((a (jolt-compile-eval "(agent 7)" "user")))
+  (jolt-agent-running?-set! a #t)
+  (jolt-agent-queue-set! a (vector '() (list 'pending-action)))
+  (def-var! "user" "$ag" a)
+  (cleanup!)
+  (ev (string-append "(jolt.host/image-write! \"" tmp "\" $ag)"))
+  (let ((r (jolt-compile-eval (string-append "(jolt.host/image-read \"" tmp "\")") "user")))
+    (def-var! "user" "$agr" r)
+    (ok "a restored agent has no phantom worker" (not (jolt-agent-running? r)))
+    (ok "a restored agent has an empty queue"
+        (let ((q (jolt-agent-queue r)))
+          (and (null? (vector-ref q 0)) (null? (vector-ref q 1)))))
+    (is "a restored agent keeps its state and still takes work"
+        "(do (send $agr inc) (await-for 5000 $agr) (deref $agr))" "8")))
+
+(ok "restore mints a live primitive over a raw one from an old image"
+    (let* ((dead (vector (make-mutex) (make-condition)))
+           (healed (let-values (((g _) (image-graph-process dead 'restore #f))) g)))
+      (and (mutex? (vector-ref healed 0))
+           (thread-condition? (vector-ref healed 1))
+           (not (eq? (vector-ref healed 0) (vector-ref dead 0)))
+           (not (eq? (vector-ref healed 1) (vector-ref dead 1))))))
+
+;; ...and the restored objects still have to WORK. These pass today by luck --
+;; an uncontended acquire on a dead mutex succeeds -- so they are here to hold
+;; the behaviour steady across the fix, not to prove the bug.
+(rtu "promise unkept" "(promise)"
+     "[(realized? $rt) (do (deliver $rt 42) (deref $rt))]"   "[false 42]")
+(rtu "promise kept"   "(let [p (promise)] (deliver p 5) p)"  "(deref $rt)" "5")
+(rtu "future"         "(let [f (future 5)] @f f)"            "(deref $rt)" "5")
+(rtu "agent"          "(agent 1)"
+     "(do (send $rt inc) (await-for 5000 $rt) (deref $rt))"  "2")
+(rtu "lazy realized"  "(doall (map inc [1 2 3]))"
+     "[(vec $rt) (str (type $rt))]"   "[[2 3 4] \"class clojure.lang.LazySeq\"]")
 
 ;; --- header / compatibility ------------------------------------------------------
 (is "reading a non-image fails with a clear message"
@@ -1014,9 +1205,9 @@
       "   (identical? (:cyc g) (:self (deref (:cyc g))))"
       "   (do (dosync (ref-set (:a g) 100)) (deref (:a g)))])")
     "[99 :hot true true 100]")
-;; format discipline: the new image writes header version 5 (3 added ref
-;; descriptors, 4 added image-rekey, 5 the jrec hasheq slot), and its bytes
-;; carry the descriptor rtd, never the live ref rtd
+;; format discipline: the new image writes header version 6 (3 added ref
+;; descriptors, 4 added image-rekey, 5 the jrec hasheq slot, 6 the image-sync
+;; marker), and its bytes carry the descriptor rtd, never the live ref rtd
 (define (bv-contains? bv s)
   (let* ((sb (string->utf8 s)) (m (bytevector-length sb)) (n (bytevector-length bv)))
     (let scan ((i 0))
@@ -1026,12 +1217,12 @@
                    (and (fx=? (bytevector-u8-ref bv (fx+ i j)) (bytevector-u8-ref sb j))
                         (cmp (fx+ j 1))))) #t)
             (else (scan (fx+ i 1)))))))
-(ok "ref-carrying image is format 5 with no raw jolt-ref rtd"
+(ok "ref-carrying image is format 6 with no raw jolt-ref rtd"
     (let ((port (open-file-input-port tmp)))
       (let* ((h (fasl-read port))
              (rest (get-bytevector-all port)))
         (close-port port)
-        (and (fx=? 5 (vector-ref h 1))
+        (and (fx=? 6 (vector-ref h 1))
              (bv-contains? rest "image-ref")
              (not (bv-contains? rest "jolt-ref-v2"))))))
 ;; an unknown format version refuses with a clean error naming both versions


### PR DESCRIPTION
"First round of epic `jolt-v17y` (state images: every supported value kind actually round-trips). Closes the P0 it turned up, plus the pinning round that found it.\n\n## Synchronisation primitives travelled as dead objects\n\nA record carrying a mutex or condition variable had no image walker of its own, so the generic record copy serialised the primitive itself. What comes back is a fasl copy, not a live kernel object:\n\n```\npromise|live-mu=#<mutex> restored-mu=#<mutex> same?=#f\nagent  |live-mu=#<mutex> restored-mu=#<mutex> same?=#f\nfuture |live-mu=#<mutex> restored-mu=#<mutex> same?=#f\n```\n\nAn *uncontended* acquire on the copy succeeds, so a promise, future or agent read out of an image looks perfectly healthy right up until something actually waits — and then it is `Exception in mutex-acquire: failed: Invalid argument` from whichever thread reached it first, with no path and no name. `jolt.image/scan` reported nothing.\n\nIt surfaced writing the value-kind matrix: with a restored agent's worker thread live, the gate died **6/6**, and **0/5** the moment anything perturbed the timing (a guard, a printf). I chased it through three wrong hypotheses before instrumenting instead of reasoning.\n\nA primitive is written as an inert `image-sync` marker now, and a fresh live one is minted on read. Done at the **walk** rather than by an arm per bearing type, so it is total — `jolt-promise`, `jolt-future`, `jolt-agent`, the per-node lock a lazy cell and a seq cell take once the process is multi-threaded, `core.async` channels, the tap and fibers queues, and a record that gains a mutex later. `jolt-atom` and `jolt-ref` were already right because they rebuild through their own constructors; that is the shape this generalises. Restoring a pre-fix image mints a live primitive over the raw one, so old files are healed rather than merely readable.\n\nFormat 6, reads 2–6.\n\n## Execution travelled too, and restored silently wedged\n\nWorse than a dead primitive, because nothing errors:\n\n```\nrunning future    @f → hangs forever (deref with a timeout: :TIMED-OUT)\nagent mid-flight  restored with running?=#t and a queue → every later send ignored, state frozen\n```\n\nA state image carries state, not execution. A running future is refused now, with a message saying so and pointing at `deref`-ing it first, and stubbed under `{:unwritable :stub}` like any other unwritable object; a completed one is just its value and still travels. An agent's state, validator and error handling travel while its queue and in-flight flag do not, so a restored agent accepts work immediately.\n\n## The pinning round\n\nAn `rtu` helper that binds a restored value and **uses** it — printing proves nothing for a kind whose identity is its meaning, since `=` is identity for a regex, an array, a StringBuilder. Rows for regex (a live `re-find` through it), class token, `java.io.File`, the three array types, StringBuilder (still appendable), cons/PersistentQueue/subvec/sorted-set-by, bigdec/NaN/±Inf/`#inst`/`#uuid`/tagged-literal/qualified symbol, atom/volatile/delay, and a var (comes back as the *live* var).\n\nPromise, future, agent and a realized lazy seq were deliberately held out of that round until the fix above — a passing row there would have enshrined the bug.\n\n## Gates\n\n- `make test` 88 CI + 3 test targets\n- `make libconformance` 47 ok / 0 regressed\n- `state-image` 202 assertions, deterministic over three runs\n- both halves mutation-checked: without the write-side marker the image still holds a mutex; without the read-side mint the marker reaches the runtime as `#[image-sync-v1 mutex] is not a mutex`\n\nRemaining in the epic: `jolt-a6k2` (lazy seqs from `clojure.core` as producer descriptors), `jolt-2cny` (var-rooted code travels by name), `jolt-zr91` (legible refusals), `jolt-ji1h` (transient, namespace identity), `jolt-hnlk` (API surface), `jolt-wo9u` (built-binary gate).\n\nCloses jolt-ojoh, jolt-1vfl.\n"