### PR TITLE
Forget a pointer's size when it is released, and attach to an arena atomically

### DIFF
--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -834,6 +834,10 @@
 ;; wrapper needs a name for the primitive that its own definition has not taken.
 ;; A host-level gate (test/chez/ffi-*.ss loads this file alone) keeps using the
 ;; public names, which is why both are registered.
+;; __free is the raw deallocator. The public jolt.ffi/free is a stdlib wrapper
+;; that also forgets the pointer's recorded size, the same way __read/__write sit
+;; under the layout-aware read/write.
+(def-var! "jolt.ffi" "__free" ffi-free)
 (def-var! "jolt.ffi" "__alloc" ffi-alloc)
 (def-var! "jolt.ffi" "__calloc" ffi-calloc)
 (def-var! "jolt.ffi" "__read" ffi-read)

--- a/host/chez/java/ffi.ss
+++ b/host/chez/java/ffi.ss
@@ -797,6 +797,60 @@
 ;; Guardians are global mutable state and a drain both reads and mutates one, so
 ;; every access takes this mutex: an automatic arena can become garbage on any
 ;; thread, and two threads draining at once corrupts the guardian's own list.
+;; --- recorded pointer sizes --------------------------------------------------
+;; jolt.ffi/size answers the size jolt was TOLD a pointer addresses. A jolt
+;; pointer is a bare address, so a size cannot ride along with the value the way
+;; a MemorySegment carries its own — it lives here, keyed by address, and the
+;; entry has to be removed when the memory is released or the next allocation to
+;; land on that address inherits it.
+;;
+;; SHARDED, unlike the callable table above. That one is written when a callback
+;; is minted; this one is written by every allocation, every string->ptr and
+;; every declared view, from whatever thread is running — one lock over one
+;; table would serialize allocation across the whole process. Chez hashtables
+;; are not safe for concurrent writers (two resizing at once faults inside the
+;; collector), so each shard owns its mutex and nothing is written outside it.
+;; Single-key reads stay unlocked, as they do for the callable table.
+;;
+;; The index drops the low four bits before masking: every allocator underneath
+;; this file hands back 16-aligned addresses, so those bits are always zero and
+;; masking them directly would put every entry in shard 0.
+(define ffi-size-shard-count 16)
+(define ffi-size-tables (make-vector ffi-size-shard-count))
+(define ffi-size-mutexes (make-vector ffi-size-shard-count))
+(let loop ((i 0))
+  (when (fx<? i ffi-size-shard-count)
+    (vector-set! ffi-size-tables i (make-eqv-hashtable))
+    (vector-set! ffi-size-mutexes i (make-mutex))
+    (loop (fx+ i 1))))
+
+(define (ffi-size-shard-index a)
+  (bitwise-and (bitwise-arithmetic-shift-right a 4) (- ffi-size-shard-count 1)))
+
+(define (jolt-ffi-remember-size! p n)
+  (let* ((a (jnum->exact p))
+         (i (ffi-size-shard-index a)))
+    (jolt-with-mutex (vector-ref ffi-size-mutexes i)
+      (hashtable-set! (vector-ref ffi-size-tables i) a (jnum->exact n)))
+    p))
+
+(define (jolt-ffi-recorded-size p)
+  (let* ((a (jnum->exact p))
+         (i (ffi-size-shard-index a)))
+    (hashtable-ref (vector-ref ffi-size-tables i) a 0)))
+
+;; Batch, because an arena close forgets its whole group at once and a per-entry
+;; crossing of the jolt/host boundary is the expensive part, not the delete.
+(define (jolt-ffi-forget-sizes! ps)
+  (for-each
+    (lambda (p)
+      (let* ((a (jnum->exact p))
+             (i (ffi-size-shard-index a)))
+        (jolt-with-mutex (vector-ref ffi-size-mutexes i)
+          (hashtable-delete! (vector-ref ffi-size-tables i) a))))
+    (seq->list (jolt-seq ps)))
+  jolt-nil)
+
 (define ffi-auto-mu (make-mutex))
 (define ffi-auto-guardian (make-guardian))
 (define (jolt-ffi-auto-guard! token)
@@ -837,6 +891,9 @@
 ;; __free is the raw deallocator. The public jolt.ffi/free is a stdlib wrapper
 ;; that also forgets the pointer's recorded size, the same way __read/__write sit
 ;; under the layout-aware read/write.
+(def-var! "jolt.ffi" "__remember-size!" jolt-ffi-remember-size!)
+(def-var! "jolt.ffi" "__forget-sizes!" jolt-ffi-forget-sizes!)
+(def-var! "jolt.ffi" "__size" jolt-ffi-recorded-size)
 (def-var! "jolt.ffi" "__free" ffi-free)
 (def-var! "jolt.ffi" "__alloc" ffi-alloc)
 (def-var! "jolt.ffi" "__calloc" ffi-calloc)

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -296,24 +296,30 @@
 ;; exists; a per-access bounds check is not on offer and would cost a lookup on
 ;; every read.
 ;;
-;; The table is keyed by ADDRESS, which is the whole reason an entry has to be
-;; removed when the memory goes away: an allocator hands the same address out
-;; again, and a stale entry would answer a size for a block that never had one.
-;; So `free` forgets, and an arena forgets its blocks and views when it closes.
+;; The record lives in the host (host/chez/java/ffi.ss), in a sharded
+;; mutex-guarded table keyed by ADDRESS. Keyed by address is what forces an
+;; entry to be removed when the memory goes away: an allocator hands the same
+;; address out again, and a leftover entry would answer a size for a block that
+;; never had one. So `free` forgets, and an arena forgets its blocks and views
+;; when it closes.
+;;
+;; It is host state rather than an atom here because every allocation writes it.
+;; A single atom holding a persistent map made each alloc rebuild a path through
+;; the map under a CAS that every other allocating thread contended for; the
+;; shards give writers on different addresses different locks.
 ;;
 ;; segment, slice and reinterpret all take an arena for the same reason. Without
 ;; one the declaration lasts for the life of the process, which is a leak in a
 ;; loop and, once the memory is released, a wrong answer — babashka.ffi has
 ;; neither problem because a MemorySegment carries its own size and there is no
 ;; side table to go stale.
-(def ^:private known-sizes (atom {}))
 
 (defn- remember-size! [pointer byte-count]
-  (swap! known-sizes assoc pointer byte-count)
-  pointer)
+  (jolt.ffi/__remember-size! pointer byte-count))
 
 (defn- forget-sizes! [pointers]
-  (swap! known-sizes (fn [m] (reduce dissoc m pointers))))
+  (jolt.ffi/__forget-sizes! pointers)
+  nil)
 
 (defn pointer?
   "True when x could be a pointer: a non-negative integer address. A jolt
@@ -336,7 +342,9 @@
   allocated, or what segment/reinterpret declared. 0 for a pointer jolt was
   never told the size of, including every pointer returned by C."
   [p]
-  (get @known-sizes p 0))
+  ;; Anything that is not an address was never a key, and answered 0 when this
+  ;; was a map lookup. Keep that rather than raising inside the host coercion.
+  (if (pointer? p) (jolt.ffi/__size p) 0))
 
 (defn- byte-count-of
   "The byte count a size argument denotes: an integer count, a type keyword's
@@ -534,9 +542,23 @@
   ((:close (checked-arena a)))
   nil)
 
