### PR TITLE
fix(adapter): a portable-bytecode build is not necessarily Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ stays authoritative.
 
 ### Fixed
 
+- **A portable-bytecode build reported itself as Linux, wherever it was running.**
+  `sa-os-family` derived the OS by substring-matching Chez's machine tag, which
+  answers for a native tag and cannot answer for a bytecode one: `pb`, `pb64l`
+  and `tpb64l` name the threading, word size and endianness and deliberately
+  name no OS, because the same bytecode is meant to run on any of them. So the
+  `else` branch fired and every bytecode build called itself Linux, macOS
+  included (#796).
+
+  That function is the single place the rest of the host asks what OS this is,
+  so one wrong answer was wrong everywhere at once: `SIGCHLD` (20 vs 17),
+  `EAGAIN` (35 vs 11), `O_NONBLOCK`, `LC_TIME`, the `struct stat` offsets, the
+  chmod and entropy fallbacks, and the link libraries. The visible route in was
+  a socket — `jolt.nrepl` handed Darwin's `socket()` the Linux `SOCK_CLOEXEC`,
+  so a bytecode build on a Mac could not bind an nREPL server at all.
+
+  A tag containing `pb` now probes the running host instead of being parsed:
+  `/System/Library/CoreServices/SystemVersion.plist` for Darwin (chosen over
+  `libSystem.B.dylib` because it is readable from inside a sandbox, which
+  anything in the dyld shared cache is not), `/proc/self/status` for Linux,
+  `SystemRoot` for Windows, cached for the life of the process. Native tags
+  never reach the branch, so `tarm64osx`, `ta6nt` and `ta6le` resolve exactly as
+  before, and an unrecognized non-`pb` tag still falls through to `linux` rather
+  than newly probing.
+
+  Still open, and pinned by the gate so it is not mistaken for done: a pb tag
+  *does* carry its word size and endianness, and neither `sa-arch` nor
+  `sa-endian` parses that shape, so `pb64l` answers `other` and `#f`. Both
+  stat-layout arms in `nio-file` therefore stay false and a pb build on x86-64
+  Linux still refuses `getPosixFilePermissions`; the Darwin case is fixed only
+  because that guard does not consult the arch. Closing it needs probes of their
+  own.
+
 - **A `File`'s path was kept exactly as given, not normalized.** Every JVM `File`
   constructor runs its path through `FileSystem.normalize()`, so runs of `/`
   collapse to one and a trailing `/` is dropped: `new File("/a/b//c").getPath()`

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscali
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform coreproc traceemit traceeval degradedbacktrace \
-  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
+  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck hostprops lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
   certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety
@@ -846,6 +846,14 @@ census:
 # contract file lists a name Chez does not provide.
 adaptercheck:
 	@$(CHEZ) --script host/scheme-adapter/chez.ss
+
+# The three derived host properties (sa-os-family / sa-arch / sa-endian) are all
+# host logic may ask about the platform, so one wrong row is a wrong SIGCHLD,
+# LC_TIME and struct-stat offset at once. The row that broke in #796 — a
+# portable-bytecode tag, which names no OS — is only reachable from a host we do
+# not build on, so the table is pinned per tag rather than per running machine.
+hostprops:
+	@$(CHEZ) --script test/chez/host-derived-props-test.ss
 
 # Every lock in the runtime must route through jolt's wrapper, because
 # preemption is refused while one is held and that only works if the runtime can

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -149,6 +149,22 @@
             ((string=? (substring tag i (+ i m)) needle) #t)
             (else (loop (+ i 1)))))))
 
