### PR TITLE
Let a lazy seq built by clojure.core travel in a state image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A lazy sequence built by `clojure.core` could not go into a state image.** A
+  lazy seq written with `lazy-seq` already travelled — that thunk is an ordinary
+  fn literal with a recorded source, so an infinite generator came back still
+  generating and an unrealized side effect still had not run. `map`, `filter`,
+  `range`, `take` and friends build their thunks as Scheme closures inside the
+  runtime instead, and a closure carries its captured values where nothing can
+  read them, so those refused. One core call anywhere in a chain was enough:
+  `(rest user-lazy)`, `(take 3 user-lazy)` and `(map inc user-lazy)` all refused
+  even though the seq they were built from travelled.
+
+  Those producers record what they are — the producer and its arguments — rather
+  than closing over them, so the image writes the producer's *name* and the
+  arguments as data and restore re-applies it. Nothing is forced: an infinite
+  seq still comes back generating, and a side effect still runs on the restoring
+  side rather than at dump. The arguments walk as ordinary data, so a producer
+  over another lazy seq nests and a self-referential one (`(def fib (lazy-cat
+  [0 1] (map + (rest fib) fib)))`) closes on itself.
+
+  Free: the forcer is a direct call where invoking the closure went through
+  `jolt-invoke`, so the benchmark suite is unchanged (`bench/seqs` 1.00x).
+
+  Not yet covered: a chain already walked part-way, whose frontier is a
+  per-element cell rather than the producer that made it. Those still refuse.
+
 - **Synchronisation primitives travelled into state images as dead objects.** A
   record carrying a mutex or condition variable had no image walker of its own,
   so the generic record copy serialised the primitive itself. What came back was