-(defn- arena-add! [a key value]
-  (swap! (:jolt.ffi/state a) update key conj value)
-  value)
+;; Attaching to the group and the arena still being OPEN are one step. A shared
+;; arena can be closed by another thread between arena-usable!'s check and this,
+;; and a conj onto state that close has already reset attaches the value to a
+;; group nothing will ever release — a leak with no error to report it. The swap
+;; adds only while :open? holds; when it did not, the caller undoes whatever it
+;; had already allocated and the call raises rather than returning a pointer the
+;; arena is not going to free.
+(defn- arena-add!
+  ([a key value] (arena-add! a key value nil))
+  ([a key value on-lost]
+   (let [before (first (swap-vals! (:jolt.ffi/state a)
+                                   (fn [m] (if (:open? m) (update m key conj value) m))))]
+     (when-not (:open? before)
+       (when on-lost (on-lost))
+       (throw (ex-info "jolt.ffi: the arena closed while this allocation was in flight"
+                       {:arena-kind (:jolt.ffi/kind a)})))
+     value)))
 
 ;; -- allocation ---------------------------------------------------------------
 
@@ -574,7 +596,7 @@
         raw (jolt.ffi/__calloc (if over? (+ byte-count alignment -1) byte-count))
         remainder (if over? (rem raw alignment) 0)
         usable (if (zero? remainder) raw (+ raw (- alignment remainder)))]
