### PR TITLE
Capture socket errno inside the foreign return path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,10 @@ when transposed.
   corrupt. Reported and first patched by @jasalt, found bringing up a
   WASM/Emscripten build.
 
+- **Socket error handling could lose `errno` between a syscall and its accessor,**
+  causing a clobbered `EAGAIN` to be treated as a terminal socket failure.
+  `connect`, `accept`, `recv`, and `send` now capture result and `errno` atomically.
+
 - **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
   layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets
   that are a per-platform ABI, and it chose them from the host's *identity*:

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -21,14 +21,17 @@
 (def ^:private SOCK-STREAM 1)
 
 (ffi/defcfn c-socket      "socket"      [:int :int :int] :int)
-(ffi/defcfn c-connect     "connect"     [:int :pointer :int] :int :blocking)
+(ffi/defcfn c-connect     "connect"     [:int :pointer :int] :int
+  {:blocking true :capture-native-error true})
 (ffi/defcfn c-bind        "bind"        [:int :pointer :int] :int)
 (ffi/defcfn c-listen      "listen"      [:int :int] :int)
 (ffi/defcfn c-accept      "accept"      [:int :pointer :pointer] :int :blocking)
 (ffi/defcfn c-setsockopt  "setsockopt"  [:int :int :int :pointer :int] :int)
 (ffi/defcfn c-getsockname "getsockname" [:int :pointer :pointer] :int)
-(ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t :blocking)
-(ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t :blocking)
+(ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t
+  {:blocking true :capture-native-error true})
+(ffi/defcfn c-send        "send"        [:int :pointer :size_t :int] :ssize_t
+  {:blocking true :capture-native-error true})
 (ffi/defcfn c-close       "close"       [:int] :int)
 ;; ioctl is (int fd, unsigned long request, ...) — the :varargs marker puts the
 ;; third argument where the callee's va_list reads it. Binding it fixed-arity
