### PR TITLE
File.getParent answers nil at the root, and listFiles answers nil off-disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,23 @@ when transposed.
   arithmetic at their signed 32- and 64-bit widths, and `AtomicLong.intValue`
   narrows to a signed 32-bit result, matching the JVM.
 
+- **`File.getParentFile` answered the filesystem root as its own parent, so a
+  walk-to-root loop never terminated (#809).** The parent was the text before
+  the last separator, which for `"/"` is `"/"` — the path back again, where the
+  JVM answers `nil`. Every `(recur (.getParentFile d) …)` is written against
+  that `nil`, and because the recur is a tail call the non-terminating loop had
+  no stack to overflow and nothing to raise: it presented as a hang. Both
+  `.getParent` and `.getParentFile` now answer `nil` whenever the computed
+  parent equals the path it came from, which is the JVM's invariant and needs no
+  special case for `"/"`.
+
+  In the same dispatch table, **`.listFiles` raised where the JVM answers
+  `nil`** — for a path that does not exist, for a plain file, and for a
+  directory the process may not read — so the ordinary
+  `(map str (.listFiles f))` died instead of yielding `()`. Its neighbour
+  `.list` already guarded the first two cases and not the third; both spellings
+  now share one guard covering all three.
+
 - **Namespaced-map prefixes could absorb separator text into a silent wrong
   namespace or accept an invalid namespace.** The reader now requires an
   explicit namespace to be a simple unqualified symbol, stops at the token

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -639,6 +639,35 @@
           (or (and (jhost? val) (string=? (jhost-tag val) "url")) (embedded-res? val))
           'pass))))
 
+;; File.getParent()/getParentFile(): the prefix up to the last separator, or nil
+;; when the path names no parent. The JVM's no-parent set is wider than "no
+;; separator in the path" -- the root is its own longest prefix, so "/" answers
+;; null there while the scan below finds "/" and hands the path straight back.
+;; Comparing the result against the input is what turns that into nil, and it
+;; costs one string=? to cover the case without naming "/" anywhere: any path
+;; whose parent would be itself has no parent, whatever normalization does next.
+;; The loop never terminating is the visible failure -- (.getParentFile d) in a
+;; walk-to-root recur is a tail call, so a parent that answers itself spins with
+;; no stack growth and no exception.
+(define (jfile-parent-path p)        ; -> the parent path, or #f when there is none
+  (let loop ((i (- (string-length p) 1)))
+    (cond ((< i 0) #f)
+          ((char=? (string-ref p i) #\/)
+           (let ((parent (if (= i 0) "/" (substring p 0 i))))
+             (and (not (string=? parent p)) parent)))
+          (else (loop (- i 1))))))
+
+;; File.list()/File.listFiles(): the JVM answers null -- not an empty array, and
+;; not a throw -- for a path that is not a readable directory, so the ordinary
+;; (map str (.listFiles f)) over a missing path or a plain file yields () rather
+;; than dying. file-directory? covers both of those; the guard covers a directory
+;; the process may not read, which is an I/O error and null on the JVM too. Both
+;; spellings go through here so they cannot drift apart again.
+(define (jfile-listing fp produce)   ; -> the listing, or jolt-nil
+  (if (file-directory? fp)
+      (guard (e (#t jolt-nil)) (produce))
+      jolt-nil))
+
 ;; --- File method surface (record-method-dispatch arm) -----------------------
 (define (jfile-method f name args)        ; -> boxed result, or #f to fall through
   (let ((p (jfile-path f))               ; the path as given (display methods)
@@ -658,12 +687,11 @@
       ((string=? name "isAbsolute")     (list (if (and (> (string-length p) 0) (char=? (string-ref p 0) #\/)) #t #f)))
       ;; listFiles builds each child from the path AS GIVEN (new File(this, name)
       ;; on the JVM), so a File made from a relative path lists relative children.
-      ((string=? name "listFiles")      (list (list->cseq (map make-jfile (jolt-list-dir p)))))
-      ;; .list -> the child NAMES (a String[]), nil if not a directory.
+      ((string=? name "listFiles")
+       (list (jfile-listing fp (lambda () (list->cseq (map make-jfile (jolt-list-dir p)))))))
+      ;; .list -> the child NAMES (a String[]), nil if not a readable directory.
       ((string=? name "list")
-       (list (if (file-directory? fp)
-                 (apply jolt-vector (sort string<? (directory-list fp)))
-                 jolt-nil)))
+       (list (jfile-listing fp (lambda () (apply jolt-vector (sort string<? (directory-list fp)))))))
       ((string=? name "length")         (list (->num (file-byte-size fp))))
       ((string=? name "lastModified")   (list (->num (file-mtime-millis fp))))
       ((string=? name "canRead")        (list (file-accessible? fp access-r-ok)))
@@ -684,10 +712,8 @@
       ((string=? name "renameTo")
        (list (let ((dst (jfile-fs (car args)))) (guard (e (#t #f)) (rename-file fp dst) #t))))
       ((string=? name "getParentFile")
-       (let loop ((i (- (string-length p) 1)))
-         (cond ((< i 0) (list jolt-nil))
-               ((char=? (string-ref p i) #\/) (list (make-jfile (if (= i 0) "/" (substring p 0 i)))))
-               (else (loop (- i 1))))))
+       (list (let ((parent (jfile-parent-path p)))
+               (if parent (make-jfile parent) jolt-nil))))
       ((string=? name "toPath")           (list (make-nio-path p)))  ; -> java.nio.file.Path (nio-file.ss)
       ((string=? name "getAbsoluteFile")  (list (make-jfile (jfile-abs fp))))
       ((string=? name "getCanonicalFile") (list (make-jfile (jfile-canonical fp))))
@@ -696,10 +722,7 @@
       ((string=? name "equals")         (list (and (jfile? (car args)) (string=? p (jfile-path (car args))))))
       ((string=? name "hashCode")       (list (->num (string-hash p))))
       ((string=? name "getParent")
-       (let loop ((i (- (string-length p) 1)))
-         (cond ((< i 0) (list jolt-nil))
-               ((char=? (string-ref p i) #\/) (list (if (= i 0) "/" (substring p 0 i))))
-               (else (loop (- i 1))))))
+       (list (or (jfile-parent-path p) jolt-nil)))
       (else #f))))
 
 (register-method-arm! arm-priority-file

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -1160,6 +1160,19 @@
   {:suite "host-interop / java.io.File" :label "exists is false off-disk" :expected "false" :actual "(do (require '[clojure.java.io :as io]) (.exists (io/file \"/no/such/path/xyz\")))" :portability :jvm}
   {:suite "host-interop / java.io.File" :label "file-seq yields File values" :expected "true" :actual "(do (require '[clojure.java.io :as io]) (every? (fn [f] (instance? java.io.File f)) (file-seq (io/file \"stdlib\"))))" :portability :jvm}
   {:suite "host-interop / java.io.File" :label "file-seq finds files" :expected "true" :actual "(do (require '[clojure.java.io :as io]) (pos? (count (filter (fn [f] (.isFile f)) (file-seq (io/file \"stdlib\"))))))" :portability :jvm}
+  ;; getParent/getParentFile answer nil where the path names no parent. The root
+  ;; is the case that bites: "/" is its own longest prefix, so a parent computed
+  ;; as "the text before the last separator" hands the path straight back, and
+  ;; the walk-to-root idiom below then never reaches its nil and spins forever.
+  {:suite "host-interop / java.io.File" :label "getParent over the no-parent set" :expected "[nil nil \"/\" \"/a\" nil \"a\" nil nil \"/\"]" :actual "(do (require '[clojure.java.io :as io]) (mapv (fn [s] (.getParent (io/file s))) [\"/\" \"//\" \"/a\" \"/a/b\" \"a\" \"a/b\" \"\" \".\" \"/tmp/\"]))" :portability :jvm}
+  {:suite "host-interop / java.io.File" :label "getParentFile agrees with getParent" :expected "[nil nil \"/\" \"/a\" nil \"a\" nil nil \"/\"]" :actual "(do (require '[clojure.java.io :as io]) (mapv (fn [s] (some-> (.getParentFile (io/file s)) str)) [\"/\" \"//\" \"/a\" \"/a/b\" \"a\" \"a/b\" \"\" \".\" \"/tmp/\"]))" :portability :jvm}
+  {:suite "host-interop / java.io.File" :label "walk to root terminates" :expected "2" :actual "(do (require '[clojure.java.io :as io]) (loop [d (io/file \"/tmp\") n 0] (cond (nil? d) n (> n 20) :did-not-terminate :else (recur (.getParentFile d) (inc n)))))" :portability :jvm}
+  ;; list/listFiles answer nil -- not an empty array, and not a throw -- for
+  ;; anything that is not a readable directory, so (map str (.listFiles f)) over
+  ;; a missing path yields () rather than dying.
+  {:suite "host-interop / java.io.File" :label "listFiles is nil off-disk and on a plain file" :expected "[nil nil]" :actual "(do (require '[clojure.java.io :as io]) [(.listFiles (io/file \"/no/such/path/xyz\")) (.listFiles (io/file \"README.md\"))])" :portability :jvm}
+  {:suite "host-interop / java.io.File" :label "list is nil off-disk and on a plain file" :expected "[nil nil]" :actual "(do (require '[clojure.java.io :as io]) [(.list (io/file \"/no/such/path/xyz\")) (.list (io/file \"README.md\"))])" :portability :jvm}
+  {:suite "host-interop / java.io.File" :label "a nil listing maps to the empty seq" :expected "()" :actual "(do (require '[clojure.java.io :as io]) (map str (.listFiles (io/file \"/no/such/path/xyz\"))))" :portability :jvm}
   {:suite "host-interop / java.nio.file.Path" :label "Paths/get joins" :expected "\"a/b/c\"" :actual "(do (import [java.nio.file Paths]) (str (Paths/get \"a\" (into-array String [\"b\" \"c\"]))))" :portability :jvm}
   {:suite "host-interop / java.nio.file.Path" :label "normalize" :expected "\"a/c/d\"" :actual "(do (import [java.nio.file Paths]) (str (.normalize (Paths/get \"a/b/../c/./d\" (into-array String [])))))" :portability :jvm}
   {:suite "host-interop / java.nio.file.Path" :label "relativize" :expected "\"c/d\"" :actual "(do (import [java.nio.file Paths]) (str (.relativize (Paths/get \"/a/b\" (into-array String [])) (Paths/get \"/a/b/c/d\" (into-array String [])))))" :portability :jvm}


### PR DESCRIPTION
Closes #809.

## getParent / getParentFile

Both computed the parent as the text before the last separator. For `"/"` that
is `"/"` — the path handed straight back, where the JVM answers `null`. The
walk-to-root idiom is written against that `nil`:

```clojure
(loop [d (io/file "/tmp") n 0]
  (cond (nil? d) n
        (> n 20) :DID-NOT-TERMINATE
        :else    (recur (.getParentFile d) (inc n))))
```

Because the `recur` is a tail call, the loop that never reached `nil` had no
stack to overflow and nothing to raise — it presented as a hang, not an error.

Both spellings now go through one `jfile-parent-path`, which answers `#f`
whenever the computed parent equals the path it came from. That is the JVM's
own invariant, it names `"/"` nowhere, and it stays correct if path
normalization changes again. Every other row of the issue's table — relative
paths, `""`, `"."`, trailing-slash — already agreed and still does.

## listFiles

In the same dispatch table, `.listFiles` raised where the JVM answers `null`:
for a path that does not exist, for a plain file, and for a directory the
process may not read. So `(map str (.listFiles f))` over a missing path died
instead of yielding `()`.

Its neighbour `.list`, fifteen lines up, guarded the first two cases and not
the third — the two disagreed with each other. Both now share one
`jfile-listing` covering all three: `file-directory?` for the missing path and
the plain file, a `guard` for the unreadable directory, which is an I/O error
and `null` on the JVM too.

`file-seq` is the only in-tree caller and already tests `.isDirectory` before
listing, so a `nil` listing reaches it only through `(seq nil)`.

`java.nio.file.Path/getParent` was checked and is already correct — `"/"` has
no segments there, so it answers `nil`.

## Tests

Six rows added to the `host-interop / java.io.File` corpus suite: the
no-parent set for both spellings, the bounded walk (`2`), both listing
spellings off-disk and on a plain file, and `(map str …)` over a `nil`
listing. Every `:expected` was measured on reference JVM Clojure before being
written, and `make certify` confirms all six against the oracle.

```
make corpus     4765/4775, 0 NEW divergences
make certify    0 NEW, 0 stale (JVM Clojure 1.12.5)
make unit       green
make smoke      192 passed, 0 failed
make selfhost   rebuild == checked-in seed
```

Reported by @burinc.