### PR TITLE
Measure the struct stat layout; probe the arch and byte order a tag does not name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,13 @@ stays authoritative.
   reach `0x4000` for a root directory. Identity still gets the first word, so a
   host that worked before reads exactly as it did; measurement gets the last, so
   a proposal it contradicts is discarded rather than used. That is also what
-  makes the aarch64 row safe to ship without an arm64 machine to measure on: if
-  those offsets are wrong, nothing verifies and the host refuses exactly as it
-  refuses today, rather than quietly answering nonsense.
+  makes a new row cheap to add: get the offsets wrong and nothing verifies, so
+  the host refuses exactly as it refuses today rather than quietly answering
+  nonsense.
+
+  Both Linux rows are `offsetof`-measured — x86-64 natively, aarch64 under
+  `qemu-aarch64` against the arm64 cross headers — and on each ABI `stat("/")`
+  matches exactly one row, the others landing on `st_nlink` and `st_uid`.
 
 - **`sa-arch` and `sa-endian` could not answer for a portable-bytecode build.**
   The follow-up half of #796. `sa-arch` matched `arm64`/`a6`/`i3` in the machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,27 @@ stays authoritative.
 
 ### Fixed
 
+- **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
+  layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets
+  that are a per-platform ABI, and it chose them from the host's *identity*:
+  Darwin, or x86-64 Linux, or else throw `UnsupportedOperationException:
+  unverified struct stat layout`. Two kinds of host fell through that were not
+  actually unknown. A portable-bytecode build has no identity to read at all —
+  its machine tag names neither OS nor architecture (#796, #798) — so every pb
+  build refused. And native **aarch64 Linux** refused too, on a machine whose
+  offsets were written in the file's own comment and never turned into a branch.
+
+  The layout is measured now instead of deduced. `stat("/")` says which
+  candidate row really is `st_mode`, because `S_IFDIR` appears in the format
+  bits of the true field and in none of the competing ones — at those offsets a
+  real host has `st_dev`'s high half, `st_nlink`, or `st_uid`, none of which
+  reach `0x4000` for a root directory. Identity still gets the first word, so a
+  host that worked before reads exactly as it did; measurement gets the last, so
+  a proposal it contradicts is discarded rather than used. That is also what
+  makes the aarch64 row safe to ship without an arm64 machine to measure on: if
+  those offsets are wrong, nothing verifies and the host refuses exactly as it
+  refuses today, rather than quietly answering nonsense.
+
 - **A portable-bytecode build reported itself as Linux, wherever it was running.**
   `sa-os-family` derived the OS by substring-matching Chez's machine tag, which
   answers for a native tag and cannot answer for a bytecode one: `pb`, `pb64l`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,24 @@ stays authoritative.
   those offsets are wrong, nothing verifies and the host refuses exactly as it
   refuses today, rather than quietly answering nonsense.
 
+- **`sa-arch` and `sa-endian` could not answer for a portable-bytecode build.**
+  The follow-up half of #796. `sa-arch` matched `arm64`/`a6`/`i3` in the machine
+  tag and `sa-endian` read its last two characters for `le`/`be`; a pb tag
+  matches neither vocabulary even though `pb64l` does name a 64-bit
+  little-endian build, in fields those derivations do not parse. Both now probe
+  past a tag that declines to say: `uname(2)`'s `machine` field for the
+  architecture (`PROCESSOR_ARCHITECTURE` on Windows, which has no `uname`), and
+  `native-endianness` for the byte order, which is exact everywhere and needs no
+  probe at all. `os.arch` on a bytecode build answers `amd64`/`aarch64` rather
+  than the raw tag.
+
+  `sa-endian` no longer has a `#f` answer — a runtime always knows its own byte
+  order. That mattered beyond the tag: `nio-x86-64-linux?` tested the
+  architecture and the byte order but never the OS, so it was correct only by
+  the accident that the Windows tag has no `le` suffix. Answering endianness
+  honestly would have made a Windows x86-64 build claim the Linux `struct stat`
+  layout, and the rewrite above removes that predicate entirely.
+
 - **A portable-bytecode build reported itself as Linux, wherever it was running.**
   `sa-os-family` derived the OS by substring-matching Chez's machine tag, which
   answers for a native tag and cannot answer for a bytecode one: `pb`, `pb64l`

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ JOLT-TARGETS-NEEDING-DEPS := \
   aotcachepathsmoke compilepathsmoke contagion corpus cts dcerefs depssmoke depsunit devboot \
   readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling \
   devbootsmoke devirt directlink ffi fibers fieldjoin fieldnum fieldread flarr fnform coreproc grenadine \
-  gateboot gatebootsmoke gosm hasheq httpsfetch infer inline inline-body irvalidate \
+  gateboot gatebootsmoke gosm hasheq httpsfetch infer inline inline-body irvalidate statlayout \
   jolt jolt-debug jolt-release joltsmoke libconformance mandelbrot-num mathfl mvnhttp \
   narrow numeric numwp oparity pic protoret printperf remint sbperf sci selfhost shakelocal \
   traceemit \
@@ -164,7 +164,7 @@ CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscali
   hasheq \
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform coreproc traceemit traceeval degradedbacktrace \
-  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck hostprops lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
+  inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck hostprops statlayout lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
   certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety
@@ -854,6 +854,14 @@ adaptercheck:
 # not build on, so the table is pinned per tag rather than per running machine.
 hostprops:
 	@$(CHEZ) --script test/chez/host-derived-props-test.ss
+
+# The other half of the same rule: knowing the platform is only useful if the
+# struct stat offsets it selects are the ones this machine actually uses. The
+# gate measures the layout with no identity to go on — the pb case — and then
+# reads a file whose mode it just set, which no offset that merely happens to
+# carry S_IFDIR would answer correctly.
+statlayout:
+	@$(CHEZ) --script test/chez/stat-layout-test.ss
 
 # Every lock in the runtime must route through jolt's wrapper, because
 # preemption is refused while one is held and that only works if the runtime can

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -702,13 +702,18 @@
 ;; #(name st_mode-offset st_mode-width st_uid-offset):
 ;;   darwin        mode@4  (16-bit) uid@16   -- all arches
 ;;   linux-x86-64  mode@24 (32-bit) uid@28   -- glibc, offsetof-measured
-;;   linux-arm64   mode@16 (32-bit) uid@24   -- glibc's generic bits/stat.h, in
-;;                                              which st_mode precedes st_nlink
-;;                                              instead of following it; read
-;;                                              from the header, not measured on
-;;                                              a machine, and so left for the
-;;                                              probe below to confirm before it
-;;                                              is ever used
+;;   linux-arm64   mode@16 (32-bit) uid@24   -- glibc, offsetof-measured under
+;;                                              qemu-aarch64 against the arm64
+;;                                              cross headers. st_mode precedes
+;;                                              st_nlink here instead of
+;;                                              following it, which is the only
+;;                                              difference from the row above --
+;;                                              and it is why aarch64 Linux is a
+;;                                              row rather than sharing one.
+;;
+;; sizeof(struct stat) is 144 on x86-64 and 128 on aarch64. st_ino@8 and
+;; st_mtim@88 were measured identical on both, which is what lets those two
+;; readers stay unguarded.
 (define nio-stat-layouts
   (list (vector 'darwin        4 2 16)
         (vector 'linux-x86-64 24 4 28)
@@ -745,17 +750,26 @@
 ;; directly: S_IFDIR has to appear in the format bits of whichever field really
 ;; is st_mode, and it appears in no other field of any of these layouts (at the
 ;; competing offsets a real host has st_dev's high half, st_nlink, or st_uid,
-;; none of which reach 0x4000 for a root directory).
+;; none of which reach 0x4000 for a root directory). Measured on both Linux
+;; ABIs -- natively on x86-64, and under qemu-aarch64 on a statically linked
+;; aarch64 build -- where stat("/") is mode 040755 and exactly one row matches:
+;;
+;;   x86-64   darwin@4 -> 0x0  linux-x86-64@24 -> 0x41ed  linux-arm64@16 -> 0x15
+;;   aarch64  darwin@4 -> 0x0  linux-x86-64@24 -> 0x0     linux-arm64@16 -> 0x41ed
+;;
+;; The rows that do not match land on st_nlink (0x15) and st_uid (0), which is
+;; the discrimination working rather than a coincidence to rely on.
 ;;
 ;; Identity gets the first word and measurement gets the last. The proposal is
 ;; preferred whenever the measurement agrees with it, so a host we already know
 ;; reads exactly as it did before; a proposal the measurement CONTRADICTS is
 ;; discarded rather than used, because a contradicted proposal is a proposal
 ;; that would read garbage -- which is the whole failure this guard exists to
-;; prevent, and throwing is what it did about it before. That is also what makes
-;; the linux-arm64 row safe to ship without an arm64 machine to measure on: if
-;; those offsets are wrong, no row verifies, and the host refuses exactly as it
-;; refuses today instead of quietly answering nonsense.
+;; prevent, and throwing is what it did about it before. That is also the
+;; property that makes a NEW row cheap to add: get the offsets wrong and nothing
+;; verifies, so the host refuses exactly as it refuses today rather than quietly
+;; answering nonsense. A row still has to be measured before it is added -- this
+;; is a backstop, not a licence to guess.
 ;;
 ;; Only when nothing can be measured (no stat entry, no root directory) does
 ;; identity stand alone, which is the pre-#798 behaviour. Only macos/linux are

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -695,18 +695,98 @@
 ;; ---- stat-backed perms + real path (increment: what the fs suite exercises) --
 ;; st_mode lives at a platform-specific offset in struct stat; read only that.
 (define nio-macos? (eq? (sa-os-family) 'macos))
-;; struct stat field offsets are platform ABIs, not portable: verified for
-;; Darwin (st_mode@4/st_uid@16, all arches) and x86_64 Linux glibc
-;; (st_mode@24/st_uid@28 -- ground-truthed via offsetof probes). aarch64 Linux
-;; DIFFERS (st_mode@16/st_uid@24), and other hosts are unknown -- reading the
-;; hardcoded offsets there returns garbage, so the mode/uid readers throw a
-;; clear error instead. st_mtim@88 is identical on both Linux ABIs, so the
-;; mtime readers stay unguarded. Add a verified branch (not a guess) when a
-;; new host is brought up.
-(define nio-x86-64-linux? (and (eq? (sa-arch) 'x86-64) (eq? (sa-endian) 'little)))
-(define nio-stat-layout-known? (or nio-macos? nio-x86-64-linux?))
+;; struct stat field offsets are platform ABIs, not portable. Only two fields
+;; move: st_mode and st_uid. st_ino@8 is identical everywhere we run, and
+;; st_mtim@88 is identical on both Linux ABIs, so those readers stay unguarded.
+;;
+;; #(name st_mode-offset st_mode-width st_uid-offset):
+;;   darwin        mode@4  (16-bit) uid@16   -- all arches
+;;   linux-x86-64  mode@24 (32-bit) uid@28   -- glibc, offsetof-measured
+;;   linux-arm64   mode@16 (32-bit) uid@24   -- glibc's generic bits/stat.h, in
+;;                                              which st_mode precedes st_nlink
+;;                                              instead of following it; read
+;;                                              from the header, not measured on
+;;                                              a machine, and so left for the
+;;                                              probe below to confirm before it
+;;                                              is ever used
+(define nio-stat-layouts
+  (list (vector 'darwin        4 2 16)
+        (vector 'linux-x86-64 24 4 28)
+        (vector 'linux-arm64  16 4 24)))
+(define (nio-layout-name l) (vector-ref l 0))
+(define (nio-layout-mode-ref l buf)
+  (if (= 2 (vector-ref l 2))
+      (bytevector-u16-ref buf (vector-ref l 1) (native-endianness))
+      (bytevector-u32-ref buf (vector-ref l 1) (native-endianness))))
+(define (nio-layout-uid-ref l buf)
+  (bytevector-u32-ref buf (vector-ref l 3) (native-endianness)))
+(define (nio-layout-named n)
+  (let loop ((ls nio-stat-layouts))
+    (cond ((null? ls) #f)
+          ((eq? (nio-layout-name (car ls)) n) (car ls))
+          (else (loop (cdr ls))))))
+
+;; The row the host's IDENTITY proposes. A proposal only -- it is what gets
+;; measured below, never what gets trusted.
+(define (nio-proposed-stat-layout)
+  (case (sa-os-family)
+    ((macos) (nio-layout-named 'darwin))
+    ((linux) (case (sa-arch)
+               ((x86-64) (nio-layout-named 'linux-x86-64))
+               ((arm64)  (nio-layout-named 'linux-arm64))
+               (else #f)))
+    (else #f)))
+
+;; MEASURE the layout instead of deducing it from the host's name, because the
+;; name is not always available to be read: a portable-bytecode build's machine
+;; tag carries no OS and no arch (jolt-lang/jolt#796, #798), so identity alone
+;; sent every such build down the "unverified" branch even on a host whose
+;; layout is one of the three above. A stat of a directory we know settles it
+;; directly: S_IFDIR has to appear in the format bits of whichever field really
+;; is st_mode, and it appears in no other field of any of these layouts (at the
+;; competing offsets a real host has st_dev's high half, st_nlink, or st_uid,
+;; none of which reach 0x4000 for a root directory).
+;;
+;; Identity gets the first word and measurement gets the last. The proposal is
+;; preferred whenever the measurement agrees with it, so a host we already know
+;; reads exactly as it did before; a proposal the measurement CONTRADICTS is
+;; discarded rather than used, because a contradicted proposal is a proposal
+;; that would read garbage -- which is the whole failure this guard exists to
+;; prevent, and throwing is what it did about it before. That is also what makes
+;; the linux-arm64 row safe to ship without an arm64 machine to measure on: if
+;; those offsets are wrong, no row verifies, and the host refuses exactly as it
+;; refuses today instead of quietly answering nonsense.
+;;
+;; Only when nothing can be measured (no stat entry, no root directory) does
+;; identity stand alone, which is the pre-#798 behaviour. Only macos/linux are
+;; measured at all: a Windows _stat is a different struct that none of these rows
+;; describes, so it stays unknown rather than risking a chance match.
+(define (nio-layout-verifies? l buf)
+  ;; bitwise-and, not fxand: a 32-bit st_mode read is not a fixnum on a 32-bit host.
+  (= #x4000 (bitwise-and (nio-layout-mode-ref l buf) #xF000)))   ; S_IFDIR
+(define (nio-probe-root-stat)
+  (and c-stat
+       (memq (sa-os-family) '(macos linux))
+       (let ((buf (make-bytevector 256 0)))
+         (and (= 0 (c-stat "/" buf)) buf))))
+(define (nio-sole-verifying-layout buf)
+  (let loop ((ls nio-stat-layouts) (hits '()))
+    (cond ((null? ls) (and (pair? hits) (null? (cdr hits)) (car hits)))
+          ((nio-layout-verifies? (car ls) buf) (loop (cdr ls) (cons (car ls) hits)))
+          (else (loop (cdr ls) hits)))))
+(define (nio-resolve-stat-layout)
+  (let ((proposed (nio-proposed-stat-layout))
+        (buf (nio-probe-root-stat)))
+    (cond ((not buf) proposed)                                   ; nothing to measure with
+          ((and proposed (nio-layout-verifies? proposed buf)) proposed)
+          (else (nio-sole-verifying-layout buf)))))
+(define nio-stat-layout-cache 'unresolved)
+(define (nio-stat-layout)
+  (when (eq? nio-stat-layout-cache 'unresolved)
+    (set! nio-stat-layout-cache (nio-resolve-stat-layout)))
+  nio-stat-layout-cache)
 (define (nio-stat-layout-guard! who)
-  (unless nio-stat-layout-known?
+  (unless (nio-stat-layout)
     (jolt-throw (jolt-host-throwable "java.lang.UnsupportedOperationException"
       (string-append who " is not supported on this host: unverified struct stat layout for "
                      (sa-host-tag))))))
@@ -715,11 +795,8 @@
   (and c-stat
        (begin
          (nio-stat-layout-guard! "getPosixFilePermissions")
-         (let ((buf (make-bytevector 256 0)))
-           (and (= 0 (c-stat fp buf))
-                (if nio-macos?
-                    (bytevector-u16-ref buf 4 (native-endianness))
-                    (bytevector-u32-ref buf 24 (native-endianness))))))))
+         (let ((lay (nio-stat-layout)) (buf (make-bytevector 256 0)))
+           (and (= 0 (c-stat fp buf)) (nio-layout-mode-ref lay buf))))))
 ;; resolve symlinks; #f if the path is absent. One binding of realpath(3) for
 ;; the whole runtime, in java/io.ss, which loads before this file and needs it
 ;; for File.getCanonicalPath.
@@ -927,8 +1004,8 @@
 (define (nio-stat-uid fp)
   (and c-stat (begin
                 (nio-stat-layout-guard! "getOwner")
-                (let ((buf (make-bytevector 256 0)))
-                  (and (= 0 (c-stat fp buf)) (bytevector-u32-ref buf (if nio-macos? 16 28) (native-endianness)))))))
+                (let ((lay (nio-stat-layout)) (buf (make-bytevector 256 0)))
+                  (and (= 0 (c-stat fp buf)) (nio-layout-uid-ref lay buf))))))
 (define (nio-uid->name uid)
   (and c-getpwuid (let ((pw (c-getpwuid uid))) (and (not (= 0 pw)) (nio-cstr-at (sa-foreign-ref 'iptr pw 0))))))
 ;; user-principal values compare and hash by name; getOwner honors NOFOLLOW.
@@ -939,8 +1016,8 @@
 (define (nio-lstat-uid fp)
   (and c-lstat (begin
                  (nio-stat-layout-guard! "getOwner")
-                 (let ((buf (make-bytevector 256 0)))
-                   (and (= 0 (c-lstat fp buf)) (bytevector-u32-ref buf (if nio-macos? 16 28) (native-endianness)))))))
+                 (let ((lay (nio-stat-layout)) (buf (make-bytevector 256 0)))
+                   (and (= 0 (c-lstat fp buf)) (nio-layout-uid-ref lay buf))))))
 (let ((files-owner2
        (list (cons "getOwner" (lambda (p . opts)
                                 (let* ((fp (nfp p))

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -201,24 +201,94 @@
 ;; Contract: the architecture symbol. Degradation: 'other for an unrecognized
 ;; host; callers treat it as unverified.
 (define (sa-arch)
-  (sa-arch-for-tag (sa-host-tag)))
+  (let ((a (sa-arch-for-tag (sa-host-tag))))
+    (if (eq? a 'other) (sa-probed-arch) a)))
 
 ;; (sa-arch-for-tag tag) -> the derivation above as a function OF the tag, on
 ;; the same terms as sa-os-family-for-tag: for the gate, not for callers.
+;; 'other means THE TAG DOES NOT SAY, which is not the same as "unknown" —
+;; sa-arch probes past it.
 (define (sa-arch-for-tag m)
   (cond ((sa-tag-contains? m "arm64") 'arm64)
         ((sa-tag-contains? m "a6") 'x86-64)
         ((sa-tag-contains? m "i3") 'i386)
         (else 'other)))
 
-;; (sa-endian) -> 'little | 'big | #f
-;; Byte order of the host. Contract: the byte order. Degradation: #f for an
-;; unrecognized suffix — the stat-layout guard treats that as unverified.
+;; (sa-probed-arch) -> 'x86-64 | 'arm64 | 'i386 | 'other
+;; The architecture for a host tag that does not carry one — every pb tag, and
+;; any native tag outside the a6/i3/arm64 vocabulary. Contract: the architecture
+;; the process is actually running on. Degradation: 'other, matching the
+;; else-branch it replaces; every caller already treats that as unverified.
+;;
+;; uname(2) rather than the tag, because a pb tag's own "64" and "l" fields
+;; describe the BYTECODE's encoding and not the machine under it. The machine
+;; field's offset is the one platform constant here: struct utsname is
+;; fixed-width char arrays, 65 on Linux (machine is the 5th, at 260) and 256 on
+;; Darwin (at 1024), and the OS is already settled by sa-os-family before this
+;; runs. Windows has no uname and answers from the environment instead.
+(define sa-arch-cache #f)
+(define (sa-probed-arch)
+  (or sa-arch-cache
+      (let ((a (or (sa-probe-arch-name) 'other)))
+        (set! sa-arch-cache a)
+        a)))
+
+(define (sa-arch-name->symbol s)
+  (cond ((not s) #f)
+        ((or (string=? s "x86_64") (string=? s "amd64") (string=? s "AMD64")) 'x86-64)
+        ((or (string=? s "aarch64") (string=? s "arm64") (string=? s "ARM64")) 'arm64)
+        ((or (string=? s "i386") (string=? s "i686") (string=? s "x86")) 'i386)
+        (else #f)))
+
+(define (sa-probe-arch-name)
+  (if (eq? (sa-os-family) 'windows)
+      (sa-arch-name->symbol (getenv "PROCESSOR_ARCHITECTURE"))
+      (sa-arch-name->symbol (sa-uname-machine))))
+
+;; The `machine` field of uname(2), or #f when it cannot be had. Probe-only and
+;; fully guarded: a statically linked build may not carry the symbol at all, and
+;; a missing arch is a documented degradation rather than a boot failure.
+;;
+;; No sa-load-shared-object here, on sa-fbytes-init!'s reasoning and for its
+;; reason: the boot took the process-global handle long before anything can ask
+;; for an arch (rt.ss binds _exit through jolt-foreign-proc-safe at its line
+;; 135, and the first caller of sa-arch is host-static-methods.ss at 1553), and
+;; re-taking it would re-promote it above every :jolt/native loaded since.
+(define (sa-uname-machine)
+  (guard (e (#t #f))
+    (and (foreign-entry? "uname")
+         (let* ((linux? (eq? (sa-os-family) 'linux))
+                (off (if linux? 260 1024))
+                (size (if linux? 512 2048))
+                (buf (foreign-alloc size)))
+           (dynamic-wind
+             (lambda ()
+               (let loop ((i 0))
+                 (when (fx<? i size)
+                   (foreign-set! 'unsigned-8 buf i 0)
+                   (loop (fx+ i 1)))))
+             (lambda ()
+               (and (= 0 ((foreign-procedure "uname" (void*) int) buf))
+                    (let loop ((i 0) (acc '()))
+                      (let ((b (foreign-ref 'unsigned-8 buf (fx+ off i))))
+                        (if (or (fx=? b 0) (fx>? i 62))
+                            (and (pair? acc) (list->string (reverse acc)))
+                            (loop (fx+ i 1) (cons (integer->char b) acc)))))))
+             (lambda () (foreign-free buf)))))))
+
+;; (sa-endian) -> 'little | 'big
+;; Byte order of the host. Contract: the byte order. Degradation: none — the
+;; runtime always knows its own byte order, so a tag that does not name one is
+;; answered by native-endianness rather than by #f.
 (define (sa-endian)
-  (sa-endian-for-tag (sa-host-tag)))
+  (or (sa-endian-for-tag (sa-host-tag)) (native-endianness)))
 
 ;; (sa-endian-for-tag tag) -> the derivation above as a function OF the tag, on
-;; the same terms as sa-os-family-for-tag: for the gate, not for callers.
+;; the same terms as sa-os-family-for-tag: for the gate, not for callers. #f
+;; means THE TAG DOES NOT SAY — the osx and nt tags carry no le/be suffix and
+;; neither does any pb tag, whose own trailing l/b names the bytecode's encoding
+;; rather than a suffix in this shape. sa-endian answers native-endianness
+;; there, which is exact on every host and needs no probe.
 (define (sa-endian-for-tag m)
   (let ((n (string-length m)))
     (if (>= n 2)

--- a/host/scheme-adapter/TARGET-CONTRACT.md
+++ b/host/scheme-adapter/TARGET-CONTRACT.md
@@ -104,10 +104,17 @@ stable identifier; nothing parses it except target-owned build machinery.
 The derived three answer for the process that is RUNNING, not for the build
 that produced it. Chez's native machine tag happens to answer both, which is
 why the adapter reads it; its portable-bytecode tags name no OS at all, and
-deriving one from them called every bytecode build Linux (#796). A port whose
-identifier is likewise portable must probe the host instead of parsing the
-identifier — `sa-probed-os-family` in the Chez adapter is one such probe, and
-the answer may be cached, since it cannot change while the process runs.
+deriving one from them called every bytecode build Linux (#796) while leaving
+the architecture and byte order unknown (#798). A port whose identifier is
+likewise portable must probe the host instead of parsing the identifier — the
+Chez adapter probes the filesystem for the OS, `uname(2)` for the architecture,
+and answers the byte order from `native-endianness` — and each answer may be
+cached, since none can change while the process runs.
+
+`sa-endian` has no degraded answer: a runtime always knows its own byte order,
+so a port answers it rather than declining. `sa-arch` may still answer `'other`,
+which callers read as "unverified" — but `'other` must mean the port could not
+find out, never merely that its identifier did not say.
 
 ## Target-owned files
 

--- a/test/chez/host-derived-props-test.ss
+++ b/test/chez/host-derived-props-test.ss
@@ -16,6 +16,13 @@
 ;; requiring the pb probe to agree with what this host's native tag says.
 
 (import (chezscheme))
+;; The boot takes the process-global handle before anything asks for an
+;; architecture (rt.ss binds _exit through jolt-foreign-proc-safe long before
+;; host-static-methods.ss reads sa-arch), and sa-probed-arch relies on that
+;; rather than re-taking it. Loading the adapter on its own here has to stand in
+;; for that, or the uname probe finds no symbol and the gate measures the
+;; degraded answer instead of the real one.
+(load-shared-object #f)
 (load "host/chez/scheme-adapter-runtime.ss")
 
 (define total 0) (define fails 0)
@@ -41,32 +48,65 @@
 (row "a6ob"      'linux   'x86-64 #f)   ; unrecognized OS still degrades to linux
 
 ;; Portable-bytecode tags: pb/pb64l/tpb64l name the threading, word size and
-;; endianness and deliberately name no OS, so the OS is PROBED and must not be
-;; hardcoded. arch stays 'other and endian stays #f: the tag's own 64/l fields
-;; are not in the shape either derivation parses, and neither is probed yet, so
-;; a pb build on x86-64 Linux still reads as "unverified struct stat layout".
-;; That is a known gap, pinned here so closing it is a deliberate edit.
+;; endianness and deliberately name no OS, and their 64/l fields are not in the
+;; shape sa-arch-for-tag/sa-endian-for-tag parse either. So all three tag
+;; derivations decline, and all three public entry points probe past them
+;; (#796 for the OS, #798 for the other two).
 (for-each
   (lambda (tag)
-    (ok (format "~a -> os is probed, not assumed" tag)
+    (ok (format "~a -> os declines to the probe" tag)
         (eq? (sa-os-family-for-tag tag) (sa-probed-os-family)))
-    (ok (format "~a -> arch other (not derived from the tag)" tag)
+    (ok (format "~a -> arch not derivable from the tag" tag)
         (eq? (sa-arch-for-tag tag) 'other))
-    (ok (format "~a -> endian #f (not derived from the tag)" tag)
+    (ok (format "~a -> endian not derivable from the tag" tag)
         (eq? (sa-endian-for-tag tag) #f)))
   '("pb" "pb64l" "pb64b" "pb32l" "tpb64l" "tpb64b"))
 
-;; The probe is a cache, and the answer cannot change while the process runs.
-(ok "probe is stable across calls" (eq? (sa-probed-os-family) (sa-probed-os-family)))
+;; The probes are caches, and none of the three answers can change while the
+;; process runs.
+(ok "os probe is stable across calls"   (eq? (sa-probed-os-family) (sa-probed-os-family)))
+(ok "arch probe is stable across calls" (eq? (sa-probed-arch) (sa-probed-arch)))
 
-;; And it is RIGHT: this run is a native build, whose tag names the OS
-;; independently. The probe has to reach the same verdict — that is the whole
-;; claim a bytecode build then rests on, checked on every host the gate runs on.
-(ok (format "probe agrees with the native tag ~s (~a)" (sa-host-tag) (sa-os-family))
-    (or (eq? (sa-os-family-for-tag (sa-host-tag)) (sa-probed-os-family))
-        ;; a pb gate run has no independent answer to compare against; the rows
-        ;; above still hold, so do not fail the gate on it.
-        (sa-tag-contains? (sa-host-tag) "pb")))
+;; The probes must produce a real answer, not the degraded one, on any host the
+;; gate runs on. sa-arch degrades to 'other when uname cannot be reached, which
+;; is a legitimate answer on a statically linked build but not on this one.
+(ok "os probe answers a real family"
+    (memq (sa-probed-os-family) '(macos windows linux)))
+(ok (format "arch probe answers a real architecture (~a)" (sa-probed-arch))
+    (memq (sa-probed-arch) '(x86-64 arm64 i386)))
+(ok (format "endian answers a real byte order (~a)" (sa-endian))
+    (memq (sa-endian) '(little big)))
+
+;; And the probes are RIGHT: this run is a native build, whose tag names the OS
+;; and the architecture independently. Each probe has to reach the same verdict
+;; as the tag it can be checked against — that is the whole claim a bytecode
+;; build then rests on, checked on every host the gate runs on.
+(define native-tag (sa-host-tag))
+(define native? (not (sa-tag-contains? native-tag "pb")))
+(ok (format "os probe agrees with the native tag ~s (~a)" native-tag (sa-os-family))
+    (or (not native?)
+        (eq? (sa-os-family-for-tag native-tag) (sa-probed-os-family))))
+(ok (format "arch probe agrees with the native tag ~s (~a)" native-tag (sa-arch))
+    (or (not native?)
+        (eq? (sa-arch-for-tag native-tag) 'other)      ; tag names no arch to compare
+        (eq? (sa-arch-for-tag native-tag) (sa-probed-arch))))
+(ok "endian agrees with the tag when the tag names one"
+    (let ((from-tag (sa-endian-for-tag native-tag)))
+      (or (not from-tag) (eq? from-tag (sa-endian)))))
+
+;; A pb build resolves all three, which is the end state #796 and #798 are
+;; between them for: nothing about a bytecode tag may leave a property unknown
+;; on a host that can answer it.
+(for-each
+  (lambda (tag)
+    (ok (format "~a -> os resolves" tag)
+        (memq (sa-os-family-for-tag tag) '(macos windows linux)))
+    (ok (format "~a -> arch resolves to this host's" tag)
+        (eq? (let ((a (sa-arch-for-tag tag))) (if (eq? a 'other) (sa-probed-arch) a))
+             (sa-arch)))
+    (ok (format "~a -> endian resolves to this host's" tag)
+        (eq? (or (sa-endian-for-tag tag) (native-endianness)) (sa-endian))))
+  '("pb" "pb64l" "tpb64l"))
 
 (printf "host-derived-props: ~a checks, ~a failures\n" total fails)
 (when (> fails 0) (exit 1))

--- a/test/chez/stat-layout-test.ss
+++ b/test/chez/stat-layout-test.ss
@@ -1,0 +1,74 @@
+;; The struct-stat layout resolution (jolt-lang/jolt#798). Run:
+;;   chez --script test/chez/stat-layout-test.ss
+;;
+;; nio-file reads st_mode and st_uid at offsets that are a per-platform ABI, and
+;; it used to pick them from the host's IDENTITY alone. A portable-bytecode
+;; build has no identity to read — its machine tag names neither OS nor arch —
+;; so every pb build fell through to "unverified struct stat layout" and refused
+;; getPosixFilePermissions and getOwner, on hosts whose layout is one this file
+;; has always known. Native aarch64 Linux refused for the same reason.
+;;
+;; The layout is measured now, so the interesting case is the one this host
+;; cannot be: resolution with NO identity to go on. That is what the middle
+;; block does — it runs the measurement alone and requires it to land on the row
+;; identity would have proposed, which is exactly what a pb build depends on.
+
+(import (chezscheme))
+(load "host/chez/gate-boot.ss")
+
+(define total 0) (define fails 0)
+(define (ok name pred)
+  (set! total (+ total 1))
+  (unless pred (set! fails (+ fails 1)) (printf "FAIL: ~a\n" name)))
+
+;; ---- the host resolves a layout at all -------------------------------------
+(define resolved (nio-stat-layout))
+(ok "this host resolves a struct stat layout" (and resolved #t))
+(ok (format "resolved layout is ~a" (and resolved (nio-layout-name resolved)))
+    (memq (and resolved (nio-layout-name resolved)) '(darwin linux-x86-64 linux-arm64)))
+
+;; ---- measurement alone, which is the pb case -------------------------------
+;; No identity input: just a real stat and the candidate table.
+(define probe-buf (nio-probe-root-stat))
+(ok "a root stat is available to measure with" (and probe-buf #t))
+(when probe-buf
+  (let ((measured (nio-sole-verifying-layout probe-buf)))
+    (ok "measurement alone identifies exactly one layout" (and measured #t))
+    (ok "measurement alone agrees with what identity proposes here"
+        (eq? measured (nio-proposed-stat-layout)))
+    (ok "measurement alone agrees with what the host actually resolved"
+        (eq? measured resolved))
+    ;; The discrimination has to be sharp, not lucky: every OTHER row must fail.
+    (for-each
+      (lambda (l)
+        (unless (eq? l measured)
+          (ok (format "~a does not also verify here" (nio-layout-name l))
+              (not (nio-layout-verifies? l probe-buf)))))
+      nio-stat-layouts)))
+
+;; ---- and the offsets it lands on actually read the file --------------------
+;; A file whose mode we just set: the layout is right only if st_mode reads back
+;; the mode we chose, which no offset that merely happens to carry S_IFDIR would.
+(define tmp (string-append "/tmp/jolt-stat-layout-" (number->string (sa-real-time-ms))))
+(when probe-buf
+  (close-port (open-file-output-port tmp (file-options no-fail)))
+  (guard (e (#t #f))
+    (let ((chmod (jolt-foreign-proc-safe "chmod" '(string int) 'int)))
+      (when chmod
+        (chmod tmp #o640)
+        (let ((mode (nio-stat-mode tmp)))
+          (ok (format "st_mode of a 0640 file reads back 0640 (got ~a)"
+                      (and mode (number->string (bitwise-and mode #o777) 8)))
+              (and mode (= #o640 (bitwise-and mode #o777))))
+          (ok "and its format bits say regular file, not directory"
+              (and mode (= #x8000 (bitwise-and mode #xF000))))))))
+  ;; st_uid of a file this process just created is this process's own uid.
+  (let ((uid (nio-stat-uid tmp))
+        (c-getuid (jolt-foreign-proc-safe "getuid" '() 'int)))
+    (when c-getuid
+      (ok (format "st_uid of a file we created is our own uid (~a)" uid)
+          (and uid (= uid (c-getuid))))))
+  (delete-file tmp))
+
+(printf "stat-layout: ~a checks, ~a failures\n" total fails)
+(when (> fails 0) (exit 1))


### PR DESCRIPTION
Closes #798, the half #797 left open.

Two commits, in this order because the second is unsafe without the first.

## 1. Measure the layout instead of deducing it from the host's name

`nio-file` reads `st_mode` and `st_uid` at offsets that are a per-platform ABI,
and chose them from the host's *identity*: Darwin, or x86-64 Linux, or else
throw `UnsupportedOperationException: unverified struct stat layout`. Two kinds
of host fell through that were not actually unknown:

- **a portable-bytecode build**, which has no identity to read — its machine tag
  names neither OS nor architecture — so every pb build refused
  `getPosixFilePermissions` and `getOwner` on hosts whose layout this file has
  always known;
- **native aarch64 Linux**, on a machine whose offsets were written in the
  file's own comment and never turned into a branch.

The layout is a table of rows now, identity only *proposes* one, and a real
`stat` decides. `S_IFDIR` appears in the format bits of whichever field really
is `st_mode` and in none of the competing ones. Measured rather than reasoned
about:

```
sizeof(struct stat)=144 st_mode@24(w=4) st_uid@28 st_ino@8 st_mtim@88
stat("/") mode=040755
  candidate darwin        @ 4 -> 0x00000000  S_IFDIR=no
  candidate linux-x86-64  @24 -> 0x000041ed  S_IFDIR=YES
  candidate linux-arm64   @16 -> 0x00000015  S_IFDIR=no   <- st_nlink
```

Identity gets the first word and measurement gets the last. A proposal the
measurement agrees with is preferred, so every host that works today reads
exactly as it did. A proposal it **contradicts** is discarded rather than used —
a contradicted proposal is one that would read garbage, and refusing is what
this guard already did about that. That is also what makes the `linux-arm64`
row safe to ship with no arm64 machine to measure it on: **if those offsets are
wrong, nothing verifies and the host refuses exactly as it refuses today**,
rather than quietly answering nonsense. Identity stands alone only where nothing
can be measured, which is the behaviour this replaces.

`nio-x86-64-linux?` goes with it. It tested the architecture and the byte order
and never the OS, so it was right only by the accident that the Windows tag
carries no `le` suffix and `sa-endian` therefore declined.

## 2. Probe the architecture and byte order

`sa-arch` matched `arm64`/`a6`/`i3` in the tag and `sa-endian` read its last two
characters for `le`/`be`. A pb tag matches neither vocabulary, though `pb64l`
does name a 64-bit little-endian build — in fields those derivations do not
parse, because they describe the *bytecode's* encoding and not the machine under
it. So both answered `'other` and `#f` on every bytecode build, and `os.arch`
handed the raw tag (`"tpb64l"`) to libraries that parse that string.

- **Byte order** needs no probe: `native-endianness` is exact on every host. So
  `sa-endian` loses its `#f` answer entirely, and the contract loses it too — a
  runtime always knows its own byte order. This is the part that is unsafe
  before commit 1: answering endianness honestly would have had a **Windows
  x86-64** build claim the Linux `struct stat` layout.
- **Architecture** comes from `uname(2)`'s `machine` field, whose offset is the
  one platform constant involved and whose OS is already settled by
  `sa-os-family` before this runs (`struct utsname` is fixed-width char arrays,
  65 on Linux and 256 on Darwin). Windows has no `uname` and answers from
  `PROCESSOR_ARCHITECTURE`.

The probe takes no `sa-load-shared-object`, on `sa-fbytes-init!`'s reasoning and
for its reason — re-taking the process-global handle re-promotes it above every
`:jolt/native` loaded since — and it does not need to: the boot takes that handle
at `rt.ss:135` (`_exit`), long before the first `sa-arch` caller at `rt.ss:1553`.
A static build carrying no `uname` degrades to `'other`, which callers already
read as unverified. What changed is what `'other` **means**: the port could not
find out, never merely that its identifier did not say.

## Gates

- `statlayout` (new, 11 checks) runs the measurement with **no identity input** —
  the pb case this host cannot otherwise be — and requires it to land where
  identity would have. Then it chmods a file to `0640` and reads the mode back;
  an offset that merely happens to carry `S_IFDIR` does not survive that.
- `hostprops` (59 checks, was 44) gains the arch and endian rows, and now
  requires each probe to agree with the native tag it can be checked against.

## Verification

- full `make ci` green locally, x86-64 Linux (92 targets)
- `uname` probe checked against ground truth (`x86_64`); `os.arch` = `amd64`,
  perms and owner resolve on `/tmp`
- **both Linux rows `offsetof`-measured**: x86-64 natively, and aarch64 by
  cross-compiling the same probe and running it under `qemu-aarch64`, statically
  linked against the arm64 cross glibc —

  ```
  sizeof(struct stat)=128 st_mode@16(w=4) st_uid@24 st_ino@8 st_mtim@88
  stat("/") mode=040755
    candidate darwin        @ 4 -> 0x00000000  S_IFDIR=no
    candidate linux-x86-64  @24 -> 0x00000000  S_IFDIR=no      <- st_uid
    candidate linux-arm64   @16 -> 0x000041ed  S_IFDIR=YES
  ```

  the exact mirror of the x86-64 run, where the arm64 candidate lands on
  `st_nlink` (`0x15`) instead. So the discrimination is a property of the
  layouts on both ABIs, not luck on one machine — and `st_ino@8` / `st_mtim@88`
  are confirmed identical across both, which is what lets those readers stay
  unguarded.

## Not covered

Windows is reasoned about and unexecuted: `PROCESSOR_ARCHITECTURE`, and the
`_stat` struct staying deliberately unknown so no row can match it by chance.
The macOS arm64 CI job covers the Darwin row and the Darwin `uname` offset.
Nothing runs jolt *itself* on aarch64 — the measurement above covers the layout
and the predicate, which is the whole arch-dependent surface, but not the
integration around it.
