### PR TITLE
Revert "Let a java.sql miss autoload the library that provides it"

### DIFF
--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -351,24 +351,6 @@
              "Socket" "java.net.Socket"
              "ServerSocket" "java.net.ServerSocket"
              "InetSocketAddress" "java.net.InetSocketAddress")
-           (box #f))
-   ;; clojure.jdbc resolves the java.sql constants as its namespaces COMPILE, so a
-   ;; program that requires jdbc.core reaches for ResultSet before anything of
-   ;; jolt-lang/db has loaded. db.jdbc-shim is what registers them, and naming it
-   ;; here is what lets `(:require [jdbc.core :as jdbc])` compile on its own — the
-   ;; published library, unmodified, exactly as on the JVM.
-   ;;
-   ;; The install namespace is db.jdbc-shim and NOT db.jdbc: db.jdbc extends
-   ;; IConnection and has to load AFTER clojure.jdbc's own extensions to win, so
-   ;; autoloading it from a miss raised mid-compile would invert the order it
-   ;; depends on. The shim only registers statics and has no clojure.jdbc
-   ;; namespace among its requires, so it cannot recurse into the compile that
-   ;; triggered it.
-   (vector "db.jdbc-shim" "io.github.jolt-lang/db"
-           '("ResultSet" "java.sql.ResultSet"
-             "Connection" "java.sql.Connection"
-             "Statement" "java.sql.Statement"
-             "DriverManager" "java.sql.DriverManager")
            (box #f))))
 (define (lib-provider-for class)
   (let loop ((ps lib-class-providers))


### PR DESCRIPTION
Reverts #810.

Naming a specific library's namespace in the runtime's class-provider registry is not the language's business. jolt-lang/db keeps the `java.sql` surface working on its own terms: `db.jdbc` registers the shim, and a consumer requires it before `jdbc.core` — which is what its README has always said.

### Nothing depends on this

Every consumer requires `db.jdbc` explicitly and passes on the released v0.8.0, which predates the entry:

- [db v0.4.0](https://github.com/jolt-lang/db/releases/tag/v0.4.0)
- `examples/ring-app`
- samizdat, veriframe

Verified on this branch: db's own clojure.jdbc conformance gate is green against the reverted runtime.

```
clojure.jdbc conformance: https://github.com/yogthos/clojure.jdbc.git @ 9fc25d66
Ran 25 tests. 78 assertions passed, 0 failures, 0 errors.
```

What goes away is only the convenience: `(:require [jdbc.core :as jdbc])` on its own now fails with `Unknown class ResultSet` again, as it did before #810, and the fix is the documented `db.jdbc` require.