### PR TITLE
Let a deps.edn declare the oldest jolt it works on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,31 @@ when transposed.
   beside `:darwin`, and answers a `{:path ...}` library map naming the candidate
   that loaded.
 
+- **`:jolt/min-version` in `deps.edn`.** A project, or a library, declares the
+  oldest jolt it works on, and a runtime below that refuses to load it rather
+  than run it:
+
+  ```clojure
+  {:paths ["src"]
+   :jolt/min-version "0.8.0"}
+  ```
+
+  Not every breaking change is visible at the call site. `ffi/write`'s argument
+  order moved in this release, and the old and new spellings are both integers,
+  so an older runtime writes to the wrong place and reports nothing — the exact
+  failure a declared floor turns into a message. A **library** is the natural
+  declarer: it knows which jolt its FFI bindings or host shims need, and the app
+  pulling it in does not. An unmet floor names what is needed, what is running,
+  and which dependency asked; several unmet floors report the newest one.
+
+  The key is honoured by the jolt that reads it, so it protects from this release
+  onward and not before — an older jolt ignores it, as it ignores every key it
+  does not know. That is the reason it arrives now rather than at the next break.
+  A runtime that names no version (a source build answers `dev`) is never
+  refused, since it reads as the oldest possible while in practice being the
+  newest; `JOLT_SKIP_MIN_VERSION=1` runs anyway for a released runtime whose
+  version string understates what it carries.
+
 - **`:&` declares a variadic C function**, as it does in babashka.ffi.
   `:varargs` is jolt's older spelling of the same marker and still works; the
   two are one code path, so every rule already gated for `:varargs` holds under

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -1,7 +1,9 @@
 (ns jolt.deps
   "Resolve a deps.edn into an ordered list of source roots. A reduced
   tools.deps: :paths, :deps (`:git/url`+`:git/sha` / `:local/root` /
-  `:mvn/version`), :aliases, :tasks. Alias maps combine with the reference
+  `:mvn/version`), :aliases, :tasks. jolt's own keys are :jolt/native (shared
+  libraries to load), :jolt/build, :nrepl/middleware, and :jolt/min-version —
+  the oldest jolt the project or library works on, refused rather than run. Alias maps combine with the reference
   tools.deps semantics (jolt.deps.edn, lifted from clojure.tools.deps.edn):
   :extra-deps / :override-deps / :default-deps / :replace-deps (legacy :deps),
   :extra-paths / :replace-paths (legacy :paths), :main-opts.
@@ -910,7 +912,7 @@
 (defn resolve-deps
   "Expand a deps map through the tools.deps expansion engine, then collect the
   selected libraries' source roots and :jolt/native declarations in stable
-  first-inclusion order. Returns {:roots [...] :natives [...] :prep [...]
+  first-inclusion order. Returns {:roots [...] :natives [...] :min-versions [...] :prep [...]
   :libs {lib coord}} — :libs is the tools.deps lib map (selected coordinate
   per library).
 
@@ -956,6 +958,13 @@
                                 [root]))
                             infos))
         :natives (vec (mapcat (fn [{:keys [edn]}] (:jolt/native edn)) infos))
+        ;; Each dep's declared jolt floor, as [lib version] — checked by
+        ;; resolve-project against the running runtime. A LIBRARY is the common
+        ;; declarer: it knows which jolt its FFI bindings or host shims need, and
+        ;; the app that pulls it in does not.
+        :min-versions (vec (keep (fn [{:keys [lib edn]}]
+                                   (when-let [v (:jolt/min-version edn)] [lib v]))
+                                 infos))
         ;; libs whose deps.edn declares :deps/prep-lib — jolt runs no prep
         ;; steps, so their compiled/generated assets will be missing; the
         ;; caller warns with the lib names.
@@ -985,6 +994,84 @@
 ;; touches the network. On a hit every cached path is checked to still exist on
 ;; disk — a pruned gitlib checkout or a deleted jar/extraction is a miss, not an
 ;; error. A corrupt or unreadable cache file is a miss too, never an error.
