### PR TITLE
A File's path is normalized, the way every JVM constructor normalizes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ stays authoritative.
   `.` and `..` are still not resolved. The JVM constructor does not resolve them
   either; that is `getCanonicalPath`.
 
+- **`clojure.java.io/file` joined an absolute child instead of rejecting it.**
+  `io/file` is not the `File` constructor: Clojure puts every child through
+  `as-relative-path`, so `(io/file "/a/b" "/c")` raises `IllegalArgumentException`
+  while `(File. "/a/b" "/c")` answers `/a/b/c`. jolt joined it either way.
+
+  Worth knowing that normalization alone would have hidden this rather than
+  fixed it — `/a/b` joined to `/c` gives `/a/b//c`, which collapses to a
+  plausible-looking `/a/b/c` answer to a call the JVM refuses. A call site that
+  newly raises here was already broken for JVM Clojure.
+
 - **`jolt run` could not write any closure `clojure.core` makes.** `cycle`,
   `repeat`, `partial`, `comp` and the rest refused with "captured local … was
   optimized into the compiled code" — while a default `jolt build` wrote them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ stays authoritative.
   `.` and `..` are still not resolved. The JVM constructor does not resolve them
   either; that is `getCanonicalPath`.
 
+  The two-arg constructor is `resolve(normalize(parent), normalize(child))` — it
+  normalizes each argument, and resolve is not a plain join. An empty parent
+  resolves against `getDefaultParent()`, so `new File("", "")` is `/`, not `""`,
+  which jolt got wrong in both directions before. (If you go measuring this
+  yourself: resolve grew its `child == "/"` case in JDK 21, so through JDK 20
+  `new File("/a/b", "/")` answered `/a/b/`, a path with a trailing separator no
+  one-arg constructor can produce. 21 onward it is `/a/b`.)
+
 - **`clojure.java.io/file` joined an absolute child instead of rejecting it.**
   `io/file` is not the `File` constructor: Clojure puts every child through
   `as-relative-path`, so `(io/file "/a/b" "/c")` raises `IllegalArgumentException`
@@ -63,6 +71,19 @@ stays authoritative.
   JVM, missing here entirely). And `io/make-parents` builds `(apply io/file f
   more)` on the JVM, so it carries the same contract: an absolute child raises
   instead of quietly joining.
+
+- **`(io/file nil)` and `(io/as-file nil)` answered an empty `File`, not `nil`.**
+  Clojure extends `Coercions` to `nil`, so both are `nil` on the JVM. A `File`
+  whose path is `""` is not a harmless stand-in for that: it names the process's
+  working directory, so a nil that should have blown up at the coercion instead
+  went on to read or write the wrong file. `as-relative-path` goes through
+  `as-file`, so a nil child now raises there too, the way `(io/file "/a" nil)`
+  does on the JVM, rather than joining as an empty segment.
+
+  The `File` constructor null-checks for the same reason: `(File. nil)` and
+  `(File. "/a" nil)` raise `NullPointerException` instead of reading the nil as
+  `""`. `(File. nil "c")` still answers `c` — a null *parent* is the one the
+  two-arg constructor accepts, and it means the child alone.
 
 - **`jolt run` could not write any closure `clojure.core` makes.** `cycle`,
   `repeat`, `partial`, `comp` and the rest refused with "captured local … was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,14 @@ stays authoritative.
   plausible-looking `/a/b/c` answer to a call the JVM refuses. A call site that
   newly raises here was already broken for JVM Clojure.
 
+  Review follow-ups, all JVM-measured: `as-relative-path` goes through `as-file`
+  first, so the thrown message names the normalized path — `(io/file "/a/b"
+  "//c")` says `/c is not a relative path`, not `//c`. `io/as-relative-path`
+  itself is now registered as a var (public API in `clojure.java.io` on the
+  JVM, missing here entirely). And `io/make-parents` builds `(apply io/file f
+  more)` on the JVM, so it carries the same contract: an absolute child raises
+  instead of quietly joining.
+
 - **`jolt run` could not write any closure `clojure.core` makes.** `cycle`,
   `repeat`, `partial`, `comp` and the rest refused with "captured local … was
   optimized into the compiled code" — while a default `jolt build` wrote them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,32 @@ stays authoritative.
 
 ### Fixed
 