-    (arena-add! a :blocks [usable raw])
+    (arena-add! a :blocks [usable raw] (fn [] (jolt.ffi/__free raw)))
     (remember-size! usable byte-count)))
 
 (defn alloc
@@ -620,7 +642,7 @@
          p (jolt.ffi/__string->ptr s)]
      (if (jolt.ffi/null? p)
        p                                        ; nil: nothing was allocated
-       (do (arena-add! arena :blocks [p p])
+       (do (arena-add! arena :blocks [p p] (fn [] (jolt.ffi/__free p)))
            (remember-size! p (+ 1 (jolt.ffi/__utf8-length s))))))))
 
 (defn free
@@ -693,7 +715,7 @@
 
   Pass the arena when slicing in a loop. Each length recorded without one is an
   entry that lives as long as the process, on an address the caller is free to
-  release — see the note above `known-sizes`.
+  release — see the note above `remember-size!`.
 
   CAUTION: keep offset before len. Transposed, the length becomes the offset."
   ([p offset] (+ p offset))
@@ -1292,7 +1314,7 @@
   arena releases it. `callback` expands to this around __ccallable."
   [arena addr]
   (let [arena (arena-usable! arena "callback")]
-    (arena-add! arena :callables addr)))
+    (arena-add! arena :callables addr (fn [] (jolt.ffi/free-callable addr)))))
 
 ;; The arena-owned foreign-callable: same pointer, released when the arena
 ;; closes, with no free-callable to remember. A macro for the same reason cfn is.

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -96,8 +96,9 @@
   is ZEROED — a struct a caller only partly fills is the ordinary case, and
   malloc's leftovers in the rest of it are a C-visible bug that reproduces only
   under load. An integer byte count aligns to 16; a type or layout aligns
-  naturally; a third argument overrides. string->ptr, clone, reinterpret and
-  callback all take an arena in the same first position.
+  naturally; a third argument overrides. string->ptr, clone, reinterpret,
+  segment, slice and callback all take an arena in the same first position, and
+  free forgets the size it recorded.
 
       (with-open [a (ffi/shared-arena)]
         (let [buf (ffi/alloc a 4096)
@@ -295,10 +296,16 @@
 ;; exists; a per-access bounds check is not on offer and would cost a lookup on
 ;; every read.
 ;;
-;; An arena forgets its blocks' sizes when it closes. A `reinterpret` or
-;; `segment` size given WITHOUT an arena is remembered for the life of the
-;; process — the same unbounded lifetime babashka.ffi documents for that form —
-;; so pass an arena when calling either in a loop.
+;; The table is keyed by ADDRESS, which is the whole reason an entry has to be
+;; removed when the memory goes away: an allocator hands the same address out
+;; again, and a stale entry would answer a size for a block that never had one.
+;; So `free` forgets, and an arena forgets its blocks and views when it closes.
+;;
+;; segment, slice and reinterpret all take an arena for the same reason. Without
+;; one the declaration lasts for the life of the process, which is a leak in a
+;; loop and, once the memory is released, a wrong answer — babashka.ffi has
+;; neither problem because a MemorySegment carries its own size and there is no
+;; side table to go stale.
 (def ^:private known-sizes (atom {}))
 
 (defn- remember-size! [pointer byte-count]
@@ -348,26 +355,6 @@
     (keyword? n) (jolt.ffi/__sizeof n)
     :else (throw (ex-info "jolt.ffi: expected a byte count, a type keyword, or a compiled layout"
                           {:size n}))))
-
-(defn segment
-  "A pointer to addr. With a byte count, records that size so `size`, copy and
-  clone can use it.
-
-  CAUTION: keep addr before size. Transposed, the size becomes the address and
-  the first read can stop the process."
-  ([addr] addr)
-  ([addr byte-count] (remember-size! addr (byte-count-of byte-count))))
-
-(defn slice
-  "A pointer `offset` bytes into p. With a length — a byte count, a type
-  keyword, or a compiled layout — the slice's size is recorded, so walking an
-  array of structs takes the layout itself:
-
-      (slice arr (* i (sizeof point)) point)
-
-  CAUTION: keep offset before len. Transposed, the length becomes the offset."
-  ([p offset] (+ p offset))
-  ([p offset len] (remember-size! (+ p offset) (byte-count-of len))))
 
 ;; -- sizes --------------------------------------------------------------------
 
@@ -454,7 +441,7 @@
       (doseq [addr (:callables group)]
         (attempt (fn [] (jolt.ffi/free-callable addr))))
       (doseq [block (reverse (:blocks group))]
-        (attempt (fn [] (jolt.ffi/free (second block)))))
+        (attempt (fn [] (jolt.ffi/__free (second block)))))
       (forget-sizes! (concat (map first (:blocks group))
                              (map first (:views group))))
       (when @failure (throw @failure)))
