### PR TITLE
One namespace gate for both namespaced-map prefix forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,10 +215,14 @@ when transposed.
   narrows to a signed 32-bit result, matching the JVM.
 
 - **Namespaced-map prefixes could absorb separator text into a silent wrong
-  namespace or accept an invalid namespace.** The reader now requires an
-  explicit namespace to be a simple unqualified symbol, stops at the token
-  boundary, allows whitespace and commas before `{`, and rejects other
-  intervening input including comments to match JVM behavior.
+  namespace or accept an invalid namespace.** The reader now requires the
+  namespace — auto-resolved (`#::a`) or explicit (`#:a`) alike — to be a simple
+  unqualified symbol, stops at the token boundary, allows whitespace and commas
+  before `{`, and rejects other intervening input including comments to match
+  JVM behavior. A missing map is reported before the namespace token is judged,
+  and an unregistered alias now says `Unknown auto-resolved namespace alias`
+  rather than `Invalid token`, so the message matches the JVM's for every
+  spelling that names a namespace.
 
 - **`getPosixFilePermissions` and `getOwner` refused to run on hosts whose
   layout jolt already knew.** `nio-file` reads `st_mode` and `st_uid` at offsets

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -905,16 +905,18 @@
       (and (symbol-t? v) (not (symbol-t-ns v))))))
 (define (rdr-read-ns-map s i end)        ; i points just past "#:"
   (let* ((auto? (and (< i end) (char=? (string-ref s i) #\:)))
-         (i2 (if auto? (+ i 1) i)))
+         (i2 (if auto? (+ i 1) i))
+         ;; Reader whitespace (a comma included) directly after the prefix means
+         ;; no namespace token was written at all. Only `#::` may still reach a
+         ;; map from there, naming the current namespace.
+         (spaced? (and (< i2 end) (rdr-ws? (string-ref s i2)))))
     ;; The namespace is a token, not every byte up to the opening brace.
-    ;; Whitespace (including commas) may separate that token from the map;
-    ;; anything else at the boundary is an error rather than part of the
-    ;; namespace or a non-map payload borrowing a later opening brace.
+    ;; Whitespace may separate that token from the map; anything else at the
+    ;; boundary is an error rather than part of the namespace or a non-map
+    ;; payload borrowing a later opening brace.
     (let-values (((nstok j) (rdr-read-token s i2 end)))
-      (when (and (not auto?) (string=? nstok ""))
+      (when (and spaced? (not auto?))
         (rdr-error s i2 "Namespaced map must specify a namespace"))
-      (when (and (not auto?) (not (rdr-simple-symbol-token? nstok)))
-        (rdr-error s i2 (string-append "Namespaced map must specify a valid namespace: " nstok)))
       (let skip-boundary ((k j))
         (cond
           ((and (< k end) (rdr-ws? (string-ref s k)))
@@ -922,12 +924,32 @@
           ((or (>= k end) (not (char=? (string-ref s k) #\{)))
            ;; A comment is a reader macro rather than whitespace at this exact
            ;; boundary on the JVM, so do not use rdr-skip-ws (which skips it).
-           (rdr-error s k "Namespaced map must specify a map"))
+           ;; A missing map is also reported BEFORE the namespace token is
+           ;; judged, which is the order the JVM reports these two in.
+           (rdr-error s k (if spaced?
+                              "Namespaced map must specify a namespace"
+                              "Namespaced map must specify a map")))
           (else
+           ;; Both prefix forms require a simple, unqualified symbol here; only
+           ;; the auto form may leave the token out, naming the current ns.
+           ;; The JVM renders the offending namespace the way Java prints the
+           ;; object it read, so an absent one reads as "null" there and as
+           ;; "nil" here. Reading a TOKEN rather than a whole form is what
+           ;; makes a non-map payload fail closed, and it is why the two
+           ;; cannot agree on every degenerate spelling (`#:"s"{}` names the
+           ;; string on the JVM and no token at all here) — so report the
+           ;; value jolt actually has rather than imitate Java's printer.
+           (when (if (string=? nstok "")
+                     (not auto?)
+                     (not (rdr-simple-symbol-token? nstok)))
+             (rdr-error s i2 (string-append "Namespaced map must specify a valid namespace: "
+                                            (if (string=? nstok "") "nil" nstok))))
            (let ((mapns (if auto?
                             (if (string=? nstok "") (chez-current-ns)
                                 (let ((a (chez-resolve-alias (chez-current-ns) nstok)))
-                                  (if a a (rdr-invalid-token (string-append "::" nstok)))))
+                                  (if a a
+                                      (rdr-error s i2 (string-append
+                                                       "Unknown auto-resolved namespace alias: " nstok)))))
                             nstok)))
              (let-values (((es next) (rdr-read-seq s (+ k 1) end #\})))
                (values (rdr-make-map (rdr-nsmap-kvs mapns es)) next)))))))))

--- a/stdlib/jolt/socket.clj
+++ b/stdlib/jolt/socket.clj
@@ -292,7 +292,11 @@
   ;; R8). EAGAIN waits for readiness — parking the fiber on the poller when
   ;; there is a current fiber, blocking on a private kevent/epoll_wait when
   ;; there is not — and retries; EINTR retries immediately; anything else is
-  ;; the syscall's real answer, returned as-is (callers read errno semantics).
+  ;; the syscall's real answer, returned as-is. OP hands back the captured
+  ;; [result errno] pair from one foreign return path (jolt.ffi
+  ;; :capture-native-error) — every binding io-call drives is declared that
+  ;; way. The errno is spent on that classification and not returned, so a
+  ;; caller sees a terminal failure only as a negative result.
   (loop []
     (let [[r e] (op)]
       (cond
@@ -312,8 +316,13 @@
 
 (defn- do-recv [fd buf len]
   ;; n <= 0 answers EOF: recv 0 is orderly shutdown; a negative return (error)
-  ;; also reads as EOF because errno isn't reachable to tell ECONNRESET from
-  ;; EINTR. Java throws SocketException there — documented divergence.
+  ;; also reads as EOF. Java throws SocketException there — documented
+  ;; divergence. What is left of the error is a CHOICE, not a limitation:
+  ;; io-call classifies a captured errno and returns only the syscall result,
+  ;; so a reset arrives here as -1 with nothing attached. Retryable errnos are
+  ;; already gone by this point — io-call loops on EINTR and waits out EAGAIN
+  ;; — so every negative n here is terminal. Narrowing that to SocketException
+  ;; on ECONNRESET means widening io-call's contract to hand the errno back.
   (let [n (io-call #(c-recv fd buf len 0) fd :read)]
     (if (pos? n)
       {:n n :bytes (ffi/read-array buf n)}
@@ -336,7 +345,10 @@
     (try
       (ffi/write out :int 0)
       ;; a failed ioctl reads as "nothing there", the way a failed recv reads as
-      ;; EOF — errno is not reachable to say more
+      ;; EOF. c-ioctl is not on a retry path, so it is bound without
+      ;; :capture-native-error and its errno is never captured to say more
+      ;; with — unlike the recv side, where the errno exists and io-call
+      ;; spends it on classification.
       (if (neg? (c-ioctl fd fionread out)) 0 (max 0 (ffi/read out :int 0)))
       (finally (ffi/free out)))))
 

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -201,6 +201,15 @@
   {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#:foo/bar{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: foo/bar\""}
   {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#:123{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: 123\""}
   {:suite "reader / namespaced-map boundary" :expr "(read-string \"#::missing-alias {:a 1}\")" :expected :throws}
+  ;; The JVM decides the payload is not a map before it judges the namespace
+  ;; token, and it applies the same token rules to both prefix forms.  Messages
+  ;; below were taken from Clojure 1.12 on the JVM.
+  {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#::foo/bar{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: foo/bar\""}
+  {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#::123{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: 123\""}
+  {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#:{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Namespaced map must specify a valid namespace: nil\""}
+  {:suite "reader / namespaced-map namespace" :expr "(try (read-string \"#::nosuchalias{:a 1}\") (catch Throwable e (ex-message e)))" :expected "\"Unknown auto-resolved namespace alias: nosuchalias\""}
+  {:suite "reader / namespaced-map boundary" :expr "[(try (read-string \"#:foo/bar :a\") (catch Throwable e (ex-message e))) (try (read-string \"#::nosuch :a\") (catch Throwable e (ex-message e))) (try (read-string \"#:foo (1)\") (catch Throwable e (ex-message e)))]" :expected "[\"Namespaced map must specify a map\" \"Namespaced map must specify a map\" \"Namespaced map must specify a map\"]"}
+  {:suite "reader / namespaced-map boundary" :expr "[(try (read-string \"#: {:a 1}\") (catch Throwable e (ex-message e))) (try (read-string \"#:: :a\") (catch Throwable e (ex-message e)))]" :expected "[\"Namespaced map must specify a namespace\" \"Namespaced map must specify a namespace\"]"}
   {:suite "hostctor" :expr "(String/format \"%d-%s\" 5 \"x\")" :expected "\"5-x\""}
   {:suite "hostctor" :expr "[(.format (java.text.NumberFormat/getInstance) 1234567.5) (.format (java.text.NumberFormat/getIntegerInstance) 1234567)]" :expected "[\"1,234,567.5\" \"1,234,567\"]"}
   {:suite "hostobj" :expr "(try (throw (ex-info \"x\" {})) (catch Throwable e [(.getNextException e) (vec (.getStackTrace e))]))" :expected "[nil []]"}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -560,15 +560,16 @@
            :jvm "\"java.lang.management.ManagementFactory\""
            :jolt "\"nil\""}
    :note "Runtime.totalMemory/freeMemory/maxMemory ARE present over Chez's collector accounting. What is missing is JMX itself. Affects criterium's benchmark reporting, not its timing."}
-  ;; A recv error reads as EOF: errno is not reachable through the FFI, so
-  ;; ECONNRESET (Java: SocketException) cannot be told from EINTR (Java: retry).
+  ;; A recv error reads as EOF: io-call classifies the captured errno itself and
+  ;; returns only the syscall result, so ECONNRESET reaches the read side as a
+  ;; bare -1 with no way to raise Java's SocketException for it.
   {:category :host-model
    :behavior "(.read (.getInputStream socket)) on a reset connection — requires (require 'jolt.socket)"
    :jvm "throws java.net.SocketException (\"Connection reset\")"
    :jolt "-1 (EOF)"
    :check :prose
    :why "needs a live TCP peer that resets the connection"
-   :note "No errno through the FFI, so error and orderly shutdown collapse to EOF. Writes DO throw (send's return distinguishes); only the read side is permissive."}
+   :note "errno IS captured atomically per syscall; io-call just consumes it for retry classification instead of returning it, so error and orderly shutdown collapse to EOF. Writes DO throw (send's return distinguishes); only the read side is permissive."}
   ;; connect's timeout argument is accepted and ignored — the underlying
   ;; connect(2) is always blocking (equivalent to Java's timeout 0).
   {:category :host-model


### PR DESCRIPTION
# One namespace gate for both namespaced-map prefix forms

Follow-up to #806 and #808, found reviewing them against a real Clojure 1.12
JVM rather than against the write-ups.

## Reader (#806 follow-up)

#806 validated the namespace token only for the explicit `#:a` prefix, and
judged it *before* looking for the map. Diffed against Clojure 1.12, that
leaves four messages wrong — all on input that already threw, so this is
message parity and code shape, not a correctness hole:

| input | before | JVM 1.12 |
|---|---|---|
| `#::foo/bar{:a 1}` | `Invalid token: ::foo/bar` | `Namespaced map must specify a valid namespace: foo/bar` |
| `#::123{:a 1}` | `Invalid token: ::123` | `Namespaced map must specify a valid namespace: 123` |
| `#:foo/bar :a` | `…valid namespace: foo/bar` | `Namespaced map must specify a map` |
| `#::nosuchalias{:a 1}` | `Invalid token: ::nosuchalias` | `Unknown auto-resolved namespace alias: nosuchalias` |

The token rules are **one gate on the namespace** now, shared by both prefix
forms, and it runs after the `{` check — the order the JVM reports those two
in. A prefix followed by whitespace and no map keeps its own message; that is
the one case where `#::` and `#:` legitimately differ.

The auto form's unknown-alias message is deliberately *not* the `Invalid
token` the keyword reader raises. The JVM distinguishes them too, because a
bare `::alias` keyword resolves against the current namespace while a
`#::alias` prefix is an alias lookup that can come up empty:

```clojure
(read-string "::nosuchalias")      ;=> :user/nosuchalias
(read-string "#::nosuchalias{}")   ;=> Unknown auto-resolved namespace alias: nosuchalias
```

### Oracle

24 spellings diffed against Clojure 1.12. The two that still differ are
`#:{}` and `#:nil{}`, where the JVM prints Java's `null` for the object it
read and jolt prints `nil`. Reading a **token** rather than a whole form is
what makes a non-map payload fail closed, so the two cannot agree on every
degenerate spelling — `#:"s"{}` names the string on the JVM and no token at
all here. The comment says so rather than imitating Java's printer.

## Socket docs (#808 follow-up)

#808 makes errno reachable *and* reliable, which falsifies three in-tree
claims that "errno is not reachable through the FFI" — in `do-recv`, in
`io-call`, and in the divergence ledger.

The recv-error-reads-as-EOF divergence is still real, but it is now a **choice
`io-call` makes** — it spends the captured errno on retry classification and
returns only the syscall result — not a limitation of the FFI. A stale reason
in the divergence ledger is worse than none: it tells the next contributor the
fix is blocked on work that has already landed.

No behavior change in this half; comments and one ledger `:note` only.

## Validation

- `make unit` — PASS, 1576/1576 (`namespaced-map boundary` 13/13,
  `namespaced-map namespace` 6/6, `atomics` 25/25)
- `make -j1 ci` — PASS, `OK: ci gate passed (93 targets)`, `GATED` on the exact
  tree (run pre-merge on the identical content; this branch differs from that
  tree only in CHANGELOG entry ordering)
- Corpus parity — `NEW divergence: 0`
- `make remint` — converged after one pass, no tracked seed change
- `make ffi` — 41/41; `bin/jolt run test/chez/socket-test.clj` — `SOCKET-TEST OK`

6 new regression rows pin the messages above.
