### PR TITLE
Let a java.sql miss autoload the library that provides it

### DIFF
--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -351,6 +351,24 @@
              "Socket" "java.net.Socket"
              "ServerSocket" "java.net.ServerSocket"
              "InetSocketAddress" "java.net.InetSocketAddress")
+           (box #f))
+   ;; clojure.jdbc resolves the java.sql constants as its namespaces COMPILE, so a
+   ;; program that requires jdbc.core reaches for ResultSet before anything of
+   ;; jolt-lang/db has loaded. db.jdbc-shim is what registers them, and naming it
+   ;; here is what lets `(:require [jdbc.core :as jdbc])` compile on its own — the
+   ;; published library, unmodified, exactly as on the JVM.
+   ;;
+   ;; The install namespace is db.jdbc-shim and NOT db.jdbc: db.jdbc extends
+   ;; IConnection and has to load AFTER clojure.jdbc's own extensions to win, so
+   ;; autoloading it from a miss raised mid-compile would invert the order it
+   ;; depends on. The shim only registers statics and has no clojure.jdbc
+   ;; namespace among its requires, so it cannot recurse into the compile that
+   ;; triggered it.
+   (vector "db.jdbc-shim" "io.github.jolt-lang/db"
+           '("ResultSet" "java.sql.ResultSet"
+             "Connection" "java.sql.Connection"
+             "Statement" "java.sql.Statement"
+             "DriverManager" "java.sql.DriverManager")
            (box #f))))
 (define (lib-provider-for class)
   (let loop ((ps lib-class-providers))


### PR DESCRIPTION
clojure.jdbc resolves the `java.sql` constants as its namespaces **compile**, so a program that requires `jdbc.core` reaches for `ResultSet` before anything of `jolt-lang/db` has loaded:

```
Unhandled exception: Unknown class ResultSet
  .../clojure.jdbc/9fc25d66/src/jdbc/constants.clj:22:1
```

`db.jdbc-shim` is what registers them. Naming it in `lib-class-providers` is what lets `(:require [jdbc.core :as jdbc])` compile on its own — the published library, unmodified, exactly as on the JVM, and the same courtesy the `jolt.crypto` and `jolt.socket` entries beside it already extend. Off the source roots the message names the dependency to add instead of leaving a bare `Unknown class`.

### Why the install namespace is `db.jdbc-shim` and not `db.jdbc`

`db.jdbc` extends `IConnection` and has to load **after** clojure.jdbc's own extensions to win, so autoloading it from a miss raised mid-compile would invert the order it depends on. The shim only registers statics and has no clojure.jdbc namespace among its requires, so it cannot recurse into the compile that triggered it.

### This is a convenience, not a fix for anything broken

Requiring `db.jdbc` first, as db's README says, works without this. [jolt-lang/db v0.4.0](https://github.com/jolt-lang/db/releases/tag/v0.4.0) and `examples/ring-app` both do that and pass on the released v0.8.0 — nothing is waiting on this PR. It removes the requirement rather than unblocking anything.

`make unit` passes.