### PR TITLE
Capture errno at the syscall, not after it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.29] - 2026-08-30
+
+Two threads. Splicing a `defn` body at a call site follows **linkage** now
+rather than a build flag, so every non-dev build inlines — and the round that
+made that true shook four bugs out of the inline pass, every one of which an
+`--opt` build could already hit.
+
+The other is state images. `jolt.image` wrote maps, vectors and records, and
+quietly could not write most of the rest of the language: a `promise` or an
+`agent` came back holding dead OS primitives that worked until something waited
+on them, a lazy sequence from `map` refused outright, a multimethod had its
+dispatch tables walked and refused at a raw hashtable, and every closure
+`clojure.core` made — `partial`, `comp`, `memoize`, `cycle` — refused because
+core's fn literals were never recorded. That last one was written up as a limit
+of the *format*; it was a limit of the build. Images round-trip every value kind
+the language has now, or refuse by name and say what to do about it.
+
 ### Added
 
 - **Every non-dev build inlines, and the seed's var references are hoisted.**
@@ -75,6 +92,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runs unchanged.
 
 ### Fixed
+
+- **A socket read could answer EOF on a live connection, under load.**
+  `jolt.socket`'s syscall wrapper read `errno` *after* the call, and twice — once
+  to ask about `EINTR`, once about `EAGAIN`. `errno` survives only until the next
+  thing that can set it, and reading it is itself a foreign call, so the two
+  questions were not about the same value: under CPU load `recv`'s `EAGAIN` (35)
+  read back as `ENOMEM` (12) often enough to matter. The retry branch was missed,
+  the `-1` fell through, and the read reported end-of-stream on a connection that
+  was simply not ready yet. Callers saw a socket close for no reason — inside a
+  `go` block, an exception and a channel that closed with no value.
+
+  `errno` is captured once now, at the syscall, and the branch reads that value;
+  the same for `connect`. Measured on the poller stress case: 13 of 60 runs under
+  load before, 0 of 100 after. `make errnocheck` fails if a syscall wrapper asks
+  twice again — the two spellings are indistinguishable in review, and this one
+  presented as a lost poller registration, which sent the search to the wrong
+  subsystem entirely.
 
 - **A closure `clojure.core` made could not be written to a state image.**
   `partial`, `comp`, `memoize`, `juxt`, `fnil`, `complement`, and every lazy
@@ -360,6 +394,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `java.lang.String`'s registration. Feature detection — which is what `resolve`
   on a class name is for — read that as "this class is present" and took the
   branch. Answers `nil` now, like the JVM.
+
+### Performance
+
+- **`bench/seqs` is 1.03x slower**, the only benchmark of 22 outside 0.98–1.02x.
+  Every lazy sequence cell carries a two-slot descriptor of the producer that
+  made it where it used to carry a closure — which is what lets a lazy sequence
+  travel in a state image unforced, walked or not. Measured against the previous
+  release on one machine, min of 5 alternating runs.
+
+- **A built binary is about 1MB larger** (roughly 4%). `clojure.core`'s fn
+  literals now record their source so core's closures can travel, which grows
+  the seed prelude from 1.30MB to 1.75MB and the compiler image from 833KB to
+  1.04MB. Startup is unchanged — 0.1806s against 0.1819s, min of 5 — because
+  the registrations are hashtable inserts, not work.
+
+- App-to-app calls are about 1.70x faster in a default release build, and
+  `clojure.core` no longer re-resolves var names at each reference. See the
+  inlining entry under Added for the per-benchmark figures.
 
 ### Internal
 

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscali
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform coreproc traceemit traceeval degradedbacktrace \
-  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck shelloutcheck irvalidate devbootsmoke \
+  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
   certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety
@@ -839,6 +839,12 @@ parkcheck:
 # remembered.
 shelloutcheck:
 	@sh host/chez/shellout-check.sh
+
+# errno survives only until the next thing that can set it, and reading it is
+# itself a foreign call — so a syscall wrapper must capture it once, at the
+# syscall, and branch on the value. See the script for what asking twice cost.
+errnocheck:
+	@sh host/chez/errno-check.sh
 
 # Makefile dependency selection: explicit Chez overrides must bypass local
 # Makes provisioning so release jobs retain their chosen compiler and libc.

