### PR TITLE
Complete the state-image round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Free: the forcer is a direct call where invoking the closure went through
   `jolt-invoke`, so the benchmark suite is unchanged (`bench/seqs` 1.00x).
 
-  Not yet covered: a chain already walked part-way, whose frontier is a
-  per-element cell rather than the producer that made it. Those still refuse.
+  A chain already walked part-way travels too: every seq cell carries the same
+  descriptor, not just the producer that made it. What still refuses is a lazy
+  seq from a `clojure.core` *overlay* fn — `cycle`, `repeatedly`, `map-indexed`
+  and the rest are fn literals in `clojure.core`, and the language's own
+  namespaces are not registered, the same limit that stops a `partial` or `comp`
+  closure travelling. That refusal names itself now instead of reporting an
+  anonymous `#<procedure>`, and says to realize the seq first.
+
+  Cost: `bench/seqs` 1.03x, the only benchmark of 22 outside 0.98–1.02x. The
+  per-element cell carries a two-slot descriptor where it used to carry a
+  closure. Measured against the previous release on one machine, min of 5
+  alternating runs.
+
+- **`jolt.image/scan` hung on an infinite unwritable sequence.** A finding
+  describes its object by printing it, and printing a lazy seq realizes it, so
+  scanning `(repeat :z)` never returned. Seqs are described by kind now.
 
 - **Synchronisation primitives travelled into state images as dead objects.** A
   record carrying a mutex or condition variable had no image walker of its own,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closure. Measured against the previous release on one machine, min of 5
   alternating runs.
 
+- **A var-rooted multimethod or `reify` was walked instead of named.** A named
+  fn travels as its var's name and comes back as the live fn. A multimethod is
+  code too, but it is a *record*, so `procedure?` missed it, nothing recorded its
+  var name, and the image descended into its dispatch tables and refused at a raw
+  hashtable naming nothing the user could act on. Both travel as the var's name
+  now and restore as the live object — `identical?`, not a copy.
+
+- **A namespace came back as a second namespace.** `find-ns` is identity-stable
+  and a var round-trips to the identical var, so a restored namespace that merely
+  `=` the live one was out of line with both. Namespaces are interned by name
+  now, like keywords.
+
+- **A transient was written silently, or half-written.** A transient vector
+  travelled while a transient map refused on its backing hashtable. A transient
+  belongs to the thread that made it, which a restore does not have; both refuse
+  now, saying to call `persistent!` first.
+
 - **`jolt.image/scan` hung on an infinite unwritable sequence.** A finding
   describes its object by printing it, and printing a lazy seq realizes it, so
   scanning `(repeat :z)` never returned. Seqs are described by kind now.

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -290,12 +290,18 @@ if [ "$got_cl" != "$want_cl" ]; then
   echo "--- binary ----"; echo "$got_cl"
   echo "--- jolt run --"; echo "$want_cl"; exit 1
 fi
-# ...and both actually wrote one, rather than agreeing on a shared failure.
+# ...and both actually wrote one, rather than agreeing on a shared failure. The
+# img-* lines cover the rest of the value kinds an image carries -- a lazy seq
+# built by clojure.core, one already walked part-way, a multimethod, an unkept
+# promise and a namespace -- through the BUILD emit path, which is a different
+# path from `jolt run` and which nothing else exercises for images.
 if ! printf '%s' "$got_cl" | grep -q '^closure-scan: 0 0$'; then
   echo "  FAIL: spliced closure is not writable (scan reported refusals)"
   echo "--- got ----"; echo "$got_cl"; exit 1
 fi
-for line in 'closure-folded: 115 115' 'closure-live: 110 110'; do
+for line in 'closure-folded: 115 115' 'closure-live: 110 110' \
+            'img-dumpable: true true' 'img-lazy: [1 2 3 4]' 'img-walked: [1 2 3]' \
+            'img-multi: :got-a :dflt' 'img-misc: false true'; do
   if ! printf '%s' "$got_cl" | grep -qF "$line"; then
     echo "  FAIL: spliced closure round trip — want '$line'"
     echo "--- got ----"; echo "$got_cl"; exit 1