+- **A `File`'s path was kept exactly as given, not normalized.** Every JVM `File`
+  constructor runs its path through `FileSystem.normalize()`, so runs of `/`
+  collapse to one and a trailing `/` is dropped: `new File("/a/b//c").getPath()`
+  is `/a/b/c`. jolt answered `/a/b//c`. The visible route in was
+  `createTempFile`, since `$TMPDIR` ends in `/` on macOS and every temp file came
+  back carrying a doubled separator.
+
+  `clojure.java.io/file` had the same gap and a second one under it. It is
+  registered as the bare file constructor, whose multi-arg loop appends `/`
+  unconditionally, so `(io/file "/a/b/" "c")` gave `/a/b//c` where the JVM gives
+  `/a/b/c` — Clojure's own docstring says the multi-arg versions are equivalent
+  to `(File. parent child)`. That is the half more likely to bite, since
+  `(io/file dir name)` is everywhere and a directory read from config or the
+  environment often carries a trailing separator.
+
+  `jolt-file-join` already normalized, but only the JOIN SEAM — a trailing
+  separator off the parent, leading ones off the child, and it never looked
+  inside either. So `(File. "/a//b" "c")` still gave `/a//b/c`. Normalization now
+  lives in the `jfile` record's protocol instead: there are nine construction
+  sites and only one is the constructor entry point, so `as-file`, the `file:`
+  URL coercion, `createTempFile`, `getParentFile` and `listRoots` were each
+  building unnormalized paths of their own.
+
+  `.` and `..` are still not resolved. The JVM constructor does not resolve them
+  either; that is `getCanonicalPath`.
+
 - **`jolt run` could not write any closure `clojure.core` makes.** `cycle`,
   `repeat`, `partial`, `comp` and the rest refused with "captured local … was
   optimized into the compiled code" — while a default `jolt build` wrote them

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -867,7 +867,10 @@
             ((char=? (string-ref p i) #\/) (mkdirs! (substring p 0 i)))
             (else (loop (- i 1)))))))
 (define (apply-make-file-path args)
-  (jfile-path (apply jolt-make-file args)))
+  ;; the JVM's make-parents builds (-> f as-file (apply file more) ...), so it
+  ;; carries io/file's as-relative-path contract: an absolute child throws
+  ;; here, it is not quietly joined the way the bare constructor would
+  (jfile-path (apply jolt-io-file args)))
 (def-var! "clojure.java.io" "make-parents" jio-make-parents)
 
 ;; io/delete-file: delete the file; raise unless :silently truthy.

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -869,8 +869,13 @@
 (define (apply-make-file-path args)
   ;; the JVM's make-parents builds (-> f as-file (apply file more) ...), so it
   ;; carries io/file's as-relative-path contract: an absolute child throws
-  ;; here, it is not quietly joined the way the bare constructor would
-  (jfile-path (apply jolt-io-file args)))
+  ;; here, it is not quietly joined the way the bare constructor would. It also
+  ;; inherits the nil: (io/file nil) is nil, and .getParentFile raises on it.
+  (let ((f (apply jolt-io-file args)))
+    (when (jolt-nil? f)
+      (throw-jvm (quote NullPointerException)
+                 "Cannot invoke \"java.io.File.getParentFile()\" because the return value of \"clojure.core$apply.invokeStatic(Object, Object, Object)\" is null"))
+    (jfile-path f)))
 (def-var! "clojure.java.io" "make-parents" jio-make-parents)
 
 ;; io/delete-file: delete the file; raise unless :silently truthy.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1137,7 +1137,26 @@
     (else (throw-jvm (quote IllegalArgumentException) (string-append "Cannot open <" (jolt-pr-str x) "> as a Writer.")))))
 
 ;; --- clojure.java.io ns -----------------------------------------------------
