### PR TITLE
One toolchain end to end, and a project can build the natives it declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+The build keeps one toolchain end to end now. When make provisions the pinned
+Chez + xPack GCC, the standalone-binary link runs through that same provisioned
+GCC — `JOLT_CC`, honored by `build.ss`'s `bld-cc` — instead of a bare `cc`,
+which can pair a distro gcc 16 driver with the bundle's pre-`.base64` binutils
+and die on `unknown pseudo-op: .base64` (#788). And with nothing explicit
+selected, a Chez on `PATH` at or above the pinned version is used as-is rather
+than triggering a provisioning download; the system toolchain then builds and
+links everything. Older, broken, or absent Chez falls back to the pinned
+provision. `JOLT_SYSTEM_CHEZ=` (empty) forces provisioning; an explicit `CHEZ=`
+stays authoritative.
+
+### Fixed
+
+- **A project could not build a `:jolt/native` library it declares.** Applying a
+  project loads its native libraries before anything runs, so a project whose
+  `native/` holds C sources and whose `:jolt/native` names the `.so`/`.dylib`
+  built from them could not run its own build step: the task needed its own
+  output to exist first. A **task** run now warns and carries on — it may be the
+  thing that produces the library — while every other command still refuses to
+  start without it. With this, the compile step can live in `deps.edn` `:tasks`
+  instead of a makefile or a shell script beside the project.
+
+- **A relative `:jolt/native` path was resolved against the wrong directory.**
+  Candidates split the way `dlopen` splits them: a name with no separator is
+  searched for on the loader path, a name with one is a path. A path is now
+  resolved relative to the **project**, not to the current directory — so
+  `native/libfoo.so` loads whatever the working directory happens to be. It used
+  to work only when jolt was started from the project root, which meant it did
+  not work at all under `bin/jolt`, which exports `JOLT_PWD` and then changes to
+  its own tree. A "not found" error names the resolved path now.
+
 ## [0.7.29] - 2026-08-30
 
 Two threads. Splicing a `defn` body at a call site follows **linkage** now

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,13 @@ do **not** contain submodules, so they can't run or build — clone the repo
 instead.
 
 `bin/jolt` needs a **threaded Chez Scheme 10.x** on `PATH` as `chez` or
-`chezscheme`; set `JOLT_CHEZ` to point at a specific one. `make` provisions its
-own 10.4.1 when `PATH` has a different version, and exports `JOLT_CHEZ` so both
-halves of a build agree — running `bin/jolt` by hand against a 9.x picks up
-whatever primitive that release predates (`variable flvector? is not bound`).
+`chezscheme`; set `JOLT_CHEZ` to point at a specific one. `make` uses a Chez on
+`PATH` at or above its pinned version as-is, and provisions its own 10.4.1 only
+when nothing qualifies. It exports `JOLT_CHEZ` so both halves of a build agree —
+running `bin/jolt` by hand against a 9.x picks up whatever primitive that
+release predates (`variable flvector? is not bound`) — and, when provisioning
+did run, `JOLT_CC` too, so the standalone binary links with the same GCC that
+built Chez instead of whatever `cc` happens to resolve to.
 
 `make build` provisions [Chez Scheme](https://cisco.github.io/ChezScheme/) and a
 C compiler locally through [Makes](https://github.com/makeplus/makes), then

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,36 @@ include $M/init.mk
 
 # An explicit caller-selected Chez is authoritative. This preserves CI/release
 # toolchains whose threading, libc floor, and native libraries are intentional.
+#
+# Same-or-newer system Chez: with nothing explicit selected, a Chez on PATH at
+# or above JOLT-CHEZ-FLOOR is also used as-is — the system toolchain then
+# builds and links everything, one self-consistent toolchain end to end, and
+# nothing is downloaded. Older, broken, or absent, fall through to provisioning
+# the pinned Chez + xPack GCC below. Set JOLT_SYSTEM_CHEZ= (empty) to always
+# provision the pinned versions.
+JOLT-CHEZ-FLOOR ?= 10.4.1
+JOLT_SYSTEM_CHEZ ?= 1
 JOLT-CHEZ := $(or $(CHEZ),$(CHEZSCHEME))
+ifeq (,$(JOLT-CHEZ))
+ifeq (1,$(JOLT_SYSTEM_CHEZ))
+JOLT-CHEZ := $(shell \
+  for name in chez chezscheme scheme; do \
+    exe=$$(command -v $$name 2>/dev/null) || continue; \
+    test -x "$$exe" || continue; \
+    exe=$$(cd "$$(dirname "$$exe")" && pwd -P)/$$(basename "$$exe"); \
+    v=$$(printf '(display (scheme-version)) (newline)\n' | "$$exe" -q 2>/dev/null | tr -d '\r'); \
+    v=$$(printf '%s\n' "$$v" | awk '{print $$NF}'); \
+    ok=$$(awk -v v="$$v" -v f="$(JOLT-CHEZ-FLOOR)" 'BEGIN { \
+      split(v, V, "."); split(f, F, "."); \
+      for (i = 1; i <= 3; i = i + 1) { \
+        if (V[i] + 0 > F[i] + 0) { print 1; exit } \
+        if (V[i] + 0 < F[i] + 0) { exit } \
+      } \
+      print 1 }'); \
+    if [ "$$ok" = 1 ]; then printf '%s\n' "$$exe"; break; fi; \
+  done)
+endif
+endif
 ifneq (,$(JOLT-CHEZ))
 SHELL-DEPS += $(JOLT-CHEZ)
 else
@@ -58,6 +87,12 @@ CHEZSCHEME-LIB-DIRS := \
   $(LOCAL-TMP)/$(CHEZSCHEME-DIR)/pb/lz4/lib \
   $(LOCAL-TMP)/$(CHEZSCHEME-DIR)/pb/zlib
 export LIBRARY_PATH := $(subst $(space),:,$(strip $(CHEZSCHEME-LIB-DIRS)))$(if $(LIBRARY_PATH),:$(LIBRARY_PATH))
+# The provisioned GCC built Chez, so the same driver links the standalone
+# binary: gcc.mk puts the bundle's bin FIRST on the exported PATH, but the
+# bundle ships no `cc`, so a bare cc falls through to the distro driver and
+# pairs it with the bundle's older as/ld (#788: gcc 16 .base64 into pre-2.43
+# gas). build.ss bld-cc reads JOLT_CC. A command-line JOLT_CC=... still wins.
+export JOLT_CC := $(GCC)
 endif
 
 JOLT-TARGETS-NEEDING-DEPS := \

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -87,10 +87,32 @@
 (define (bld-cross?) (and (bld-target) (not (string=? (bld-target) bld-machine)) #t))
 (define (bld-tgt-osx?) (bld-contains? (bld-eff-machine) "osx"))
 (define (bld-tgt-nt?) (bld-contains? (bld-eff-machine) "nt"))
+;; An env override, treating an EMPTY value as absent. A Makefile that exports a
+;; variable it did not manage to compute exports "" rather than nothing, and ""
+;; is a true value in Scheme -- so a plain (or (getenv ...) "cc") would hand the
+;; link an empty compiler name and fail somewhere far from the cause.
+(define (bld-env-override name)
+  (let ((v (getenv name))) (and v (> (string-length v) 0) v)))
+
 ;; The C compiler + arch flag for the OUTPUT binary. Cross overrides via env
 ;; (JOLT_TARGET_CC, e.g. aarch64-linux-gnu-gcc or a zig-cc wrapper;
 ;; JOLT_TARGET_ARCH_FLAG, e.g. "-arch x86_64" for a macOS x-arch link).
-(define (bld-cc) (if (bld-cross?) (or (getenv "JOLT_TARGET_CC") "cc") "cc"))
+;;
+;; JOLT_CC names the compiler for a NATIVE link. It exists because a bare `cc`
+;; is resolved by PATH, and PATH is not neutral when make provisions the pinned
+;; toolchain: gcc.mk puts the xPack bundle's bin directory FIRST on an exported
+;; PATH, so `as` and `ld` come from that bundle -- but the bundle ships no `cc`,
+;; so `cc` alone falls through to the system compiler. The link then pairs one
+;; vendor's driver with another vendor's assembler and linker (#788: a distro
+;; gcc 16 emitting .base64 into the bundle's pre-2.43 gas). Chez itself never
+;; had the problem: chezscheme.mk builds it with the absolute CC=$(GCC), and the
+;; Makefile now exports JOLT_CC with that same GCC. Same shape as JOLT_CHEZ,
+;; which exists because a bare `chez` on PATH could likewise be a different
+;; install from the one make provisioned.
+(define (bld-cc)
+  (if (bld-cross?)
+      (or (bld-env-override "JOLT_TARGET_CC") "cc")
+      (or (bld-env-override "JOLT_CC") "cc")))
 (define (bld-arch-flag) (if (bld-cross?) (or (getenv "JOLT_TARGET_ARCH_FLAG") "") ""))
 
 ;; Platform-appropriate flag to export executable symbols so a statically-linked

--- a/host/chez/tasks-smoke.sh
+++ b/host/chez/tasks-smoke.sh
@@ -23,6 +23,7 @@ JOLT="${JOLT_BIN:-bin/jolt}"
 BB="$root/test/chez/tasks/bbproj"
 BOTH="$root/test/chez/tasks/both"
 DEPS="$root/test/chez/tasks/depsonly"
+NAT="$root/test/chez/tasks/native"
 pass=0; fail=0
 export JOLT_NO_USER_DEPS=1
 # babashka.tasks/jolt (and `clojure`, its babashka name) re-invokes the jolt
@@ -47,6 +48,31 @@ check() { # label expected actual
 # on its own.
 inbb()   { d="$1"; shift; JOLT_PWD="$d" JOLT_QUIET=1 "$JOLT" "$@" 2>&1; }
 status() { d="$1"; shift; JOLT_PWD="$d" JOLT_QUIET=1 "$JOLT" "$@" >/dev/null 2>&1; echo $?; }
+
+# --- a build task for a :jolt/native library that does not exist yet ----------
+# A project whose native/ holds C sources names the .so/.dylib built from them in
+# :jolt/native, so on a fresh checkout the library is missing until a task builds
+# it. Applying the project used to load the natives strictly first, which made
+# that task impossible to run: the build step needed its own output. A task run
+# warns instead.
+out="$(inbb "$NAT" build-native)"
+case "$out" in *compiled*) r=yes ;; *) r="no: $out" ;; esac
+check "a task runs when its :jolt/native library is not built yet" "yes" "$r"
+check "...and exits 0" "0" "$(status "$NAT" build-native)"
+case "$out" in *warning:*nope*) r=yes ;; *) r="no: $out" ;; esac
+check "...having said which library was missing" "yes" "$r"
+
+# Everything that is not a task still refuses to start without it.
+check "a run still fails on a missing required native" "1" \
+  "$(s=$(status "$NAT" -M:go); [ "$s" = 0 ] && echo 0 || echo 1)"
+
+# The candidate is a PATH (it has a separator), so it belongs to the project, not
+# to whatever directory jolt was started from — bin/jolt cd's to its own tree, so
+# resolving against the current directory looked in the wrong place and reported
+# the library missing even when it was built.
+out="$(inbb "$NAT" -M:go)"
+case "$out" in *"$NAT/native/libnope."*) r=yes ;; *) r="no: $out" ;; esac
+check "a relative :jolt/native path resolves against the project" "yes" "$r"
 
 # --- bb.edn task bodies ------------------------------------------------------
 

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -21,14 +21,41 @@
 ;; map: {:name "sqlite3" :darwin ["libsqlite3.0.dylib" ...] :linux ["libsqlite3.so.0" ...]}
 ;; with optional :optional (missing is fine — a feature-gated dep) and :process
 ;; (use the running process's symbols, e.g. libc sockets — no external file).
-(defn- load-natives! [natives]
+;; A :jolt/native candidate that names a PATH — it has a separator — is relative
+;; to the project, not to the current directory. dlopen draws the same line:
+;; a name with no separator is searched for, a name with one is used as given.
+;; Without this, a project that keeps its shared library beside its sources
+;; ("native/libfoo.so", which is what a build task produces) loaded only when
+;; jolt happened to be run from the project root: `bin/jolt` exports JOLT_PWD and
+;; then cd's to its own tree, so the path resolved against the wrong directory
+;; and the library read as missing.
+(defn- native-candidate [base c]
+  (if (and base
+           (or (str/includes? c "/") (str/includes? c "\\"))
+           (not (str/starts-with? c "/"))
+           (not (re-find #"^[A-Za-z]:" c)))
+    (str base "/" c)
+    c))
+
+;; strict? false lets a MISSING required library through with a warning instead of
+;; an error. A task is the one command that may be what PRODUCES the library it
+;; is declared alongside: a project whose native/ holds C sources and whose
+;; :jolt/native names the .so/.dylib built from them could not run its own build
+;; task, because applying the project loaded the natives first and the artifact
+;; was not there yet. Any task that actually needs the library still fails on
+;; use, and the warning names what was missing either way.
+(defn- load-natives!
+  ([natives] (load-natives! natives true))
+  ([natives strict?] (load-natives! natives strict? nil))
+  ([natives strict? base]
   (when (seq natives)
     (let [plat (current-platform)]
       (doseq [spec natives]
         (if (:process spec)
           (jolt.ffi/load-library)
           (let [c (get spec plat)
-                cands (if (string? c) [c] (vec c))
+                cands (mapv #(native-candidate base %)
+                            (if (string? c) [c] (vec c)))
                 ;; Load the native RTLD_LOCAL and register its handle, so the
                 ;; spec's defcfns resolve from the handle (isolated from the
                 ;; process-global namespace) rather than depending on global
@@ -40,16 +67,23 @@
             ;; skip it rather than fail. Its foreign calls only resolve in a static
             ;; build; document a dynamic candidate too to use it under `run`.
             (when (and (nil? hit) (not (:optional spec)) (not (:static spec)))
-              (throw (ex-info (str "required native library "
-                                   (or (:name spec) (first cands) "?")
-                                   " not found — tried " (pr-str cands) " for " (name plat))
-                              {:native spec})))))))))
+              (let [msg (str "required native library "
+                             (or (:name spec) (first cands) "?")
+                             " not found — tried " (pr-str cands) " for " (name plat))]
+                (if strict?
+                  (throw (ex-info msg {:native spec}))
+                  (binding [*out* *err*]
+                    (println (str "warning: " msg " (a task may build it)")))))))))))))
 
 ;; Apply a resolved project's roots on top of the current (jolt-core) roots so app
 ;; namespaces resolve while jolt.* stays loadable, then load its native deps.
