### PR TITLE
Normalize File paths like the JVM constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+`java.io.File` normalizes its path the way the JVM constructor does: runs of
+separators collapse and one trailing separator drops (the root `/` alone keeps
+its), while `.` and `..` are still left alone (#793). The normalization lives
+in the jfile record constructor, so every File creation site — including
+`getParentFile`, `listFiles` children, `io/as-file`, and `File/createTempFile`,
+whose temp paths no longer carry a doubled separator when `$TMPDIR` ends in `/`
+— answers normalized paths. The two-arg constructor now implements
+`UnixFileSystem.resolve` over normalized inputs, and `clojure.java.io/file`'s
+multi-arg forms gained Clojure's `as-relative-path` contract (registered as
+`io/as-relative-path` too): an absolute child throws
+IllegalArgumentException (`… is not a relative path`) instead of quietly
+joining, matching the JVM. `io/make-parents` follows `io/file` semantics for
+the same reason.
+
 The build keeps one toolchain end to end now. When make provisions the pinned
 Chez + xPack GCC, the standalone-binary link runs through that same provisioned
 GCC — `JOLT_CC`, honored by `build.ss`'s `bld-cc` — instead of a bare `cc`,

--- a/host/chez/java/io-streams.ss
+++ b/host/chez/java/io-streams.ss
@@ -867,7 +867,9 @@
             ((char=? (string-ref p i) #\/) (mkdirs! (substring p 0 i)))
             (else (loop (- i 1)))))))
 (define (apply-make-file-path args)
-  (jfile-path (apply jolt-make-file args)))
+  ;; the JVM's make-parents is (.mkdirs (as-file (apply file f more))) — io/file
+  ;; semantics, not the bare ctor, so an absolute child throws here too
+  (jfile-path (apply jolt-io-file args)))
 (def-var! "clojure.java.io" "make-parents" jio-make-parents)
 
 ;; io/delete-file: delete the file; raise unless :silently truthy.

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -13,8 +13,28 @@
 ;; natives-meta.ss / records.ss / printing.ss (jolt-type / instance-check /
 ;; jolt-str-render-one, which it extends).
 
-(define-record-type jfile (fields path) (nongenerative jolt-jfile-v1))
+(define-record-type (jfile %make-jfile jfile?) (fields path) (nongenerative jolt-jfile-v1))
 (define (jolt-file? x) (jfile? x))