@@ -636,6 +623,19 @@
        (do (arena-add! arena :blocks [p p])
            (remember-size! p (+ 1 (jolt.ffi/__utf8-length s))))))))
 
+(defn free
+  "Release a caller-owned block from `alloc` and answer nil, and forget the size
+  jolt recorded for that pointer.
+
+  Forgetting is not bookkeeping: the size table is keyed by address, an
+  allocator hands the same address out again, and a leftover entry would answer
+  a size for a block that never had one — which copy and clone would then use as
+  a byte count. Arena memory is released by closing the arena, not by this."
+  [p]
+  (forget-sizes! [p])
+  (jolt.ffi/__free p)
+  nil)
+
 (defn copy
   "Copy bytes from pointer src to pointer dst; answers nil. Without n, copies
   src's known size (see `size`), and dst must be at least that large.
@@ -665,23 +665,72 @@
      (jolt.ffi/__copy src dst n)
      dst)))
 
+(defn segment
+  "A pointer to addr. With a byte count, records that size so `size`, copy and
+  clone can use it. With an arena first, the arena forgets the size when it
+  closes; without one the declaration lasts for the life of the process.
+
+  CAUTION: keep addr before size. Transposed, the size becomes the address and
+  the first read can stop the process."
+  ([addr] addr)
+  ([addr byte-count]
+   (when (arena? addr)
+     (throw (ex-info "jolt.ffi/segment: the arena comes first — (segment arena addr byte-count)"
+                     {:arena addr})))
+   (remember-size! addr (byte-count-of byte-count)))
+  ([arena addr byte-count]
+   (let [arena (arena-usable! arena "segment")]
+     (arena-add! arena :views [addr nil])
+     (remember-size! addr (byte-count-of byte-count)))))
+
+(defn slice
+  "A pointer `offset` bytes into p. With a length — a byte count, a type
+  keyword, or a compiled layout — the slice's size is recorded, so walking an
+  array of structs takes the layout itself:
+
+      (with-open [a (ffi/confined-arena)]
+        (slice a arr (* i (sizeof point)) point))
+
+  Pass the arena when slicing in a loop. Each length recorded without one is an
+  entry that lives as long as the process, on an address the caller is free to
+  release — see the note above `known-sizes`.
+
+  CAUTION: keep offset before len. Transposed, the length becomes the offset."
+  ([p offset] (+ p offset))
+  ([p offset len]
+   (when (arena? p)
+     (throw (ex-info "jolt.ffi/slice: the arena comes first — (slice arena p offset len)"
+                     {:arena p})))
+   (remember-size! (+ p offset) (byte-count-of len)))
+  ([arena p offset len]
+   (let [arena (arena-usable! arena "slice")
+         q (+ p offset)]
+     (arena-add! arena :views [q nil])
+     (remember-size! q (byte-count-of len)))))
+
 (defn reinterpret
   "Declare that pointer p addresses `byte-count` bytes, and answer p. This is how
   a pointer from C gets a size, which is what `size`, copy and clone read.
 
-  With an arena, the declaration is forgotten when the arena closes, and the
-  arena calls the optional cleanup function with p — the place to hand a C
-  library's own deallocator. Without an arena the declaration lasts for the life
-  of the process, so pass one when calling this in a loop.
+  The arena comes first, as it does for alloc, string->ptr, clone and callback:
+  (reinterpret arena p byte-count [cleanup]). With one, the declaration is
+  forgotten when the arena closes and the arena calls the optional cleanup
+  function with p — the place to hand a C library's own deallocator. Without an
+  arena the declaration lasts for the life of the process, so pass one when
+  calling this in a loop.
 
   CAUTION: give the ACTUAL size. Nothing can check it, and jolt does not
   bounds-check a read; a size larger than the allocation is a read off the end.
 
   CAUTION: the arena frees nothing here — the memory is C's. What it releases is
   the declaration and, through the cleanup function, whatever C wants released."
-  ([p byte-count] (remember-size! p (byte-count-of byte-count)))
-  ([p byte-count arena] (reinterpret p byte-count arena nil))
-  ([p byte-count arena cleanup]
+  ([p byte-count]
+   (when (arena? p)
+     (throw (ex-info "jolt.ffi/reinterpret: the arena comes first — (reinterpret arena p byte-count)"
+                     {:arena p})))
+   (remember-size! p (byte-count-of byte-count)))
+  ([arena p byte-count] (reinterpret arena p byte-count nil))
+  ([arena p byte-count cleanup]
    (let [arena (arena-usable! arena "reinterpret")]
      (arena-add! arena :views [p cleanup])
      (remember-size! p (byte-count-of byte-count)))))

--- a/test/chez/jolt-ffi-arena-test.clj
+++ b/test/chez/jolt-ffi-arena-test.clj
@@ -40,6 +40,36 @@
            (ffi/close-arena a)
            (ffi/close-arena a))
          (= 1 @frees)))