+
+;; --- :jolt/min-version ------------------------------------------------------
+;; A project or a library declares the oldest jolt it works on, and a runtime
+;; below that refuses to load it rather than run it. Not every breaking change is
+;; visible at the call site — ffi/write's argument order moved, and the old and
+;; new spellings are both integers, so an older runtime writes to the wrong place
+;; and reports nothing — and a declared floor turns that into a message.
+;;
+;; Honoured by the jolt that READS the key, so it protects from this release
+;; onward and not before: an older jolt ignores it, as it ignores every key it
+;; does not know. That is the reason to add it now rather than at the next break.
+(defn- version-parts
+  "The leading numeric components of a version string, as a vector of longs.
+  Tolerates a `v` prefix and reads each component's numeric PREFIX, stopping at
+  the first component that has none — so \"v0.7.29-24-gabc\" is [0 7 29], the git
+  describe suffix riding along on the last component, and \"0.8\" is [0 8]. A
+  string with no numeric components at all (a source build's \"dev\") is []."
+  [v]
+  (let [v (str v)
+        v (if (and (pos? (count v)) (= "v" (subs v 0 1))) (subs v 1) v)]
+    (loop [parts (str/split v #"\.") acc []]
+      (if (empty? parts)
+        acc
+        (let [digits (re-find #"^[0-9]+" (first parts))]
+          (if digits
+            (recur (rest parts) (conj acc (parse-long digits)))
+            acc))))))
+
+(defn- version<
+  "True when version a orders before version b on their numeric components, a
+  missing component reading as 0 ([0 8] and [0 8 0] are the same version)."
+  [a b]
+  (let [x (version-parts a) y (version-parts b)
+        n (max (count x) (count y))
+        at (fn [v i] (or (get v i) 0))]
+    (loop [i 0]
+      (cond
+        (= i n) false
+        (< (at x i) (at y i)) true
+        (> (at x i) (at y i)) false
+        :else (recur (inc i))))))
+
+;; The decision, pure and separate from the throw: a source build fails no floor,
+;; so this is the only way the refusal is testable at all.
+(defn- min-version-failure
+  "nil when every declared floor is met, else [message ex-data] for the HIGHEST
+  unmet one — one message naming the newest thing needed, not one per dependency.
+  `declared` is a seq of [who version], `who` being a lib symbol or nil for the
+  project itself."
+  [running declared]
+  ;; A runtime naming no version — a source build answers "dev" — is never
+  ;; refused: it reads as 0.0.0, the oldest possible, while in practice it is the
+  ;; newest. The floor protects a released runtime, and those always name one.
+  (when (seq (version-parts running))
+    (let [unmet (filter (fn [[_ v]] (version< running v)) declared)]
+      (when (seq unmet)
+        ;; max-key would compare version VECTORS as numbers and throw the moment
+        ;; two floors were unmet — and never compare at all with one, so the
+        ;; crash hid behind every single-dependency project.
+        (let [[who wanted] (reduce (fn [a b] (if (version< (second a) (second b)) b a))
+                                   unmet)]
+          [(str "this project needs jolt " wanted " or newer, and this is "
+                running
+                (when who (str " (required by " who ")"))
+                ". Upgrade jolt, or set JOLT_SKIP_MIN_VERSION=1 to run anyway.")
+           {:jolt/running running
+            :jolt/required wanted
+            :jolt/required-by who
+            :jolt/unmet (vec unmet)}])))))
+
+(defn- check-min-versions!
+  "Refuse to run when the project, or any dependency, declares a jolt floor the
+  running runtime is below. JOLT_SKIP_MIN_VERSION runs anyway, for a runtime
+  whose version string understates what it actually carries."
+  [declared]
+  (when-not (getenv "JOLT_SKIP_MIN_VERSION")
+    (when-let [[msg data] (min-version-failure (jolt.host/jolt-version) declared)]
+      (throw (ex-info msg data)))))
 
 (defn- cpcache-enabled?
   "Same posture as the AOT namespace cache: ON by default, OFF under
@@ -1284,6 +1371,12 @@
   {:roots [...] :main-opts [...] :tasks {...} :natives [...]}; :natives are the
   project's + deps' :jolt/native shared-library declarations.
 
+  :jolt/min-version, declared by the project or by any dependency, is the oldest
+  jolt that entry works on; a runtime below it raises here rather than running
+  code written for a newer API. A library is the natural declarer — it knows
+  which jolt its FFI bindings or host shims need. JOLT_SKIP_MIN_VERSION=1
+  overrides, for a dev build off main (which reads as its last tag).
+
   A bb.edn beside (or instead of) the deps.edn contributes its :tasks always,
   and its :paths/:deps when the :tasks? option is set — see the comment above.
 
@@ -1357,7 +1450,8 @@
           ;; and an alias's :main-opts / :exec-fn and the project's :tasks come
           ;; from there. tools.deps' --skip-cp draws the line in the same place:
           ;; the merged edn and argmap, without calc-basis.
-          {dep-roots :roots dep-natives :natives prep-libs :prep dep-trace :trace}
+          {dep-roots :roots dep-natives :natives prep-libs :prep dep-trace :trace
+           dep-min-versions :min-versions}
           (when-not cp
             (binding [*mvn-local-repo* (when-let [r (:mvn/local-repo edn)]
                                          (abspath project-dir r))
@@ -1366,6 +1460,14 @@
                                    {:override-deps (:override-deps argmap)
                                     :default-deps (:default-deps argmap)
                                     :trace? trace?})))
+         ;; The floor is checked AFTER resolution, so a dep's own declaration is
+         ;; in hand — a library is the natural declarer, since it knows which
+         ;; jolt its bindings need and the app pulling it in does not. The
+         ;; project's own declaration is checked here too, and is what an app
+         ;; uses to pin the runtime it was written against.
+         _ (check-min-versions!
+            (concat (when-let [v (:jolt/min-version edn)] [[nil v]])
+                    dep-min-versions))
          _ (when (seq prep-libs)
              (warn "deps declare :deps/prep-lib steps jolt does not run "
                    "(their compiled/generated assets will be missing): "

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1544,6 +1544,34 @@
   {:suite "jolt-version" :label "property and host fn match the var" :expected "true" :expr "(= *jolt-version* (System/getProperty \"jolt.version\") (jolt.host/jolt-version))"}
   {:suite "add-deps" :label "inline :local/root dep becomes requirable" :expected ":pong" :expr "(do (require 'jolt.deps) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/jolt-adddep-unit\")] (jolt.host/sh (str \"rm -rf \" d)) (jolt.host/sh (str \"mkdir -p \" d \"/src/adddep\")) (spit (str d \"/deps.edn\") \"{}\") (spit (str d \"/src/adddep/core.clj\") \"(ns adddep.core) (defn ping [] :pong)\") (jolt.deps/add-deps {:deps {'adddep/adddep {:local/root d}}}) (require 'adddep.core) ((resolve 'adddep.core/ping))))"}
   {:suite "add-deps" :label "added roots append after existing roots" :expected "true" :expr "(do (require 'jolt.deps) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/jolt-adddep-unit\") before (vec (jolt.host/source-roots)) _ (jolt.deps/add-deps {:deps {'adddep/adddep {:local/root d}}}) after (vec (jolt.host/source-roots))] (= before (vec (take (count before) after)))))"}
+  ;; :jolt/min-version — the runtime floor a project or library declares. The
+  ;; comparison reads the LEADING NUMERIC components only, because the version
+  ;; string is a git describe: "v0.7.29-24-gabc" is 0.7.29 plus commits, and the
+  ;; commit count says nothing about which APIs are present. Component-wise, not
+  ;; lexicographic — 0.10.0 is newer than 0.8.0, which a string compare gets
+  ;; backwards, and that is the whole class of bug this comparison exists to avoid.
+  {:suite "min-version" :label "version-parts reads the numeric prefix of a git describe" :expected "true" :expr "(do (require 'jolt.deps) (let [p @#'jolt.deps/version-parts] (and (= [0 7 29] (p \"v0.7.29-24-g5ac1f4a0\")) (= [0 7 29] (p \"0.7.29\")) (= [0 8] (p \"0.8\")) (= [1 0 0] (p \"v1.0.0\")) (= [0 7 29] (p \"v0.7.29-dirty\")))))"}
+  {:suite "min-version" :label "version< compares components, not strings" :expected "true" :expr "(do (require 'jolt.deps) (let [lt @#'jolt.deps/version<] (and (lt \"0.7.29\" \"0.8.0\") (not (lt \"0.8.0\" \"0.7.29\")) (not (lt \"0.10.0\" \"0.8.0\")) (lt \"0.8.0\" \"0.10.0\") (not (lt \"0.8.0\" \"0.8\")) (not (lt \"0.8\" \"0.8.0\")) (not (lt \"v0.8.1-3-gabc\" \"0.8.0\")))))"}
+  {:suite "min-version" :label "a dev build reads as its last tag, so a floor above it is unmet" :expected "true" :expr "(do (require 'jolt.deps) (@#'jolt.deps/version< \"v0.7.29-24-g5ac1f4a0\" \"0.8.0\"))"}
+  ;; Pure, so the assertion does not need a runtime that actually fails the
+  ;; floor — under a source build nothing does, which is the case this gate runs
+  ;; in and the reason the decision is separated from the throw.
+  {:suite "min-version" :label "an unmet floor answers a message naming both versions" :expected "true" :expr "(do (require 'jolt.deps) (let [f (@#'jolt.deps/min-version-failure \"v0.7.29\" [[nil \"0.8.0\"]])] (and (some? f) (clojure.string/includes? (first f) \"0.8.0\") (clojure.string/includes? (first f) \"v0.7.29\") (clojure.string/includes? (first f) \"JOLT_SKIP_MIN_VERSION\") (= \"0.8.0\" (:jolt/required (second f))))))"}
+  {:suite "min-version" :label "a met floor answers nil" :expected "true" :expr "(do (require 'jolt.deps) (nil? (@#'jolt.deps/min-version-failure \"v0.8.0\" [[nil \"0.8.0\"] [(quote a/b) \"0.7.0\"]])))"}
+  ;; A library is the natural declarer, so an unmet dep floor has to name the dep.
+  {:suite "min-version" :label "an unmet dependency floor names the dependency" :expected "true" :expr "(do (require 'jolt.deps) (let [f (@#'jolt.deps/min-version-failure \"v0.7.29\" [[(quote minver/lib) \"98.0.0\"]])] (and (clojure.string/includes? (first f) \"98.0.0\") (clojure.string/includes? (first f) \"minver/lib\") (= (quote minver/lib) (:jolt/required-by (second f))))))"}
+  ;; Several unmet floors report ONE message, for the newest thing needed.
+  {:suite "min-version" :label "the highest unmet floor is the one reported" :expected "true" :expr "(do (require 'jolt.deps) (= \"0.10.0\" (:jolt/required (second (@#'jolt.deps/min-version-failure \"v0.7.0\" [[(quote a/a) \"0.8.0\"] [(quote b/b) \"0.10.0\"] [(quote c/c) \"0.9.0\"]])))))"}
+  {:suite "min-version" :label "a met project floor resolves" :expected "true" :expr "(do (require 'jolt.deps) (let [d (str (System/getProperty \"java.io.tmpdir\") \"/jolt-minver-unit2\")] (jolt.host/sh (str \"rm -rf \" d)) (jolt.host/sh (str \"mkdir -p \" d \"/src\")) (spit (str d \"/deps.edn\") \"{:paths [\\\"src\\\"] :jolt/min-version \\\"0.0.1\\\"}\") (vector? (:roots (jolt.deps/resolve-project d)))))"}
+  ;; A LIBRARY is the natural declarer — it knows which jolt its FFI bindings
+  ;; need, and the app pulling it in does not. So a dep's floor has to be read
+  ;; and reported with the dep named.
+  ;; A source build answers "dev", which has no numeric components. Compared as
+  ;; 0.0.0 it is the OLDEST possible runtime and every floor refused it — so a
+  ;; contributor running from a clone could not run any project that declared
+  ;; one. An unnamed version is never refused.
+  {:suite "min-version" :label "a runtime that names no version is never refused" :expected "true" :expr "(do (require 'jolt.deps) (and (= [] (@#'jolt.deps/version-parts \"dev\")) (@#'jolt.deps/version< \"dev\" \"0.0.1\")))"}
+  {:suite "min-version" :label "JOLT_SKIP_MIN_VERSION is not consulted per-call but per-process" :expected "true" :expr "(do (require 'jolt.deps) (fn? @#'jolt.deps/check-min-versions!))"}
   {:suite "m2-repo" :label ":mvn/local-repo, JOLT_MAVEN_REPOSITORY, GRENADINE_MAVEN_REPOSITORY, HOME/.m2 precedence" :expected "true" :expr "(do (require 'jolt.deps) (let [m2 @#'jolt.deps/m2-repo-dir] (and (= \"/cfg\" (m2 \"/cfg\" \"/j\" \"/g\" \"/h\" \".\")) (= \"/j\" (m2 nil \"/j\" \"/g\" \"/h\" \".\")) (= \"/g\" (m2 nil nil \"/g\" \"/h\" \".\")) (= \"/h/.m2/repository\" (m2 nil nil nil \"/h\" \".\")))))"}
   {:suite "gitlibs-cache" :label "JOLT_GITLIBS_DIR, GRENADINE_GITLIBS_DIR, GITLIBS, HOME precedence" :expected "true" :expr "(do (require 'jolt.deps) (let [cache @#'jolt.deps/gitlibs-dir] (and (= \"/j\" (cache \"/j\" \"/g\" \"/t\" \"/h\")) (= \"/g/jolt\" (cache nil \"/g\" \"/t\" \"/h\")) (= \"/t/jolt\" (cache nil nil \"/t\" \"/h\")) (= \"/h/.jolt/gitlibs\" (cache nil nil nil \"/h\")))))"}
   {:suite "gitlibs-cache" :label "require-deps host exposes the effective Jolt Gitlibs directory" :expected "true" :expr "(do (require 'jolt.deps) (= (@#'jolt.deps/gitlibs-dir) ((:gitlibs-dir (@#'jolt.deps/required-host)))))"}


### PR DESCRIPTION
Stacked on #802 — the CHANGELOG entry lands in the `### Added` section that PR
creates, and the two ship in the same release. Base retargets to `main` when
#802 merges.

A project or a library declares `:jolt/min-version`, and a runtime below it
refuses to load the project rather than run it:

```clojure
{:paths ["src"]
 :jolt/min-version "0.8.0"}
```

## Why now

Not every breaking change is visible at the call site. `ffi/write`'s argument
order moves in #802, and the old and new spellings are both integers — so an
older runtime writes to the wrong place and reports nothing.

Nothing downstream has a runtime floor at all today: the libraries are git deps
and jolt is installed separately, so a library has no way to say which jolt its
FFI bindings need. This is the missing mechanism, and it is worth having on its
own terms rather than only for this break.

**A library is the natural declarer** — it knows what its bindings need and the
app pulling it in does not. So the floor is read from every dependency's
`deps.edn` as well as the project's, collected in the same walk as
`:jolt/native`, and reported with the dependency named. Several unmet floors
report the newest one, once, rather than one message per dependency.

## What it does not do

**It is honoured by the jolt that reads the key, so it protects from this release
onward and not before.** An older jolt ignores it, as it ignores every key it
does not know — I verified 0.7.29 runs a project declaring `:jolt/min-version
"9.9.9"` without comment. So this does not close the window on the `ffi/write`
change itself; the CHANGELOG carries that, and the key is here so the *next*
break has a mechanism waiting.

A runtime that names no version — a source build answers `dev` — is never
refused. It reads as `0.0.0`, the oldest possible, while in practice being the
newest; refusing every contributor's run would make the floor unusable for the
people most likely to meet it. `JOLT_SKIP_MIN_VERSION=1` runs anyway, for a
released runtime whose version string understates what it carries.

## Comparison

Leading numeric components, taking each component's numeric *prefix*: the
version string is a git describe, so `v0.7.29-24-gabc` is `0.7.29` with the
suffix riding along on the last component. Component-wise rather than
lexicographic, because `0.10.0` is newer than `0.8.0` and a string compare gets
that backwards.

## Shape

The decision is a pure function of `(running, declared)`, separate from the
throw. That is the only way the refusal is testable — a source build fails no
floor, and that is the environment the gate runs in.

It earned the shape immediately. The first draft picked the highest unmet floor
with `max-key`, which compares version *vectors* as numbers and threw a cast
error the moment two floors were unmet — while never comparing at all with one,
so the crash hid behind every single-dependency project until a multi-floor gate
row went in.

## Gates

`make unit` — 10 `min-version` rows: the git-describe parse, component-wise
ordering including `0.10` vs `0.8`, the unnamed-version exemption, an unmet
project floor, an unmet dependency floor naming the dependency, and the
highest-of-many selection. Plus `depsunit` and `depssmoke`. Seed re-minted.