--- a/host/chez/errno-check.sh
+++ b/host/chez/errno-check.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# errno-check.sh — the socket layer must ask about a syscall's errno exactly
+# once, at the syscall, and branch on the captured VALUE.
+#
+# WHY THIS GATE EXISTS. errno survives only until the next thing that can set
+# it, and on this runtime that includes READING it: jolt.ffi/errno is a foreign
+# call (__error / __errno_location) and an allocation on the way can trip a
+# collection whose mmap leaves ENOMEM behind. So a caller that asks two
+# questions about one syscall -- (eintr?) and then (eagain?) -- is asking about
+# two different values.
+#
+# That is not theoretical. io-call did exactly that, and under CPU load recv's
+# EAGAIN read back as ENOMEM often enough to matter: the retry branch was
+# missed, the -1 fell through, and do-recv answered EOF on a live connection.
+# Downstream that surfaced as a go block throwing on (String. b 0 -1 "UTF-8"),
+# its channel closing empty, and a poller stress case reporting "1 of 8
+# readiness registrations lost" -- a failure that named the poller, which was
+# innocent. Measured 13 of 60 runs under load; 0 of 60 once the errno was
+# captured once, at the call.
+#
+# The shape is invisible in review -- (poller/eagain?) reads exactly like
+# (poller/eagain? e) -- and the failure it produces points somewhere else
+# entirely, so it is checked here rather than left to whoever writes the next
+# syscall wrapper to remember.
+#
+#   sh host/chez/errno-check.sh
+set -eu
+cd "$(dirname "$0")/../.."
+
+bad=0
+
+# The no-arg predicates read errno themselves. In the socket layer, where the
+# read follows a syscall whose result is already in hand, the value-taking
+# arity is the only correct form.
+for f in stdlib/jolt/socket.clj; do
+  [ -f "$f" ] || continue
+  hits=$(grep -n '(poller/eagain?)\|(poller/eintr?)' "$f" || true)
+  if [ -n "$hits" ]; then
+    echo "errno-check: $f asks errno a second time instead of branching on the"
+    echo "             value captured at the syscall:"
+    echo "$hits" | sed 's/^/             /'
+    bad=1
+  fi
+done
+
+# More than one errno read per syscall wrapper is the same defect wearing a
+# different spelling.
+n=$(grep -c '(poller/errno)' stdlib/jolt/socket.clj || true)
+if [ "$n" -gt 2 ]; then
+  echo "errno-check: stdlib/jolt/socket.clj reads errno $n times."
+  echo "             One read per syscall site (io-call, connect). If a new"
+  echo "             syscall wrapper needs one, raise this bound deliberately."
+  bad=1
+fi
+
+if [ "$bad" -ne 0 ]; then exit 1; fi
+echo "errno-check: errno is captured at the syscall"

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -586,17 +586,39 @@ else
   # tear the evidence down — to say which stage dropped the wakeup: still :pending
   # (never drained), waiters parked with no event (kernel set), or ready with no
   # waiters (resume lost). `tail -1` kept only the verdict and discarded exactly
-  # that, which is why the one occurrence on record (1 of 8 in round 29, during a
-  # make test run, not reproducible in ~105 runs since — isolated, 8-way
-  # concurrent, and under full CPU load) cannot be attributed to a stage.
+  # that, which is why the first occurrence on record could not be attributed to
+  # a stage.
   #