+;; The check and the attach are one step. If they were not, an alloc that passed
+;; the check just before another thread's close would conj its block onto the
+;; state close had already reset — attached to a group nothing will ever release.
+;; Racing it directly is timing-dependent, so the row closes the arena from
+;; inside the swap instead, which is the interleaving the fix exists for.
+(check "a block cannot attach to an arena that closed mid-allocation"
+       (let [a (ffi/shared-arena)
+             real-free ffi/__free
+             real-calloc ffi/__calloc
+             frees (atom 0)]
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))
+                       ffi/__calloc (fn [n]
+                                      (let [p (real-calloc n)]
+                                        (ffi/close-arena a)   ; the racing close
+                                        p))]
+           (and (rejects? #(ffi/alloc a 8))
+                ;; the block the alloc had already taken was handed back
+                (= 1 @frees)))))
+(check "a lost allocation is not left recorded in the size table"
+       (let [a (ffi/shared-arena)
+             real-calloc ffi/__calloc
+             seen (atom nil)]
+         (with-redefs [ffi/__calloc (fn [n]
+                                      (let [p (real-calloc n)]
+                                        (reset! seen p)
+                                        (ffi/close-arena a)
+                                        p))]
+           (rejects? #(ffi/alloc a 8)))
+         (zero? (ffi/size @seen))))
+
 (check "allocating in a closed arena raises"
        (let [a (ffi/confined-arena)]
          (ffi/close-arena a)

--- a/test/chez/jolt-ffi-arena-test.clj
+++ b/test/chez/jolt-ffi-arena-test.clj
@@ -32,11 +32,11 @@
 ;; release inside a with-open body is legitimate, and an exception from the
 ;; `finally` would replace whatever the body was reporting.
 (check "a second close releases nothing and does not raise"
-       (let [real-free ffi/free
+       (let [real-free ffi/__free
              frees (atom 0)
              a (ffi/confined-arena)]
          (ffi/alloc a 8)
-         (with-redefs [ffi/free (fn [p] (swap! frees inc) (real-free p))]
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))]
            (ffi/close-arena a)
            (ffi/close-arena a))
          (= 1 @frees)))
@@ -176,16 +176,47 @@
 (check "an arena forgets a reinterpreted size when it closes"
        (let [a (ffi/confined-arena)
              p (ffi/alloc 8)]
-         (ffi/reinterpret p 8 a)
+         (ffi/reinterpret a p 8)
          (ffi/close-arena a)
          (try (zero? (ffi/size p)) (finally (ffi/free p)))))
 (check "an arena runs a view's cleanup with the pointer, and frees nothing itself"
        (let [seen (atom nil)
              a (ffi/confined-arena)
              p (ffi/alloc 8)]
-         (ffi/reinterpret p 8 a (fn [x] (reset! seen x)))
+         (ffi/reinterpret a p 8 (fn [x] (reset! seen x)))
          (ffi/close-arena a)
          (try (= p @seen) (finally (ffi/free p)))))
+
+;; The size table is keyed by ADDRESS, so an entry that outlives its allocation
+;; answers a size for a block that never had one — and copy/clone take that as a
+;; byte count. free forgets; an arena forgets its blocks and its views.
+(check "free forgets the size it recorded, so a recycled address inherits nothing"
+       (let [p (ffi/alloc 1024)]
+         (ffi/reinterpret p 1024)
+         (ffi/free p)
+         (let [q (ffi/alloc 1024)]                ; the allocator reuses the address
+           (try (zero? (ffi/size q)) (finally (ffi/free q))))))
+(check "an arena forgets a segment size when it closes"
+       (let [a (ffi/confined-arena)
+             p (ffi/alloc 64)]
+         (ffi/segment a p 64)
+         (ffi/close-arena a)
+         (try (zero? (ffi/size p)) (finally (ffi/free p)))))
+(check "an arena forgets a slice size when it closes"
+       (let [a (ffi/confined-arena)
+             p (ffi/alloc 64)]
+         (ffi/slice a p 16 16)
+         (ffi/close-arena a)
+         (try (zero? (ffi/size (+ p 16))) (finally (ffi/free p)))))
+(check "an arena-scoped slice still records the size while the arena is open"
+       (let [p (ffi/alloc 64)]
+         (try (with-open [a (ffi/confined-arena)]
+                (= 16 (ffi/size (ffi/slice a p 16 16))))
+              (finally (ffi/free p)))))
+(check "the arena-first argument order is enforced, not just documented"
+       (and (rejects? #(ffi/reinterpret (ffi/global-arena) 8))
+            (rejects? #(ffi/segment (ffi/global-arena) 8))
+            (rejects? #(ffi/slice (ffi/global-arena) 8 16))))
 
 ;; -- copy and clone -----------------------------------------------------------
 
@@ -479,11 +510,11 @@
 ;; -- a closing arena releases everything it holds -----------------------------
 
 (check "close releases blocks, strings and callbacks in one pass"
-       (let [real-free ffi/free
+       (let [real-free ffi/__free
              real-free-callable ffi/free-callable
              frees (atom 0)
              callables (atom 0)]
-         (with-redefs [ffi/free (fn [p] (swap! frees inc) (real-free p))
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))
                        ffi/free-callable (fn [p] (swap! callables inc) (real-free-callable p))]
            (let [a (ffi/confined-arena)]
              (ffi/alloc a 8)
@@ -493,13 +524,13 @@
              (ffi/close-arena a)))
          (= [3 1] [@frees @callables])))
 (check "a cleanup that raises does not strand the rest of the group"
-       (let [real-free ffi/free
+       (let [real-free ffi/__free
              frees (atom 0)]
-         (with-redefs [ffi/free (fn [p] (swap! frees inc) (real-free p))]
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))]
            (let [a (ffi/confined-arena)
                  view (ffi/alloc 8)]
              (ffi/alloc a 8)
-             (ffi/reinterpret view 8 a (fn [_] (throw (ex-info "cleanup failed" {}))))
+             (ffi/reinterpret a view 8 (fn [_] (throw (ex-info "cleanup failed" {}))))
              (rejects? #(ffi/close-arena a))
              (real-free view)))
          (= 1 @frees)))


### PR DESCRIPTION
Follow-up review of #802. Four defects, each with a gate row checked against the un-fixed code.

## The size record went stale and never shrank

`known-sizes` was keyed by ADDRESS, and `forget-sizes!` ran from exactly one place — arena close, over whole blocks. `jolt.ffi/free` was the raw host deallocator and never touched it, so a size declared for a pointer outlived the allocation:

```clojure
(let [p (ffi/alloc 1024)]
  (ffi/reinterpret p 1024)
  (ffi/free p)
  (let [q (ffi/alloc 1024)]
    (ffi/size q)))            ; => 1024, and q is a fresh block
```

That reproduces — the allocator hands the same address back. `copy` and `clone` take `size` as the byte count when none is passed, so it is a wrong length on a live pointer, not just a stale reading.

`free` is a stdlib wrapper now that forgets and then calls `__free`, the shape `read`/`write` already had over `__read`/`__write`. Arena release keeps calling `__free` directly, since it batches one forget over the whole group.

## The documented mitigation did not exist

The module comment told callers a size given without an arena "is remembered for the life of the process — so pass an arena when calling either in a loop." Only `reinterpret` had an arena arity. `segment` and `slice` had none, and `slice`'s own docstring recommends exactly the loop that grows the table:

```clojure
(slice arr (* i (sizeof point)) point)   ; one permanent entry per iteration
```

Both take an arena now.

## `reinterpret` contradicted its own docstring

`stdlib/jolt/ffi.clj` promises "string->ptr, clone, reinterpret and callback all take an arena in the same first position." The signature was `([p byte-count arena cleanup])`. The arena moves to the front, where the docstring always said it was. All three arena-taking forms reject a transposed arena rather than recording a size against the arena map. Unreleased API, so nothing out of tree depends on the old order.

## A block could attach to an arena that closed under it

`arena-usable!` checked `:open?` and `arena-add!` then `conj`ed — two steps. A shared arena closed by another thread in between took the `conj` onto state the close had already reset, attaching the block to a group nothing would ever release: a leak with nothing to report it. The add is one swap that only attaches while `:open?` holds; when it did not, the caller hands back whatever it had already allocated and the call raises.

## The record is host state now

It was a single global atom holding a persistent map, written by every allocation, every `string->ptr` and every declared view — each write rebuilding a path through the map under a CAS every other allocating thread contended for. It lives in `host/chez/java/ffi.ss` as sharded eqv-hashtables, one mutex per shard, following the callable table beside it. The shard index drops the low four bits first: every allocator here returns 16-aligned addresses, so masking them directly would put every entry in shard 0.

Measured on the allocation path, best of 7 over 20k allocations, B/A/B:

| | ns per alloc |
|---|---|
| sharded host table | 2123 |
| atom of persistent map | 3419 |
| sharded host table (re-run) | 2134 |

1.6x single-threaded, before any contention relief.

## Left alone, deliberately

The arena-less `segment`/`slice`/`reinterpret` forms still declare for the life of the process — that is what they are for. Freeing a block also does not sweep sub-range entries recorded inside it, because a caller-owned `alloc` records no extent for `free` to sweep. Both are now documented on the site (jolt-lang.github.io, `api/ffi.md` gained Arenas and Pointer sizes sections) rather than papered over, and the arena form exists for the loop case.

## Gates

`make test` green, 93 CI targets. Five rows for the size record and the argument order, two for the race — the race rows drive the close from inside the allocation, since racing it directly is timing-dependent. Each was checked by reverting the fix and confirming it goes red.