@@ -171,10 +174,7 @@
   (let [ip (resolve-host host)
         sa (make-sockaddr ip port)
         r  (loop []
-             (let [r (c-connect fd sa 16)
-                   ;; captured before anything else runs, for the reason io-call
-                   ;; spells out above
-                   e (if (zero? r) 0 (poller/errno))]
+             (let [[r e] (c-connect fd sa 16)]
                (cond
                  (zero? r) 0
                  (poller/connect-pending? e)
@@ -293,16 +293,15 @@
   ;; there is not — and retries; EINTR retries immediately; anything else is
   ;; the syscall's real answer, returned as-is (callers read errno semantics).
   (loop []
-    (let [r (op)
-          ;; ERRNO IS READ HERE AND NOWHERE ELSE. It survives only until the next
-          ;; thing that can set it, and that includes reading it: the accessor is
-          ;; a foreign call, and an allocation on the way can trip a collection
-          ;; whose mmap leaves ENOMEM behind. Asking twice -- once for EINTR, once
-          ;; for EAGAIN -- read recv's EAGAIN as ENOMEM often enough to matter: the
-          ;; retry was missed, the -1 fell through, and a socket read answered EOF
-          ;; on a live connection. The (neg? r) guard is a fixnum compare, which
-          ;; allocates nothing and so cannot collect.
-          e (if (neg? r) (poller/errno) 0)]
+    (let [result (op)
+          captured? (vector? result)
+          r (if captured? (nth result 0) result)
+          ;; recv/send return [result errno] from the foreign return path.
+          ;; accept retains its legacy scalar binding and delayed read until
+          ;; that separate call is migrated.
+          e (if captured?
+              (nth result 1)
+              (if (neg? r) (poller/errno) 0))]
       (cond
         (and (neg? r) (poller/eintr? e)) (recur)
         (and (neg? r) (poller/eagain? e)) (do (poller/wait-ready fd wait-kind) (recur))

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -25,7 +25,8 @@
   {:blocking true :capture-native-error true})
 (ffi/defcfn c-bind        "bind"        [:int :pointer :int] :int)
 (ffi/defcfn c-listen      "listen"      [:int :int] :int)
-(ffi/defcfn c-accept      "accept"      [:int :pointer :pointer] :int :blocking)
+(ffi/defcfn c-accept      "accept"      [:int :pointer :pointer] :int
+  {:blocking true :capture-native-error true})
 (ffi/defcfn c-setsockopt  "setsockopt"  [:int :int :int :pointer :int] :int)
 (ffi/defcfn c-getsockname "getsockname" [:int :pointer :pointer] :int)
 (ffi/defcfn c-recv        "recv"        [:int :pointer :size_t :int] :ssize_t
@@ -293,15 +294,7 @@
   ;; there is not — and retries; EINTR retries immediately; anything else is
   ;; the syscall's real answer, returned as-is (callers read errno semantics).
   (loop []
-    (let [result (op)
-          captured? (vector? result)
-          r (if captured? (nth result 0) result)
-          ;; recv/send return [result errno] from the foreign return path.
-          ;; accept retains its legacy scalar binding and delayed read until
-          ;; that separate call is migrated.
-          e (if captured?
-              (nth result 1)
-              (if (neg? r) (poller/errno) 0))]
+    (let [[r e] (op)]
       (cond
         (and (neg? r) (poller/eintr? e)) (recur)
         (and (neg? r) (poller/eagain? e)) (do (poller/wait-ready fd wait-kind) (recur))

--- a/test/chez/ffi-native-error-test.ss
+++ b/test/chez/ffi-native-error-test.ss
@@ -223,6 +223,47 @@
 (ok "captured pair survives a later slot-overwriting native call"
     (evb "(let [a (c-fail-err 42) _ (c-clobber-scalar 7)] (and (= (first a) -1) (= (second a) 42)))"))
 
+;; --- socket consumer: recv classification uses the captured pair --------------
+;; Exercise the production jolt.socket binding and retry loop, not merely the
+;; lower-level FFI contract above.  The accepted loopback fd is nonblocking and
+;; has no bytes available, so its first recv returns EAGAIN.  Before io-call can
+;; classify that result, the operation sends one byte (making the fd readable)
+;; and overwrites ambient errno with EBADF.  A delayed errno read therefore
+;; mistakes the retryable recv for a terminal failure and returns -1.  Atomic
+;; capture preserves EAGAIN, waits, retries, and returns the one available byte.
+;;
+;; jolt.socket is POSIX-only, while this FFI gate also validates GetLastError on
+;; Windows. Keep the socket consumer witness on the platforms that provide it.
+(define machine-name (symbol->string (machine-type)))
+(define windows-host?
+  (let ((n (string-length machine-name)))
+    (and (>= n 2) (string=? "nt" (substring machine-name (- n 2) n)))))
+(unless windows-host?
+  (ev "(require 'jolt.socket)")
+  (ok "socket recv keeps EAGAIN across an intervening errno clobber"
+      (evb "(let [server (java.net.ServerSocket. 0)
+                   client (java.net.Socket. \"127.0.0.1\" (.getLocalPort server))
+                   conn (.accept server)
+                   fd (jolt.host/ref-get conn :fd)
+                   buf (ffi/alloc 1)
+                   out (.getOutputStream client)
+                   first? (atom true)
+                   raw-recv (deref (ns-resolve 'jolt.socket 'c-recv))
+                   io-call (deref (ns-resolve 'jolt.socket 'io-call))
+                   op (fn []
+                        (let [result (raw-recv fd buf 1 0)]
+                          (when (compare-and-set! first? true false)
+                            (.write out (byte-array [65]) 0 1)
+                            (c-clobber-scalar 9))
+                          result))]
+               (try
+                 (= 1 (io-call op fd :read))
+                 (finally
+                   (ffi/free buf)
+                   (.close conn)
+                   (.close client)
+                   (.close server))))")))
+
 ;; --- scalar preserved: omitted / empty / legacy :blocking / false -------------
 ;; Every non-capturing form must keep the existing scalar result. This is the
 ;; backwards-compatibility floor: the option is strictly additive.

--- a/test/chez/ffi-native-error-test.ss
+++ b/test/chez/ffi-native-error-test.ss
@@ -234,11 +234,7 @@
 ;;
 ;; jolt.socket is POSIX-only, while this FFI gate also validates GetLastError on
 ;; Windows. Keep the socket consumer witness on the platforms that provide it.
-(define machine-name (symbol->string (machine-type)))
-(define windows-host?
-  (let ((n (string-length machine-name)))
-    (and (>= n 2) (string=? "nt" (substring machine-name (- n 2) n)))))
-(unless windows-host?
+(unless (eq? (sa-os-family) 'windows)
   (ev "(require 'jolt.socket)")
   (ok "socket recv keeps EAGAIN across an intervening errno clobber"
       (evb "(let [server (java.net.ServerSocket. 0)
@@ -262,6 +258,37 @@
                    (ffi/free buf)
                    (.close conn)
                    (.close client)
+                   (.close server))))"))
+
+  (ok "socket accept keeps EAGAIN across an intervening errno clobber"
+      (evb "(let [server (java.net.ServerSocket. 0)
+                   server-fd (jolt.host/ref-get server :fd)
+                   client (atom nil)
+                   accepted-fd (atom -1)
+                   sa (ffi/alloc 16)
+                   lenp (ffi/alloc 4)
+                   first? (atom true)
+                   raw-accept (deref (ns-resolve 'jolt.socket 'c-accept))
+                   raw-close (deref (ns-resolve 'jolt.socket 'c-close))
+                   io-call (deref (ns-resolve 'jolt.socket 'io-call))
+                   op (fn []
+                        (let [result (raw-accept server-fd sa lenp)]
+                          (when (compare-and-set! first? true false)
+                            (reset! client
+                                    (java.net.Socket. \"127.0.0.1\"
+                                                      (.getLocalPort server)))
+                            (c-clobber-scalar 9))
+                          result))]
+               (try
+                 (do
+                   (ffi/write lenp :int 0 16)
+                   (reset! accepted-fd (io-call op server-fd :read))
+                   (not (neg? @accepted-fd)))
+                 (finally
+                   (when-not (neg? @accepted-fd) (raw-close @accepted-fd))
+                   (when @client (.close @client))
+                   (ffi/free sa)
+                   (ffi/free lenp)
                    (.close server))))")))
 
 ;; --- scalar preserved: omitted / empty / legacy :blocking / false -------------


### PR DESCRIPTION
# Capture socket errno inside the foreign return path

## Summary

- bind `connect`, `accept`, `recv`, and `send` with atomic native-error capture
- classify retry, readiness, and terminal results from the returned
  `[native-result error-code]` pair
- add deterministic loopback regressions that overwrite ambient errno before
  the socket retry loop can classify `recv`/`accept` `EAGAIN`

## Problem

`connect`, `accept`, `recv`, and `send` are collect-safe foreign calls, but their
error handling reads `errno` only after the call has returned to Jolt. Any
intervening native call, allocation, or collection can replace that
thread-local value.

For `recv`, losing `EAGAIN` makes the readiness retry fall through as a terminal
`-1`; `do-recv` then reports EOF on a connection that is still alive.

Commit `e7e418fd` narrowed this race from two ambient reads to one. Its
unsubstituted load measurements observed failures in 13/60 and 15/60 runs
before that repair and 0/100 afterward, establishing that the ambient slot is
clobbered in ordinary execution. This change removes the remaining
call-to-accessor window by using the existing
`{:blocking true :capture-native-error true}` FFI option.

The related correctness-ledger report is included as provenance and supporting
analysis, but is not required to understand or test this patch:
https://github.com/chucklehead-dev/jolt-aspect-packs/issues/52

## Fix

Capture returns the syscall result and native error as one value from the same
foreign return path. `connect-fd!` destructures that pair directly. The shared
`io-call` retry loop now uniformly destructures captured results for `accept`,
`recv`, and `send`; no socket retry path reads ambient `errno` afterward.

No FFI primitives, Scheme host code, process bindings, or new test harnesses are
introduced.

## Deterministic regression

The regressions use real nonblocking loopback sockets and the production
`jolt.socket` `c-recv`/`c-accept` bindings and `io-call` retry loop. The injected
`c-clobber-scalar` call is a deterministic substitute for the ordinary clobber
whose reachability the `e7e418fd` stress measurements established:

1. `recv` on an empty accepted socket returns `-1`/`EAGAIN`.
2. Before classification, the operation sends one byte to the peer and calls a
   native helper that overwrites ambient errno with `EBADF`.
3. A delayed errno read sees `EBADF` and returns terminal `-1` even though the
   byte is ready.
4. Atomic capture preserves `EAGAIN`, waits, retries, and reads one byte.

### RED — `f986c7435476067ad18d07d58f5fecd4804ca14b` plus the regression

```text
FAIL: socket recv keeps EAGAIN across an intervening errno clobber
39/40 passed
```

The native-error sub-gate exited 1:

```sh
sh test/chez/ffi-native-error-test.sh "$JOLT_CHEZ"
```

At `e4941bcd` plus only the accept regression, `recv` remains green and the new
case fails on the legacy delayed `errno` read:

```text
FAIL: socket accept keeps EAGAIN across an intervening errno clobber
40/41 passed
```

### GREEN — this branch

```text
41/41 passed
```

The same command exits 0.

## Validation

- rebased onto `jolt-lang/jolt@ccd6a73fd20b8e69cba654e008024958d5b4bd8a`
- branch tip: `1a461d02a88223f26c3195e35a82f9095b111f3b`
- `make ffi` — passed
- `bin/jolt run test/chez/socket-test.clj` — `SOCKET-TEST OK`
- the pre-rebase tree passed `make -j1 ci` (92 targets) and `make gate-status`
- exact-tip fork workflows — PASS: [tests](https://github.com/casselc/jolt/actions/runs/33460683546), [flake](https://github.com/casselc/jolt/actions/runs/33460683544)

All validation commands ran through Chez Scheme 10.4.1 with isolated
`JOLT_CACHE_DIR` and `JOLT_GATEBOOT_BUILD_DIR` values.

## Commits

- `8627186b` — test: deterministic `recv`
  clobber witness
- `1b35b0e1` — fix: atomic capture for
  `connect`, `recv`, and `send`
- `bff791e6` — test: deterministic `accept`
  clobber witness
- `1a461d02` — fix: atomic capture for
  `accept`, uniform retry results, and changelog

## Scope

This deliberately does not change `jolt.process` or add a Scheme native-error
primitive. Those are separate call sites with separate review surfaces.

`stdlib/jolt/mvn_http.clj` also owns scalar `connect`, `recv`, and `send`
bindings. It does not perform this patch's delayed errno classification, so it
does not have the defect fixed here. Its bare `EINTR` behavior can still turn a
dependency download into a hard failure and is explicitly left as a separate
follow-up rather than widening this socket retry patch.