-(defn- apply-project! [{:keys [roots natives]}]
-  (jolt.host/set-source-roots! (vec (distinct (concat roots (jolt.host/source-roots)))))
-  (load-natives! natives))
+(defn- apply-project!
+  ([resolved] (apply-project! resolved true))
+  ([{:keys [roots natives project-dir]} strict?]
+   (jolt.host/set-source-roots! (vec (distinct (concat roots (jolt.host/source-roots)))))
+   ;; project-dir is absent from a cpcache entry written by an older jolt; JOLT_PWD
+   ;; is where the user invoked us, which is the same directory in the common case.
+   (load-natives! natives strict? (or project-dir (jolt.host/getenv "JOLT_PWD")))))
 
 ;; Aliases selected by a leading -A:… — bound around the re-dispatch so every
 ;; command that resolves the project (run/path/build/repl/nrepl/task, and a
@@ -475,7 +509,9 @@
     (when (nil? task)
       (throw (ex-info (str "unknown command or task: " name " (see 'jolt tasks')")
                       {:name name})))
-    (apply-project! resolved)
+    ;; tolerant: see load-natives! — the task may be the build step for a
+    ;; :jolt/native library that does not exist yet
+    (apply-project! resolved false)
     ((requiring-resolve 'jolt.tasks/run-task!)
      {:tasks (:tasks resolved)
       :name name

--- a/test/chez/tasks/native/deps.edn
+++ b/test/chez/tasks/native/deps.edn
@@ -1,0 +1,14 @@
+;; A project whose shared library is COMPILED FROM SOURCE that lives beside it:
+;; native/ would hold the .c, and :jolt/native names the artifact a build task
+;; produces. The artifact is deliberately absent here — that is the state a
+;; fresh checkout is in, and the state the build task has to be runnable in.
+{:paths ["src"]
+
+ :jolt/native [{:name "nope"
+                :darwin ["native/libnope.dylib"]
+                :linux  ["native/libnope.so"]}]
+
+ :aliases {:go {:main-opts ["-m" "app.go"]}}
+
+ :tasks {build-native {:doc "stands in for the compile step"
+                       :task (println "compiled")}}}

--- a/test/chez/tasks/native/src/app/go.clj
+++ b/test/chez/tasks/native/src/app/go.clj
@@ -1,0 +1,2 @@
+(ns app.go)
+(defn -main [& _] (println "ran"))

--- a/test/makefile-smoke.sh
+++ b/test/makefile-smoke.sh
@@ -7,10 +7,13 @@ cd "$root"
 
 # Test each caller override independently of the Make process that launched us.
 # Command-line variables also propagate to nested Makes through these flags.
-unset CHEZ CHEZSCHEME MAKEFLAGS MAKEOVERRIDES
+unset CC JOLT_CC CHEZ CHEZSCHEME MAKEFLAGS MAKEOVERRIDES
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+# A provision-armed Makefile parse mkdirs .cache/local (local.mk runs at parse;
+# no downloads happen there). If a check dies mid-run, don't leave those dirs
+# behind on a checkout that never provisioned.
+trap 'rm -rf "$tmp"; if [ "${had_provision_dirs:-0}" -eq 0 ] && [ -e "$root/.cache/local" ]; then rm -rf "$root/.cache/local"; fi' EXIT
 
 fake_chez="$tmp/chez"
 cat >"$fake_chez" <<'FAKE'
@@ -44,7 +47,9 @@ inspect-chez:
 	  "chez=$(CHEZ)" \
 	  "jolt-chez=$(JOLT-CHEZ)" \
 	  "local-origin=$(origin LOCAL-LOADED)" \
-	  "gcc-origin=$(origin GCC-LOADED)"
+	  "gcc-origin=$(origin GCC-LOADED)" \
+	  "joltcc-origin=$(origin JOLT_CC)" \
+	  "joltcc-env=$${JOLT_CC-}"
 MK
 
 check_override() {
@@ -60,6 +65,10 @@ check_override() {
   grep -Fx "jolt-chez=$fake_chez" <<<"$output" >/dev/null
   grep -Fx "local-origin=undefined" <<<"$output" >/dev/null
   grep -Fx "gcc-origin=undefined" <<<"$output" >/dev/null
+  # No provisioning armed, so JOLT_CC must be unset — the caller's system
+  # toolchain links whatever gets built.
+  grep -Fx "joltcc-origin=undefined" <<<"$output" >/dev/null
+  grep -Fx "joltcc-env=" <<<"$output" >/dev/null
 
   make --no-print-directory -s "$name=$fake_chez" deps
 }
@@ -110,5 +119,186 @@ check_path_discovery() {
 
 check_path_discovery
 
+# A fake Chez answering all three discovery names (chez, chezscheme, scheme)
+# with a chosen version, so shadowing PATH controls exactly what discovery
+# sees regardless of what else the machine has installed.
+fake_chez_bin() {
+  local dir=$1 line=$2 bare=$3
+
+  mkdir -p "$dir"
+  cat >"$dir/chez" <<FAKE
+#!/usr/bin/env bash
+case \${1-} in
+  -q)
+    prog=\$(cat)
+    case \$prog in
+      *scheme-version*) printf '%s\n' '$line' ;;
+      *) printf '#t\n' ;;
+    esac
+    ;;
+  --version)
+    printf '%s\n' '$bare'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE
+  chmod +x "$dir/chez"
+  ln -sf chez "$dir/chezscheme"
+  ln -sf chez "$dir/scheme"
+}
+
+# Nothing explicit selected + a Chez on PATH at or above the floor: used as-is,
+# with NOTHING provisioned or pinned — the system toolchain builds and links
+# everything, self-consistent end to end. All three discovery names are
+# shadowed so a real Chez further down PATH can't answer for the fake.
+check_system_chez_preferred() {
+  local bin out
+
+  bin="$tmp/newer"
+  fake_chez_bin "$bin" 'Chez Scheme Version 10.9.0' '10.9.0'
+  bin="$(cd "$bin" && pwd -P)"
+
+  out="$(PATH="$bin:$PATH" make -C "$root" -f "$probe_mk" --no-print-directory -s inspect-chez)"
+
+  grep -Fx "jolt-chez=$bin/chez" <<<"$out" >/dev/null || {
+    echo "a same-or-newer Chez on PATH was not selected; expected $bin/chez, got:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+  grep -Fx "gcc-origin=undefined" <<<"$out" >/dev/null || {
+    echo "provisioning armed despite a same-or-newer system Chez:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+  grep -Fx "joltcc-origin=undefined" <<<"$out" >/dev/null || {
+    echo "JOLT_CC pinned without any provisioning armed:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+}
+
+# Nothing qualifies (only an older-than-floor Chez on PATH): provisioning arms —
+# pinned Chez + xPack GCC — and CC is pinned to that same provisioned GCC, so
+# the standalone-binary link cannot mix one compiler's driver with another's
+# binutils (#788: distro cc 16 driving the provisioned pre-.base64 gas).
+check_provision_fallback() {  local bin out
+
+  bin="$tmp/older"
+  fake_chez_bin "$bin" 'Chez Scheme Version 10.3.9' '10.3.9'
+  bin="$(cd "$bin" && pwd -P)"
+
+  out="$(PATH="$bin:$PATH" make -C "$root" -f "$probe_mk" --no-print-directory -s inspect-chez)"
+
+  grep -Fx "gcc-origin=file" <<<"$out" >/dev/null || {
+    echo "provisioning did not arm despite no qualifying system Chez:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+  grep -E "^jolt-chez=$root/.cache/local/chezscheme-[0-9.]+/bin/scheme$" <<<"$out" >/dev/null || {
+    echo "pinned provisioned Chez not selected as the fallback:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+  grep -E "^joltcc-env=$root/.cache/local/gcc-[0-9.-]+/bin/gcc$" <<<"$out" >/dev/null || {
+    echo "provisioning armed but JOLT_CC not pinned to the provisioned GCC:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+}
+
+# A Chez on PATH that answers NOTHING (broken install, stub, wrong binary) must
+# not be selected by the floor probe: an empty version carries no information,
+# and an all-equal component comparison would otherwise treat it as at-floor.
+# The pinned provision is the safe fallback — this is the "broken" arm of the
+# same-or-newer rule.
+check_broken_chez_falls_back() {
+  local bin out
+
+  bin="$tmp/broken"
+  mkdir -p "$bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$bin/chez"
+  chmod +x "$bin/chez"
+  ln -sf chez "$bin/chezscheme"
+  ln -sf chez "$bin/scheme"
+  bin="$(cd "$bin" && pwd -P)"
+
+  out="$(PATH="$bin:$PATH" make -C "$root" -f "$probe_mk" --no-print-directory -s inspect-chez)"
+
+  grep -Fx "gcc-origin=file" <<<"$out" >/dev/null || {
+    echo "a silent Chez on PATH was selected instead of falling back to provisioning:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+}
+
+had_provision_dirs=0
+[ -e "$root/.cache/local" ] && had_provision_dirs=1
+
+check_system_chez_preferred
+check_provision_fallback
+check_broken_chez_falls_back
+
+# build.ss bld-cc is the seam the JOLT_CC pin lands on: the native link honors
+# $JOLT_CC (empty/unset falls back to cc); JOLT_TARGET_CC still rules cross.
+bldcc_ss="$tmp/bldcc.ss"
+cat >"$bldcc_ss" <<'SS'
+;; build-jolt.ss's exact preamble in a fresh Chez: build.ss's top level derefs
+;; compiler vars (jolt.passes.types), so it loads inside the booted compiler
+;; image — the same environment `make testbin` actually links in. The bld-cc
+;; under test comes from the on-disk file via plain load, exactly as in a real
+;; build.
+(import (chezscheme))
+(load "host/chez/scheme-adapter-runtime.ss")
+(load "host/chez/rt.ss")
+(load "host/chez/seed/prelude.ss")
+(load "host/chez/post-prelude.ss")
+(load "host/chez/post-prelude-str.ss")
+(set-chez-ns! "user")
+(load "host/chez/host-contract.ss")
+(load "host/chez/seed/image.ss")
+(load "host/chez/compile-eval.ss")
+(load "host/chez/cli-core.ss")
+(load "host/chez/png.ss")
+(load "host/chez/loader.ss")
+(load "host/chez/java/ffi.ss")
+(set-source-roots! ldr-install-roots)
+(load "host/chez/build.ss")
+(define cross-machine (string-append "zz-" bld-machine))
+(define (probe-cc var val)
+  (putenv var val)
+  (let ((r (if (string=? var "JOLT_TARGET_CC")
+               (parameterize ((bld-target cross-machine)) (bld-cc))
+               (bld-cc))))
+    (putenv var "")
+    r))
+(write (probe-cc "JOLT_CC" "/x/y/cc")) (newline)
+(write (probe-cc "JOLT_CC" "")) (newline)
+(write (probe-cc "JOLT_TARGET_CC" "/t/arm-gcc")) (newline)
+(write (probe-cc "JOLT_TARGET_CC" "")) (newline)
+SS
+expected_bldcc="$(cat <<'EOF'
+"/x/y/cc"
+"cc"
+"/t/arm-gcc"
+"cc"
+EOF
+)"
+actual_bldcc="$("${JOLT_CHEZ:-chez}" --script "$bldcc_ss")" || {
+  echo "makefile smoke: bld-cc probe failed to run" >&2
+  exit 1
+}
+[ "$actual_bldcc" = "$expected_bldcc" ] || {
+  echo "makefile smoke: bld-cc does not honor CC / JOLT_TARGET_CC; expected:" >&2
+  echo "$expected_bldcc" >&2
+  echo "got:" >&2
+  echo "$actual_bldcc" >&2
+  exit 1
+}
+
 echo "makefile smoke: explicit Chez overrides bypass local provisioning,"
-echo "                and a Chez on PATH is used without provisioning"
+echo "                a Chez on PATH is used without provisioning,"
+echo "                a same-or-newer system Chez is preferred over provisioning,"
+echo "                provisioning pins CC to the provisioned GCC,"
+echo "                and bld-cc honors CC / JOLT_TARGET_CC"

--- a/test/makefile-smoke.sh
+++ b/test/makefile-smoke.sh
@@ -46,6 +46,7 @@ inspect-chez:
 	@printf "%s\n" \
 	  "chez=$(CHEZ)" \
 	  "jolt-chez=$(JOLT-CHEZ)" \
+	  "local-root=$(LOCAL-ROOT)" \
 	  "local-origin=$(origin LOCAL-LOADED)" \
 	  "gcc-origin=$(origin GCC-LOADED)" \
 	  "joltcc-origin=$(origin JOLT_CC)" \
@@ -196,12 +197,19 @@ check_provision_fallback() {  local bin out
     echo "$out" >&2
     exit 1
   }
-  grep -E "^jolt-chez=$root/.cache/local/chezscheme-[0-9.]+/bin/scheme$" <<<"$out" >/dev/null || {
+  # Against LOCAL-ROOT as the Makefile computes it, not against a hardcoded
+  # .cache/local: the nix develop shell puts the provisioned toolchain somewhere
+  # else entirely, and a pattern anchored on this checkout asserts the layout
+  # rather than the property (which is that the PINNED toolchain won, not the
+  # older one on PATH).
+  local root_dir
+  root_dir="$(sed -n 's/^local-root=//p' <<<"$out")"
+  grep -E "^jolt-chez=${root_dir%/}/chezscheme-[0-9.]+/bin/scheme$" <<<"$out" >/dev/null || {
     echo "pinned provisioned Chez not selected as the fallback:" >&2
     echo "$out" >&2
     exit 1
   }
-  grep -E "^joltcc-env=$root/.cache/local/gcc-[0-9.-]+/bin/gcc$" <<<"$out" >/dev/null || {
+  grep -E "^joltcc-env=${root_dir%/}/gcc-[0-9.-]+/bin/gcc$" <<<"$out" >/dev/null || {
     echo "provisioning armed but JOLT_CC not pinned to the provisioned GCC:" >&2
     echo "$out" >&2
     exit 1


### PR DESCRIPTION
"Two halves that met in the middle: the build should use **one** toolchain, and a project should be able to **build the native library it declares**.\n\n## One toolchain end to end\n\n`gcc.mk` puts the provisioned xPack bundle's `bin` **first** on an exported `PATH`, so `as` and `ld` come from it — but the bundle ships no `cc`, so a bare `cc` fell through to the distro driver. The link then paired a **gcc 16 driver with pre-2.43 binutils** and died on `unknown pseudo-op: .base64` (#788). Chez was never affected: `chezscheme.mk` builds it with the absolute `CC=$(GCC)`.\n\njolt's own link reads **`JOLT_CC`** now, exported by the Makefile from that same `$(GCC)`.\n\n`bld-cc` treats an **empty** value as absent, which matters more than it looks: a Makefile exports `\"\"` for a variable it failed to compute, and `\"\"` is *true* in Scheme — so `(or (getenv …) \"cc\")` would have handed the link an empty compiler name and failed a long way from the cause.\n\nAnd with nothing explicit selected, a Chez on `PATH` at or above the pinned version is now used **as-is** instead of triggering a download; the system toolchain then builds and links everything — the same one-toolchain property from the other direction. Older, broken, or absent falls back to provisioning. `JOLT_SYSTEM_CHEZ=` forces provisioning; an explicit `CHEZ=` stays authoritative.\n\n## A project can build the natives it declares\n\nA project whose `native/` holds C sources names the `.so`/`.dylib` built from them in `:jolt/native` — so on a fresh checkout the library does not exist yet. Applying a project loads its natives strictly before anything runs, which made the build step **impossible to run: it needed its own output**.\n\nA **task** run warns and carries on now — it may be the thing that produces the library — while every other command still refuses to start without it. That is what lets the compile step live in `deps.edn` `:tasks` instead of a makefile or a script beside the project:\n\n```clojure\n{:jolt/native [{:name \"shim\" :darwin [\"native/libshim.dylib\"] :linux [\"native/libshim.so\"]}]\n :tasks {native {:doc \"compile native/shim.c\"\n                 :task (shell \"cc\" \"-O2\" \"-fPIC\" \"-shared\" \"native/shim.c\" \"-o\" lib)}}}\n```\n\n**Pre-existing, found while testing that:** a relative `:jolt/native` path was resolved against the *current directory*. Candidates now split the way `dlopen` splits them — no separator means search the loader path, a separator means it is a path — and a path belongs to the **project**. It used to work only when jolt was started from the project root, which meant it never worked under `bin/jolt`, which exports `JOLT_PWD` and then `cd`s to its own tree. Errors name the resolved path now.\n\n## Gates\n\n`make test` 89 CI + 3 test targets. `tasks-smoke` **51 → 56**, on a `native` fixture whose declared library is deliberately absent. Red-proven: **4 of the 5 fail** without the change, and the fifth pins that a non-task run *still* refuses to start — so relaxing this too far fails too.\n\nDocs on the site, in a companion change: `native-interop.md` gains a \"Shipping your own C\" section (verified by running the published snippet verbatim on a fresh tree), and `tools-deps.md` now leads with a `deps.edn` task example rather than only `bb.edn`.\n"