### PR TITLE
Delimit and validate namespaced-map namespace tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,10 +205,10 @@ when transposed.
   WASM/Emscripten build.
 
 - **Namespaced-map prefixes could absorb separator text into a silent wrong
-  namespace.** The reader now stops at the namespace-token boundary, allows
-  whitespace and commas before `{`, and rejects other intervening input —
-  including comments, matching JVM boundary behavior — and rejects invalid
-  explicit namespace symbols.
+  namespace or accept an invalid namespace.** The reader now requires an
+  explicit namespace to be a simple unqualified symbol, stops at the token
+  boundary, allows whitespace and commas before `{`, and rejects other
+  intervening input including comments to match JVM behavior.
 
 - **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
   layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,12 @@ when transposed.
   corrupt. Reported and first patched by @jasalt, found bringing up a
   WASM/Emscripten build.
 
+- **Namespaced-map prefixes could absorb separator text into a silent wrong
+  namespace.** The reader now stops at the namespace-token boundary, allows
+  whitespace and commas before `{`, and rejects other intervening input —
+  including comments, matching JVM boundary behavior — and rejects invalid
+  explicit namespace symbols.
+
 - **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
   layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets
   that are a per-platform ABI, and it chose them from the host's *identity*:

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -902,19 +902,29 @@
 (define (rdr-read-ns-map s i end)        ; i points just past "#:"
   (let* ((auto? (and (< i end) (char=? (string-ref s i) #\:)))
          (i2 (if auto? (+ i 1) i)))
-    (let loop ((j i2))
-      (cond
-        ((>= j end) (rdr-error s j "EOF in namespaced map literal"))
-        ((char=? (string-ref s j) #\{)
-         (let* ((nstok (substring s i2 j))
-                (mapns (if auto?
-                           (if (string=? nstok "") (chez-current-ns)
-                               (let ((a (chez-resolve-alias (chez-current-ns) nstok)))
-                                 (if a a (rdr-invalid-token (string-append "::" nstok)))))
-                           nstok)))
-           (let-values (((es k) (rdr-read-seq s (+ j 1) end #\})))
-             (values (rdr-make-map (rdr-nsmap-kvs mapns es)) k))))
-        (else (loop (+ j 1)))))))
+    ;; The namespace is a token, not every byte up to the opening brace.
+    ;; Whitespace (including commas) may separate that token from the map;
+    ;; anything else at the boundary is an error rather than part of the
+    ;; namespace or a non-map payload borrowing a later opening brace.
+    (let-values (((nstok j) (rdr-read-token s i2 end)))
+      (let skip-boundary ((k j))
+        (cond
+          ((and (not auto?) (string=? nstok ""))
+           (rdr-error s i2 "Namespaced map must specify a namespace"))
+          ((and (< k end) (rdr-ws? (string-ref s k)))
+           (skip-boundary (+ k 1)))
+          ((or (>= k end) (not (char=? (string-ref s k) #\{)))
+           ;; A comment is a reader macro rather than whitespace at this exact
+           ;; boundary on the JVM, so do not use rdr-skip-ws (which skips it).
+           (rdr-error s k "Namespaced map must specify a map"))
+          (else
+           (let ((mapns (if auto?
+                            (if (string=? nstok "") (chez-current-ns)
+                                (let ((a (chez-resolve-alias (chez-current-ns) nstok)))
+                                  (if a a (rdr-invalid-token (string-append "::" nstok)))))
+                            nstok)))
+             (let-values (((es next) (rdr-read-seq s (+ k 1) end #\})))
+               (values (rdr-make-map (rdr-nsmap-kvs mapns es)) next)))))))))
 
 ;; *read-eval* gate for #= — the cell is captured lazily (the var is def'd
 ;; after this file loads) and the value read per use, so a

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -899,6 +899,10 @@
         ((null? (cdr es)) es)
         (else (cons (rdr-nsmap-key mapns (car es))
                     (cons (cadr es) (rdr-nsmap-kvs mapns (cddr es)))))))
+(define (rdr-simple-symbol-token? tok)
+  (guard (e (#t #f))
+    (let ((v (rdr-token->value tok)))
+      (and (symbol-t? v) (not (symbol-t-ns v))))))
 (define (rdr-read-ns-map s i end)        ; i points just past "#:"
   (let* ((auto? (and (< i end) (char=? (string-ref s i) #\:)))
          (i2 (if auto? (+ i 1) i)))
@@ -907,10 +911,12 @@
     ;; anything else at the boundary is an error rather than part of the
     ;; namespace or a non-map payload borrowing a later opening brace.
     (let-values (((nstok j) (rdr-read-token s i2 end)))
+      (when (and (not auto?) (string=? nstok ""))
+        (rdr-error s i2 "Namespaced map must specify a namespace"))
+      (when (and (not auto?) (not (rdr-simple-symbol-token? nstok)))
+        (rdr-error s i2 (string-append "Namespaced map must specify a valid namespace: " nstok)))
       (let skip-boundary ((k j))
         (cond
-          ((and (not auto?) (string=? nstok ""))
-           (rdr-error s i2 "Namespaced map must specify a namespace"))
           ((and (< k end) (rdr-ws? (string-ref s k)))
            (skip-boundary (+ k 1)))
           ((or (>= k end) (not (char=? (string-ref s k) #\{)))

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -184,6 +184,21 @@
   {:suite "sdf" :expr "(let [f (java.text.SimpleDateFormat. \"yyyy-MM-dd\")] (.format f (.parse f \"2023-07-15\")))" :expected "\"2023-07-15\""}
   {:suite "reader" :expr "(let [r (-> \"foo bar baz\" java.io.StringReader. java.io.PushbackReader.)] [(read r) (slurp r)])" :expected "[foo \" bar baz\"]"}
   {:suite "reader" :expr "(let [r (-> \"(+ 1 2) 99\" java.io.StringReader. java.io.PushbackReader.)] [(read r) (read r)])" :expected "[(+ 1 2) 99]"}
+  ;; A namespaced-map prefix ends at the namespace token.  Ordinary reader
+  ;; whitespace and commas may separate it from the opening map delimiter.
+  {:suite "reader / namespaced-map boundary" :expr "(= #:nsmap.foo{:a 1 :_/raw 2} #:nsmap.foo {:a 1 :_/raw 2})" :expected "true"}
+  {:suite "reader / namespaced-map boundary" :expr "(= #::{:a 1 :_/raw 2} #:: {:a 1 :_/raw 2})" :expected "true"}
+  {:suite "reader / namespaced-map boundary" :expr "(do (alias (quote nsmap-str) (quote clojure.string)) (= (read-string \"#::nsmap-str{:a 1}\") (read-string \"#::nsmap-str {:a 1}\")))" :expected "true"}
+  {:suite "reader / namespaced-map boundary" :expr "[(= #:nsmap.foo{:a 1} #:nsmap.foo, {:a 1}) (= #::{:a 1} #::, {:a 1}) (do (alias (quote nsmap-str) (quote clojure.string)) (= (read-string \"#::nsmap-str{:a 1}\") (read-string \"#::nsmap-str, {:a 1}\")))]" :expected "[true true true]"}
+  {:suite "reader / namespaced-map boundary" :expr "(= #:nsmap.foo{:a 1} (read-string \"#:nsmap.foo {; comment inside the map\\n :a 1}\"))" :expected "true"}
+  ;; JVM Clojure treats a comment as a reader macro, not whitespace at this
+  ;; exact boundary.  Junk and malformed/non-map payloads also fail closed.
+  {:suite "reader / namespaced-map boundary" :expr "(read-string \"#:nsmap.foo ; not boundary whitespace\\n{:a 1}\")" :expected :throws}
+  {:suite "reader / namespaced-map boundary" :expr "(read-string \"#:foo bar{:a 1}\")" :expected :throws}
+  {:suite "reader / namespaced-map boundary" :expr "(read-string \"#:nsmap.foo\")" :expected :throws}
+  {:suite "reader / namespaced-map boundary" :expr "(read-string \"#:nsmap.foo :a\")" :expected :throws}
+  {:suite "reader / namespaced-map boundary" :expr "(read-string \"#: {:a 1}\")" :expected :throws}
+  {:suite "reader / namespaced-map boundary" :expr "(read-string \"#::missing-alias {:a 1}\")" :expected :throws}
   {:suite "hostctor" :expr "(String/format \"%d-%s\" 5 \"x\")" :expected "\"5-x\""}
   {:suite "hostctor" :expr "[(.format (java.text.NumberFormat/getInstance) 1234567.5) (.format (java.text.NumberFormat/getIntegerInstance) 1234567)]" :expected "[\"1,234,567.5\" \"1,234,567\"]"}
   {:suite "hostobj" :expr "(try (throw (ex-info \"x\" {})) (catch Throwable e [(.getNextException e) (vec (.getStackTrace e))]))" :expected "[nil []]"}

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -198,6 +198,8 @@
   {:suite "reader / namespaced-map boundary" :expr "(read-string \"#:nsmap.foo\")" :expected :throws}
   {:suite "reader / namespaced-map boundary" :expr "(read-string \"#:nsmap.foo :a\")" :expected :throws}
   {:suite "reader / namespaced-map boundary" :expr "(read-string \"#: {:a 1}\")" :expected :throws}
+  {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#:foo/bar{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: foo/bar\""}
+  {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#:123{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: 123\""}
   {:suite "reader / namespaced-map boundary" :expr "(read-string \"#::missing-alias {:a 1}\")" :expected :throws}
   {:suite "hostctor" :expr "(String/format \"%d-%s\" 5 \"x\")" :expected "\"5-x\""}
   {:suite "hostctor" :expr "[(.format (java.text.NumberFormat/getInstance) 1234567.5) (.format (java.text.NumberFormat/getIntegerInstance) 1234567)]" :expected "[\"1,234,567.5\" \"1,234,567\"]"}


### PR DESCRIPTION
# Delimit and validate namespaced-map namespace tokens

## Summary

Make namespaced-map prefixes consume a namespace token, then ordinary reader
whitespace (including commas), before requiring the opening `{`.
Explicit namespace tokens must also read as simple, unqualified symbols.

Previously the reader scanned every character up to the next `{` into the
namespace string.  That silently produced keys in a namespace such as
`"foo "`, and let a non-map payload borrow a later map delimiter:

```clojure
(let [m #:foo {:a 1}]
  [(keys m) (= 1 (:foo/a m)) (= m {:foo/a 1})])
;; before: [(:foo /a) false false]
;; after:  [(:foo/a) true true]

(read-string "#:foo bar{:a 1}")
;; before: accepted as a map in namespace "foo bar"
;; after:  reader error
```

The change reuses the reader's token terminators, skips only ordinary reader
whitespace/commas at the boundary, and then requires `{`.  It intentionally
does not use the general whitespace skipper: JVM Clojure treats a comment at
this exact boundary as a reader macro and rejects it.

Explicit prefixes now reject qualified or non-symbol namespace tokens with the
JVM-compatible `Namespaced map must specify a valid namespace: <sym>` message.

## Compatibility oracle

The accepted space/comma forms and the listed rejected junk/malformed forms
were checked against JVM Clojure 1.12.2 and Babashka 1.12.218. Both agree on
those cases.
For the comment-boundary control, JVM Clojure rejects while Babashka accepts;
this patch follows JVM Clojure, consistent with Jolt's Clojure compatibility
target.
JVM Clojure 1.12.2 also rejects `#:foo/bar{:a 1}` and `#:123{:a 1}` with the
exact messages asserted by the new tests.

The tests cover:

- explicit, current-namespace, and alias-resolved prefixes, adjacent and spaced;
- comma separators for all three prefix forms;
- a comment inside the map versus a comment between prefix and map;
- exact junk input `#:foo bar{:a 1}`;
- qualified and non-symbol explicit namespaces, including exact error messages;
- missing, empty-explicit, non-map, and missing-alias payloads.

## Red to green evidence

Base: `jolt-lang/jolt@f986c7435476067ad18d07d58f5fecd4804ca14b`

With the tests committed before the fix:

```text
unit gate: 1535/1543 passed
  3/11  reader / namespaced-map boundary

8 FAIL(s):
  want `true` got `false`  ; spaced explicit prefix
  raised                   ; spaced current-namespace prefix
  raised                   ; spaced alias-resolved prefix
  raised                   ; comma-separated prefixes
  want `true` got `false`  ; comment inside the map
  expected throw; got ...  ; comment at the prefix boundary
  expected throw; got ...  ; #:foo bar{:a 1}
  expected throw; got ...  ; empty explicit namespace
```

After the fix:

```text
unit gate: 1543/1543 passed
  11/11  reader / namespaced-map boundary
```

The follow-up namespace-validation tests were also committed before their fix:

```text
unit gate: 1543/1545 passed
  0/2  reader / namespaced-map namespace

2 FAIL(s):
  want `"Namespaced map must specify a valid namespace: foo/bar"`
  got `#:foo/bar{:a 1}`
  want `"Namespaced map must specify a valid namespace: 123"`
  got `#:123{:a 1}`
```

After validating explicit namespace tokens as simple unqualified symbols:

```text
unit gate: 1545/1545 passed
  2/2  reader / namespaced-map namespace
```

`make remint` converged after one pass and produced no tracked seed change.
The reader is loaded directly by `host/chez/rt.ss`; re-minting is still required
because reader behavior can change how compiler/core seed sources are read, but
none of those sources contain an affected boundary form.  `make gambitseed`
likewise produced no tracked seed change.

A detached checkout of the original boundary test and fix commits, with no
`target/` directory and a fresh Jolt cache, independently exercised the
committed source through `bin/jolt`:

```text
fresh checkout: target absent
[true :rejected]
```

The two results are equality with `{:foo/a 1}` for `#:foo {:a 1}`, and rejection
of exact junk input `#:foo bar{:a 1}`.

## Validation

- rebased onto `jolt-lang/jolt@ccd6a73fd20b8e69cba654e008024958d5b4bd8a`
- branch tip: `faad871661e0a734723be743ee53952811758ba2`
- `make unit` — PASS, 1555/1555
- `make -j1 ci` — PASS
- exact-tip fork workflows — PASS: [tests](https://github.com/casselc/jolt/actions/runs/33460678128), [flake](https://github.com/casselc/jolt/actions/runs/33460678099)

Both were run through Chez Scheme 10.4.1 with isolated Jolt cache and gate-build
directories:

```text
OK: ci gate passed (93 targets)
GATED: ci gate passed on this exact tree
```

## Provenance

This was found during an external Jolt correctness audit and is tracked as
[chucklehead-dev/jolt-aspect-packs#56](https://github.com/chucklehead-dev/jolt-aspect-packs/issues/56).
That ledger is provenance only; understanding or accepting this patch does not
depend on its infrastructure.

## Scope

The branch changes `host/chez/reader.ss`, reader rows in `test/chez/unit.edn`,
and the Unreleased/Fixed section of `CHANGELOG.md`. It adds no new test harness,
build target, or fork-only infrastructure.