--- a/host/chez/lazy-bridge.ss
+++ b/host/chez/lazy-bridge.ss
@@ -45,6 +45,10 @@
         (let ((m (make-mutex))) (jolt-lazyseq-lock-set! x m) m))))
 
 (define (jolt-make-lazy-seq thunk) (make-jolt-lazyseq thunk jolt-nil #f #f #f))
+;; the descriptor form: a producer that records what it is instead of closing
+;; over it, so the cell can be written to a state image (seq.ss lazy-src).
+(define (jolt-make-lazy-src fn a b c)
+  (make-jolt-lazyseq (make-lazy-src fn a b c) jolt-nil #f #f #f))
 
 ;; force once and memoize. The thunk is (fn [] (coll->cells body)); coll->cells
 ;; already coerced the body to a seq (cseq | nil) via the live jolt-seq, so the
@@ -62,7 +66,11 @@
                (jolt-lazyseq-realized?-set! x #t)
                (jolt-lazyseq-thunk-set! x #f)
                (raise e)))
-      (let ((r (jolt-invoke (jolt-lazyseq-thunk x))))
+      ;; the thunk is a procedure (a user `lazy-seq` form's fn literal) or a
+      ;; lazy-src descriptor (a clojure.core producer, recorded so the cell can
+      ;; travel in a state image -- see seq.ss). Both force to a seq | nil.
+      (let* ((t (jolt-lazyseq-thunk x))
+             (r (if (lazy-src? t) (lazy-src-force t) (jolt-invoke t))))
         (jolt-lazyseq-val-set! x r)
         (jolt-lazyseq-realized?-set! x #t)
         (jolt-lazyseq-thunk-set! x #f)
@@ -113,9 +121,14 @@
 ;; (cons x lazyseq): keep the tail lazy — force it only when the cseq cell is
 ;; walked, so an infinite (repeat/iterate/cycle) stays productive.
 (define %ls-cons jolt-cons)
+;; the deferral is a descriptor, not a closure, so a cons onto a lazy seq can be
+;; written to a state image -- (rest user-lazy) reaches this too, since a user
+;; `lazy-seq` body is usually (cons x (recur ...)) (seq.ss lazy-src).
+(define lz-cons-tail
+  (register-lazy-src! 'cons-tail (lambda (coll _b _c) (force-lazyseq coll))))
 (set! jolt-cons (lambda (x coll)
   (if (jolt-lazyseq? coll)
-      (cseq-lazy x (lambda () (force-lazyseq coll)))
+      (cseq-lazy x (make-lazy-src lz-cons-tail coll #f #f))
       (%ls-cons x coll))))
 
 ;; (conj lazyseq x): conj onto a seq prepends, like any seq — (conj (rest xs) y).

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -104,6 +104,76 @@
 (define (cseq-lazy head tail-thunk) (make-cseq head tail-thunk #f sk-cons #f 0 #f #f))
 (define (cseq-lazy/k head tail-thunk kind) (make-cseq head tail-thunk #f kind #f 0 #f #f))
 (define (cseq-list head tail) (make-cseq head tail #t sk-list #f 0 #f #f))   ; a PersistentList node
+
+;; --- a lazy cell's thunk, as DATA ---------------------------------------------
+;; A thunk built in Scheme carries its captured values where nothing can read
+;; them, which is why a lazy seq clojure.core produced could not be written to a
+;; state image at all -- while one a user `lazy-seq` form produced could, its
+;; thunk being an ordinary fn literal with a recorded source. Recording the
+;; producer and its arguments closes that without forcing anything: the image
+;; writes the producer's NAME and the arguments as data, and restore re-applies
+;; it, so what comes back is STILL LAZY -- an infinite seq keeps generating and a
+;; side effect still has not run.
+;;
+;; fn is the forcer, always a top-level procedure, so forcing a descriptor is one
+;; indirect call: the same shape as invoking the closure it replaces, with no
+;; dispatch on a tag added to the hot path. Three argument slots because that
+;; covers every producer here; unused ones are #f.
+;;
+;; Defined in seq.ss rather than beside the lazy cell in lazy-bridge.ss because
+;; the producers live here and lazy-bridge loads afterwards.
+;; Fields are mutable so the image walk can memoize the record BEFORE walking its
+;; arguments -- a self-referential producer ((def fib (lazy-cat [0 1] (map + fib
+;; (rest fib))))) reaches its own cell through them.
+(define-record-type lazy-src
+  (fields (mutable fn) (mutable a) (mutable b) (mutable c))
+  (nongenerative jolt-lazy-src-v1))
+
+;; producer name <-> forcer. The dump needs name-of (a procedure cannot travel);
+;; the restore needs proc-of. Registered at load, next to each producer.
+(define lazy-src-name-tbl (make-eq-hashtable))
+(define lazy-src-proc-tbl (make-eq-hashtable))
+(define (register-lazy-src! name proc)
+  (hashtable-set! lazy-src-name-tbl proc name)
+  (hashtable-set! lazy-src-proc-tbl name proc)
+  proc)
+(define (lazy-src-name-of proc) (hashtable-ref lazy-src-name-tbl proc #f))
+(define (lazy-src-proc-of name) (hashtable-ref lazy-src-proc-tbl name #f))
+(define (lazy-src-force t)
+  ((lazy-src-fn t) (lazy-src-a t) (lazy-src-b t) (lazy-src-c t)))
+;; a cseq's unforced tail is either a thunk or a descriptor, same as a lazy
+;; cell's. One record predicate on the force path, measured at no cost.
+(define (cseq-run-tail t) (if (lazy-src? t) (lazy-src-force t) (t)))
+
+;; forced tail of a seq whose own tail was not yet realized (jolt-rest)
+(define lz-rest
+  (register-lazy-src! 'rest (lambda (s _b _c) (jolt-seq (seq-more s)))))
+(define lz-map-chunk
+  (register-lazy-src! 'map-chunk
+    (lambda (f s _c) (jolt-seq (map-seq f (jolt-seq (na-chunk-rest s)))))))
+(define lz-filter-chunk
+  (register-lazy-src! 'filter-chunk
+    (lambda (pred s keep) (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)))))
+;; range carries four values through three slots: step and kind share the last.
+(define lz-range
+  (register-lazy-src! 'range
+    (lambda (v end step+kind)
+      (jolt-seq (range-chunked v end (car step+kind) (cdr step+kind))))))
+(define lz-take
+  (register-lazy-src! 'take
+    (lambda (n coll _c)
+      (jolt-seq
+       (if (and (flonum? n) (infinite? n))
+           (if (> n 0.0) (jolt-seq coll) jolt-empty-list)
+           (let ((n (->idx n)))
+             (if (fx<=? n 0)
+                 jolt-empty-list                 ; (take 0 coll) must not seq its source
+                 (let loop ((n n) (s (jolt-seq coll)))
+                   (cond
+                     ((or (fx<=? n 0) (jolt-nil? s)) jolt-empty-list)
+                     ((fx=? n 1) (cseq-lazy (seq-first s) (lambda () jolt-empty-list)))
+                     (else (cseq-lazy (seq-first s)
+                                      (lambda () (loop (fx- n 1) (jolt-seq (seq-more s)))))))))))))))
 ;; clojure.core/list? — Clojure's (instance? IPersistentList x), which among the
 ;; seq flavors only PersistentList is.
 (define (cseq-list? s) (fx=? (cseq-kind s) sk-list))
@@ -208,11 +278,11 @@
   (cond
     ((not jolt-mt?)
      (if (cseq-forced? s) (cseq-tail s)
-         (let ((t (if (cseq-cvec s) (cseq-cvec-more s #t) ((cseq-tail s)))))
+         (let ((t (if (cseq-cvec s) (cseq-cvec-more s #t) (cseq-run-tail (cseq-tail s)))))
            (cseq-tail-set! s t) (cseq-forced?-set! s #t) t)))
     (else (jolt-with-mutex (cseq-ensure-lock! s)     ; multi-threaded: always lock
             (if (cseq-forced? s) (cseq-tail s)
-                (let ((t (if (cseq-cvec s) (cseq-cvec-more s #t) ((cseq-tail s)))))
+                (let ((t (if (cseq-cvec s) (cseq-cvec-more s #t) (cseq-run-tail (cseq-tail s)))))
                   (cseq-tail-set! s t) (cseq-forced?-set! s #t) t))))))
 
 ;; The empty seq (Clojure's empty list ()), distinct from nil. The (unused) field
@@ -370,7 +440,7 @@
       ;; result (which may be jolt-empty-list, e.g. map's tail) back to cseq | nil,
       ;; the contract force-lazyseq relies on — else (seq (rest s)) of an empty
       ;; tail yields a truthy empty-list and walkers (distinct, dedupe) overrun.
-      (else (jolt-make-lazy-seq (lambda () (jolt-seq (seq-more s))))))))
+      (else (jolt-make-lazy-src lz-rest s #f #f)))))
 (define (jolt-next x)                  ; nil when the rest is empty
   ;; next = (seq (rest x)): the rest must be RE-SEQ'd so an empty tail collapses to
   ;; nil. seq-more on a lazy seq (e.g. map's) forces to jolt-empty-list, which is
@@ -1095,7 +1165,7 @@
       ((jolt-nil? s) jolt-empty-list)
       ((na-chunked-seq? s)
        (cseq-chunked (na-chunk-map-first s g) 0
-                     (jolt-make-lazy-seq (lambda () (jolt-seq (map-seq f (jolt-seq (na-chunk-rest s))))))))
+                     (jolt-make-lazy-src lz-map-chunk f s #f)))
       (else
        (cseq-lazy (g (seq-first s)) (lambda () (map-seq f (jolt-seq (seq-more s)))))))))
 (define (map-seq* f seqs)              ; multi-collection map; stops at the shortest
@@ -1108,10 +1178,14 @@
 ;; once yields the cseq chain, which then iterates with no per-element overhead.
 ;; jolt-seq coerces map-seq's result (cseq | jolt-empty-list) to cseq | nil, the
 ;; contract force-lazyseq relies on (see jolt-rest).
+(define lz-map1
+  (register-lazy-src! 'map1 (lambda (f coll _) (jolt-seq (map-seq f (jolt-seq coll))))))
+(define lz-mapN
+  (register-lazy-src! 'mapN (lambda (f colls _) (jolt-seq (map-seq* f (map jolt-seq colls))))))
 (define (jolt-map f . colls)
   (if (null? (cdr colls))
-      (jolt-make-lazy-seq (lambda () (jolt-seq (map-seq f (jolt-seq (car colls))))))
-      (jolt-make-lazy-seq (lambda () (jolt-seq (map-seq* f (map jolt-seq colls)))))))
+      (jolt-make-lazy-src lz-map1 f (car colls) #f)
+      (jolt-make-lazy-src lz-mapN f colls #f)))
 
 ;; Chunk-preserving, like core.clj filter: a chunked source has pred applied to the
 ;; whole chunk, the kept elements packed into a fresh (possibly smaller) chunk, and
@@ -1133,9 +1207,7 @@
              (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)
              (cseq-chunked
               c 0
-              (jolt-make-lazy-seq
-               (lambda ()
-                 (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) keep))))))))
+              (jolt-make-lazy-src lz-filter-chunk pred s keep)))))
       (else
        (let walk ((s s))
          (cond ((jolt-nil? s) jolt-empty-list)
@@ -1144,10 +1216,10 @@
                (else (walk (jolt-seq (seq-more s))))))))))
 ;; filter/remove are fully lazy (LazySeq): defer the predicate and the source seq
 ;; until forced, like Clojure. (lazy-seq* = a 0-arg lazy node coercing to cseq|nil.)
-(define (jolt-filter pred coll)
-  (jolt-make-lazy-seq (lambda () (jolt-seq (filter-seq pred (jolt-seq coll) #t)))))
-(define (jolt-remove pred coll)
-  (jolt-make-lazy-seq (lambda () (jolt-seq (filter-seq pred (jolt-seq coll) #f)))))
+(define lz-filter
+  (register-lazy-src! 'filter (lambda (pred coll keep) (jolt-seq (filter-seq pred (jolt-seq coll) keep)))))
+(define (jolt-filter pred coll) (jolt-make-lazy-src lz-filter pred coll #t))
+(define (jolt-remove pred coll) (jolt-make-lazy-src lz-filter pred coll #f))
 
 ;; honors `reduced`: a reducing fn that returns (reduced x) stops the fold and
 ;; unwraps to x (so does a reduced INIT). Checked at entry, so the value returned
@@ -1310,7 +1382,7 @@
            ;; the JVM's own arrangement (both LongRange and Range implement
            ;; IChunkedSeq).
            (cseq-chunked/k (make-pvec (list->vector (reverse acc))) 0
-                           (jolt-make-lazy-seq (lambda () (jolt-seq (range-chunked v end step kind))))
+                           (jolt-make-lazy-src lz-range v end (cons step kind))
                            kind))))
     (else jolt-empty-list)))
 ;; Which range class the args select. clojure.core/range sends every argument
@@ -1358,19 +1430,7 @@
   ;; Double/POSITIVE_INFINITY coll) takes the whole coll on the JVM (the count
   ;; never reaches 0); test.check's rose-tree unchunk relies on it. Coercing +inf.0
   ;; to a fixnum index would throw, so take all up front in that case.
-  (jolt-make-lazy-seq
-   (lambda ()
-     (jolt-seq
-      (if (and (flonum? n) (infinite? n))
-          (if (> n 0.0) (jolt-seq coll) jolt-empty-list)
-          (let ((n (->idx n)))
-            (if (fx<=? n 0)
-                jolt-empty-list                  ; (take 0 coll) must not seq its source
-                (let loop ((n n) (s (jolt-seq coll)))
-                  (cond
-                    ((or (fx<=? n 0) (jolt-nil? s)) jolt-empty-list)
-                    ((fx=? n 1) (cseq-lazy (seq-first s) (lambda () jolt-empty-list)))
-                    (else (cseq-lazy (seq-first s) (lambda () (loop (fx- n 1) (jolt-seq (seq-more s)))))))))))))))
+  (jolt-make-lazy-src lz-take n coll #f))
 ;; Dropping from a vector-backed cell is an index jump, not a walk: the result is
 ;; the same backing vector seen from further along. PersistentVector$ChunkedSeq
 ;; implements IDrop on the JVM for exactly this, and it is the difference between
@@ -1410,13 +1470,15 @@
 (define (concat2 a brest)
   (if (jolt-nil? a) (jolt-seq (brest))
       (cseq-lazy (seq-first a) (lambda () (concat2 (jolt-seq (seq-more a)) brest)))))
-(define (jolt-concat . colls)
-  (jolt-make-lazy-seq
-   (lambda ()
-     (jolt-seq
-      (cond ((null? colls) jolt-empty-list)
-            ((null? (cdr colls)) (jolt-seq (car colls)))
-            (else (concat2 (jolt-seq (car colls)) (lambda () (apply jolt-concat (cdr colls))))))))))
+(define lz-concat
+  (register-lazy-src! 'concat
+    (lambda (colls _b _c)
+      (jolt-seq
+       (cond ((null? colls) jolt-empty-list)
+             ((null? (cdr colls)) (jolt-seq (car colls)))
+             (else (concat2 (jolt-seq (car colls))
+                            (lambda () (apply jolt-concat (cdr colls))))))))))
+(define (jolt-concat . colls) (jolt-make-lazy-src lz-concat colls #f #f))
 
 ;; Lazily concatenate a (possibly infinite) SEQ of colls — what (apply concat ss)
 ;; means, but without realizing ss. Pulls one coll at a time, so mapcat /

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -945,6 +945,38 @@
                                     (walk (jolt-agent-validator x) (cons "@validator" path))
                                     (walk (jolt-agent-err-handler x) (cons "@error-handler" path))
                                     #t)))
+                             ;; A clojure.core lazy producer, recorded as its
+                             ;; arguments plus a forcer (seq.ss lazy-src). The
+                             ;; forcer is a procedure and cannot travel, so the
+                             ;; image carries the producer's NAME in its place
+                             ;; and the restore puts the live one back. The
+                             ;; arguments are ordinary values and walk as data,
+                             ;; so a producer over another lazy seq nests and a
+                             ;; self-referential one closes on the memo.
+                             ;;
+                             ;; Restoring a seq this way, rather than forcing it
+                             ;; at dump, is the whole point: an infinite seq
+                             ;; keeps generating and a side effect still has not
+                             ;; run (jolt-a6k2).
+                             ((and (lazy-src? x)
+                                   (if (eq? mode 'restore)
+                                       (lazy-src-proc-of (lazy-src-fn x))
+                                       (lazy-src-name-of (lazy-src-fn x))))
+                              => (lambda (swapped)
+                                   (if (image-rebuild-mode? mode)
+                                       (let ((nx (make-lazy-src swapped #f #f #f)))
+                                         (hashtable-set! memo x nx)
+                                         (image-meta-copy! x nx)
+                                         (lazy-src-a-set! nx (walk (lazy-src-a x) (cons "lazy-arg" path)))
+                                         (lazy-src-b-set! nx (walk (lazy-src-b x) (cons "lazy-arg" path)))
+                                         (lazy-src-c-set! nx (walk (lazy-src-c x) (cons "lazy-arg" path)))
+                                         nx)
+                                       (begin
+                                         (hashtable-set! memo x #t)
+                                         (walk (lazy-src-a x) (cons "lazy-arg" path))
+                                         (walk (lazy-src-b x) (cons "lazy-arg" path))
+                                         (walk (lazy-src-c x) (cons "lazy-arg" path))
+                                         #t))))
                              ((mutex? x)
                               (cond ((eq? mode 'restore) (make-mutex))
                                     ((image-rebuild-mode? mode) (make-image-sync 'mutex))

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -141,6 +141,32 @@
 (rtu "StringBuilder" "(StringBuilder. \"ab\")"
      "(do (.append $rt \"c\") (str $rt))"                    "\"abc\"")
 
+;; --- lazy sequences built by clojure.core (jolt-a6k2) --------------------------
+;; A lazy seq whose thunk is a jolt `lazy-seq` form already travels: the thunk is
+;; an ordinary fn literal, so it registers and rebuilds like any closure, and the
+;; restored seq is still lazy (an infinite one keeps generating). What did not
+;; travel is a thunk clojure.core built -- map/filter/range/take/rest/cons build
+;; theirs as Chez lambdas in seq.ss, runtime Scheme with no source form -- and
+;; ONE core call anywhere in a chain poisoned the whole thing.
+(ev "(defn img-nat [n] (lazy-seq (cons n (img-nat (inc n)))))")
+
+(rtu "core map, unrealized"  "(map inc [1 2 3])"       "(vec $rt)"  "[2 3 4]")
+(rtu "core filter"           "(filter odd? [1 2 3 4])" "(vec $rt)"  "[1 3]")
+(rtu "core range"            "(range 3)"               "(vec $rt)"  "[0 1 2]")
+(rtu "rest of a user lazy"   "(rest (img-nat 0))"      "(vec (take 3 $rt))" "[1 2 3]")
+(rtu "core map over a user lazy" "(map inc (img-nat 0))" "(vec (take 3 $rt))" "[1 2 3]")
+(rtu "take of a user lazy"   "(take 3 (img-nat 0))"    "(vec $rt)"  "[0 1 2]")
+(rtu "cons onto a user lazy" "(cons 9 (img-nat 0))"    "(vec (take 3 $rt))" "[9 0 1]")
+
+;; and the point of carrying it as a producer rather than forcing it at dump: the
+;; restored seq is STILL LAZY. Forcing would both hang on an infinite seq and
+;; move when the side effect runs.
+(ev "(def img-lazy-count (atom 0))")
+(rtu "a restored core lazy seq is still lazy"
+     "(map (fn [x] (swap! img-lazy-count inc) x) [1 2 3])"
+     "[(deref img-lazy-count) (vec $rt) (deref img-lazy-count)]"
+     "[0 [1 2 3] 3]")
+
 (rtu "cons onto vec" "(cons 1 [2 3])"          "(vec $rt)"   "[1 2 3]")
 (rtu "PersistentQueue"
      "(conj clojure.lang.PersistentQueue/EMPTY 1 2)"


### PR DESCRIPTION
"Epic `jolt-v17y`, the round you asked me to measure. Closes `jolt-a6k2`.\n\n## What was broken\n\nA lazy seq written with `lazy-seq` **already travelled** — that thunk is an ordinary fn literal with a recorded source, so it rebuilt like any closure and came back *still lazy*: an infinite generator kept generating, and an unrealized side effect still ran on the restoring side rather than at dump.\n\n`map`, `filter`, `range`, `take` and friends build their thunks as Scheme closures inside the runtime, and a closure carries its captured values where nothing can read them. One core call anywhere in a chain was enough to poison it:\n\n```\n(nat 0)                    travels\n(rest (nat 0))             REFUSED\n(take 3 (nat 0))           REFUSED\n(map inc (nat 0))          REFUSED\n(cons 9 (nat 0))           REFUSED\n```\n\n## What it does now\n\nThose producers record *what they are* — a `lazy-src` descriptor holding the forcer and its arguments — instead of closing over them. The image writes the producer's **name** and the arguments as data; restore re-applies it.\n\nNothing is forced, which is the whole point: forcing would hang on an infinite seq and would move when a side effect runs. The arguments walk as ordinary data, so a producer over another lazy seq nests, and a self-referential one closes on the memo — `(def fib (lazy-cat [0 1] (map + (rest fib) fib)))` round-trips.\n\n`jolt-cons`'s deferred tail is converted too, since a user `lazy-seq` body is usually `(cons x (recur …))` and that single site is what `(rest user-lazy)` hits. `seq-more` gains one record predicate on the force path for it.\n\n## Cost\n\n**Free**, and that is why it is done this way rather than with a sixth field on the cell: the forcer is a top-level procedure called directly, where invoking the closure it replaces went through `jolt-invoke`.\n\nFull suite against `main`, one machine, min of 3 alternating runs:\n\n| | |\n|---|---|\n| 22/22 benches | 0.99x – 1.02x |\n| `seqs` | 1.00x |\n| `collections` / `vecops` / `transients` | 0.99x – 1.02x |\n\n## What is not covered\n\nA chain already walked **part-way**, whose unforced frontier is a per-element `cseq` cell rather than the producer that built it, still refuses. The remaining sites are the per-*element* allocations (`map-seq`, `filter-seq`'s walk, `take`'s loop, `concat2`), two of which need restructuring — `take`'s tail closes over a named-let local, `concat2`'s over a thunk — and where the cost question is genuinely open rather than settled, unlike the per-*call* producers converted here. Tracked as `jolt-0u7m`.\n\n## Gates\n\n`make test` 88 CI + 3 test targets · `make libconformance` 47 ok / 0 regressed · `state-image` 210 assertions · bench 22/22.\n\nSeven new round-trip rows, written failing first: core `map`/`filter`/`range`, `rest`/`take`/`cons`/`map` over a user lazy seq, and one asserting a restored core lazy seq is **still lazy** (a side-effecting producer has not run at dump, and runs on the far side).\n"