--- a/host/chez/lazy-bridge.ss
+++ b/host/chez/lazy-bridge.ss
@@ -47,8 +47,8 @@
 (define (jolt-make-lazy-seq thunk) (make-jolt-lazyseq thunk jolt-nil #f #f #f))
 ;; the descriptor form: a producer that records what it is instead of closing
 ;; over it, so the cell can be written to a state image (seq.ss lazy-src).
-(define (jolt-make-lazy-src fn a b c)
-  (make-jolt-lazyseq (make-lazy-src fn a b c) jolt-nil #f #f #f))
+(define (jolt-make-lazy-src fn a b)
+  (make-jolt-lazyseq (make-lazy-src fn a b) jolt-nil #f #f #f))
 
 ;; force once and memoize. The thunk is (fn [] (coll->cells body)); coll->cells
 ;; already coerced the body to a seq (cseq | nil) via the live jolt-seq, so the
@@ -125,10 +125,10 @@
 ;; written to a state image -- (rest user-lazy) reaches this too, since a user
 ;; `lazy-seq` body is usually (cons x (recur ...)) (seq.ss lazy-src).
 (define lz-cons-tail
-  (register-lazy-src! 'cons-tail (lambda (coll _b _c) (force-lazyseq coll))))
+  (register-lazy-src! 'cons-tail (lambda (coll _b) (force-lazyseq coll))))
 (set! jolt-cons (lambda (x coll)
   (if (jolt-lazyseq? coll)
-      (cseq-lazy x (make-lazy-src lz-cons-tail coll #f #f))
+      (cseq-lazy x (make-lazy-src lz-cons-tail coll #f))
       (%ls-cons x coll))))
 
 ;; (conj lazyseq x): conj onto a seq prepends, like any seq — (conj (rest xs) y).

--- a/host/chez/multimethods.ss
+++ b/host/chez/multimethods.ss
@@ -64,6 +64,10 @@
           cache (mutable cache-epoch) (mutable cache-hier))
   (nongenerative jolt-multifn-v2))
 
+;; a multimethod is CODE: a var holding one travels in a state image as the var's
+;; NAME, the way a named fn does, instead of having its dispatch tables walked.
+(register-code-value! jolt-multifn?)
+
 (define kw-default (keyword #f "default"))
 (define (new-mm-table) (make-hashtable key-hash jolt=))
 

--- a/host/chez/natives-seq.ss
+++ b/host/chez/natives-seq.ss
@@ -111,19 +111,31 @@
       ;; lazily concat the per-element results — no seq->list, so mapcat over an
       ;; infinite source stays lazy; the outer lazy-seq node defers the first
       ;; element so a side-effecting f does not fire at construction (LazySeq).
-      (jolt-make-lazy-seq (lambda () (jolt-seq (lazy-concat-seq (apply jolt-map f colls)))))))
+      (jolt-make-lazy-src lz-mapcat f colls)))
 
 ;; take-while / drop-while: 1-arg -> transducer; 2-arg -> a seq over the coll.
+(define lz-mapcat
+  (register-lazy-src! 'mapcat
+    (lambda (f colls) (jolt-seq (lazy-concat-seq (apply jolt-map f colls))))))
+(define lz-take-while-top
+  (register-lazy-src! 'take-while-top
+    (lambda (pred coll) (jolt-seq (take-while-seq pred (jolt-seq coll))))))
+(define lz-drop-while
+  (register-lazy-src! 'drop-while
+    (lambda (pred coll) (jolt-seq (drop-while-seq pred coll)))))
+(define lz-take-while
+  (register-lazy-src! 'take-while
+    (lambda (pred s) (take-while-seq pred (jolt-seq (seq-more s))))))
 (define (take-while-seq pred s)
   (if (jolt-nil? s) jolt-empty-list
       (let ((x (seq-first s)))
         (if (jolt-truthy? (jolt-invoke pred x))
-            (cseq-lazy x (lambda () (take-while-seq pred (jolt-seq (seq-more s)))))
+            (cseq-lazy x (make-lazy-src lz-take-while pred s))
             jolt-empty-list))))
 (define jolt-take-while
   (case-lambda
     ((pred) (td-take-while pred))
-    ((pred coll) (jolt-make-lazy-seq (lambda () (jolt-seq (take-while-seq pred (jolt-seq coll))))))))
+    ((pred coll) (jolt-make-lazy-src lz-take-while-top pred coll))))
 (define (drop-while-seq pred coll)
   (let loop ((s (jolt-seq coll)))
     (if (and (not (jolt-nil? s)) (jolt-truthy? (jolt-invoke pred (seq-first s))))
@@ -132,37 +144,50 @@
 (define jolt-drop-while
   (case-lambda
     ((pred) (td-drop-while pred))
-    ((pred coll) (jolt-make-lazy-seq (lambda () (jolt-seq (drop-while-seq pred coll)))))))
+    ((pred coll) (jolt-make-lazy-src lz-drop-while pred coll))))
 
 ;; partition: (partition n coll), (partition n step coll), or
 ;; (partition n step pad coll). Only complete partitions of size n are kept;
 ;; with pad, a short final partition is padded from pad (and may be < n if pad
 ;; runs out). Each partition is a seq; the whole result is a lazy seq of seqs.
+(define lz-partition
+  (register-lazy-src! 'partition
+    (lambda (shape coll)
+      (jolt-seq (partition* (car shape) (cadr shape) (caddr shape) (cadddr shape) coll)))))
+(define lz-partition-more
+  (register-lazy-src! 'partition-more
+    (lambda (shape s)
+      (partition-walk (car shape) (cadr shape) (caddr shape) (cadddr shape)
+                      (jolt-seq (advance-by (cadr shape) s))))))
 (define jolt-partition
   (case-lambda
-    ((n coll) (jolt-make-lazy-seq (lambda () (jolt-seq (partition* (->idx n) (->idx n) #f #f coll)))))
-    ((n step coll) (jolt-make-lazy-seq (lambda () (jolt-seq (partition* (->idx n) (->idx step) #f #f coll)))))
-    ((n step pad coll) (jolt-make-lazy-seq (lambda () (jolt-seq (partition* (->idx n) (->idx step) #t pad coll)))))))
+    ((n coll) (jolt-make-lazy-src lz-partition (list (->idx n) (->idx n) #f #f) coll))
+    ((n step coll) (jolt-make-lazy-src lz-partition (list (->idx n) (->idx step) #f #f) coll))
+    ((n step pad coll) (jolt-make-lazy-src lz-partition (list (->idx n) (->idx step) #t pad) coll))))
 (define (take-n n s)               ; -> (values list-of-first-n remaining-seq taken-count)
   (let loop ((n n) (s s) (acc '()))
     (if (or (fx<=? n 0) (jolt-nil? s))
         (values (reverse acc) s (length acc))
         (loop (fx- n 1) (jolt-seq (seq-more s)) (cons (seq-first s) acc)))))
-(define (partition* n step has-pad pad coll)
-  (let loop ((s (jolt-seq coll)))
+(define (partition* n step has-pad pad coll) (partition-walk n step has-pad pad (jolt-seq coll)))
+;; a top-level walk, not a named let, so a cell's tail can name it. The four
+;; shape values ride in one slot as a list -- lazy-src carries three.
+(define (partition-walk n step has-pad pad s0)
+  (let ((shape (list n step has-pad pad)))   ; once per walk, not once per cell
+   (let loop ((s s0))
     (if (jolt-nil? s) jolt-empty-list
         (let-values (((part rest taken) (take-n n s)))
           (cond
             ;; full partition: emit it, advance `step` from its START
             ((fx=? taken n)
              (cseq-lazy (list->cseq part)
-                        (lambda () (loop (jolt-seq (advance-by step s))))))
+                        (make-lazy-src lz-partition-more shape s)))
             ;; short final partition with pad: top up to n from pad, then stop
             ((and has-pad (fx>? taken 0))
              (let ((padded (append part (take-list (- n taken) (jolt-seq pad)))))
-               (cseq-lazy (list->cseq padded) (lambda () jolt-empty-list))))
+               (cseq-lazy (list->cseq padded) (make-lazy-src lz-empty #f #f))))
             ;; short final partition, no pad: dropped (Clojure keeps only full ones)
-            (else jolt-empty-list))))))
+            (else jolt-empty-list)))))))
 (define (advance-by step s)        ; drop `step` elements from s (seq), returns a seq
   (let loop ((step step) (s s))
     (if (or (fx<=? step 0) (jolt-nil? s)) s
@@ -267,10 +292,12 @@
 ;; "vector-backed, ASCENDING from ci" and drive the O(1) count/drop and the
 ;; vec-reduce fast paths, so a descending seq wearing those fields would make all
 ;; three answer for the wrong direction.
+(define lz-vec-rseq
+  (register-lazy-src! 'vec-rseq (lambda (v i) (vec->rseq v (fx- i 1)))))
 (define (vec->rseq v i)
   (if (fx<? i 0)
       jolt-nil
-      (cseq-lazy/k (pvec-nth-d v i jolt-nil) (lambda () (vec->rseq v (fx- i 1))) sk-rseq)))
+      (cseq-lazy/k (pvec-nth-d v i jolt-nil) (make-lazy-src lz-vec-rseq v i) sk-rseq)))
 (define (jolt-rseq coll)
   (cond
     ((pvec? coll)

--- a/host/chez/records-dispatch.ss
+++ b/host/chez/records-dispatch.ss
@@ -393,6 +393,8 @@
 ;; table does not. clojure.core/proxy over a concrete class builds one that way —
 ;; see java/proxy.ss. A plain reify has no delegate and a method miss still throws.
 (define-record-type jreify (fields methods protos delegate) (nongenerative chez-jreify-v2))
+;; likewise a reify: (def r (reify ...)) is code the restoring build already has.
+(register-code-value! jreify?)
 (define (reified-methods obj) (and (jreify? obj) (jreify-methods obj)))
 (define (reify-delegate obj) (and (jreify? obj) (jreify-delegate obj)))
 ;; (get reify k) / (:k reify) routes to a reify's ILookup valAt — clojure.spec.alpha

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -809,10 +809,24 @@
 (define (var-redefined? ns name)
   (jolt-with-mutex var-table-mu
     (hashtable-contains? var-redefined-set (string-append ns "/" name))))
+;; A var root that is CODE rather than data. A procedure always is; a multimethod
+;; and a reify are code too, but they are RECORDS, so `procedure?` misses them and
+;; nothing recorded their name -- which is why a state image walked a multimethod's
+;; dispatch tables and refused it, instead of writing the var's name and resolving
+;; it back to the live one (jolt-2cny). Registered rather than hardcoded because
+;; multimethods.ss and records.ss both load after this file.
+(define code-value-arms '())
+(define (register-code-value! pred) (set! code-value-arms (cons pred code-value-arms)))
+(define (code-value? v)
+  (let loop ((ps code-value-arms))
+    (cond ((null? ps) #f)
+          (((car ps) v) #t)
+          (else (loop (cdr ps))))))
+
 (define (def-var! ns name v)
   ;; first def of a given proc wins, so an alias like (def inc' inc) — which binds
   ;; the SAME proc to a second var — doesn't rename inc.
-  (when (procedure? v)
+  (when (or (procedure? v) (code-value? v))
     (jolt-with-mutex proc-name-mu
       (unless (hashtable-contains? proc-name-tbl v)
         (hashtable-set! proc-name-tbl v (cons ns name)))))

--- a/host/chez/seq.ss
+++ b/host/chez/seq.ss
@@ -126,7 +126,7 @@
 ;; arguments -- a self-referential producer ((def fib (lazy-cat [0 1] (map + fib
 ;; (rest fib))))) reaches its own cell through them.
 (define-record-type lazy-src
-  (fields (mutable fn) (mutable a) (mutable b) (mutable c))
+  (fields (mutable fn) (mutable a) (mutable b))
   (nongenerative jolt-lazy-src-v1))
 
 ;; producer name <-> forcer. The dump needs name-of (a procedure cannot travel);
@@ -139,41 +139,68 @@
   proc)
 (define (lazy-src-name-of proc) (hashtable-ref lazy-src-name-tbl proc #f))
 (define (lazy-src-proc-of name) (hashtable-ref lazy-src-proc-tbl name #f))
-(define (lazy-src-force t)
-  ((lazy-src-fn t) (lazy-src-a t) (lazy-src-b t) (lazy-src-c t)))
+(define (lazy-src-force t) ((lazy-src-fn t) (lazy-src-a t) (lazy-src-b t)))
 ;; a cseq's unforced tail is either a thunk or a descriptor, same as a lazy
 ;; cell's. One record predicate on the force path, measured at no cost.
 (define (cseq-run-tail t) (if (lazy-src? t) (lazy-src-force t) (t)))
 
 ;; forced tail of a seq whose own tail was not yet realized (jolt-rest)
 (define lz-rest
-  (register-lazy-src! 'rest (lambda (s _b _c) (jolt-seq (seq-more s)))))
+  (register-lazy-src! 'rest (lambda (s _b) (jolt-seq (seq-more s)))))
+(define lz-map-more
+  (register-lazy-src! 'map-more
+    (lambda (f s) (map-seq f (jolt-seq (seq-more s))))))
+(define lz-mapN-more
+  (register-lazy-src! 'mapN-more
+    (lambda (f seqs)
+      (map-seq* f (map (lambda (s) (jolt-seq (seq-more s))) seqs)))))
+(define lz-filter-more
+  (register-lazy-src! 'filter-more
+    (lambda (pred s) (filter-seq pred (jolt-seq (seq-more s)) #t))))
+(define lz-remove-more
+  (register-lazy-src! 'remove-more
+    (lambda (pred s) (filter-seq pred (jolt-seq (seq-more s)) #f))))
+(define lz-str-seq
+  (register-lazy-src! 'str-seq (lambda (s i) (str->seq s (fx+ i 1)))))
+(define lz-range-from
+  (register-lazy-src! 'range-from (lambda (n _b) (range-from (+ n 1)))))
+(define lz-repeat
+  (register-lazy-src! 'repeat
+    (lambda (n end+step) (range-chunked n (car end+step) (cdr end+step) sk-repeat))))
+(define lz-iterate
+  (register-lazy-src! 'iterate (lambda (f x) (jolt-iterate f (jolt-invoke1 f x)))))
 (define lz-map-chunk
   (register-lazy-src! 'map-chunk
-    (lambda (f s _c) (jolt-seq (map-seq f (jolt-seq (na-chunk-rest s)))))))
+    (lambda (f s) (jolt-seq (map-seq f (jolt-seq (na-chunk-rest s)))))))
 (define lz-filter-chunk
   (register-lazy-src! 'filter-chunk
-    (lambda (pred s keep) (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)))))
+    (lambda (pred s) (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) #t)))))
+(define lz-remove-chunk
+  (register-lazy-src! 'remove-chunk
+    (lambda (pred s) (jolt-seq (filter-seq pred (jolt-seq (na-chunk-rest s)) #f)))))
 ;; range carries four values through three slots: step and kind share the last.
 (define lz-range
   (register-lazy-src! 'range
-    (lambda (v end step+kind)
-      (jolt-seq (range-chunked v end (car step+kind) (cdr step+kind))))))
+    (lambda (v rest) (jolt-seq (range-chunked v (car rest) (cadr rest) (caddr rest))))))
+(define lz-empty (register-lazy-src! 'empty (lambda (_a _b) jolt-empty-list)))
+;; take's walk is a top-level fn, not a named let, so a cell's tail can name it
+(define (take-walk n s)
+  (cond
+    ((or (fx<=? n 0) (jolt-nil? s)) jolt-empty-list)
+    ((fx=? n 1) (cseq-lazy (seq-first s) (make-lazy-src lz-empty #f #f)))
+    (else (cseq-lazy (seq-first s) (make-lazy-src lz-take-walk (fx- n 1) s)))))
+(define lz-take-walk
+  (register-lazy-src! 'take-walk (lambda (n s) (take-walk n (jolt-seq (seq-more s))))))
 (define lz-take
   (register-lazy-src! 'take
-    (lambda (n coll _c)
+    (lambda (n coll)
       (jolt-seq
        (if (and (flonum? n) (infinite? n))
            (if (> n 0.0) (jolt-seq coll) jolt-empty-list)
            (let ((n (->idx n)))
              (if (fx<=? n 0)
                  jolt-empty-list                 ; (take 0 coll) must not seq its source
-                 (let loop ((n n) (s (jolt-seq coll)))
-                   (cond
-                     ((or (fx<=? n 0) (jolt-nil? s)) jolt-empty-list)
-                     ((fx=? n 1) (cseq-lazy (seq-first s) (lambda () jolt-empty-list)))
-                     (else (cseq-lazy (seq-first s)
-                                      (lambda () (loop (fx- n 1) (jolt-seq (seq-more s)))))))))))))))
+                 (take-walk n (jolt-seq coll)))))))))
 ;; clojure.core/list? — Clojure's (instance? IPersistentList x), which among the
 ;; seq flavors only PersistentList is.
 (define (cseq-list? s) (fx=? (cseq-kind s) sk-list))
@@ -361,7 +388,7 @@
 ;; A string's characters. clojure.lang.StringSeq, and the tail is one too.
 (define (str->seq s i)
   (if (fx>=? i (string-length s)) jolt-nil
-      (cseq-lazy/k (string-ref s i) (lambda () (str->seq s (fx+ i 1))) sk-string-seq)))
+      (cseq-lazy/k (string-ref s i) (make-lazy-src lz-str-seq s i) sk-string-seq)))
 ;; ---- seq arms: host types register here instead of set!-wrapping jolt-seq ----
 ;; Arms dispatch newest-registration-first (cons front, walk head-first), matching
 ;; the precedence the set! chains produced. The built-in types stay inline in
@@ -440,7 +467,7 @@
       ;; result (which may be jolt-empty-list, e.g. map's tail) back to cseq | nil,
       ;; the contract force-lazyseq relies on — else (seq (rest s)) of an empty
       ;; tail yields a truthy empty-list and walkers (distinct, dedupe) overrun.
-      (else (jolt-make-lazy-src lz-rest s #f #f)))))
+      (else (jolt-make-lazy-src lz-rest s #f)))))
 (define (jolt-next x)                  ; nil when the rest is empty
   ;; next = (seq (rest x)): the rest must be RE-SEQ'd so an empty tail collapses to
   ;; nil. seq-more on a lazy seq (e.g. map's) forces to jolt-empty-list, which is
@@ -1165,13 +1192,13 @@
       ((jolt-nil? s) jolt-empty-list)
       ((na-chunked-seq? s)
        (cseq-chunked (na-chunk-map-first s g) 0
-                     (jolt-make-lazy-src lz-map-chunk f s #f)))
+                     (jolt-make-lazy-src lz-map-chunk f s)))
       (else
-       (cseq-lazy (g (seq-first s)) (lambda () (map-seq f (jolt-seq (seq-more s)))))))))
+       (cseq-lazy (g (seq-first s)) (make-lazy-src lz-map-more f s))))))
 (define (map-seq* f seqs)              ; multi-collection map; stops at the shortest
   (if (any-nil? seqs) jolt-empty-list
       (cseq-lazy (apply jolt-invoke f (map seq-first seqs))
-                 (lambda () (map-seq* f (map (lambda (s) (jolt-seq (seq-more s))) seqs))))))
+                 (make-lazy-src lz-mapN-more f seqs))))
 ;; map is fully lazy: Clojure's (map f coll) is a LazySeq whose body — including
 ;; (f (first coll)) — runs only when forced, so a side-effecting f does not fire
 ;; at construction. Wrap the (eager-headed) map-seq in a lazy-seq node; forcing it
@@ -1179,13 +1206,13 @@
 ;; jolt-seq coerces map-seq's result (cseq | jolt-empty-list) to cseq | nil, the
 ;; contract force-lazyseq relies on (see jolt-rest).
 (define lz-map1
-  (register-lazy-src! 'map1 (lambda (f coll _) (jolt-seq (map-seq f (jolt-seq coll))))))
+  (register-lazy-src! 'map1 (lambda (f coll) (jolt-seq (map-seq f (jolt-seq coll))))))
 (define lz-mapN
-  (register-lazy-src! 'mapN (lambda (f colls _) (jolt-seq (map-seq* f (map jolt-seq colls))))))
+  (register-lazy-src! 'mapN (lambda (f colls) (jolt-seq (map-seq* f (map jolt-seq colls))))))
 (define (jolt-map f . colls)
   (if (null? (cdr colls))
-      (jolt-make-lazy-src lz-map1 f (car colls) #f)
-      (jolt-make-lazy-src lz-mapN f colls #f)))
+      (jolt-make-lazy-src lz-map1 f (car colls))
+      (jolt-make-lazy-src lz-mapN f colls)))
 
 ;; Chunk-preserving, like core.clj filter: a chunked source has pred applied to the
 ;; whole chunk, the kept elements packed into a fresh (possibly smaller) chunk, and
@@ -1207,19 +1234,22 @@
              (filter-seq pred (jolt-seq (na-chunk-rest s)) keep)
              (cseq-chunked
               c 0
-              (jolt-make-lazy-src lz-filter-chunk pred s keep)))))
+              (jolt-make-lazy-src (if keep lz-filter-chunk lz-remove-chunk) pred s)))))
       (else
        (let walk ((s s))
          (cond ((jolt-nil? s) jolt-empty-list)
                ((eq? keep (tp (seq-first s)))
-                (cseq-lazy (seq-first s) (lambda () (filter-seq pred (jolt-seq (seq-more s)) keep))))
+                (cseq-lazy (seq-first s)
+                           (make-lazy-src (if keep lz-filter-more lz-remove-more) pred s)))
                (else (walk (jolt-seq (seq-more s))))))))))
 ;; filter/remove are fully lazy (LazySeq): defer the predicate and the source seq
 ;; until forced, like Clojure. (lazy-seq* = a 0-arg lazy node coercing to cseq|nil.)
 (define lz-filter
-  (register-lazy-src! 'filter (lambda (pred coll keep) (jolt-seq (filter-seq pred (jolt-seq coll) keep)))))
-(define (jolt-filter pred coll) (jolt-make-lazy-src lz-filter pred coll #t))
-(define (jolt-remove pred coll) (jolt-make-lazy-src lz-filter pred coll #f))
+  (register-lazy-src! 'filter (lambda (pred coll) (jolt-seq (filter-seq pred (jolt-seq coll) #t)))))
+(define lz-remove
+  (register-lazy-src! 'remove (lambda (pred coll) (jolt-seq (filter-seq pred (jolt-seq coll) #f)))))
+(define (jolt-filter pred coll) (jolt-make-lazy-src lz-filter pred coll))
+(define (jolt-remove pred coll) (jolt-make-lazy-src lz-remove pred coll))
 
 ;; honors `reduced`: a reducing fn that returns (reduced x) stops the fold and
 ;; unwraps to x (so does a reduced INIT). Checked at entry, so the value returned
@@ -1355,7 +1385,7 @@
 
 ;; (range) with no bound is clojure.lang.Iterate on the JVM — it IS (iterate inc' 0)
 ;; there — so it wears the same flavor jolt-iterate does.
-(define (range-from n) (cseq-lazy/k n (lambda () (range-from (+ n 1))) sk-iterate))
+(define (range-from n) (cseq-lazy/k n (make-lazy-src lz-range-from n #f) sk-iterate))
 ;; A bounded range is a real chunked-seq, like clojure.lang.LongRange: eager, with
 ;; chunk-first handing out a block of up to 32 consecutive values. Each block is
 ;; materialized into a pvec and chunk-cons'd onto a lazy continuation, so a chunked
@@ -1373,7 +1403,7 @@
     ((= step 0)
      ;; JVM: (range start end 0) is Repeat.create(start) — it repeats start
      ;; forever, and is a clojure.lang.Repeat, not a range class at all.
-     (cseq-lazy/k n (lambda () (range-chunked n end step sk-repeat)) sk-repeat))
+     (cseq-lazy/k n (make-lazy-src lz-repeat n (cons end step)) sk-repeat))
     ((if (> step 0.0) (< n end) (> n end))
      (let loop ((i 0) (v n) (acc '()))
        (if (and (fx<? i seq-chunk-size) (if (> step 0.0) (< v end) (> v end)))
@@ -1382,7 +1412,7 @@
            ;; the JVM's own arrangement (both LongRange and Range implement
            ;; IChunkedSeq).
            (cseq-chunked/k (make-pvec (list->vector (reverse acc))) 0
-                           (jolt-make-lazy-src lz-range v end (cons step kind))
+                           (jolt-make-lazy-src lz-range v (list end step kind))
                            kind))))
     (else jolt-empty-list)))
 ;; Which range class the args select. clojure.core/range sends every argument
@@ -1430,16 +1460,16 @@
   ;; Double/POSITIVE_INFINITY coll) takes the whole coll on the JVM (the count
   ;; never reaches 0); test.check's rose-tree unchunk relies on it. Coercing +inf.0
   ;; to a fixnum index would throw, so take all up front in that case.
-  (jolt-make-lazy-src lz-take n coll #f))
+  (jolt-make-lazy-src lz-take n coll))
 ;; Dropping from a vector-backed cell is an index jump, not a walk: the result is
 ;; the same backing vector seen from further along. PersistentVector$ChunkedSeq
 ;; implements IDrop on the JVM for exactly this, and it is the difference between
 ;; 625ns and 18.5ms when dropping a million elements. As with count, the step
 ;; loop re-checks per cell so a few plain cells in front of a vector-backed one
 ;; still reach the jump.
-(define (jolt-drop n coll)
-  (jolt-make-lazy-seq
-   (lambda ()
+(define lz-drop
+  (register-lazy-src! 'drop
+    (lambda (n coll)
      (jolt-seq
       (let loop ((n (->idx n)) (s (jolt-seq coll)))
         (cond
@@ -1449,6 +1479,7 @@
            (let ((v (cseq-cvec s)) (i (fx+ (cseq-ci s) n)))
              (if (fx>=? i (pvec-count v)) jolt-empty-list (vec->seq v i))))
           (else (loop (fx- n 1) (jolt-seq (seq-more s))))))))))
+(define (jolt-drop n coll) (jolt-make-lazy-src lz-drop n coll))
 
 ;; (iterate f x) — x, (f x), (f (f x)), … as ONE lazy cell per element.
 ;; The overlay spelling, (cons x (lazy-seq (iterate f (f x)))), costs two records
@@ -1460,25 +1491,30 @@
 ;; Not chunked, matching clojure.lang.Iterate: chunking would realize up to 31
 ;; elements ahead and break the laziness contract callers depend on.
 (define (jolt-iterate f x)
-  (cseq-lazy/k x (lambda () (jolt-iterate f (jolt-invoke1 f x))) sk-iterate))
+  (cseq-lazy/k x (make-lazy-src lz-iterate f x) sk-iterate))
 
 ;; lazily append seq a then the seqable produced by the thunk `brest` — the rest
 ;; is NOT forced until a is exhausted, so concat is fully lazy (Clojure semantics).
 ;; This matters for a self-referential lazy-cat (fib = (lazy-cat [0 1] (map + (rest
 ;; fib) fib))): forcing the rest eagerly at construction would read fib before its
 ;; def binds, memoizing the tail as empty.
+;; brest is the REMAINING COLLS, not a thunk over them: a thunk is a closure, and
+;; a cell whose tail is one cannot be written to a state image (seq.ss lazy-src).
+;; (apply jolt-concat '()) is the empty seq, so the exhausted case still ends.
 (define (concat2 a brest)
-  (if (jolt-nil? a) (jolt-seq (brest))
-      (cseq-lazy (seq-first a) (lambda () (concat2 (jolt-seq (seq-more a)) brest)))))
+  (if (jolt-nil? a) (jolt-seq (apply jolt-concat brest))
+      (cseq-lazy (seq-first a) (make-lazy-src lz-concat2 a brest))))
+(define lz-concat2
+  (register-lazy-src! 'concat2
+    (lambda (a brest) (concat2 (jolt-seq (seq-more a)) brest))))
 (define lz-concat
   (register-lazy-src! 'concat
-    (lambda (colls _b _c)
+    (lambda (colls _b)
       (jolt-seq
        (cond ((null? colls) jolt-empty-list)
              ((null? (cdr colls)) (jolt-seq (car colls)))
-             (else (concat2 (jolt-seq (car colls))
-                            (lambda () (apply jolt-concat (cdr colls))))))))))
-(define (jolt-concat . colls) (jolt-make-lazy-src lz-concat colls #f #f))
+             (else (concat2 (jolt-seq (car colls)) (cdr colls))))))))
+(define (jolt-concat . colls) (jolt-make-lazy-src lz-concat colls #f))
 
 ;; Lazily concatenate a (possibly infinite) SEQ of colls — what (apply concat ss)
 ;; means, but without realizing ss. Pulls one coll at a time, so mapcat /
@@ -1495,19 +1531,24 @@
 ;; An empty inner coll is skipped without emitting a cell, and the outer seq is
 ;; advanced only at a boundary — so f runs once per inner collection, lazily,
 ;; exactly as before.
-(define (lazy-concat-seq ss)
-  (let outer ((s (jolt-seq ss)))
-    (if (jolt-nil? s)
-        jolt-empty-list
-        (let inner ((cur (jolt-seq (seq-first s))))
-          (if (jolt-nil? cur)
-              (outer (jolt-seq (seq-more s)))          ; empty inner: skip, no cell
-              (cseq-lazy (seq-first cur)
-                         (lambda ()
-                           (let ((nx (jolt-seq (seq-more cur))))
-                             (if (jolt-nil? nx)
-                                 (outer (jolt-seq (seq-more s)))   ; boundary
-                                 (inner nx))))))))))
+;; outer/inner are top-level rather than a named let, so a cell's tail can name
+;; them instead of closing over them (seq.ss lazy-src).
+(define (lazy-concat-outer s)
+  (if (jolt-nil? s)
+      jolt-empty-list
+      (lazy-concat-inner (jolt-seq (seq-first s)) s)))
+(define (lazy-concat-inner cur s)
+  (if (jolt-nil? cur)
+      (lazy-concat-outer (jolt-seq (seq-more s)))      ; empty inner: skip, no cell
+      (cseq-lazy (seq-first cur) (make-lazy-src lz-concat-inner cur s))))
+(define lz-concat-inner
+  (register-lazy-src! 'concat-inner
+    (lambda (cur s)
+      (let ((nx (jolt-seq (seq-more cur))))
+        (if (jolt-nil? nx)
+            (lazy-concat-outer (jolt-seq (seq-more s)))   ; boundary
+            (lazy-concat-inner nx s))))))
+(define (lazy-concat-seq ss) (lazy-concat-outer (jolt-seq ss)))
 
 ;; (apply f a b ... coll): spread the trailing seqable into the call.
 ;;

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -61,7 +61,13 @@
       (keyword? x)
       (and (hashtable? x) (not (image-eq-hashtable? x)))
       (port? x)
-      (thread? x)))
+      (thread? x)
+      ;; A var-rooted multimethod or reify: code, like a named fn, and written the
+      ;; same way -- as the var's name through the fn-ref descriptor. code-value?
+      ;; is a two-predicate check and runs before the table lookup, so this costs
+      ;; a walked value nothing it did not already pay (jolt-2cny).
+      (jns? x)
+      (and (code-value? x) (proc-name-of x) #t)))
 
 ;; A record's fields for image purposes: its own AND every parent's, root first —
 ;; the order record-constructor takes them in. record-type-field-names reports only
@@ -256,10 +262,17 @@
     (cond
       (h (list 'handler (jolt-invoke (cadr h) x)))
       ((keyword? x) (list 'kw (keyword-t-ns x) (keyword-t-name x)))
-      ((procedure? x)
+      ;; a namespace is interned by name, exactly like a keyword: a fasl copy
+      ;; would be a SECOND `user` that merely = the live one, where find-ns is
+      ;; identity-stable and a var round-trips to the identical var (jolt-ji1h)
+      ((jns? x) (list 'ns (jns-name x)))
+      ;; A named fn travels as its var's name. So does any other CODE value some
+      ;; var roots -- a multimethod, a reify -- which is not a procedure but is
+      ;; equally something the restoring build already has (rt.ss code-value?).
+      ;; A bare closure has no stable identity to write, so it is refused here
+      ;; and reported with its path.
+      ((or (procedure? x) (proc-name-of x))
        (let ((p (proc-name-of x)))
-         ;; A named fn travels as its var's name. A bare closure has no stable
-         ;; identity to write, so it is refused here and reported with its path.
          (and p (list 'fn-ref (car p) (cdr p)))))
       ;; A non-eq hashtable is refused rather than described. Its contents would
       ;; have to ride in the descriptor stream, which is written WITHOUT an
@@ -273,6 +286,7 @@
   (case (car d)
     ;; back through the intern table, so the restored keyword IS the live one
     ((kw) (keyword (cadr d) (caddr d)))
+    ((ns) (intern-ns! (cadr d)))
     ((fn-ref)
      (let ((c (var-cell-lookup (cadr d) (caddr d))))
        (if (and c (not (jolt-var-unbound? (var-cell-root c))))
@@ -1013,6 +1027,39 @@
                                          (walk (lazy-src-a x) (cons "lazy-arg" path))
                                          (walk (lazy-src-b x) (cons "lazy-arg" path))
                                          #t))))
+                             ;; a var-rooted multimethod or reify: code the
+                             ;; restoring build already has, so it travels as the
+                             ;; var's NAME through the same fn-ref external a
+                             ;; named fn uses. Without this the walk descended
+                             ;; into a multifn's dispatch tables and refused at a
+                             ;; raw hashtable the user could do nothing about
+                             ;; (jolt-2cny).
+                             ;; A transient is thread-owned mutable state whose
+                             ;; owning thread is gone by definition after a
+                             ;; restore, and half of them could not travel anyway
+                             ;; -- a transient vector wrote silently while a
+                             ;; transient map refused on its backing hashtable.
+                             ;; Refuse both, saying what to do (jolt-ji1h).
+                             ((jolt-transient? x)
+                              (cond
+                                ((eq? mode 'rebuild-stub)
+                                 (let ((st (make-stub x path "a transient")))
+                                   (hashtable-set! memo x st) st))
+                                ((image-rebuild-mode? mode)
+                                 (jolt-throw
+                                   (jolt-ex-info
+                                     (string-append
+                                       "image: cannot write a transient at "
+                                       (image-path->string path)
+                                       ": it belongs to the thread that made it, which"
+                                       " a restore does not have. Call persistent! on it"
+                                       " first.")
+                                     empty-pmap)))
+                                (else (hashtable-set! memo x #t)
+                                      (report! x path (image-report-disposition mode)))))
+                             ((and (not (procedure? x)) (proc-name-of x))
+                              (hashtable-set! memo x x)
+                              x)
                              ((mutex? x)
                               (cond ((eq? mode 'restore) (make-mutex))
                                     ((image-rebuild-mode? mode) (make-image-sync 'mutex))

--- a/host/chez/state-image.ss
+++ b/host/chez/state-image.ss
@@ -142,6 +142,13 @@
 (define (image-describe-obj x)
   (cond
     ((procedure? x) "#<procedure>")
+    ;; Never PRINT a seq to describe it. Printing forces it, and an unrealized
+    ;; one can be infinite -- (image-scan (repeat :z)) would hang instead of
+    ;; reporting. A description exists to identify the object, and this does.
+    ;; Reachable since an unwritable lazy cell is refused as ITSELF rather than
+    ;; as the anonymous procedure inside it (jolt-zr91).
+    ((jolt-lazyseq? x) "#<lazy-seq>")
+    ((cseq? x) "#<seq>")
     ((port? x) "#<port>")
     ((thread? x) "#<thread>")
     ((hashtable? x) "#<hashtable>")
@@ -945,6 +952,37 @@
                                     (walk (jolt-agent-validator x) (cons "@validator" path))
                                     (walk (jolt-agent-err-handler x) (cons "@error-handler" path))
                                     #t)))
+;; An unrealized lazy cell whose thunk is a closure the image cannot record.
+                             ;; clojure.core's NATIVE producers carry a descriptor
+                             ;; and travel (below); its overlay ones -- cycle,
+                             ;; repeatedly, map-indexed and the rest -- are fn
+                             ;; literals in clojure.core, and the language's own
+                             ;; namespaces are not registered, which is the same
+                             ;; limit that stops a partial/comp closure travelling.
+                             ;; Refuse by NAME rather than let the generic
+                             ;; procedure refusal report an anonymous #<procedure>
+                             ;; at a path ending in "thunk" (jolt-zr91).
+                             ((and (jolt-lazyseq? x)
+                                   (not (jolt-lazyseq-realized? x))
+                                   (procedure? (jolt-lazyseq-thunk x))
+                                   (not (image-fnsrc-probe (jolt-lazyseq-thunk x))))
+                              (cond
+                                ((eq? mode 'rebuild-stub)
+                                 (let ((st (make-stub x path "an unrealized lazy sequence")))
+                                   (hashtable-set! memo x st) st))
+                                ((image-rebuild-mode? mode)
+                                 (jolt-throw
+                                   (jolt-ex-info
+                                     (string-append
+                                       "image: cannot write an unrealized lazy sequence at "
+                                       (image-path->string path)
+                                       ": it was produced by a clojure.core fn whose body the"
+                                       " image cannot record, the same reason a partial or comp"
+                                       " closure cannot travel. Realize it first (doall), or"
+                                       " store the data it produces.")
+                                     empty-pmap)))
+                                (else (hashtable-set! memo x #t)
+                                      (report! x path (image-report-disposition mode)))))
                              ;; A clojure.core lazy producer, recorded as its
                              ;; arguments plus a forcer (seq.ss lazy-src). The
                              ;; forcer is a procedure and cannot travel, so the
@@ -964,18 +1002,16 @@
                                        (lazy-src-name-of (lazy-src-fn x))))
                               => (lambda (swapped)
                                    (if (image-rebuild-mode? mode)
-                                       (let ((nx (make-lazy-src swapped #f #f #f)))
+                                       (let ((nx (make-lazy-src swapped #f #f)))
                                          (hashtable-set! memo x nx)
                                          (image-meta-copy! x nx)
                                          (lazy-src-a-set! nx (walk (lazy-src-a x) (cons "lazy-arg" path)))
                                          (lazy-src-b-set! nx (walk (lazy-src-b x) (cons "lazy-arg" path)))
-                                         (lazy-src-c-set! nx (walk (lazy-src-c x) (cons "lazy-arg" path)))
                                          nx)
                                        (begin
                                          (hashtable-set! memo x #t)
                                          (walk (lazy-src-a x) (cons "lazy-arg" path))
                                          (walk (lazy-src-b x) (cons "lazy-arg" path))
-                                         (walk (lazy-src-c x) (cons "lazy-arg" path))
                                          #t))))
                              ((mutex? x)
                               (cond ((eq? mode 'restore) (make-mutex))

--- a/host/gambit/records-gambit.ss
+++ b/host/gambit/records-gambit.ss
@@ -2287,6 +2287,8 @@
   (fields methods protos delegate)
   (nongenerative chez-jreify-v2))
 
+(register-code-value! jreify?)
+
 (define (reified-methods obj)
   (and (jreify? obj) (jreify-methods obj)))
 

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -1255,6 +1255,11 @@
 ;; the anon-fn emission registers source forms for image closure capture — a
 ;; no-op keeps those calls inert, matching the image-off degradation.
 (define (image-register-fn-form! . _) #f)
+;; chez's def-var! records the var name of a code value (a multimethod, a reify)
+;; so a state image can write it as a reference. Gambit has no image, so the
+;; registration is a no-op and nothing is ever a named code value.
+(define (register-code-value! . _) #f)
+(define (code-value? x) #f)
 
 ;; jclass?/jclass-name and the class objects they read live in host-vars.ss.
 

--- a/test/chez/build-app/src/app/core.clj
+++ b/test/chez/build-app/src/app/core.clj
@@ -71,7 +71,23 @@
       (img/dump! path folded)
       (println "closure-folded:" (folded 5) ((img/read-image path) 5))
       (img/dump! path live)
-      (println "closure-live:" (live 5) ((img/read-image path) 5))))
+      (println "closure-live:" (live 5) ((img/read-image path) 5))
+      ;; the rest of the value kinds an image is supposed to carry, checked HERE
+      ;; because a built binary is a different emit path from `jolt run` and
+      ;; nothing else exercises images through it
+      (let [lazy (map inc (range 4))
+            walked (let [s (map inc (range 100))] (first s) s)]
+        (println "img-dumpable:" (img/dumpable? lazy) (img/dumpable? util/image-mm))
+        (img/dump! path lazy)
+        (println "img-lazy:" (vec (img/read-image path)))
+        (img/dump! path walked)
+        (println "img-walked:" (vec (take 3 (img/read-image path))))
+        (img/dump! path util/image-mm)
+        (println "img-multi:" ((img/read-image path) :a) ((img/read-image path) :zz))
+        (img/dump! path {:p (promise) :n (find-ns (quote app.core))})
+        (let [back (img/read-image path)]
+          (println "img-misc:" (realized? (:p back))
+                   (identical? (:n back) (find-ns (quote app.core))))))))
 
   ;; --innerfn: a named inner fn inside a spliced callee (jolt-pzos).
   (when (= (first args) "--innerfn")

--- a/test/chez/build-app/src/app/util.clj
+++ b/test/chez/build-app/src/app/util.clj
@@ -110,3 +110,11 @@
 
 (defn make-closure [n]
   (fn [y] (+ closure-base n y)))
+
+;; A multimethod and a lazy sequence, for the built-binary image case in
+;; app.core. Both are things a real program holds in its state, and both used to
+;; refuse in an image: a multimethod had its dispatch tables walked, and a lazy
+;; seq clojure.core built had no recorded source for its thunk.
+(defmulti image-mm (fn [x] x))
+(defmethod image-mm :a [_] :got-a)
+(defmethod image-mm :default [_] :dflt)

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -745,6 +745,37 @@
     (is "a restored agent keeps its state and still takes work"
         "(do (send $agr inc) (await-for 5000 $agr) (deref $agr))" "8")))
 
+;; --- code a var roots travels as the var's NAME (jolt-2cny) --------------------
+;; A named fn already did. A multimethod and a reify are code too, but they are
+;; RECORDS, so `procedure?` missed them, nothing recorded their var name, and the
+;; walk descended into a multifn's dispatch tables and refused at a raw hashtable
+;; the user could do nothing about. They restore as the LIVE object, not a copy.
+(ev "(defmulti sim-mm (fn [x] x)) (defmethod sim-mm :a [_] :got-a) (defmethod sim-mm :default [_] :dflt)")
+(ev "(defprotocol SimP (sim-px [x])) (def sim-rfy (reify SimP (sim-px [_] :from-reify)))")
+(rtu "multimethod"  "sim-mm"
+     "[($rt :a) ($rt :zz) (identical? $rt sim-mm)]"          "[:got-a :dflt true]")
+(rtu "reify"        "sim-rfy"
+     "[(sim-px $rt) (identical? $rt sim-rfy)]"               "[:from-reify true]")
+(rtu "a multimethod inside app state" "{:handler sim-mm}"
+     "((:handler $rt) :a)"                                   ":got-a")
+(is "a multimethod scans clean" "(count (jolt.host/image-scan sim-mm))" "0")
+
+;; --- a namespace is interned, a transient is not written at all (jolt-ji1h) ----
+;; find-ns is identity-stable and a var round-trips to the identical var, so a
+;; namespace coming back as a SECOND `user` that merely = the live one was out of
+;; line with both. It travels by name now, like a keyword.
+(rtu "namespace" "(find-ns 'user)"
+     "[(identical? $rt (find-ns 'user)) (str (ns-name $rt))]"  "[true \"user\"]")
+;; A transient belongs to the thread that made it. A transient VECTOR used to be
+;; written silently while a transient MAP refused on its backing hashtable --
+;; both refuse now, saying what to do.
+(ok "a transient refuses, saying what to do"
+    (str-has? (refusal-of "(transient [1 2])") "persistent!"))
+(is "a transient map refuses too"
+    "(count (jolt.host/image-scan (transient {:a 1})))" "1")
+(is "persistent! is the way through"
+    "(count (jolt.host/image-scan (persistent! (transient [1 2]))))" "0")
+
 (ok "restore mints a live primitive over a raw one from an old image"
     (let* ((dead (vector (make-mutex) (make-condition)))
            (healed (let-values (((g _) (image-graph-process dead 'restore #f))) g)))
@@ -1298,6 +1329,41 @@
 
 (cleanup!)
 (when (file-exists? (string-append tmp ".txt")) (delete-file (string-append tmp ".txt")))
+
+;; --- the API surface (jolt-hnlk) ----------------------------------------------
+;; The handler READ side had no coverage at all: the existing handler test writes
+;; and inspects the graph, and never restores through image-restore-handler. So
+;; the restore-fn running, the first-accepting-wins order, and a restore-fn that
+;; THROWS falling through to the next -- the contract register-handler!'s own
+;; docstring states -- were unasserted.
+(ev "(jolt.host/image-register-handler! (fn [x] (and (map? x) (:res2 x))) (fn [x] {:tag :second}) (fn [d] (if (= (:tag d) :second) {:restored :by-second} (throw (ex-info \"not mine\" {})))))")
+;; registered LAST, so it is tried FIRST and must decline by throwing
+(ev "(jolt.host/image-register-handler! (fn [x] (and (map? x) (:res2 x))) (fn [x] {:tag :second}) (fn [d] (throw (ex-info \"never mine\" {}))))")
+(rtu "a handler's restore-fn runs" "{:r {:res2 true}}"
+     "(:restored (:r $rt))"                                  ":by-second")
+
+;; dump-world! takes an explicit namespace list, and {:unwritable :fail} restores
+;; dump!'s strictness where the default stubs.
+(ev "(in-ns 'apiworld) (def api-data {:a 1}) (in-ns 'user)")
+(def-var! "apiworld" "api-port"
+  (open-file-output-port (string-append tmp ".api-probe.txt") (file-options no-fail)))
+(is "dump-world! of a named ns writes it"
+    (string-append "(do (jolt.host/image-dump-world! \"" tmp "\" [\"apiworld\"]) "
+                   " (jolt.host/image-restore-world! \"" tmp "\"))")
+    "2")
+;; NOT covered here: dump-world! {:unwritable :fail}. It walks whole namespaces,
+;; and by this point in the file enough handlers and resolvers are registered that
+;; the default stubs NOTHING -- so a row asserting ":fail refuses where the default
+;; stubs" asserts nothing at all. Verified by hand instead (jolt-hnlk).
+
+;; a resolver spec may be a KIND STRING rather than a predicate; only the
+;; predicate form was covered. Asserted on the matcher directly, because
+;; resolvers are global and registration order decides which one claims a stub.
+(ok "a resolver spec given as a kind string matches that kind"
+    (and (image-stub-resolver-match ":object"
+           (jolt-hash-map (jolt-keyword "kind") ":object"))
+         (not (image-stub-resolver-match ":port"
+                (jolt-hash-map (jolt-keyword "kind") ":object")))))
 
 (printf "~a/~a state-image assertions passed\n" (- total fails) total)
 (when (> fails 0) (exit 1))

--- a/test/chez/state-image-test.ss
+++ b/test/chez/state-image-test.ss
@@ -93,6 +93,25 @@
 (rt "empty colls" "[[] {} #{} ()]"                 "[[] {} #{} ()]")
 (rt "record"      "(do (defrecord P [x y]) (->P 1 2))" "#user.P{:x 1, :y 2}")
 
+(define (str-has? s sub)
+  (let ((n (string-length s)) (m (string-length sub)))
+    (let loop ((i 0))
+      (cond ((fx>? (fx+ i m) n) #f)
+            ((string=? (substring s i (fx+ i m)) sub) #t)
+            (else (loop (fx+ i 1)))))))
+(define (refusal-of expr)
+  (cleanup!)
+  (call/cc (lambda (k)
+    (with-exception-handler
+      (lambda (e) (k (if (jolt-ex-info-record? e)
+                         (jolt-ex-info-record-message e)
+                         (call/cc (lambda (k2)
+                           (with-exception-handler (lambda (_) (k2 "?"))
+                             (lambda () (condition->message-string e))))))))
+      (lambda ()
+        (ev (string-append "(jolt.host/image-write! \"" tmp "\" " expr ")"))
+        "WROTE")))))
+
 ;; --- the value-kind matrix: restored values must still WORK ---------------------
 ;; `rt` above compares printed forms, which settles a value type. It settles
 ;; nothing for a value whose identity IS its meaning: = is identity for an atom, a
@@ -166,6 +185,41 @@
      "(map (fn [x] (swap! img-lazy-count inc) x) [1 2 3])"
      "[(deref img-lazy-count) (vec $rt) (deref img-lazy-count)]"
      "[0 [1 2 3] 3]")
+
+;; ...and a chain already walked PART-WAY. Its unforced frontier is a per-element
+;; cell rather than the producer that built it, so these needed every cseq tail
+;; to carry a descriptor too, not just the producer entry points (jolt-0u7m).
+(rtu "map walked part-way"
+     "(let [s (map inc (range 100))] (first s) s)"
+     "(vec (take 4 $rt))"                                    "[1 2 3 4]")
+(rtu "rest of a core map"    "(rest (map inc [1 2 3]))" "(vec $rt)" "[3 4]")
+(rtu "filter walked part-way"
+     "(let [s (filter odd? (range 100))] (first s) s)"
+     "(vec (take 3 $rt))"                                    "[1 3 5]")
+(rtu "infinite iterate walked"
+     "(let [s (iterate inc 0)] (first s) (rest s))"
+     "(vec (take 3 $rt))"                                    "[1 2 3]")
+;; cycle and repeat are clojure.core OVERLAY fns: their thunk is a fn literal in
+;; clojure.core, and the language's own namespaces are not registered -- the same
+;; limit that stops a partial or comp closure travelling. They refuse, and the
+;; refusal has to name what it is rather than report an anonymous #<procedure>.
+(ok "scanning an INFINITE unwritable seq terminates"
+    ;; describing a finding used to print the object, which forces it
+    (= 1 (jolt-count (jolt-compile-eval "(jolt.host/image-scan (repeat :z))" "user"))))
+(ok "an overlay lazy seq refuses, naming itself"
+    (str-has? (refusal-of "(cycle [1 2])") "unrealized lazy sequence"))
+(is "an overlay lazy seq scans as unwritable"
+    "(count (jolt.host/image-scan (repeat :z)))" "1")
+(is "realizing it first is the way through"
+    "(count (jolt.host/image-scan (doall (take 3 (repeat :z)))))" "0")
+(rtu "take-while"   "(take-while odd? [1 3 4 5])" "(vec $rt)" "[1 3]")
+(rtu "partition"    "(partition 2 (range 7))"    "(vec (map vec $rt))" "[[0 1] [2 3] [4 5]]")
+(rtu "mapcat"       "(mapcat (fn [x] [x x]) [1 2])" "(vec $rt)" "[1 1 2 2]")
+(rtu "string seq walked"
+     "(let [s (seq \"abc\")] (first s) s)"      "(vec $rt)"  "[\\a \\b \\c]")
+(rtu "rseq"         "(rseq [1 2 3])"             "(vec $rt)"  "[3 2 1]")
+(rtu "concat walked part-way"
+     "(let [s (concat [1] [2 3])] (first s) s)"  "(vec $rt)"  "[1 2 3]")
 
 (rtu "cons onto vec" "(cons 1 [2 3])"          "(vec $rt)"   "[1 2 3]")
 (rtu "PersistentQueue"
@@ -664,24 +718,6 @@
 ;; restored running future never completes, so deref hangs forever, and a
 ;; restored agent that believes it has a busy worker queues every later send
 ;; behind nothing.
-(define (str-has? s sub)
-  (let ((n (string-length s)) (m (string-length sub)))
-    (let loop ((i 0))
-      (cond ((fx>? (fx+ i m) n) #f)
-            ((string=? (substring s i (fx+ i m)) sub) #t)
-            (else (loop (fx+ i 1)))))))
-(define (refusal-of expr)
-  (cleanup!)
-  (call/cc (lambda (k)
-    (with-exception-handler
-      (lambda (e) (k (if (jolt-ex-info-record? e)
-                         (jolt-ex-info-record-message e)
-                         (call/cc (lambda (k2)
-                           (with-exception-handler (lambda (_) (k2 "?"))
-                             (lambda () (condition->message-string e))))))))
-      (lambda ()
-        (ev (string-append "(jolt.host/image-write! \"" tmp "\" " expr ")"))
-        "WROTE")))))
 
 ;; sleeps far longer than the gate takes, so it is still running when written --
 ;; no window to get wrong, since the row only needs "not done yet"


### PR DESCRIPTION
"Finishes epic `jolt-v17y`. State images round-trip every value kind the language has, or refuse by name.\n\n## Lazy sequences, walked or not\n\n#783 gave the lazy *producers* descriptors. A chain already walked part-way still refused, because its unforced frontier is a per-element `cseq` cell. Every seq cell carries a descriptor now — `map-seq`, `filter-seq`, `take`'s walk, `concat2`, `lazy-concat-seq`, `str->seq`, `range-from`, `repeat`, `iterate`, `take-while`, `partition`, `rseq`, `drop`. Four needed restructuring first: `take`'s and `partition`'s walks were named lets whose tails closed over the loop variable, `concat2` closed over a thunk rather than the colls behind it, `lazy-concat-seq` over two. All top-level now, which is what lets a cell's tail *name* them.\n\n**This one is not free.** `bench/seqs` 1.03x — the only bench of 22 outside 0.98–1.02x, min of 5 alternating runs against `main`. The per-element cell carries a two-slot descriptor where it carried a closure. The first cut was **1.08x** with three slots; narrowing to two (splitting the filter/remove forcers on their boolean instead of passing it, packing `range` and `repeat`'s rare tails, hoisting `partition`'s shape list out of its loop) took it to 1.03x. Worth it for the correctness and well inside the 1.1x ceiling, but it is a real cost on the hottest path and should be read as one.\n\nStill refused: a lazy seq from a `clojure.core` **overlay** fn (`cycle`, `repeatedly`, `map-indexed`). Those thunks are fn literals in `clojure.core`, and the language's own namespaces are not registered — the same limit that stops a `partial` closure travelling, and its cause is that the seed prelude must stay byte-identical. Lifting it means letting core literals register, which grows the prelude; a separate decision. The refusal names itself now.\n\n## Code, namespaces, transients\n\n- **A var-rooted multimethod or `reify`** is code the restoring build has, like a named fn — but both are *records*, so `def-var!`'s `procedure?` test missed them and the walk descended into a multifn's dispatch tables, refusing at a raw hashtable. They travel as the var's name and restore `identical?` to the live object.\n- **A namespace** came back as a *second* namespace. `find-ns` is identity-stable and a var round-trips to the identical var, so this was out of line with both. Interned by name now.\n- **A transient** was written silently — a transient vector travelled while a transient map refused on its backing hashtable. Both refuse now, saying to call `persistent!`.\n\n## Two bugs the tests found\n\n- `jolt.image/scan` **hung** on an infinite unwritable sequence: a finding describes its object by printing it, and printing a lazy seq realizes it. Seqs are described by kind.\n- The Gambit host needed the mirrored shim — `records-gambit.ss` is generated from `records-dispatch.ss`, so the new registration reached it.\n\n## Coverage\n\nThe handler **read** side was entirely untested: the restore-fn running, first-accepting-wins across two handlers, and a restore-fn that throws falling through — the contract `register-handler!`'s own docstring states. Pinned, along with `dump-world!` with an explicit namespace list and a resolver given a kind string.\n\n`dump-world!` `{:unwritable :fail}` is **not** pinned, and the file says so: it walks whole namespaces, and by that point enough handlers and resolvers are registered that the default stubs nothing — the row asserted nothing, so it was removed rather than shipped green.\n\n`build-smoke`'s `--closure` case grew into a real image case: a core lazy seq, one walked part-way, a multimethod, an unkept promise and a namespace, all round-tripped **inside a built binary** — a different emit path from `jolt run`, which nothing else exercised for images.\n\n## Gates\n\n`make test` 88 CI + 3 test targets · `make libconformance` 47 ok / 0 regressed · `state-image` 235 assertions deterministic over three runs · bench 22/22.\n\nCloses jolt-0u7m, jolt-2cny, jolt-ji1h, jolt-hnlk, jolt-wo9u, jolt-zr91 — and epic jolt-v17y.\n"