### PR TITLE
Name every core fn in value position, so values built from one can travel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set!`-extended after their `def-var!` so the procedure you get was never the
   one recorded.
 
+- **Ten `clojure.core` fns could not be written to a state image when used as a
+  VALUE.** `seq`, `get`, `nth`, `peek`, `pop`, `min`, `max`, `mod`, `rem` and
+  `quot`, plus `bit-and`/`bit-or`/`bit-xor`/`some?` — so `(tree-seq branch? seq
+  root)` refused, and so would `(map seq colls)`. A core fn in value position
+  compiles to the runtime's own procedure rather than the var's root, and an
+  image writes a procedure as its var name; `def-var!` records that name for the
+  procedure it was handed, but these are `set!`-extended afterwards (lazy
+  sequences taught to `seq`, arrays to `nth`, the checked numeric layer taking
+  over `min` and `quot`), and the extension was a new procedure nothing named.
+
+  The names are re-registered after every extension has run. `make coreproc`
+  sweeps the var table and fails if any core fn is unnameable in value position,
+  so the next extension that forgets is caught here rather than surfacing as an
+  image that will not write. It checks 719 fns.
+
 - **`jolt.image/scan` disagreed with `dump!` about captured values.** The scan
   walked a registered closure's free values with a stub that inspected nothing,
   so a value whose capture was unwritable scanned clean and then refused at dump

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ JOLT-TARGETS-NEEDING-DEPS := \
   aotcacheperf aotcachesmoke aotfingerprint asynctimer buildlibsmoke buildsmoke \
   aotcachepathsmoke compilepathsmoke contagion corpus cts dcerefs depssmoke depsunit devboot \
   readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling \
-  devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform grenadine \
+  devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform coreproc grenadine \
   gateboot gatebootsmoke gosm hasheq httpsfetch infer inline inline-body irvalidate \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
   narrow numeric numwp oparity pic protoret printperf remint sbperf sci selfhost shakelocal \
@@ -128,7 +128,7 @@ CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscali
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
-  fnform traceemit traceeval degradedbacktrace \
+  fnform coreproc traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck shelloutcheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
@@ -709,6 +709,14 @@ directlink:
 # closure's inspector name must agree; system-ns closures stay unregistered.
 fnform:
 	@$(CHEZ) --script test/chez/fnform-test.ss
+
+# Every clojure.core fn must be nameable in value position: the state image
+# writes a procedure as its var NAME, and a native that is set!-extended after
+# its def-var! leaves a procedure nothing named — so values built from it stop
+# being writable, silently. Swept from the var table, so a fn added later is
+# covered without anyone remembering.
+coreproc:
+	@$(CHEZ) --script test/chez/core-proc-name-test.ss
 
 # Compilation-unit context: the emit-session state (mode flags, direct-link
 # registries, ctor shapes, gensym, cache cells) is per-unit, so two units are

--- a/host/chez/post-prelude.ss
+++ b/host/chez/post-prelude.ss
@@ -358,3 +358,45 @@
                  (number? x) (char? x) (boolean? x) (jolt-nil? x) (procedure? x))
              #f)
             (else (jolt-invoke1 prev x))))))
+
+;; --- value-position natives are nameable ---------------------------------------
+;; A core fn used as a VALUE compiles to the runtime's Scheme procedure, not to
+;; the var's root, and the image writes a procedure as its var NAME. def-var!
+;; records that name -- but only for the procedure it was handed, and seq/get/nth
+;; are set!-EXTENDED afterwards (lazy-bridge for a lazy seq, records-coll for a
+;; deftype, natives-array for an array, nio-file for a Path). The extension is a
+;; new procedure nothing named, so (tree-seq vector? seq coll) refused to travel
+;; while 37 of 40 core fns sampled were fine.
+;;
+;; Registered HERE rather than beside each set!, because "the last extension" is
+;; not a place any one file can know it is: three files extend jolt-nth. This
+;; runs after every one of them. Same fix rt.ss already applies to the comparison
+;; chain singletons (jolt-lt/gt/le/ge), for the same reason (jolt-6cwk).
+;;
+;; `make coreproc` fails if any core fn goes unnameable, so a new extension that
+;; forgets is caught rather than discovered by an image that will not write.
+(for-each (lambda (p) (register-proc-name! (cdr p) "clojure.core" (car p)))
+          (list (cons "seq" jolt-seq)
+                  (cons "get" jolt-get)
+                  (cons "nth" jolt-nth)
+                  (cons "sequential?" jolt-sequential?)
+                  (cons "seq?" jolt-seq?)
+                  (cons "peek" jolt-peek)
+                  (cons "pop" jolt-pop)
+                  ;; value position compiles to the checked numeric layer's own
+                  ;; procedures, while the var roots went elsewhere -- the same
+                  ;; split as the comparison chain registered in rt.ss
+                  (cons "min" jolt-min)
+                  (cons "max" jolt-max)
+                  (cons "mod" jolt-mod)
+                  (cons "rem" jolt-rem)
+                  (cons "quot" jolt-quot)
+                  (cons "bit-and" jolt-bit-and*)
+                  (cons "bit-or" jolt-bit-or*)
+                  (cons "bit-xor" jolt-bit-xor*)
+                  (cons "some?" jolt-some?-fn)
+                  ;; protocol dispatch entry points: internal, but they are var
+                  ;; roots and a value built from one is as unwritable as any
+                  (cons "protocol-dispatch1" protocol-dispatch1)
+                  (cons "protocol-dispatch2" protocol-dispatch2)
+                (cons "protocol-dispatch3" protocol-dispatch3)))

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -803,6 +803,16 @@
 ;; (java/host-class.ss) — so none of them can afford to skip it either.
 (define proc-name-mu (make-mutex))
 (define (proc-name-of v) (jolt-with-mutex proc-name-mu (hashtable-ref proc-name-tbl v #f)))
+;; Name a procedure def-var! never saw. A core fn in VALUE position compiles to
+;; the runtime's own procedure, not the var's root, and a native that is
+;; set!-extended after its def-var! leaves that procedure unnamed -- so an image,
+;; which writes a procedure as its var name, could not write values built from it.
+;; post-prelude.ss calls this once everything has finished extending; the shared
+;; file reaches it through this rather than the table, so the Gambit host can shim
+;; it (jolt-6cwk).
+(define (register-proc-name! v ns name)
+  (jolt-with-mutex proc-name-mu (hashtable-set! proc-name-tbl v (cons ns name)))
+  v)
 ;; "ns/name" of every var defined more than once with a value. Guarded by
 ;; var-table-mu like the other var-table side sets; reads are single-key.
 (define var-redefined-set (make-hashtable string-hash string=?))

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -1259,6 +1259,9 @@
 ;; so a state image can write it as a reference. Gambit has no image, so the
 ;; registration is a no-op and nothing is ever a named code value.
 (define (register-code-value! . _) #f)
+;; chez names a procedure def-var! never saw, so a state image can write it as a
+;; var reference. Gambit has no image; the registration is a no-op.
+(define (register-proc-name! v . _) v)
 (define (code-value? x) #f)
 
 ;; jclass?/jclass-name and the class objects they read live in host-vars.ss.

--- a/stdlib/jolt/image.clj
+++ b/stdlib/jolt/image.clj
@@ -14,10 +14,18 @@
   evaluates the fn sources it carries, so only load images you trust, the
   same way you would only load code you trust.
 
+  Lazy sequences travel unforced, and stay lazy: an infinite one keeps
+  generating after a restore, and a side effect that had not run still has not.
+  A multimethod, a reify, and a namespace travel as their name and come back as
+  the live object.
+
   What still refuses: a closure whose captured local was optimized into the
   compiled code (a let over compile-time constants — the message names the
-  capture), and open resources with neither a handler nor stub mode. Use
-  `scan` to find both without writing anything."
+  capture), a future that has not completed and a transient (both belong to a
+  thread a restore does not have), a fn the runtime built rather than analyzed,
+  and open resources with neither a handler nor stub mode. Use `scan` to find
+  any of them without writing anything; `dump!` with {:unwritable :stub} writes
+  placeholders instead of refusing."
   (:require [jolt.host :as host]))
 
 (defn dump!

--- a/test/chez/core-proc-name-test.ss
+++ b/test/chez/core-proc-name-test.ss
@@ -1,0 +1,69 @@
+;; Every clojure.core fn must be NAMEABLE in value position. Run:
+;;   chez --script test/chez/core-proc-name-test.ss
+;;
+;; A core fn used as a VALUE — (tree-seq branch? seq root), (map seq colls),
+;; (sorted-map-by >) — compiles to the runtime's own Scheme procedure, not to the
+;; var's root. The state image writes a procedure as its var NAME, and def-var!
+;; records that name for the procedure it was handed. When a native is
+;; set!-EXTENDED afterwards (lazy-bridge teaching seq about lazy seqs,
+;; natives-array teaching nth about arrays, the numeric layer taking over min and
+;; quot), the extension is a NEW procedure nothing named — and every value built
+;; from it silently stops being writable.
+;;
+;; That is how seq, get, nth, peek, pop, min, max, mod, rem and quot came to be
+;; unwritable while 37 of 40 fns spot-checked were fine (jolt-6cwk). The names are
+;; re-registered in post-prelude.ss, after every extension has run; this gate is
+;; what makes the NEXT extension that forgets fail here instead of surfacing as an
+;; image that will not write.
+;;
+;; Swept from the var table rather than a hand-written list, so a fn added later
+;; is covered without anyone remembering to add it.
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define total 0) (define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))
+
+;; a name whose value position cannot even be EVALUATED is a macro or a special
+;; form, not a fn — skipped, not failed
+(define (value-of name)
+  (call/cc (lambda (k)
+    (with-exception-handler (lambda (e) (k 'no-value))
+      (lambda () (jolt-compile-eval name "user"))))))
+
+(define unnameable '())
+(define checked 0)
+(for-each
+  (lambda (name)
+    (let ((root (var-deref "clojure.core" name)))
+      (when (procedure? root)
+        (let ((v (value-of name)))
+          (when (procedure? v)
+            (set! checked (+ checked 1))
+            (unless (proc-name-of v)
+              (set! unnameable (cons name unnameable))))))))
+  ;; var-table is keyed "ns/name"; take clojure.core's, unqualified
+  (sort string<?
+        (let loop ((ks (vector->list (hashtable-keys var-table))) (acc '()))
+          (cond ((null? ks) acc)
+                ((and (> (string-length (car ks)) 13)
+                      (string=? (substring (car ks) 0 13) "clojure.core/"))
+                 (loop (cdr ks) (cons (substring (car ks) 13 (string-length (car ks))) acc)))
+                (else (loop (cdr ks) acc))))))
+
+(ok (string-append "every core fn is nameable in value position; unnameable: "
+                   (let loop ((l (sort string<? unnameable)) (acc ""))
+                     (if (null? l) (if (string=? acc "") "none" acc)
+                         (loop (cdr l) (string-append acc (if (string=? acc "") "" " ") (car l))))))
+    (null? unnameable))
+
+;; the shape that found it: tree-seq hands `seq` in as a value
+(ok "a value-position native travels in an image"
+    (zero? (jolt-count (jolt-compile-eval
+                         "(jolt.host/image-scan (tree-seq vector? seq [[1] 2]))" "user"))))
+
+(printf "core-proc-name: ~a core fns checked, ~a/~a assertions passed\n"
+        checked (- total fails) total)
+(exit (if (= fails 0) 0 1))


### PR DESCRIPTION
"Closes `jolt-6cwk`, the residual from #785.\n\nTen `clojure.core` fns could not be written to a state image when used as a **value** — and the sweep below turned that into fifteen:\n\n```\nseq get nth peek pop min max mod rem quot\nbit-and bit-or bit-xor some? protocol-dispatch{1,2,3}\n```\n\n`(tree-seq branch? seq root)` refused because of it. So would `(map seq colls)`, or a comparator stored as `(sorted-map-by min)`.\n\n## Why\n\nA core fn in value position compiles to the runtime's own procedure, not to the var's root, and an image writes a procedure as its var **name**. `def-var!` records that name — for the procedure it was handed. These are `set!`-**extended** afterwards (`lazy-bridge` teaching `seq` about lazy seqs, `natives-array` teaching `nth` about arrays, `nio-file` about a `Path`, the checked numeric layer taking over `min` and `quot`), and the extension is a new procedure nothing ever named.\n\n`rt.ss` already fixed exactly this for the comparison-chain singletons `jolt-lt`/`gt`/`le`/`ge`, with the same comment. Those registrations run mid-`rt.ss`, before the later extensions — hence this one runs in `post-prelude.ss`, after all of them. Three files extend `jolt-nth` alone, so \"beside the last `set!`\" is not a place any single file can know it is.\n\nIt goes through a new `rt.ss` seam rather than poking `proc-name-tbl` directly, because `post-prelude.ss` is shared with the Gambit host, which has no such table and now shims the seam.\n\n## The durable part\n\n`make coreproc` sweeps the **var table** — not a hand-written list — resolves every `clojure.core` fn in value position, and fails if any is unnameable. **719 fns checked.** A name that cannot be evaluated at all is a macro or special form, and is skipped rather than failed. It also pins the shape that found this, `tree-seq` handing `seq` in as a value.\n\nThat sweep is what turned a fix for three names into a fix for fifteen: the hand-list I started from reported 3 of 40.\n\n## Gates\n\n`make test` 88 CI + 3 test targets (89 with `coreproc`) · `make libconformance` 47 ok / 0 regressed · `gambitboot` OK.\n\nSite docs next: RFC 0009's Limits section still says `partial`/`comp`/`memoize` closures cannot travel, which #785 made false.\n"