-  # A wedge or a throw prints no POLLER-DEBUG at all, so fall back to the tail
-  # rather than reporting nothing.
-  if printf '%s' "$pr_out" | grep -q '^POLLER'; then
-    printf '%s\n' "$pr_out" | grep '^POLLER' | sed 's/^/    /'
-  else
-    printf '%s\n' "$pr_out" | tail -3 | sed 's/^/    /'
-  fi
+  # WHAT THIS ACTUALLY CAUGHT (2026-08-30). Not a lost registration: the poller
+  # was innocent every time. jolt.socket's io-call read errno AFTER the syscall,
+  # and twice -- once for EINTR, once for EAGAIN. errno survives only until the
+  # next thing that can set it, and reading it is itself a foreign call, so under
+  # load recv's EAGAIN (35) read back as ENOMEM (12): the retry branch was missed,
+  # the -1 fell through, and do-recv answered EOF on a live connection. The go
+  # block then threw on (String. b 0 -1 "UTF-8"), its channel closed empty, and
+  # alts!! returned nil instantly -- which this case reports as a lost
+  # registration. 13 of 60 runs under load; 0 of 100 with errno captured at the
+  # syscall. Guarded now by host/chez/errno-check.sh.
+  #
+  # Two things worth keeping from the hunt. The failing run is FASTER than a
+  # passing one (it stops at the losing round) and no timeout elapses -- that is
+  # what says "channel closed empty", not "wakeup lost". And the exception was in
+  # the captured output all along; the tail -1 that this block replaced is what
+  # hid it.
+  #
+  # To reproduce the class: saturate the CPU (eight background
+  # `jolt -e '(reduce + (map inc (range 3000000)))'` loops) and run this case in a
+  # loop. On an idle machine it is ~0 in 145 runs, which is why it only ever
+  # appeared inside a parallel `make test`. Instrumenting the case itself changes
+  # the answer -- a probe in one-round took 6-of-60 to 0-of-60 -- so measure the
+  # rate before concluding anything from a quiet run, and probe the runtime
+  # rather than the workload.
+
+  # EVERYTHING, not just the POLLER lines. The cause turned out to be an
+  # exception printed by the go block ("Exception in go/fiber body (channel
+  # closed)"), which a ^POLLER filter drops on the floor — the same mistake as
+  # the tail -1 this replaced, one level up.
+  printf '%s\n' "$pr_out" | sed 's/^/    /' 
   fails=$((fails + 1))
 fi
 