-(def-var! "clojure.java.io" "file" jolt-make-file)
+;; io/file is NOT the File constructor. It puts every child through
+;; as-relative-path, which throws on an absolute one, so (io/file "/a/b" "/c")
+;; raises where (File. "/a/b" "/c") happily answers "/a/b/c" -- both checked
+;; against the JVM. jolt registered io/file as jolt-make-file, which has no
+;; notion of a child, so the absolute one was silently joined.
+;;
+;; Normalization alone would have HIDDEN this rather than fixed it: joining
+;; "/a/b" and "/c" produces "/a/b//c", which now collapses to "/a/b/c" and looks
+;; like a correct answer to a call the JVM rejects.
+(define (io-file-relative-child c)
+  (let ((s (file-path-of c)))
+    (when (and (fx>? (string-length s) 0) (char=? (string-ref s 0) #\/))
+      (throw-jvm (quote IllegalArgumentException)
+                 (string-append s " is not a relative path")))
+    s))
+(define (jolt-io-file a . rest)
+  (if (null? rest)
+      (jolt-make-file a)
+      (apply jolt-make-file a (map io-file-relative-child rest))))
+(def-var! "clojure.java.io" "file" jolt-io-file)
 ;; io/as-file of a file: URL yields the file it points at (JVM: new
 ;; File(url.toURI())); a URL with any other protocol has no filesystem path —
 ;; IllegalArgumentException, as the JVM's File(URI) throws.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -13,34 +13,47 @@
 ;; natives-meta.ss / records.ss / printing.ss (jolt-type / instance-check /
 ;; jolt-str-render-one, which it extends).
 
-;; Every JVM File constructor runs its path through FileSystem.normalize(), so a
-;; File's path is ALWAYS normalized: runs of "/" collapse to one and a trailing
-;; "/" is dropped. "." and ".." are left alone -- the constructor does not resolve
+;; FileSystem.normalize(): runs of "/" collapse to one and a trailing "/" is
+;; dropped. "." and ".." are left alone -- the JVM's constructor does not resolve
 ;; those, and neither does this. new File("/a/b//c").getPath() is "/a/b/c".
 ;;
-;; Applied in the record's protocol rather than at the call sites, because there
-;; are nine of them and only one is the constructor entry point: as-file, the
-;; file: URL coercion, createTempFile, getParentFile and listRoots all build a
-;; jfile directly. The invariant belongs where it cannot be bypassed by the next
-;; one added.
+;; Every path the ONE-argument constructor produces is normalized, and so is
+;; every path built by as-file, the file: URL coercion, createTempFile,
+;; getParentFile and listRoots -- nine construction sites of which only one is
+;; the constructor entry point. So make-jfile normalizes and they all go through
+;; it, rather than the invariant being restated nine times.
+;;
+;; The two-argument constructor normalizes each ARGUMENT and then resolves them.
+;; That result is normal too, on every JDK from 21. See jolt-file-join.
+(define (path-has-double-sep? p n)
+  (let loop ((i 1))
+    (and (fx<? i n)
+         (or (and (char=? (string-ref p i) #\/) (char=? (string-ref p (fx- i 1)) #\/))
+             (loop (fx+ i 1))))))
+
 (define (jolt-path-normalize p)
   (let ((n (string-length p)))
-    (if (fx=? n 0)
-        p
-        (let ((out (make-string n)))
-          (let loop ((i 0) (j 0) (prev-slash? #f))
-            (if (fx=? i n)
-                ;; a trailing separator goes, but "/" is a path, not an empty one
-                (let ((j (if (and (fx>? j 1) (char=? (string-ref out (fx- j 1)) #\/))
-                             (fx- j 1)
-                             j)))
-                  ;; nothing collapsed and nothing trimmed -> hand back the
-                  ;; original rather than an identical copy
-                  (if (fx=? j n) p (substring out 0 j)))
-                (let ((c (string-ref p i)))
-                  (cond ((and (char=? c #\/) prev-slash?) (loop (fx+ i 1) j #t))
-                        (else (string-set! out j c)
-                              (loop (fx+ i 1) (fx+ j 1) (char=? c #\/)))))))))))
+    (cond
+      ;; an already-normal path is the overwhelmingly common case, and a jfile is
+      ;; built per entry on every directory listing: look before copying, so the
+      ;; answer is p itself and nothing is allocated
+      ((not (path-has-double-sep? p n))
+       ;; a trailing separator goes, but "/" is a path, not an empty one
+       (if (and (fx>? n 1) (char=? (string-ref p (fx- n 1)) #\/))
+           (substring p 0 (fx- n 1))
+           p))
+      (else
+       (let ((out (make-string n)))
+         (let loop ((i 0) (j 0) (prev-slash? #f))
+           (if (fx=? i n)
+               (let ((j (if (and (fx>? j 1) (char=? (string-ref out (fx- j 1)) #\/))
+                            (fx- j 1)
+                            j)))
+                 (substring out 0 j))
+               (let ((c (string-ref p i)))
+                 (cond ((and (char=? c #\/) prev-slash?) (loop (fx+ i 1) j #t))
+                       (else (string-set! out j c)
+                             (loop (fx+ i 1) (fx+ j 1) (char=? c #\/))))))))))))
 
 (define-record-type jfile (fields path) (nongenerative jolt-jfile-v1)
   (protocol (lambda (new) (lambda (p) (new (jolt-path-normalize p))))))
@@ -1154,6 +1167,11 @@
 ;; Registered as io/as-relative-path too: public API in clojure.java.io on
 ;; the JVM, and missing here entirely before.
 (define (jolt-as-relative-path x)
+  ;; as-file first, so nil coerces to nil and .isAbsolute raises on it rather
+  ;; than the child being read as ""
+  (when (jolt-nil? x)
+    (throw-jvm (quote NullPointerException)
+               "Cannot invoke \"java.io.File.isAbsolute()\" because \"f\" is null"))
   (let ((p (jfile-path (make-jfile (file-path-of x)))))
     (when (and (fx>? (string-length p) 0) (char=? (string-ref p 0) #\/))
       (throw-jvm (quote IllegalArgumentException)
@@ -1161,9 +1179,10 @@
     p))
 (def-var! "clojure.java.io" "as-relative-path" jolt-as-relative-path)
 (define (jolt-io-file a . rest)
-  (if (null? rest)
-      (jolt-make-file a)
-      (apply jolt-make-file a (map jolt-as-relative-path rest))))
+  (cond ((pair? rest) (apply jolt-make-file a (map jolt-as-relative-path rest)))
+        ;; one-arg io/file IS as-file, and as-file of nil is nil
+        ((jolt-nil? a) a)
+        (else (jolt-make-file a))))
 (def-var! "clojure.java.io" "file" jolt-io-file)
 ;; io/as-file of a file: URL yields the file it points at (JVM: new
 ;; File(url.toURI())); a URL with any other protocol has no filesystem path —
@@ -1173,7 +1192,11 @@
       (make-jfile (url-strip-scheme (url-spec u)))
       (throw-jvm 'IllegalArgumentException (string-append "Not a file: " (url-spec u)))))
 (def-var! "clojure.java.io" "as-file"
-  (lambda (x) (cond ((jfile? x) x)
+  ;; Clojure extends Coercions to nil, so (io/as-file nil) is nil -- NOT a File
+  ;; whose path is "". The difference is load-bearing one call downstream, where
+  ;; the JVM raises on the nil and jolt was quietly reading the process's cwd.
+  (lambda (x) (cond ((jolt-nil? x) x)
+                    ((jfile? x) x)
                     ((and (jhost? x) (string=? (jhost-tag x) "url")) (url-file-coercion x))
                     (else (make-jfile (file-path-of x))))))
 ;; "reader" is bound by natives-array.ss (loaded later) so a char[] argument is
@@ -1483,30 +1506,51 @@
   (register-class-statics! "java.lang.Thread" statics))
 
 ;; --- java.io.File / java.util.UUID constructors -----------------------------
-;; (java.io.File. parent child) joins with exactly ONE separator: File(parent,
-;; child) normalizes, so a parent that already ends in "/" does not produce a
-;; doubled slash (ring's resource middleware builds "assets/" + "index.html").
-;; A child that starts with a separator is joined the same way, and an empty
-;; child yields the parent's path alone -- all four checked against the JVM.
+;; (java.io.File. parent child) answers resolve(normalize(parent),
+;; normalize(child)) -- it normalizes each ARGUMENT, and then:
+;;
+;;   resolve(p, c) = p              when c is "" or "/"
+;;                 = c              when c is absolute and p is "/"
+;;                 = p + c          when c is absolute
+;;                 = p + c          when p is "/"
+;;                 = p + "/" + c    otherwise
+;;
+;; So a parent that already ends in "/" does not produce a doubled slash (ring's
+;; resource middleware builds "assets/" + "index.html"), a duplicate INSIDE
+;; either argument collapses, and a separator-only child yields the parent alone.
+;;
+;; A null parent is the child by itself. An EMPTY parent is not: it resolves
+;; against getDefaultParent(), which is "/" -- new File("", "c") is "/c", not
+;; "c", and new File("", "") is "/", not "". Both measured against the JVM.
+;;
+;; Worth knowing before measuring this yourself: resolve grew its c == "/" case
+;; in JDK 21. Through JDK 20, new File("/a/b", "/") answered "/a/b/" -- a path
+;; carrying a trailing separator no one-argument constructor can produce, whose
+;; .getName() was "". From 21 on it is "/a/b", which is what this matches.
+;;
+;; A null CHILD is not a null parent: the constructor null-checks it up front and
+;; throws, message and all -- new File("/a", null) raises NPE rather than
+;; answering "/a". jolt read it as "" and quietly answered the parent, the same
+;; silently-wrong-file shape as the nil coercions above.
 (define (jolt-file-join parent child)
-  (let* ((p (file-path-of parent))
-         (c (file-path-of child))
-         (p (if (and (> (string-length p) 1)
-                     (char=? (string-ref p (- (string-length p) 1)) #\/))
-                (substring p 0 (- (string-length p) 1))
-                p))
-         (c (let strip ((i 0))
-              (cond ((= i (string-length c)) c)
-                    ((char=? (string-ref c i) #\/) (strip (+ i 1)))
-                    (else (substring c i (string-length c)))))))
-    (cond ((string=? c "") p)
-          ((string=? p "/") (string-append "/" c))
-          (else (string-append p "/" c)))))
-(register-class-ctor! "File"
-  (lambda (a . rest)
-    (if (pair? rest)
-        (jolt-make-file (jolt-file-join a (car rest)))
-        (jolt-make-file a))))
+  (when (jolt-nil? child) (throw-jvm (quote NullPointerException) jolt-nil))
+  (let ((c (jolt-path-normalize (file-path-of child))))
+    (if (jolt-nil? parent)
+        c
+        (let* ((p (jolt-path-normalize (file-path-of parent)))
+               (p (if (string=? p "") "/" p)))
+          (cond ((or (string=? c "") (string=? c "/")) p)
+                ((char=? (string-ref c 0) #\/)
+                 (if (string=? p "/") c (string-append p c)))
+                ((string=? p "/") (string-append p c))
+                (else (string-append p "/" c)))))))
+;; new File((String)null) throws too, with a null message of its own. Only the
+;; two-arg form takes a null parent, and there it means "the child alone".
+(define (jolt-file-ctor a . rest)
+  (cond ((pair? rest) (jolt-make-file (jolt-file-join a (car rest))))
+        ((jolt-nil? a) (throw-jvm (quote NullPointerException) jolt-nil))
+        (else (jolt-make-file a))))
+(register-class-ctor! "File" jolt-file-ctor)
 ;; File statics: the platform separators plus createTempFile / listRoots.
 (define temp-file-counter 0)
 (define (file-create-temp prefix suffix . dir)
@@ -1536,11 +1580,7 @@
                      (cons "listRoots" (lambda () (jolt-vector (make-jfile "/")))))))
   (register-class-statics! "File" statics)
   (register-class-statics! "java.io.File" statics))
-(register-class-ctor! "java.io.File"
-  (lambda (a . rest)
-    (if (pair? rest)
-        (jolt-make-file (jolt-file-join a (car rest)))
-        (jolt-make-file a))))
+(register-class-ctor! "java.io.File" jolt-file-ctor)
 ;; java.nio.charset.StandardCharsets: the constants ARE the charset names —
 ;; every jolt charset seam (.getBytes, String ctors, InputStreamReader) takes
 ;; the name string, so the constant composes with all of them (clj-uuid's v3/v5

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -13,7 +13,37 @@
 ;; natives-meta.ss / records.ss / printing.ss (jolt-type / instance-check /
 ;; jolt-str-render-one, which it extends).
 
-(define-record-type jfile (fields path) (nongenerative jolt-jfile-v1))
+;; Every JVM File constructor runs its path through FileSystem.normalize(), so a
+;; File's path is ALWAYS normalized: runs of "/" collapse to one and a trailing
+;; "/" is dropped. "." and ".." are left alone -- the constructor does not resolve
+;; those, and neither does this. new File("/a/b//c").getPath() is "/a/b/c".
+;;
+;; Applied in the record's protocol rather than at the call sites, because there
+;; are nine of them and only one is the constructor entry point: as-file, the
+;; file: URL coercion, createTempFile, getParentFile and listRoots all build a
+;; jfile directly. The invariant belongs where it cannot be bypassed by the next
+;; one added.
+(define (jolt-path-normalize p)
+  (let ((n (string-length p)))
+    (if (fx=? n 0)
+        p
+        (let ((out (make-string n)))
+          (let loop ((i 0) (j 0) (prev-slash? #f))
+            (if (fx=? i n)
+                ;; a trailing separator goes, but "/" is a path, not an empty one
+                (let ((j (if (and (fx>? j 1) (char=? (string-ref out (fx- j 1)) #\/))
+                             (fx- j 1)
+                             j)))
+                  ;; nothing collapsed and nothing trimmed -> hand back the
+                  ;; original rather than an identical copy
+                  (if (fx=? j n) p (substring out 0 j)))
+                (let ((c (string-ref p i)))
+                  (cond ((and (char=? c #\/) prev-slash?) (loop (fx+ i 1) j #t))
+                        (else (string-set! out j c)
+                              (loop (fx+ i 1) (fx+ j 1) (char=? c #\/)))))))))))
+
+(define-record-type jfile (fields path) (nongenerative jolt-jfile-v1)
+  (protocol (lambda (new) (lambda (p) (new (jolt-path-normalize p))))))
 (define (jolt-file? x) (jfile? x))
 
 ;; path string of any value: a jfile -> its path, else its str rendering.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1146,16 +1146,24 @@
 ;; Normalization alone would have HIDDEN this rather than fixed it: joining
 ;; "/a/b" and "/c" produces "/a/b//c", which now collapses to "/a/b/c" and looks
 ;; like a correct answer to a call the JVM rejects.
-(define (io-file-relative-child c)
-  (let ((s (file-path-of c)))
-    (when (and (fx>? (string-length s) 0) (char=? (string-ref s 0) #\/))
+;; as-relative-path is Clojure's own coercion, and on the JVM it goes through
+;; as-file FIRST: normalize(child) is what .isAbsolute sees, so the thrown
+;; message names the normalized path -- (io/file "/a/b" "//c") says
+;; "/c is not a relative path", not "//c". io-file-relative-child checked the
+;; raw string, so the accept/reject set was right but the message diverged.
+;; Registered as io/as-relative-path too: public API in clojure.java.io on
+;; the JVM, and missing here entirely before.
+(define (jolt-as-relative-path x)
+  (let ((p (jfile-path (make-jfile (file-path-of x)))))
+    (when (and (fx>? (string-length p) 0) (char=? (string-ref p 0) #\/))
       (throw-jvm (quote IllegalArgumentException)
-                 (string-append s " is not a relative path")))
-    s))
+                 (string-append p " is not a relative path")))
+    p))
+(def-var! "clojure.java.io" "as-relative-path" jolt-as-relative-path)
 (define (jolt-io-file a . rest)
   (if (null? rest)
       (jolt-make-file a)
-      (apply jolt-make-file a (map io-file-relative-child rest))))
+      (apply jolt-make-file a (map jolt-as-relative-path rest))))
 (def-var! "clojure.java.io" "file" jolt-io-file)
 ;; io/as-file of a file: URL yields the file it points at (JVM: new
 ;; File(url.toURI())); a URL with any other protocol has no filesystem path —

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -998,6 +998,18 @@ else
   fails=$((fails + 1))
 fi
 
+# java.io.File path normalization — every JVM constructor collapses duplicate
+# separators and drops a trailing one, so a File's path is always normalized.
+# "." and ".." are left alone; resolving those is getCanonicalPath's job above.
+norm_out="$($jolt run test/chez/path-normalize-test.clj 2>&1)"
+if printf '%s' "$norm_out" | grep -q 'PATH-NORMALIZE OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: File path normalization"
+  printf '%s\n' "$norm_out" | tail -8 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # java.net autoloads jolt.socket, in a FRESH process with no require: a program
 # reaching for InetAddress or NetworkInterface should not have to know which
 # namespace installs them, any more than it does on the JVM. Each of these is a

--- a/test/chez/path-normalize-test.clj
+++ b/test/chez/path-normalize-test.clj
@@ -1,0 +1,98 @@
+;; java.io.File path-normalization gate — every JVM File constructor runs its
+;; path through FileSystem.normalize(), so a File's path is always normalized:
+;; runs of "/" collapse to one and a trailing "/" is dropped. "." and ".." are
+;; NOT resolved, by the JVM or here — that is getCanonicalPath's job, which
+;; canonical-path-test.clj covers.
+;;
+;; jolt used to keep the path exactly as given, so (File. "/a/b//c") answered
+;; "/a/b//c". The visible route in was createTempFile: $TMPDIR ends in "/" on
+;; macOS, so every temp file came back with a doubled separator in its path.
+;;
+;; The expected values below are JVM values, measured against Clojure 1.12.3 on
+;; OpenJDK 25 rather than reasoned about.
+;;
+;; Run: bin/jolt run test/chez/path-normalize-test.clj (smoke.sh greps for
+;; "PATH-NORMALIZE OK").
+(ns path-normalize-test
+  (:require [clojure.java.io :as io])
+  (:import [java.io File]))
+
+(def failures (atom []))
+(defn check [label got want]
+  (when-not (= got want)
+    (swap! failures conj (str label ": want " (pr-str want) " got " (pr-str got)))))
+
+;; --- the one-arg constructor -------------------------------------------------
+
+(doseq [[given want] [["/a/b//c"   "/a/b/c"]
+                      ["/a/b/"     "/a/b"]
+                      ["/a//b//c"  "/a/b/c"]
+                      ["//a/b"     "/a/b"]
+                      ["a//b"      "a/b"]
+                      ["//a//b//"  "/a/b"]
+                      ["///a"      "/a"]
+                      ["a//"       "a"]
+                      ["/a//"      "/a"]
+                      ;; a separator-only path is "/", not the empty string
+                      ["//"        "/"]
+                      ["/"         "/"]
+                      [""          ""]
+                      ;; "." and ".." survive: the constructor does not resolve
+                      ;; them, so neither may normalization
+                      ["."         "."]
+                      ["./"        "."]
+                      ["..//"      ".."]
+                      ["/a/./b"    "/a/./b"]
+                      ["/a/b/../c" "/a/b/../c"]]]
+  (check (str "(File. " (pr-str given) ")") (.getPath (File. given)) want))
+
+;; --- the two-arg constructor -------------------------------------------------
+;; The seam already joined correctly. What did not was a duplicate INSIDE either
+;; argument, which the seam-local join never looked at.
+
+(check "(File. parent-with-trailing child)" (.getPath (File. "/a/b/" "c")) "/a/b/c")
+(check "(File. parent-with-inner-dup child)" (.getPath (File. "/a//b" "c")) "/a/b/c")
+(check "(File. parent child-with-dup)" (.getPath (File. "/a" "b//c")) "/a/b/c")
+;; the two-arg constructor has no as-relative-path contract: it joins an
+;; absolute child rather than rejecting it, and the JVM agrees
+(check "(File. parent absolute-child)" (.getPath (File. "/a/b" "/c")) "/a/b/c")
+
+;; --- clojure.java.io/file and as-file ----------------------------------------
+;; io/file never reached the joining path at all: it is jolt-make-file directly,
+;; whose multi-arg loop appends "/" unconditionally.
+
+(check "(io/file parent child)" (.getPath (io/file "/a/b/" "c")) "/a/b/c")
+(check "(io/file parent child more)" (.getPath (io/file "/a/b/" "c" "d")) "/a/b/c/d")
+(check "(io/file dup)" (.getPath (io/file "/a//b")) "/a/b")
+(check "(io/as-file trailing)" (.getPath (io/as-file "/a//b/")) "/a/b")
+
+;; --- the route in ------------------------------------------------------------
+;; createTempFile builds its path from $TMPDIR, which ends in "/" on macOS. It
+;; also builds its jfile directly rather than through the constructor, which is
+;; why the invariant belongs at the record and not at one call site.
+
+(let [tmp (File/createTempFile "jolt-pathnorm" ".tmp")]
+  (try
+    (check "createTempFile has no doubled separator"
+           (boolean (re-find #"//" (.getPath tmp))) false)
+    (check "createTempFile still names a real file" (.exists tmp) true)
+    (finally (.delete tmp))))
+
+;; a File built under a directory whose path carries a trailing separator still
+;; round-trips through the filesystem
+(let [d (File. (str (System/getProperty "java.io.tmpdir") "/"))
+      f (io/file (.getPath d) (str "jolt-pathnorm-" (System/currentTimeMillis) ".txt"))]
+  (try
+    (spit f "ok")
+    (check "write/read under a trailing-separator dir" (slurp f) "ok")
+    (check "and its path has no doubled separator"
+           (boolean (re-find #"//" (.getPath f))) false)
+    (finally (.delete f))))
+
+;; --- report ------------------------------------------------------------------
+
+(if (seq @failures)
+  (do (println "PATH-NORMALIZE FAILURES:")
+      (doseq [f @failures] (println "  " f))
+      (System/exit 1))
+  (println "PATH-NORMALIZE OK"))

--- a/test/chez/path-normalize-test.clj
+++ b/test/chez/path-normalize-test.clj
@@ -56,6 +56,17 @@
 ;; the two-arg constructor has no as-relative-path contract: it joins an
 ;; absolute child rather than rejecting it, and the JVM agrees
 (check "(File. parent absolute-child)" (.getPath (File. "/a/b" "/c")) "/a/b/c")
+;; a separator-only child normalizes to "/" first, and resolve then joins
+;; parent+"/" -- which the constructor's normalize pass collapses back down.
+;; All five measured on the JVM.
+(check "(File. parent separator-only-child)" (.getPath (File. "/a/b" "///")) "/a/b")
+(check "(File. parent double-sep-only-child)" (.getPath (File. "/a/b" "//")) "/a/b")
+(check "(File. root separator-only-child)" (.getPath (File. "/" "//")) "/")
+(check "(File. parent absolute-child-trailing)" (.getPath (File. "/a/b/" "/c/")) "/a/b/c")
+(check "(File. parent absolute-child-single)" (.getPath (File. "/a/b" "/")) "/a/b")
+(check "(File. parent empty-child)" (.getPath (File. "/a/b" "")) "/a/b")
+(check "(File. root child)" (.getPath (File. "/" "c")) "/c")
+(check "(File. file-parent child)" (.getPath (File. (File. "/a//b") "c")) "/a/b/c")
 
 ;; --- clojure.java.io/file and as-file ----------------------------------------
 ;; io/file never reached the joining path at all: it is jolt-make-file directly,
@@ -82,9 +93,30 @@
        (raises-not-relative? #(io/file "/a/b" "/c")) true)
 (check "(io/file parent child absolute-more) raises"
        (raises-not-relative? #(io/file "/a" "b" "/c")) true)
+;; as-relative-path goes through as-file first, so what .isAbsolute sees -- and
+;; what the thrown message names -- is the NORMALIZED path
+(check "(io/file parent absolute-dup-child) message names the normalized path"
+       (try (io/file "/a/b" "//c") nil
+            (catch IllegalArgumentException e (.getMessage e)))
+       "/c is not a relative path")
 ;; a child with an interior separator is still relative, and joins
 (check "(io/file parent nested-relative-child)" (.getPath (io/file "/a" "b/c")) "/a/b/c")
 (check "(io/file relative relative)" (.getPath (io/file "a" "b")) "a/b")
+
+;; io/as-relative-path itself: public in clojure.java.io on the JVM, and it
+;; answers the normalized path on the way through
+(check "(io/as-relative-path relative-dup)" (io/as-relative-path "a//b") "a/b")
+(check "(io/as-relative-path trailing)" (io/as-relative-path "b/") "b")
+(check "(io/as-relative-path of a File)" (io/as-relative-path (File. "x//y")) "x/y")
+(check "(io/as-relative-path absolute-dup) message names the normalized path"
+       (try (io/as-relative-path "//c") nil
+            (catch IllegalArgumentException e (.getMessage e)))
+       "/c is not a relative path")
+
+;; io/make-parents builds (apply io/file f more) on the JVM, so it carries the
+;; same contract: an absolute child raises rather than quietly joining
+(check "(io/make-parents parent absolute-child) raises"
+       (raises-not-relative? #(io/make-parents "/a/b" "/c")) true)
 
 ;; --- the route in ------------------------------------------------------------
 ;; createTempFile builds its path from $TMPDIR, which ends in "/" on macOS. It

--- a/test/chez/path-normalize-test.clj
+++ b/test/chez/path-normalize-test.clj
@@ -66,6 +66,26 @@
 (check "(io/file dup)" (.getPath (io/file "/a//b")) "/a/b")
 (check "(io/as-file trailing)" (.getPath (io/as-file "/a//b/")) "/a/b")
 
+;; --- io/file's as-relative-path contract -------------------------------------
+;; io/file is not the File constructor. Clojure puts every child through
+;; as-relative-path, which throws on an absolute one, while the two-arg
+;; constructor above joins it. Normalization alone would have hidden this:
+;; joining "/a/b" and "/c" gives "/a/b//c", which collapses to a plausible
+;; "/a/b/c" answer to a call the JVM rejects.
+
+(defn- raises-not-relative? [f]
+  (try (f) false
+       (catch IllegalArgumentException e
+         (boolean (re-find #"is not a relative path" (.getMessage e))))))
+
+(check "(io/file parent absolute-child) raises"
+       (raises-not-relative? #(io/file "/a/b" "/c")) true)
+(check "(io/file parent child absolute-more) raises"
+       (raises-not-relative? #(io/file "/a" "b" "/c")) true)
+;; a child with an interior separator is still relative, and joins
+(check "(io/file parent nested-relative-child)" (.getPath (io/file "/a" "b/c")) "/a/b/c")
+(check "(io/file relative relative)" (.getPath (io/file "a" "b")) "a/b")
+
 ;; --- the route in ------------------------------------------------------------
 ;; createTempFile builds its path from $TMPDIR, which ends in "/" on macOS. It
 ;; also builds its jfile directly rather than through the constructor, which is

--- a/test/chez/path-normalize-test.clj
+++ b/test/chez/path-normalize-test.clj
@@ -1,8 +1,12 @@
 ;; java.io.File path-normalization gate — every JVM File constructor runs its
-;; path through FileSystem.normalize(), so a File's path is always normalized:
-;; runs of "/" collapse to one and a trailing "/" is dropped. "." and ".." are
-;; NOT resolved, by the JVM or here — that is getCanonicalPath's job, which
-;; canonical-path-test.clj covers.
+;; arguments through FileSystem.normalize(): runs of "/" collapse to one and a
+;; trailing "/" is dropped. "." and ".." are NOT resolved, by the JVM or here —
+;; that is getCanonicalPath's job, which canonical-path-test.clj covers.
+;;
+;; The one-arg constructor normalizes and is done. The two-arg one normalizes
+;; each ARGUMENT and then resolves them, which is a different contract: an empty
+;; parent resolves against getDefaultParent() rather than against "". Both
+;; shapes are pinned below.
 ;;
 ;; jolt used to keep the path exactly as given, so (File. "/a/b//c") answered
 ;; "/a/b//c". The visible route in was createTempFile: $TMPDIR ends in "/" on
@@ -56,17 +60,46 @@
 ;; the two-arg constructor has no as-relative-path contract: it joins an
 ;; absolute child rather than rejecting it, and the JVM agrees
 (check "(File. parent absolute-child)" (.getPath (File. "/a/b" "/c")) "/a/b/c")
-;; a separator-only child normalizes to "/" first, and resolve then joins
-;; parent+"/" -- which the constructor's normalize pass collapses back down.
-;; All five measured on the JVM.
-(check "(File. parent separator-only-child)" (.getPath (File. "/a/b" "///")) "/a/b")
-(check "(File. parent double-sep-only-child)" (.getPath (File. "/a/b" "//")) "/a/b")
-(check "(File. root separator-only-child)" (.getPath (File. "/" "//")) "/")
 (check "(File. parent absolute-child-trailing)" (.getPath (File. "/a/b/" "/c/")) "/a/b/c")
-(check "(File. parent absolute-child-single)" (.getPath (File. "/a/b" "/")) "/a/b")
+(check "(File. parent absolute-child-dup)" (.getPath (File. "/a/b" "/c//d")) "/a/b/c/d")
 (check "(File. parent empty-child)" (.getPath (File. "/a/b" "")) "/a/b")
 (check "(File. root child)" (.getPath (File. "/" "c")) "/c")
 (check "(File. file-parent child)" (.getPath (File. (File. "/a//b") "c")) "/a/b/c")
+(check "(File. parent-with-trailing-dup child)" (.getPath (File. "/a/b//" "c")) "/a/b/c")
+(check "(File. parent child-with-trailing)" (.getPath (File. "/a/b" "c//")) "/a/b/c")
+(check "(File. parent dotdot-child)" (.getPath (File. "/a/b" "..//")) "/a/b/..")
+(check "(File. dot-parent child)" (.getPath (File. "." "b")) "./b")
+(check "(File. relative empty-child)" (.getPath (File. "a" "")) "a")
+
+;; a separator-only child normalizes to "/", and resolve answers the parent
+;; alone. Careful measuring this one against an old JVM: resolve grew its
+;; c == "/" case in JDK 21, and through JDK 20 (File. "/a/b" "/") was "/a/b/",
+;; a trailing separator no one-arg constructor can produce. 21 onward it is
+;; "/a/b" — checked on 20, 21 and 26, and jolt matches 21+.
+(check "(File. parent separator-only-child)" (.getPath (File. "/a/b" "///")) "/a/b")
+(check "(File. parent double-sep-only-child)" (.getPath (File. "/a/b" "//")) "/a/b")
+(check "(File. parent absolute-child-single)" (.getPath (File. "/a/b" "/")) "/a/b")
+(check "(File. root separator-only-child)" (.getPath (File. "/" "//")) "/")
+
+;; an EMPTY parent resolves against getDefaultParent(), which is "/" -- not
+;; against the empty string, so the child comes back absolute
+(check "(File. empty-parent child)" (.getPath (File. "" "c")) "/c")
+(check "(File. empty-parent absolute-child)" (.getPath (File. "" "/c")) "/c")
+(check "(File. empty-parent empty-child)" (.getPath (File. "" "")) "/")
+(check "(File. empty-file-parent child)" (.getPath (File. (File. "") "c")) "/c")
+;; The hinted local below is only there to pick an overload for the JVM
+;; compiler, which cannot resolve (File. nil "c") on its own. Every File
+;; constructor taking a null in that position agrees on the answer.
+(let [^String s-nil nil]
+  ;; a nil parent is the child alone, default parent not consulted
+  (check "(File. nil-parent child)" (.getPath (File. s-nil "c")) "c")
+  (check "(File. nil-parent absolute-child)" (.getPath (File. s-nil "/c")) "/c")
+  ;; a null CHILD is null-checked before any of that, and so is the one-arg
+  ;; constructor's only argument — both raise rather than reading nil as ""
+  (check "(File. parent nil-child) raises"
+         (try (File. "/a" s-nil) false (catch NullPointerException _ true)) true)
+  (check "(File. nil) raises"
+         (try (File. s-nil) false (catch NullPointerException _ true)) true))
 
 ;; --- clojure.java.io/file and as-file ----------------------------------------
 ;; io/file never reached the joining path at all: it is jolt-make-file directly,
@@ -113,10 +146,24 @@
             (catch IllegalArgumentException e (.getMessage e)))
        "/c is not a relative path")
 
+;; Coercions is extended to nil, so as-file and the one-arg io/file answer nil
+;; rather than a File whose path is "" — which is the cwd, a different file
+;; altogether. as-relative-path goes through as-file, so a nil child is an NPE
+;; on the .isAbsolute rather than an empty child that quietly joins to nothing.
+(check "(io/as-file nil)" (io/as-file nil) nil)
+(check "(io/file nil)" (io/file nil) nil)
+(check "(io/file parent nil-child) raises"
+       (try (io/file "/a" nil) false (catch NullPointerException _ true)) true)
+(check "(io/as-relative-path nil) raises"
+       (try (io/as-relative-path nil) false (catch NullPointerException _ true)) true)
+
 ;; io/make-parents builds (apply io/file f more) on the JVM, so it carries the
 ;; same contract: an absolute child raises rather than quietly joining
 (check "(io/make-parents parent absolute-child) raises"
        (raises-not-relative? #(io/make-parents "/a/b" "/c")) true)
+;; and the nil, since (io/file nil) is nil and .getParentFile raises on it
+(check "(io/make-parents nil) raises"
+       (try (io/make-parents nil) false (catch NullPointerException _ true)) true)
 
 ;; --- the route in ------------------------------------------------------------
 ;; createTempFile builds its path from $TMPDIR, which ends in "/" on macOS. It


### PR DESCRIPTION
Fixes #793.

Two commits, and the second is deliberately separable — see "The second commit is a decision, not a fix" below.

## What was wrong

Every JVM `File` constructor runs its path through `FileSystem.normalize()`, so a `File`'s path is always normalized: runs of `/` collapse to one, a trailing `/` is dropped. jolt kept the string as given.

```
                           JVM        jolt (before)
(File. "/a/b//c")          /a/b/c     /a/b//c
(File. "/a/b/")            /a/b       /a/b/
(File. "/a//b" "c")        /a/b/c     /a//b/c
(io/file "/a/b/" "c")      /a/b/c     /a/b//c
(io/file "/a/b/" "c" "d")  /a/b/c/d   /a/b//c/d
(io/as-file "/a//b/")      /a/b       /a//b/
```

`.` and `..` are not resolved by the JVM constructor either, and jolt already matched there. That is `getCanonicalPath`, which `canonical-path-test.clj` covers.

The visible route in is `createTempFile`: `$TMPDIR` ends in `/` on macOS, so every temp file came back carrying a doubled separator.

## Where the fix went

Not in `jolt-file-join`, and not at the `io/file` registration. Both were tempting and both are wrong places.

`jolt-file-join` already normalized, but only the **join seam** — it strips a trailing separator from the parent and leading ones from the child, and never looks inside either. That is why `(File. "/a//b" "c")` still gave `/a//b/c`.

The deeper problem is that there are nine `make-jfile` call sites and only one is the constructor entry point. `as-file`, the `file:` URL coercion, `createTempFile`, `getParentFile` and `listRoots` all build a `jfile` directly, which is why `io/as-file` had the bug too. So normalization goes in the record's own protocol, where the JVM's actual invariant lives and where the next call site added cannot bypass it.

## The second commit is a decision, not a fix

**Drop the second commit if you would rather `io/file` kept joining an absolute child.** It changes behavior on its own and it is your call, not mine. Each commit carries its own `CHANGELOG.md` entry for exactly this reason, so dropping one leaves the other's entry intact and correct.

But please do not take the first commit alone. `clojure.java.io/file` is not the `File` constructor: Clojure puts every child through `as-relative-path`, which throws on an absolute one, while the two-arg constructor joins it.

```
(io/file "/a/b" "/c")   JVM raises IllegalArgumentException "/c is not a relative path"
(File. "/a/b" "/c")     JVM answers /a/b/c
```

Normalization alone **hides** this rather than fixing it. `"/a/b"` joined to `"/c"` produces `/a/b//c`, which now collapses to `/a/b/c` — a plausible-looking answer to a call the JVM refuses. Shipping the first commit by itself trades a visibly wrong path for a silently wrong one, and the difference matters in practice: `/a/b//c` is something a person notices in a log, whereas `/a/b/c` quietly pointing at the wrong file is not.

Only `io/file` gains the contract. The constructor keeps joining, and the gate asserts both side by side rather than one of them.

On the risk of taking it: a call site that newly throws under this commit is a call site that is **already broken for JVM Clojure**, because `io/file` has always rejected an absolute child there. So the change cannot break code that works on the JVM today. It can only surface code that jolt was quietly accepting and the JVM was not, which is the same class of thing the corpus and `certify` exist to catch.

## Gate

New: `test/chez/path-normalize-test.clj`, wired into `host/chez/smoke.sh` next to `canonical-path-test.clj`, same self-check-plus-marker shape.

Every expected value is a JVM value, measured against Clojure 1.12.3 on OpenJDK 25 rather than reasoned about — including the cases where normalization must **not** fire (`/` stays `/`, `""` stays `""`, `/a/./b` and `/a/b/../c` unchanged, `..//` becomes `..`), and the `as-relative-path` throw across arities.

## What I ran

| gate | result |
|---|---|
| `make smoke` | 192 passed, 0 failed (up one, the new gate) |
| `make unit` | green |
| `make corpus` | 4759/4769, **0 NEW divergences**, 10 known |
| `make certify` | 108/108 divergences known, **0 new, 0 stale** |
| `make test` | **OK: ci gate passed (90 targets)**, test gate passed (3 targets) |
| `make libconformance` | **not run** — no library checkout on this machine |

`libconformance` is a genuine gap rather than a pass, so the 47-suite replay is unverified from my side. Since this touches path handling that libraries lean on, that is the coverage I would most want before merge.

`make remint` was not run: `host/chez/java/io.ss` is a runtime host file loaded by `rt.ss`, not a compiler source, so the seed is unaffected. Please tell me if that reading is wrong.

## On the underlying question

#793 asked whether the verbatim path was deliberate, and I have written this PR on the assumption it was not — the reasoning is in the issue. If it was in fact a decision, this can be closed and I would still rather know the reason than be right.