+
+;; java.io.FileSystem#normalize (Unix), which every JVM File constructor runs
+;; its path through: a run of separators collapses to one, and one trailing
+;; separator drops — except on the root "/" alone. "." and ".." are NOT
+;; resolved, and a relative path stays relative. Routing it through the record
+;; constructor makes "a File's path is always normalized" an invariant here
+;; too: no creation site below can store a verbatim path, same as the JVM.
+(define (jolt-normalize-path p)
+  (let ((n (string-length p)))
+    (let ((buf (make-string n)))
+      (let collapse ((i 0) (j 0))
+        (if (= i n)
+            (let ((j (if (and (> j 1) (char=? (string-ref buf (- j 1)) #\/)) (- j 1) j)))
+              (if (= j n) p (substring buf 0 j)))
+            (let ((c (string-ref p i)))
+              (if (and (char=? c #\/) (> j 0) (char=? (string-ref buf (- j 1)) #\/))
+                  (collapse (+ i 1) j)
+                  (begin (string-set! buf j c) (collapse (+ i 1) (+ j 1))))))))))
+
+(define (make-jfile p) (%make-jfile (jolt-normalize-path p)))
 
 ;; path string of any value: a jfile -> its path, else its str rendering.
 (define (file-path-of x) (if (jfile? x) (jfile-path x) (jolt-str-render-one x)))
@@ -209,17 +229,19 @@
         ;; path — leave it alone rather than prefixing "./".
         (if (string=? base ".") p (string-append base "/" p)))))
 
-;; (io/file path) / (io/file parent child) — join children with "/". The File
-;; keeps the path AS GIVEN (like the JVM: new File("rel").getPath() is "rel");
-;; a relative path resolves against JOLT_PWD only when the filesystem is touched
-;; (jfile-fs / slurp / spit / the stream constructors).
+;; (io/file path) / (io/file parent child) — join children with "/". Like the
+;; JVM, the stored path is normalized (duplicate separators collapse, a
+;; trailing one drops — the record constructor does it) but NOT made absolute:
+;; new File("rel").getPath() is "rel", and a relative path resolves against
+;; JOLT_PWD only when the filesystem is touched (jfile-fs / slurp / spit /
+;; the stream constructors).
 (define (jolt-make-file path . rest)
   (let loop ((p (file-path-of path)) (cs rest))
     (if (null? cs)
         ;; (io/file url) strips the scheme — File of url.toURI on the JVM; only a
         ;; file: url names a path. url-file-coercion is defined below; call-time ref.
         (if (and (null? rest) (jhost? path) (string=? (jhost-tag path) "url")) (url-file-coercion path) (make-jfile p))
-        (loop (string-append p "/" (file-path-of (car cs))) (cdr cs)))))
+        (loop (jolt-file-join p (car cs)) (cdr cs)))))
 ;; the on-disk path of a value: a relative path resolves against JOLT_PWD.
 (define (jfile-fs f) (project-relative (file-path-of f)))
 
@@ -235,8 +257,9 @@
 ;; Resolving the base to an absolute path first made every child absolute, so a
 ;; caller that relativized the results against the directory it passed in (a
 ;; classpath scanner turning files into namespace names) got ../../-prefixed
-;; garbage. A trailing slash is dropped the way the File constructor normalizes
-;; it away.
+;; garbage. A trailing separator is trimmed inline so children join with
+;; exactly one separator (the File constructor would normalize it away too —
+;; but this also takes raw strings, which are stored as given).
 (define (jolt-list-dir path)
   (let* ((given (file-path-of path))
          (p (project-relative given))
@@ -1107,7 +1130,26 @@
     (else (throw-jvm (quote IllegalArgumentException) (string-append "Cannot open <" (jolt-pr-str x) "> as a Writer.")))))
 
 ;; --- clojure.java.io ns -----------------------------------------------------
-(def-var! "clojure.java.io" "file" jolt-make-file)
+;; io/file is Clojure's, not the bare ctor: the single-arg form is as-file
+;; (jolt-make-file keeps the url coercion here); every multi-arg step is
+;; (File. (as-file parent) (as-relative-path child)), so a child must be
+;; RELATIVE — IllegalArgumentException, exactly the JVM message — rather than
+;; quietly joined the way (File. "/a/b" "/c") does. Checked against Clojure
+;; 1.12 io.clj.
+(define (jolt-as-relative-path x)
+  (let ((p (jfile-path (make-jfile (file-path-of x)))))
+    (if (and (> (string-length p) 0) (char=? (string-ref p 0) #\/))
+        (throw-jvm 'IllegalArgumentException (string-append p " is not a relative path"))
+        p)))
+(def-var! "clojure.java.io" "as-relative-path" jolt-as-relative-path)
+(define (jolt-io-file a . rest)
+  (if (null? rest)
+      (jolt-make-file a)
+      (let loop ((f (jolt-make-file (jolt-file-join a (jolt-as-relative-path (car rest)))))
+                 (more (cdr rest)))
+        (if (null? more) f
+            (loop (jolt-make-file (jolt-file-join f (jolt-as-relative-path (car more)))) (cdr more))))))
+(def-var! "clojure.java.io" "file" jolt-io-file)
 ;; io/as-file of a file: URL yields the file it points at (JVM: new
 ;; File(url.toURI())); a URL with any other protocol has no filesystem path —
 ;; IllegalArgumentException, as the JVM's File(URI) throws.
@@ -1426,29 +1468,28 @@
   (register-class-statics! "java.lang.Thread" statics))
 
 ;; --- java.io.File / java.util.UUID constructors -----------------------------
-;; (java.io.File. parent child) joins with exactly ONE separator: File(parent,
-;; child) normalizes, so a parent that already ends in "/" does not produce a
-;; doubled slash (ring's resource middleware builds "assets/" + "index.html").
-;; A child that starts with a separator is joined the same way, and an empty
-;; child yields the parent's path alone -- all four checked against the JVM.
+;; (java.io.File. parent child) is resolve(normalize(parent), normalize(child))
+;; — UnixFileSystem.resolve: an empty child yields the parent alone; a child
+;; that starts with a separator is appended with its slash as the join seam
+;; (File("/a/b" "/c") is "/a/b/c"); the root parent takes the child without a
+;; second separator; otherwise exactly one separator between them (ring's
+;; resource middleware builds "assets/" + "index.html"). All cases checked
+;; against the JVM.
 (define (jolt-file-join parent child)
-  (let* ((p (file-path-of parent))
-         (c (file-path-of child))
-         (p (if (and (> (string-length p) 1)
-                     (char=? (string-ref p (- (string-length p) 1)) #\/))
-                (substring p 0 (- (string-length p) 1))
-                p))
-         (c (let strip ((i 0))
-              (cond ((= i (string-length c)) c)
-                    ((char=? (string-ref c i) #\/) (strip (+ i 1)))
-                    (else (substring c i (string-length c)))))))
+  (let* ((p (jolt-normalize-path (file-path-of parent)))
+         (c (jolt-normalize-path (file-path-of child))))
     (cond ((string=? c "") p)
-          ((string=? p "/") (string-append "/" c))
+          ((char=? (string-ref c 0) #\/)
+           (if (string=? p "/") c (string-append p c)))
+          ((string=? p "/") (string-append p c))
           (else (string-append p "/" c)))))
+;; File(parent, child) stores resolve()'s output as-is — a separator-only
+;; child ("//") yields "/parent/" — so build the record directly from the join
+;; instead of re-normalizing it through jolt-make-file.
 (register-class-ctor! "File"
   (lambda (a . rest)
     (if (pair? rest)
-        (jolt-make-file (jolt-file-join a (car rest)))
+        (%make-jfile (jolt-file-join a (car rest)))
         (jolt-make-file a))))
 ;; File statics: the platform separators plus createTempFile / listRoots.
 (define temp-file-counter 0)
@@ -1467,8 +1508,10 @@
               (set! temp-file-counter (+ temp-file-counter 1))
               temp-file-counter)))
     (let loop ((n n))
-      (let ((p (string-append d "/" (jolt-str-render-one prefix)
-                              (number->string (now-millis)) "-" (number->string n) sfx)))
+      (let ((p (jolt-file-join d (string-append (jolt-str-render-one prefix)
+                              (number->string (now-millis)) "-" (number->string n) sfx))))
+        ;; the JVM builds new File(dir, name), so the join normalizes — $TMPDIR
+        ;; ends in a separator on macOS and must not yield a doubled one
         (if (file-exists? p) (loop (+ n 1))
             (begin (close-port (open-output-file p 'truncate)) (make-jfile p))))))))
 (let ((statics (list (cons "separator" "/")
@@ -1482,7 +1525,7 @@
 (register-class-ctor! "java.io.File"
   (lambda (a . rest)
     (if (pair? rest)
-        (jolt-make-file (jolt-file-join a (car rest)))
+        (%make-jfile (jolt-file-join a (car rest)))
         (jolt-make-file a))))
 ;; java.nio.charset.StandardCharsets: the constants ARE the charset names —
 ;; every jolt charset seam (.getBytes, String ctors, InputStreamReader) takes

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -998,6 +998,19 @@ else
   fails=$((fails + 1))
 fi
 
+# java.io.File / clojure.java.io/file path normalization — the JVM constructor
+# collapses duplicate separators and drops one trailing one; io/file adds
+# Clojure's as-relative-path contract on the multi-arg forms (#793). Self-checks,
+# one marker.
+norm_out="$($jolt run test/chez/file-normalize-test.clj 2>&1)"
+if printf '%s' "$norm_out" | grep -q 'FILE-NORMALIZE OK'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: File path normalization"
+  printf '%s\n' "$norm_out" | tail -8 | sed 's/^/    /'
+  fails=$((fails + 1))
+fi
+
 # java.net autoloads jolt.socket, in a FRESH process with no require: a program
 # reaching for InetAddress or NetworkInterface should not have to know which
 # namespace installs them, any more than it does on the JVM. Each of these is a

--- a/test/chez/file-normalize-test.clj
+++ b/test/chez/file-normalize-test.clj
@@ -1,0 +1,106 @@
+;; java.io.File path normalization gate — the JVM constructor runs its path
+;; through FileSystem.normalize: runs of separators collapse and one trailing
+;; separator drops (the root "/" alone keeps its slash); "." and ".." are NOT
+;; resolved. clojure.java.io/file layers as-relative-path on the multi-arg
+;; forms: each child must be relative or IllegalArgumentException, and the
+;; join goes through File(parent, child), which normalizes the seam.
+;; (jolt-lang/jolt#793)
+;;
+;; Run: bin/jolt run test/chez/file-normalize-test.clj (smoke.sh greps for
+;; "FILE-NORMALIZE OK").
+(ns file-normalize-test
+  (:import [java.io File])
+  (:require [clojure.java.io :as io]))
+
+(def failures (atom []))
+(defn check [label got want]
+  (when-not (= got want)
+    (swap! failures conj (str label ": want " (pr-str want) " got " (pr-str got)))))
+
+(defn path ^String [f] (.getPath f))
+
+;; --- one-arg constructor: normalize, don't resolve ---------------------------
+
+(check "duplicate separators collapse" (path (File. "/a/b//c")) "/a/b/c")
+(check "trailing separator drops" (path (File. "/a/b/")) "/a/b")
+(check "several runs collapse" (path (File. "/a//b//c")) "/a/b/c")
+(check "leading run collapses" (path (File. "//a/b")) "/a/b")
+(check "relative run collapses" (path (File. "a//b")) "a/b")
+(check "root stays root" (path (File. "/")) "/")
+(check "only separators is root" (path (File. "///")) "/")
+(check "empty stays empty" (path (File. "")) "")
+(check "dot is not resolved" (path (File. "/a/./b")) "/a/./b")
+(check "dotdot is not resolved" (path (File. "/a/b/../c")) "/a/b/../c")
+(check "str sees the normalized path" (str (File. "/a//b")) "/a/b")
+(check "relative stays relative" (path (File. "rel//x")) "rel/x")
+
+;; --- two-arg constructor: resolve(normalize parent, normalize child) ---------
+
+(check "seam with trailing parent" (path (File. "/a/b/" "c")) "/a/b/c")
+(check "parent run collapses" (path (File. "/a//b" "c")) "/a/b/c")
+(check "absolute child is joined" (path (File. "/a/b" "/c")) "/a/b/c")
+(check "empty child yields parent" (path (File. "/a/b" "")) "/a/b")
+(check "root parent takes child" (path (File. "/" "c")) "/c")
+(check "separator-only child" (path (File. "/a/b" "///")) "/a/b/")
+(check "child trailing separator" (path (File. "/a/b/" "c/")) "/a/b/c")
+(check "File parent argument" (path (File. (File. "/a//b") "c")) "/a/b/c")
+
+;; --- clojure.java.io/file ----------------------------------------------------
+
+(check "io/file single arg normalizes" (path (io/file "/a/b//c")) "/a/b/c")
+(check "io/file seam" (path (io/file "/a/b/" "c")) "/a/b/c")
+(check "io/file reduce over more" (path (io/file "/a/b/" "c" "d")) "/a/b/c/d")
+(check "io/file parent run" (path (io/file "/a//b" "c")) "/a/b/c")
+(check "io/file relative child run" (path (io/file "/a/b" "c//d")) "/a/b/c/d")
+(check "io/file File parent" (path (io/file (File. "/a//b") "c")) "/a/b/c")
+(check "io/file File passthrough" (path (io/file (io/file "/a/b//c"))) "/a/b/c")
+
+(check "io/file absolute child throws"
+       (try (path (io/file "/a/b" "/c")) :no-throw
+            (catch IllegalArgumentException e :threw))
+       :threw)
+(check "io/file absolute child message"
+       (try (path (io/file "/a/b" "//c")) nil
+            (catch IllegalArgumentException e (.getMessage e)))
+       "/c is not a relative path")
+(check "io/file absolute File child throws"
+       (try (path (io/file "/a/b" (io/file "/c"))) :no-throw
+            (catch IllegalArgumentException _ :threw))
+       :threw)
+(check "io/file absolute child in more throws"
+       (try (path (io/file "/a/b" "c" "/d")) :no-throw
+            (catch IllegalArgumentException _ :threw))
+       :threw)
+
+;; --- the method surface sees normalized paths --------------------------------
+
+(check "getParentFile of collapsed path" (path (.getParentFile (File. "/a//b/c"))) "/a/b")
+(check "getAbsolutePath normalizes the tail" (.endsWith (.getAbsolutePath (File. "a//b")) "/a/b") true)
+(check "getName of collapsed path" (.getName (File. "/a//b")) "b")
+
+;; --- createTempFile: the temp dir often ends in a separator ------------------
+
+(def tmp (System/getProperty "java.io.tmpdir"))
+(def tmp-file (File/createTempFile "joltnorm" ".tmp" (io/file (str tmp "/"))))
+(check "createTempFile joins one separator" (re-find #"//" (path tmp-file)) nil)
+(check "createTempFile keeps suffix" (.endsWith (path tmp-file) ".tmp") true)
+(.delete tmp-file)
+
+;; --- listFiles children carry the normalized parent --------------------------
+
+(def norm-dir (str tmp "/jolt-norm-" (System/currentTimeMillis)))
+(.mkdirs (File. (str norm-dir "//sub")))
+(spit (str norm-dir "/sub/f.txt") "x")
+(def children (map path (.listFiles (File. (str norm-dir "/sub/")))))
+(check "listFiles child has no doubled separator" (some #(re-find #"//" %) children) nil)
+(check "listFiles finds the file" (some #(.endsWith % "f.txt") children) true)
+(doseq [f [(str norm-dir "/sub/f.txt") (str norm-dir "/sub") norm-dir]]
+  (try (.delete (File. f)) (catch Throwable _ nil)))
+
+;; --- report ------------------------------------------------------------------
+
+(if (seq @failures)
+  (do (println "FILE-NORMALIZE FAILURES:")
+      (doseq [f @failures] (println " " f))
+      (System/exit 1))
+  (println "FILE-NORMALIZE OK"))


### PR DESCRIPTION
Fixes #793.

Every `java.io.File` constructor on the JVM runs its path through `FileSystem.normalize`: runs of separators collapse and one trailing separator drops (the root `/` alone keeps its), while `.` and `..` are left alone. jolt stored the path as given. Three changes close the gap:

- **The normalize lives in the jfile record constructor** (`host/chez/java/io.ss`), so "a File's path is always normalized" is an invariant — every creation site answers normalized paths, including `getParentFile`, `listFiles` children, `io/as-file`, and URL coercion, which no site can opt out of.
- **`jolt-file-join` now implements `UnixFileSystem.resolve(normalize(parent), normalize(child))`** instead of only trimming the join seam, so `(File. "/a//b" "c")` is `/a/b/c`. The two-arg ctor stores the resolved result verbatim (a separator-only child yields `/parent/`, JVM-faithful). `File/createTempFile` joins through it, so `$TMPDIR` ending in `/` no longer produces `.../T//name`.
- **`clojure.java.io/file`'s multi-arg forms carry Clojure's `as-relative-path` contract** (registered as `io/as-relative-path` too): an absolute child throws `IllegalArgumentException` with the JVM's `… is not a relative path` message rather than silently joining — the gap the issue called out as worth deciding deliberately. `io/make-parents` routes through the same semantics, since the JVM builds it from `(apply file f more)`.

Scope is exactly the issue's: duplicate and trailing separators. `.`/`..` resolution is untouched, matching the JVM.

New gate `test/chez/file-normalize-test.clj` (wired into `smoke.sh` as the `FILE-NORMALIZE` case) covers the issue's measured table plus the as-relative-path throws, `createTempFile`, and `listFiles` children.

Verified: `make smoke` 192/192, `make unit` 1532/1532, `make corpus` 0 new divergences (10 known allowlisted), `make documented` 35/35, `make ioscaling` and `make grenadine` pass.