--- a/stdlib/jolt/io_poller.clj
+++ b/stdlib/jolt/io_poller.clj
@@ -84,8 +84,12 @@
 
 ;; -- fd helpers (the socket layer's syscall surface) ---------------------------
 (defn errno [] (ffi/errno))
-(defn eagain? [] (= EAGAIN (errno)))
-(defn eintr? [] (= EINTR (errno)))
+;; errno is only meaningful until the next thing that can set it, and reading it
+;; is itself a foreign call -- so a caller that asks two questions about one
+;; syscall can get two different answers. Capture the value ONCE at the call site
+;; and pass it in; the no-arg forms remain for a caller that reads it directly.
+(defn eagain? ([] (= EAGAIN (errno))) ([e] (= EAGAIN e)))
+(defn eintr? ([] (= EINTR (errno))) ([e] (= EINTR e)))
 (defn connect-pending? [e] (or (= EINPROGRESS e) (= EALREADY e)))
 (defn nonblock! [fd]
   (let [f (c-fcntl fd F-GETFL 0)]

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -170,10 +170,13 @@
   (let [ip (resolve-host host)
         sa (make-sockaddr ip port)
         r  (loop []
-             (let [r (c-connect fd sa 16)]
+             (let [r (c-connect fd sa 16)
+                   ;; captured before anything else runs, for the reason io-call
+                   ;; spells out above
+                   e (if (zero? r) 0 (poller/errno))]
                (cond
                  (zero? r) 0
-                 (poller/connect-pending? (poller/errno))
+                 (poller/connect-pending? e)
                  (do (poller/wait-ready fd :write)
                      (let [e (poller/so-error fd)]
                        (if (zero? e)
@@ -289,11 +292,30 @@
   ;; there is not — and retries; EINTR retries immediately; anything else is
   ;; the syscall's real answer, returned as-is (callers read errno semantics).
   (loop []
-    (let [r (op)]
+    (let [r (op)
+          ;; ERRNO IS READ HERE AND NOWHERE ELSE. It survives only until the next
+          ;; thing that can set it, and that includes reading it: the accessor is
+          ;; a foreign call, and an allocation on the way can trip a collection
+          ;; whose mmap leaves ENOMEM behind. Asking twice -- once for EINTR, once
+          ;; for EAGAIN -- read recv's EAGAIN as ENOMEM often enough to matter: the
+          ;; retry was missed, the -1 fell through, and a socket read answered EOF
+          ;; on a live connection. The (neg? r) guard is a fixnum compare, which
+          ;; allocates nothing and so cannot collect.
+          e (if (neg? r) (poller/errno) 0)]
       (cond
-        (and (neg? r) (poller/eintr?)) (recur)
-        (and (neg? r) (poller/eagain?)) (do (poller/wait-ready fd wait-kind) (recur))
-        :else r))))
+        (and (neg? r) (poller/eintr? e)) (recur)
+        (and (neg? r) (poller/eagain? e)) (do (poller/wait-ready fd wait-kind) (recur))
+        :else
+        (do
+          ;; A negative return that is neither retryable nor a wait is where a
+          ;; socket read turns into EOF (do-recv below), and the caller then sees
+          ;; a closed connection with no reason attached. It is the one place a
+          ;; syscall failure goes quiet, so say what it was when asked.
+          (when (and (neg? r) (jolt.host/getenv "JOLT_DEBUG"))
+            (binding [*out* *err*]
+              (println "jolt.socket: fd" fd wait-kind "syscall failed, errno" e
+                       "- answered as EOF")))
+          r)))))
 
 (defn- do-recv [fd buf len]
   ;; n <= 0 answers EOF: recv 0 is orderly shutdown; a negative return (error)


### PR DESCRIPTION
"`jolt.socket`'s syscall wrapper read `errno` **after** the call, and **twice** — once to ask about `EINTR`, once about `EAGAIN`:\n\n```clojure\n(let [r (op)]\n  (cond\n    (and (neg? r) (poller/eintr?))  (recur)\n    (and (neg? r) (poller/eagain?)) (do (poller/wait-ready fd wait-kind) (recur))\n    :else r))\n```\n\n`errno` survives only until the next thing that can set it, and on this runtime that includes **reading** it — `jolt.ffi/errno` is a foreign call, and an allocation on the way can trip a collection whose `mmap` leaves `ENOMEM` behind. So the two questions were not about the same value.\n\nUnder CPU load `recv`'s **EAGAIN (35)** read back as **ENOMEM (12)** often enough to matter. Neither branch matched, the `-1` fell through as \"the syscall's real answer\", and `do-recv` turned it into **EOF — on a connection that was simply not ready yet**. A `go` block reading a socket then threw on `(String. b 0 -1 \"UTF-8\")`, its channel closed with no value, and `alts!!` answered `nil` immediately.\n\nCaught in the act:\n\n```\nIO-CALL-NEG r= -1  e0= 35 (EAGAIN)  later= 12 (ENOMEM)\n```\n\n## This is what has been failing `make test`\n\nThe smoke case reports it as **\"1 of 8 readiness registrations lost under concurrent parking\"**. The poller was innocent in every occurrence — the fd is absent from its table because the fiber **never parked**, not because a registration was dropped. The case's name and its comment block sent the search to the wrong subsystem for a long time.\n\nTwo clues that finally turned it, both worth keeping: a failing run is **faster** than a passing one and **no timeout elapses**, which says \"channel closed empty\" rather than \"wakeup lost\". And the exception was in the captured output the entire time.\n\n## The fix\n\n`errno` is captured once, at the call, and the `cond` branches on that value. `eagain?`/`eintr?` gain a value-taking arity. `connect` had the same shape and gets the same treatment.\n\n**Measured**, eight background CPU hogs: **13 of 60** runs lost before (also 15/60 and 6/60 across sessions), **0 of 100** after.\n\n## Gate\n\n`make errnocheck` fails if a syscall wrapper asks twice again. `(poller/eagain?)` and `(poller/eagain? e)` are indistinguishable in review, and this defect presented as a bug in another subsystem — so it is checked rather than left to whoever writes the next wrapper. Red-proven: reintroducing the no-arg call fails the gate.\n\n## Diagnosis fixes riding along\n\n- The smoke case printed only `^POLLER` lines on failure, dropping the go block's exception — the same mistake as the `tail -1` it once replaced, one level up. It prints everything now.\n- `io-call` names the errno under `JOLT_DEBUG` when a syscall failure is about to be answered as EOF — the one place a failure goes quiet.\n\n## Gates\n\n`make test` 88 CI + 3 test targets (89 with `errnocheck`) · `make libconformance` 47 ok / 0 regressed.\n\nCloses jolt-wrv6. Unblocks the v0.7.29 release.\n"