### PR TITLE
Enforce JVM typed semantics for modeled atomic classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,7 +207,8 @@ when transposed.
 - **Modeled atomic classes used Clojure value equality and unbounded
   arithmetic.** `AtomicReference.compareAndSet` now compares object identity,
   while `AtomicInteger` and `AtomicLong` validate primitive arguments and wrap
-  arithmetic at their signed 32- and 64-bit widths, matching the JVM.
+  arithmetic at their signed 32- and 64-bit widths, and `AtomicLong.intValue`
+  narrows to a signed 32-bit result, matching the JVM.
 
 - **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
   layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,11 @@ when transposed.
   corrupt. Reported and first patched by @jasalt, found bringing up a
   WASM/Emscripten build.
 
+- **Modeled atomic classes used Clojure value equality and unbounded
+  arithmetic.** `AtomicReference.compareAndSet` now compares object identity,
+  while `AtomicInteger` and `AtomicLong` validate primitive arguments and wrap
+  arithmetic at their signed 32- and 64-bit widths, matching the JVM.
+
 - **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
   layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets
   that are a per-platform ABI, and it chose them from the host's *identity*:

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -876,7 +876,10 @@
         (cons "getAndAdd" (lambda (self d)
           (let ((delta (atomic-convert self d)))
             (atomic-numeric-transition! self delta #t))))
-        (cons "intValue" (lambda (self) (jnum->exact (unbox (atomic-box self)))))
+        (cons "intValue" (lambda (self)
+          (if (eq? (atomic-kind self) 'long)
+              (jolt-unchecked-int (unbox (atomic-box self)))
+              (jnum->exact (unbox (atomic-box self))))))
         (cons "longValue" (lambda (self) (jnum->exact (unbox (atomic-box self)))))
         (cons "toString" (lambda (self) (jolt-str-render-one (unbox (atomic-box self)))))))
 ;; java.util.Collections/synchronizedMap|List|Set wrap a collection for

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -773,54 +773,109 @@
 ;; java.util.concurrent.atomic.Atomic{Reference,Integer,Long,Boolean}: a
 ;; thread-safe mutable cell (mutex-guarded, shared heap). One "atomic" jhost
 ;; serves all four; the numeric ops are meaningful only on Integer/Long.
-(define (make-atomic init)
-  (make-jhost "atomic" (vector (box init) (make-mutex))))
+;; AtomicReference CAS compares object identity, while the primitive wrappers
+;; compare their unboxed values. Keep that closed distinction in the cell
+;; instead of making the shared CAS path guess from the values it contains (or
+;; calling a stored, potentially generic comparator while the mutex is held).
+(define (make-atomic init kind)
+  (make-jhost "atomic" (vector (box init) (make-mutex) kind)))
 (define (atomic-box self) (vector-ref (jhost-state self) 0))
 (define (atomic-lock self) (vector-ref (jhost-state self) 1))
+(define (atomic-kind self) (vector-ref (jhost-state self) 2))
+;; Convert a modeled Java method argument at the signature boundary. Numeric
+;; atomic cells never contain an unbounded jolt integer: the constructor and
+;; every value-taking method accept exactly the primitive width named by their
+;; Java signature. Keep this outside the mutex because conversion may throw.
+(define (atomic-convert self value)
+  (case (atomic-kind self)
+    ((integer) (jolt-int-cast value))
+    ((long) (jolt-long-cast value))
+    (else value)))
+;; Java's primitive atomic arithmetic is two's-complement arithmetic. Its
+;; result wraps even though a checked cast at a method boundary rejects an
+;; out-of-range argument. VALUE is an exact sum or difference of already
+;; converted cell data, so this helper is leaf-only inside the counted mutex.
+(define (atomic-wrap self value)
+  (case (atomic-kind self)
+    ((integer) (jolt-unchecked-int value))
+    ((long) (jolt-wrap64 value))
+    (else value)))
+(define (atomic-numeric-transition! self delta return-old?)
+  (jolt-with-mutex (atomic-lock self)
+    (let* ((old (unbox (atomic-box self)))
+           (next (atomic-wrap self (+ old delta))))
+      (set-box! (atomic-box self) next)
+      (if return-old? old next))))
 ;; CAS under the atomic's mutex. updateAndGet/getAndUpdate run the user fn
 ;; LOCK-FREE in a CAS retry loop (JVM parity), so the fn may re-enter the same
 ;; atomic; a mutex-held fn deadlocked on the non-recursive Chez mutex there
 ;; (PSL R4 cluster 4).
 (define (atomic-cas! self o n)
-  (jolt-with-mutex (atomic-lock self)
-    (if (jolt=2 (unbox (atomic-box self)) o)
-        (begin (set-box! (atomic-box self) n) #t) #f)))
-(let ((ref-ctor (lambda args (make-atomic (if (pair? args) (car args) jolt-nil))))
-      (num-ctor (lambda args (make-atomic (if (pair? args) (car args) 0))))
-      (bool-ctor (lambda args (make-atomic (if (pair? args) (car args) #f)))))
+  (let* ((kind (atomic-kind self))
+         (expected (atomic-convert self o))
+         (next (atomic-convert self n)))
+    (jolt-with-mutex (atomic-lock self)
+      (let ((current (unbox (atomic-box self))))
+        (if (case kind
+              ((reference boolean) (eq? current expected))
+              ((integer long) (= current expected))
+              (else #f))
+            (begin (set-box! (atomic-box self) next) #t)
+            #f)))))
+(let ((ref-ctor (lambda args
+                  (make-atomic (if (pair? args) (car args) jolt-nil) 'reference)))
+      (int-ctor (lambda args
+                  (make-atomic (jolt-int-cast (if (pair? args) (car args) 0)) 'integer)))
+      (long-ctor (lambda args
+                   (make-atomic (jolt-long-cast (if (pair? args) (car args) 0)) 'long)))
+      (bool-ctor (lambda args
+                   (make-atomic (if (pair? args) (car args) #f) 'boolean))))
   (for-each (lambda (n) (register-class-ctor! n ref-ctor))
             '("AtomicReference" "java.util.concurrent.atomic.AtomicReference"))
-  (for-each (lambda (n) (register-class-ctor! n num-ctor))
-            '("AtomicInteger" "java.util.concurrent.atomic.AtomicInteger"
-              "AtomicLong" "java.util.concurrent.atomic.AtomicLong"))
+  (for-each (lambda (n) (register-class-ctor! n int-ctor))
+            '("AtomicInteger" "java.util.concurrent.atomic.AtomicInteger"))
+  (for-each (lambda (n) (register-class-ctor! n long-ctor))
+            '("AtomicLong" "java.util.concurrent.atomic.AtomicLong"))
   (for-each (lambda (n) (register-class-ctor! n bool-ctor))
             '("AtomicBoolean" "java.util.concurrent.atomic.AtomicBoolean")))
 (register-host-methods! "atomic"
   (list (cons "get" (lambda (self) (unbox (atomic-box self))))
-        (cons "set" (lambda (self v) (set-box! (atomic-box self) v) jolt-nil))
-        (cons "getAndSet" (lambda (self v) (jolt-with-mutex (atomic-lock self)
-                            (let ((o (unbox (atomic-box self)))) (set-box! (atomic-box self) v) o))))
+        ;; Serialization of the plain set method against read-modify-write
+        ;; methods is a separate concern. Preserve its current write boundary
+        ;; here while ensuring conversion completes before state changes.
+        (cons "set" (lambda (self v)
+          (let ((next (atomic-convert self v)))
+            (set-box! (atomic-box self) next)
+            jolt-nil)))
+        (cons "getAndSet" (lambda (self v)
+          (let ((next (atomic-convert self v)))
+            (jolt-with-mutex (atomic-lock self)
+              (let ((o (unbox (atomic-box self))))
+                (set-box! (atomic-box self) next)
+                o)))))
         (cons "compareAndSet" (lambda (self o n) (atomic-cas! self o n)))
         (cons "updateAndGet" (lambda (self f)
           (let loop ((v (unbox (atomic-box self))))
-            (let ((n (jolt-invoke f v)))
+            (let ((n (atomic-convert self (jolt-invoke f v))))
               (if (atomic-cas! self v n) n (loop (unbox (atomic-box self))))))))
         (cons "getAndUpdate" (lambda (self f)
           (let loop ((v (unbox (atomic-box self))))
-            (let ((n (jolt-invoke f v)))
+            (let ((n (atomic-convert self (jolt-invoke f v))))
               (if (atomic-cas! self v n) v (loop (unbox (atomic-box self))))))))
-        (cons "incrementAndGet" (lambda (self) (jolt-with-mutex (atomic-lock self)
-                                  (let ((n (+ (unbox (atomic-box self)) 1))) (set-box! (atomic-box self) n) n))))
-        (cons "decrementAndGet" (lambda (self) (jolt-with-mutex (atomic-lock self)
-                                  (let ((n (- (unbox (atomic-box self)) 1))) (set-box! (atomic-box self) n) n))))
-        (cons "getAndIncrement" (lambda (self) (jolt-with-mutex (atomic-lock self)
-                                  (let ((o (unbox (atomic-box self)))) (set-box! (atomic-box self) (+ o 1)) o))))
-        (cons "getAndDecrement" (lambda (self) (jolt-with-mutex (atomic-lock self)
-                                  (let ((o (unbox (atomic-box self)))) (set-box! (atomic-box self) (- o 1)) o))))
-        (cons "addAndGet" (lambda (self d) (jolt-with-mutex (atomic-lock self)
-                            (let ((n (+ (unbox (atomic-box self)) (jnum->exact d)))) (set-box! (atomic-box self) n) n))))
-        (cons "getAndAdd" (lambda (self d) (jolt-with-mutex (atomic-lock self)
-                            (let ((o (unbox (atomic-box self)))) (set-box! (atomic-box self) (+ o (jnum->exact d))) o))))
+        (cons "incrementAndGet"
+          (lambda (self) (atomic-numeric-transition! self 1 #f)))
+        (cons "decrementAndGet"
+          (lambda (self) (atomic-numeric-transition! self -1 #f)))
+        (cons "getAndIncrement"
+          (lambda (self) (atomic-numeric-transition! self 1 #t)))
+        (cons "getAndDecrement"
+          (lambda (self) (atomic-numeric-transition! self -1 #t)))
+        (cons "addAndGet" (lambda (self d)
+          (let ((delta (atomic-convert self d)))
+            (atomic-numeric-transition! self delta #f))))
+        (cons "getAndAdd" (lambda (self d)
+          (let ((delta (atomic-convert self d)))
+            (atomic-numeric-transition! self delta #t))))
         (cons "intValue" (lambda (self) (jnum->exact (unbox (atomic-box self)))))
         (cons "longValue" (lambda (self) (jnum->exact (unbox (atomic-box self)))))
         (cons "toString" (lambda (self) (jolt-str-render-one (unbox (atomic-box self)))))))

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -856,6 +856,8 @@
         (cons "compareAndSet" (lambda (self o n) (atomic-cas! self o n)))
         (cons "updateAndGet" (lambda (self f)
           (let loop ((v (unbox (atomic-box self))))
+            ;; atomic-cas! deliberately re-normalizes V and N. This keeps every
+            ;; CAS caller behind one typed boundary; conversion is idempotent.
             (let ((n (atomic-convert self (jolt-invoke f v))))
               (if (atomic-cas! self v n) n (loop (unbox (atomic-box self))))))))
         (cons "getAndUpdate" (lambda (self f)

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1651,6 +1651,18 @@
   {:suite "atomics" :label "swap-vals! on nil is a NullPointerException" :expected "\"java.lang.NullPointerException\"" :expr "(try (swap-vals! nil inc) (catch Throwable e (.getName (class e))))"}
   {:suite "atomics" :label "reset-vals! on nil is a NullPointerException" :expected "\"java.lang.NullPointerException\"" :expr "(try (reset-vals! nil 1) (catch Throwable e (.getName (class e))))"}
   {:suite "atomics" :label "CAS-retry increments across futures lose no updates (atomic native)" :expected "\"true\"" :expr "(do (let [a (atom 0) done (atom 0) n 4 per 2000 target (* n per)] (dotimes [_ n] (future (dotimes [_ per] (loop [] (let [cur (deref a)] (when-not (compare-and-set! a cur (inc cur)) (recur))))) (swap! done inc))) (loop [w 0] (cond (== (deref done) n) :fin (> w 1000000) :timeout :else (do (Thread/yield) (recur (inc w))))) (str (== (deref a) target))))"}
+  {:suite "atomics" :label "AtomicInteger constructors preserve valid primitive values" :expected "[0 7]" :expr "[(.get (AtomicInteger.)) (.get (AtomicInteger. 7))]"}
+  {:suite "atomics" :label "AtomicLong constructors preserve valid primitive values" :expected "[0 9]" :expr "[(.get (AtomicLong.)) (.get (AtomicLong. 9))]"}
+  {:suite "atomics" :label "AtomicInteger constructor rejects an out-of-range value" :expected :throws :expr "(AtomicInteger. 2147483648)"}
+  {:suite "atomics" :label "AtomicInteger addAndGet wraps signed overflow" :expected "-2147483648" :expr "(.addAndGet (AtomicInteger. 2147483647) 1)"}
+  {:suite "atomics" :label "AtomicInteger decrementAndGet wraps signed underflow" :expected "2147483647" :expr "(.decrementAndGet (AtomicInteger. -2147483648))"}
+  {:suite "atomics" :label "AtomicLong addAndGet wraps signed overflow" :expected "-9223372036854775808" :expr "(.addAndGet (AtomicLong. 9223372036854775807) 1)"}
+  {:suite "atomics" :label "AtomicLong decrementAndGet wraps signed underflow" :expected "9223372036854775807" :expr "(.decrementAndGet (AtomicLong. -9223372036854775808))"}
+  {:suite "atomics" :label "AtomicLong getAndAdd returns old and stores wrapped result" :expected "[9223372036854775807 -9223372036854775808]" :expr "(let [a (AtomicLong. 9223372036854775807)] [(.getAndAdd a 1) (.get a)])"}
+  {:suite "atomics" :label "AtomicInteger getAndSet validates before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.getAndSet a 2147483648) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
+  {:suite "atomics" :label "AtomicInteger compareAndSet validates next before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.compareAndSet a 7 2147483648) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
+  {:suite "atomics" :label "AtomicReference compareAndSet rejects equal distinct expectations" :expected "[false true]" :expr "(let [v (list 1) a (AtomicReference. v)] [(.compareAndSet a (list 1) :bad) (identical? v (.get a))])"}
+  {:suite "atomics" :label "AtomicReference compareAndSet accepts the same expectation" :expected "[true :ok]" :expr "(let [v (list 1) a (AtomicReference. v)] [(.compareAndSet a v :ok) (.get a)])"}
   ;; shadow-emitted (compiler-review R2 stage 1). Each row binds a local whose
   ;; name is a bare Scheme head the back end emits, in the scope of a construct
   ;; that emits that head, so the local would shadow the emitted form. Pre-remint

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1662,6 +1662,7 @@
   {:suite "atomics" :label "AtomicLong intValue narrows to signed 32 bits" :expected "[1 -2147483648 2147483647 7]" :expr "[(.intValue (AtomicLong. 4294967297)) (.intValue (AtomicLong. 2147483648)) (.intValue (AtomicLong. -2147483649)) (.intValue (AtomicInteger. 7))]"}
   {:suite "atomics" :label "AtomicInteger getAndSet validates before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.getAndSet a 2147483648) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
   {:suite "atomics" :label "AtomicInteger compareAndSet validates next before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.compareAndSet a 7 2147483648) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
+  {:suite "atomics" :label "AtomicInteger compareAndSet validates expected before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.compareAndSet a 2147483648 8) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
   {:suite "atomics" :label "AtomicReference compareAndSet rejects equal distinct expectations" :expected "[false true]" :expr "(let [v (list 1) a (AtomicReference. v)] [(.compareAndSet a (list 1) :bad) (identical? v (.get a))])"}
   {:suite "atomics" :label "AtomicReference compareAndSet accepts the same expectation" :expected "[true :ok]" :expr "(let [v (list 1) a (AtomicReference. v)] [(.compareAndSet a v :ok) (.get a)])"}
   ;; shadow-emitted (compiler-review R2 stage 1). Each row binds a local whose

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1659,6 +1659,7 @@
   {:suite "atomics" :label "AtomicLong addAndGet wraps signed overflow" :expected "-9223372036854775808" :expr "(.addAndGet (AtomicLong. 9223372036854775807) 1)"}
   {:suite "atomics" :label "AtomicLong decrementAndGet wraps signed underflow" :expected "9223372036854775807" :expr "(.decrementAndGet (AtomicLong. -9223372036854775808))"}
   {:suite "atomics" :label "AtomicLong getAndAdd returns old and stores wrapped result" :expected "[9223372036854775807 -9223372036854775808]" :expr "(let [a (AtomicLong. 9223372036854775807)] [(.getAndAdd a 1) (.get a)])"}
+  {:suite "atomics" :label "AtomicLong intValue narrows to signed 32 bits" :expected "[1 -2147483648 2147483647 7]" :expr "[(.intValue (AtomicLong. 4294967297)) (.intValue (AtomicLong. 2147483648)) (.intValue (AtomicLong. -2147483649)) (.intValue (AtomicInteger. 7))]"}
   {:suite "atomics" :label "AtomicInteger getAndSet validates before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.getAndSet a 2147483648) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
   {:suite "atomics" :label "AtomicInteger compareAndSet validates next before mutation" :expected "[:threw 7]" :expr "(let [a (AtomicInteger. 7)] [(try (.compareAndSet a 7 2147483648) :no-throw (catch ArithmeticException _ :threw)) (.get a)])"}
   {:suite "atomics" :label "AtomicReference compareAndSet rejects equal distinct expectations" :expected "[false true]" :expr "(let [v (list 1) a (AtomicReference. v)] [(.compareAndSet a (list 1) :bad) (identical? v (.get a))])"}


### PR DESCRIPTION
# Enforce JVM typed semantics for modeled atomic classes

## Summary

Jolt models `AtomicReference`, `AtomicBoolean`, `AtomicInteger`, and
`AtomicLong` with one shared host object. The shared implementation did not
retain which modeled class constructed a cell, so it could not implement the
different comparison and width rules of those classes:

- `AtomicReference.compareAndSet` compared with Clojure value equality rather
  than object identity;
- integer and long arithmetic grew into arbitrary-precision values instead of
  wrapping at signed 32- and 64-bit boundaries;
- numeric constructor and mutation arguments were stored without the primitive
  conversion required by the modeled Java signatures; and
- `AtomicLong.intValue` returned the full 64-bit value instead of narrowing it
  to a signed 32-bit result.

This change records a closed kind tag in each atomic cell, converts numeric
arguments at the method boundary, selects identity or typed numeric comparison
for CAS, and funnels numeric read-modify-write operations through one
fixed-width transition helper. User functions passed to `updateAndGet` and
`getAndUpdate` remain outside the mutex in their existing CAS retry loops.
`AtomicLong.intValue` uses the same kind tag to select signed 32-bit narrowing,
while `AtomicInteger.intValue` preserves its stored value.

Potentially throwing conversions are completed before the counted mutex. This
is a structural lock-safety property of the implementation; the behavioral
tests below establish conversion-before-mutation, not an independent dynamic
proof of lock placement.

## JVM oracle

On Clojure 1.12/JVM:

```clojure
(import '(java.util.concurrent.atomic
           AtomicInteger AtomicLong AtomicReference))

(.addAndGet (AtomicInteger. Integer/MAX_VALUE) 1)
;; => -2147483648

(.addAndGet (AtomicLong. Long/MAX_VALUE) 1)
;; => -9223372036854775808

(let [v (list 1)
      a (AtomicReference. v)]
  [(.compareAndSet a (list 1) :bad)
   (identical? v (.get a))
   (.compareAndSet a v :ok)
   (.get a)])
;; => [false true true :ok]

(AtomicInteger. 2147483648)
;; => java.lang.ArithmeticException: integer overflow

[(.intValue (AtomicLong. 4294967297))
 (.intValue (AtomicLong. 2147483648))
 (.intValue (AtomicLong. -2147483649))
 (.intValue (AtomicInteger. 7))]
;; => [1 -2147483648 2147483647 7]
```

## Red to green

The tests were committed first and run against
`jolt-lang/jolt@f986c7435476067ad18d07d58f5fecd4804ca14b`.

Before the implementation:

```text
unit gate: 1535/1544 passed

9 FAIL(s):
  AtomicInteger accepted an out-of-range constructor value
  AtomicInteger overflow produced 2147483648
  AtomicInteger underflow produced -2147483649
  AtomicLong overflow produced 9223372036854775808N
  AtomicLong underflow produced -9223372036854775809N
  AtomicLong getAndAdd stored an unbounded result
  AtomicInteger getAndSet accepted and stored an out-of-range value
  AtomicInteger compareAndSet accepted and stored an out-of-range value
  AtomicReference CAS accepted an equal but distinct expectation
```

After the implementation (before the two review follow-ups below):

```text
unit gate: 1544/1544 passed
atomics: 23/23 passed
```

The added rows also retain positive controls for valid integer/long
constructors and successful same-object `AtomicReference` CAS.

A review follow-up added the accessor narrowing row before its implementation.
It failed on the then-current branch as follows:

```text
unit gate: 1544/1545 passed
atomics: 23/24 passed

want `[1 -2147483648 2147483647 7]`
got  `[4294967297 2147483648 -2147483649 7]`
```

A second review follow-up covers conversion of an out-of-range CAS expected
value, complementing the existing next-value row. The implementation converts
both operands before taking the mutex or mutating the cell. The CAS retry loops
also intentionally pass their already-normalized values through that same
idempotent conversion boundary, keeping all CAS callers behind one typed path.

## Validation

- rebased onto `jolt-lang/jolt@ccd6a73fd20b8e69cba654e008024958d5b4bd8a`
- branch tip: `de2c89f61b999c0826ed24b70d72df63cdb2fce9`
- `make unit` — PASS, 1556/1556 (atomics 25/25)
- the pre-rebase accessor-inclusive tree passed `make -j1 ci` (92 targets)
  and `make gate-status`
- exact-tip fork workflows — PASS: [tests](https://github.com/casselc/jolt/actions/runs/33460680499), [flake](https://github.com/casselc/jolt/actions/runs/33460680470)
- `NO_JVM=1 bench/run.sh` — completed before and after the change
- alternating exact-base/candidate benchmark recheck (three rounds per side):
  `arrays` 1.00x, `collections` 1.02x, `hash-eq` 0.97x; gate PASS

All Jolt commands used threaded Chez Scheme 10.4.1.

## Scope

The patch changes one contiguous implementation block in
`host/chez/java/host-static-classes.ss`, adds rows to the existing
`test/chez/unit.edn` `atomics` suite, and records the fix under the existing
`Unreleased / Fixed` changelog section. It adds no test target, harness, or
fork infrastructure.

Four known atomic-model gaps are deliberately left for follow-up: serialization
of plain `set` against locked read-modify-write operations; the missing
`floatValue`/`doubleValue` methods; strict JVM-shaped `AtomicBoolean`
constructor argument validation; and rejecting numeric-only methods at dispatch
time for reference and boolean atomics. This patch does not claim to resolve
those separate surfaces.

The external correctness ledger records the original evidence and broader
audit context:

- https://github.com/chucklehead-dev/jolt-aspect-packs/issues/23
- https://github.com/chucklehead-dev/jolt-aspect-packs/issues/35
- https://github.com/chucklehead-dev/jolt-aspect-packs/issues/36

Those links are provenance only; understanding or testing this patch does not
depend on the external harness.