+;; (sa-probed-os-family) -> 'macos | 'windows | 'linux
+;; The OS family for a host tag that does not carry one, probed from the
+;; filesystem. Contract: the family the process is actually running on.
+;; Degradation: 'linux, matching the else-branch it replaces. Cached because
+;; sa-os-family is consulted from hot paths and the answer cannot change while
+;; the process runs.
+(define sa-os-family-cache #f)
+(define (sa-probed-os-family)
+  (or sa-os-family-cache
+      (let ((fam (cond ((file-exists? "/System/Library/CoreServices/SystemVersion.plist") 'macos)
+                       ((file-exists? "/proc/self/status") 'linux)
+                       ((getenv "SystemRoot") 'windows)
+                       (else 'linux))))
+        (set! sa-os-family-cache fam)
+        fam)))
+
 ;; (sa-os-family) -> 'macos | 'windows | 'linux
 ;; The OS family every host OS branch derives: SIGCHLD/SIG_BLOCK numerics
 ;; (process.ss, concurrency.ss), LC_TIME (tz-primitives.ss), struct-stat
@@ -157,10 +173,18 @@
 ;; of the three symbols. Degradation: none — the sites have no safe assumed
 ;; default; an unrecognized host falls back to 'linux, matching today's
 ;; else-branches.
+;;
+;; Portable-bytecode tags (pb, pb64l, tpb64l, ...) name the threading, word
+;; size and endianness and deliberately name no OS, because the same bytecode
+;; is meant to run on any of them. The tag therefore cannot answer for them and
+;; the else-branch called every bytecode build 'linux, including one running on
+;; macOS — which picks the Linux SIGCHLD, EAGAIN, O_NONBLOCK, LC_TIME and
+;; struct-stat values on a Darwin host. Probe instead.
 (define (sa-os-family)
   (let ((m (sa-host-tag)))
     (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")) 'macos)
           ((or (sa-tag-contains? m "nt") (sa-tag-contains? m "windows")) 'windows)
+          ((sa-tag-contains? m "pb") (sa-probed-os-family))
           (else 'linux))))
 
 ;; (sa-arch) -> 'x86-64 | 'arm64 | 'i386 | 'other

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -181,28 +181,46 @@
 ;; macOS — which picks the Linux SIGCHLD, EAGAIN, O_NONBLOCK, LC_TIME and
 ;; struct-stat values on a Darwin host. Probe instead.
 (define (sa-os-family)
-  (let ((m (sa-host-tag)))
-    (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")) 'macos)
-          ((or (sa-tag-contains? m "nt") (sa-tag-contains? m "windows")) 'windows)
-          ((sa-tag-contains? m "pb") (sa-probed-os-family))
-          (else 'linux))))
+  (sa-os-family-for-tag (sa-host-tag)))
+
+;; (sa-os-family-for-tag tag) -> 'macos | 'windows | 'linux
+;; The derivation above, as a function OF the tag, so the gate can pin the whole
+;; table on one host instead of only the row that host happens to be
+;; (test/chez/host-derived-props-test.ss). The bug this splits out of was in
+;; this cond and was reported with the cond transcribed into Clojure, because
+;; there was no way to ask it about a tag. NOT for callers: anything with a tag
+;; to pass is branching on the tag, which sa-host-tag's contract forbids.
+(define (sa-os-family-for-tag m)
+  (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")) 'macos)
+        ((or (sa-tag-contains? m "nt") (sa-tag-contains? m "windows")) 'windows)
+        ((sa-tag-contains? m "pb") (sa-probed-os-family))
+        (else 'linux)))
 
 ;; (sa-arch) -> 'x86-64 | 'arm64 | 'i386 | 'other
 ;; The machine architecture — the nio-file stat-layout guard keys on x86-64.
 ;; Contract: the architecture symbol. Degradation: 'other for an unrecognized
 ;; host; callers treat it as unverified.
 (define (sa-arch)
-  (let ((m (sa-host-tag)))
-    (cond ((sa-tag-contains? m "arm64") 'arm64)
-          ((sa-tag-contains? m "a6") 'x86-64)
-          ((sa-tag-contains? m "i3") 'i386)
-          (else 'other))))
+  (sa-arch-for-tag (sa-host-tag)))
+
+;; (sa-arch-for-tag tag) -> the derivation above as a function OF the tag, on
+;; the same terms as sa-os-family-for-tag: for the gate, not for callers.
+(define (sa-arch-for-tag m)
+  (cond ((sa-tag-contains? m "arm64") 'arm64)
+        ((sa-tag-contains? m "a6") 'x86-64)
+        ((sa-tag-contains? m "i3") 'i386)
+        (else 'other)))
 
 ;; (sa-endian) -> 'little | 'big | #f
 ;; Byte order of the host. Contract: the byte order. Degradation: #f for an
 ;; unrecognized suffix — the stat-layout guard treats that as unverified.
 (define (sa-endian)
-  (let* ((m (sa-host-tag)) (n (string-length m)))
+  (sa-endian-for-tag (sa-host-tag)))
+
+;; (sa-endian-for-tag tag) -> the derivation above as a function OF the tag, on
+;; the same terms as sa-os-family-for-tag: for the gate, not for callers.
+(define (sa-endian-for-tag m)
+  (let ((n (string-length m)))
     (if (>= n 2)
         (let ((suf (substring m (- n 2) n)))
           (cond ((string=? suf "le") 'little)

--- a/host/scheme-adapter/TARGET-CONTRACT.md
+++ b/host/scheme-adapter/TARGET-CONTRACT.md
@@ -101,6 +101,14 @@ Logic branches on derived properties only: `sa-os-family` ('macos | 'windows
 NAMES only (release dirs, image headers, telemetry) — a port chooses any
 stable identifier; nothing parses it except target-owned build machinery.
 
+The derived three answer for the process that is RUNNING, not for the build
+that produced it. Chez's native machine tag happens to answer both, which is
+why the adapter reads it; its portable-bytecode tags name no OS at all, and
+deriving one from them called every bytecode build Linux (#796). A port whose
+identifier is likewise portable must probe the host instead of parsing the
+identifier — `sa-probed-os-family` in the Chez adapter is one such probe, and
+the answer may be cached, since it cannot change while the process runs.
+
 ## Target-owned files
 
 The lint's allowlist may only name these; everything else routes through the

--- a/test/chez/host-derived-props-test.ss
+++ b/test/chez/host-derived-props-test.ss
@@ -1,0 +1,72 @@
+;; The derived host properties (jolt-lang/jolt#796): what sa-os-family, sa-arch
+;; and sa-endian answer for each Chez machine tag. Run:
+;;   chez --script test/chez/host-derived-props-test.ss
+;;
+;; These three are the ONLY things host logic may ask about the platform — the
+;; tag itself is naming-only — so a wrong row here is a wrong SIGCHLD, EAGAIN,
+;; O_NONBLOCK, LC_TIME, struct-stat offset, chmod fallback and link library, on
+;; every caller at once. #796 was exactly that: portable-bytecode tags carry no
+;; OS, so the else-branch called every bytecode build Linux, including one
+;; running on macOS, and a Darwin pb build could not open a socket because
+;; jolt.nrepl handed Darwin's socket() the Linux SOCK_CLOEXEC.
+;;
+;; The table is pinned over the tags a run does NOT have, because the row that
+;; broke can only be reached from a host we do not build on. The *-for-tag
+;; entry points exist for that; the last check ties the table back to reality by
+;; requiring the pb probe to agree with what this host's native tag says.
+
+(import (chezscheme))
+(load "host/chez/scheme-adapter-runtime.ss")
+
+(define total 0) (define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))
+(define (row tag fam arch endian)
+  (ok (format "~a -> os ~a" tag fam)     (eq? (sa-os-family-for-tag tag) fam))
+  (ok (format "~a -> arch ~a" tag arch)  (eq? (sa-arch-for-tag tag) arch))
+  (ok (format "~a -> endian ~a" tag endian) (eq? (sa-endian-for-tag tag) endian)))
+
+;; Native tags: the tag names the OS and every row is decided by the tag alone.
+;; endian is #f for the osx/nt tags because their suffix is not le/be — the
+;; stat-layout guard reads that as "unverified" and nio-file keys those hosts
+;; off sa-os-family instead.
+(row "tarm64osx" 'macos   'arm64  #f)
+(row "a6osx"     'macos   'x86-64 #f)
+(row "ta6nt"     'windows 'x86-64 #f)
+(row "i3nt"      'windows 'i386   #f)
+(row "ta6le"     'linux   'x86-64 'little)
+(row "arm64le"   'linux   'arm64  'little)
+(row "i3le"      'linux   'i386   'little)
+(row "a6ob"      'linux   'x86-64 #f)   ; unrecognized OS still degrades to linux
+
+;; Portable-bytecode tags: pb/pb64l/tpb64l name the threading, word size and
+;; endianness and deliberately name no OS, so the OS is PROBED and must not be
+;; hardcoded. arch stays 'other and endian stays #f: the tag's own 64/l fields
+;; are not in the shape either derivation parses, and neither is probed yet, so
+;; a pb build on x86-64 Linux still reads as "unverified struct stat layout".
+;; That is a known gap, pinned here so closing it is a deliberate edit.
+(for-each
+  (lambda (tag)
+    (ok (format "~a -> os is probed, not assumed" tag)
+        (eq? (sa-os-family-for-tag tag) (sa-probed-os-family)))
+    (ok (format "~a -> arch other (not derived from the tag)" tag)
+        (eq? (sa-arch-for-tag tag) 'other))
+    (ok (format "~a -> endian #f (not derived from the tag)" tag)
+        (eq? (sa-endian-for-tag tag) #f)))
+  '("pb" "pb64l" "pb64b" "pb32l" "tpb64l" "tpb64b"))
+
+;; The probe is a cache, and the answer cannot change while the process runs.
+(ok "probe is stable across calls" (eq? (sa-probed-os-family) (sa-probed-os-family)))
+
+;; And it is RIGHT: this run is a native build, whose tag names the OS
+;; independently. The probe has to reach the same verdict — that is the whole
+;; claim a bytecode build then rests on, checked on every host the gate runs on.
+(ok (format "probe agrees with the native tag ~s (~a)" (sa-host-tag) (sa-os-family))
+    (or (eq? (sa-os-family-for-tag (sa-host-tag)) (sa-probed-os-family))
+        ;; a pb gate run has no independent answer to compare against; the rows
+        ;; above still hold, so do not fail the gate on it.
+        (sa-tag-contains? (sa-host-tag) "pb")))
+
+(printf "host-derived-props: ~a checks, ~a failures\n" total fails)
+(when (> fails 0) (exit 1))


### PR DESCRIPTION
Fixes #796.

`sa-os-family` derives the OS by substring-matching the Chez machine tag, which
works for a native tag and cannot work for a portable-bytecode one: `pb`,
`pb64l` and `tpb64l` name the threading, word size and endianness and
deliberately name no OS, because the same bytecode is meant to run on any of
them. The `else` branch therefore called every bytecode build Linux, including
one running on macOS — and that function is the single place the rest of the
host asks about the OS, so it also picks `SIGCHLD` (20 vs 17), `EAGAIN`
(35 vs 11), `O_NONBLOCK`, `LC_TIME` and the `struct stat` offsets.

The issue has the full symptom, including a bytecode build being unable to open
a socket at all because `jolt.nrepl` passed Linux `SOCK_CLOEXEC` to Darwin's
`socket()`.

## The change

24 lines, pure addition. One new branch in `sa-os-family` for tags containing
`pb`, and a probe behind it:

```scheme
((sa-tag-contains? m "pb") (sa-probed-os-family))
```

The probe checks the filesystem once and caches, since `sa-os-family` is
consulted from hot paths and the answer cannot change while the process runs.
`/System/Library/CoreServices/SystemVersion.plist` was chosen as the Darwin
marker specifically because it is readable from inside a sandboxed process;
`/usr/lib/libSystem.B.dylib` is not, since it lives in the dyld shared cache
and `file-exists?` answers false for it.

## What is unchanged

Native tags never reach the new branch, so `tarm64osx`, `ta6nt` and `ta6le`
resolve exactly as before. An unrecognized non-`pb` tag still falls through to
`'linux`, matching today's behaviour rather than newly probing for it — that
seemed the smaller change, though probing there too would be defensible.

## Verification

- `make manifestcheck` — passed
- `make adaptercheck` — 76 contract names checked, contract satisfied
- `make test` — see below
- native build still reports `os.name = Mac OS X`, `os.arch = aarch64`
- the bytecode path was verified on a real `tpb64l` build, where an nREPL
  server that previously could not bind now starts

## The judgement I left to you

Darwin resolves to `'macos` because the contract is three symbols and none of
them is Darwin. That is right for every caller listed above, since those
constants are Darwin's either way, but it does mean a Darwin bytecode build
answers `"Mac OS X"` to `os.name` — trading one inaccuracy for a smaller one
rather than removing it. Whether the contract should grow a fourth symbol is a
larger change than this fix and yours to make; happy to follow up either way.

Verified against `main` at `6f1d436f` (`v0.7.29-15`), macOS/AArch64.
