### PR TITLE
Say plainly that :jolt/min-version cannot cover its own release's break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,21 +93,31 @@ when transposed.
    :jolt/min-version "0.8.0"}
   ```
 
-  Not every breaking change is visible at the call site. `ffi/write`'s argument
-  order moved in this release, and the old and new spellings are both integers,
-  so an older runtime writes to the wrong place and reports nothing — the exact
-  failure a declared floor turns into a message. A **library** is the natural
-  declarer: it knows which jolt its FFI bindings or host shims need, and the app
-  pulling it in does not. An unmet floor names what is needed, what is running,
-  and which dependency asked; several unmet floors report the newest one.
+  The key is honoured by the jolt that **reads** it, so it protects from this
+  release onward and not before — an older jolt ignores it, as it ignores every
+  key it does not know.
 
-  The key is honoured by the jolt that reads it, so it protects from this release
-  onward and not before — an older jolt ignores it, as it ignores every key it
-  does not know. That is the reason it arrives now rather than at the next break.
-  A runtime that names no version (a source build answers `dev`) is never
-  refused, since it reads as the oldest possible while in practice being the
-  newest; `JOLT_SKIP_MIN_VERSION=1` runs anyway for a released runtime whose
-  version string understates what it carries.
+  That cuts one way worth stating plainly: **the floor cannot cover this
+  release's own breaking changes.** `ffi/write`'s argument order moved here, and
+  the old and new spellings are both integers, so an older runtime writes to the
+  wrong place and reports nothing — the shape of failure a floor exists for, and
+  the one it cannot catch, because the jolt that reads the key arrived in the
+  commit after the one that moved the arguments. Every runtime old enough to take
+  the offset first is too old to parse `:jolt/min-version`, and skips it.
+  Declaring `"0.8.0"` does not turn that break into a message; on such a runtime
+  you get the untreated failure — a misdirected write, or a namespace that will
+  not load — and not a refusal. Pin the toolchain for that one. What the floor
+  catches is the *next* break of that shape, where the runtime on both sides of
+  the change can read the key. That is the reason it arrives now rather than at
+  the next break.
+
+  A **library** is the natural declarer: it knows which jolt its FFI bindings or
+  host shims need, and the app pulling it in does not. An unmet floor names what
+  is needed, what is running, and which dependency asked; several unmet floors
+  report the newest one. A runtime that names no version (a source build answers
+  `dev`) is never refused, since it reads as the oldest possible while in
+  practice being the newest; `JOLT_SKIP_MIN_VERSION=1` runs anyway for a released
+  runtime whose version string understates what it carries.
 
 - **`:&` declares a variadic C function**, as it does in babashka.ffi.
   `:varargs` is jolt's older spelling of the same marker and still works; the

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -1014,13 +1014,18 @@
 ;; --- :jolt/min-version ------------------------------------------------------
 ;; A project or a library declares the oldest jolt it works on, and a runtime
 ;; below that refuses to load it rather than run it. Not every breaking change is
-;; visible at the call site — ffi/write's argument order moved, and the old and
-;; new spellings are both integers, so an older runtime writes to the wrong place
-;; and reports nothing — and a declared floor turns that into a message.
+;; visible at the call site — ffi/write's argument order moved in 0.8.0, and the
+;; old and new spellings are both integers, so an older runtime writes to the
+;; wrong place and reports nothing — and a declared floor turns the NEXT break of
+;; that shape into a message.
 ;;
-;; Honoured by the jolt that READS the key, so it protects from this release
-;; onward and not before: an older jolt ignores it, as it ignores every key it
-;; does not know. That is the reason to add it now rather than at the next break.
+;; Honoured by the jolt that READS the key, so it protects from 0.8.0 onward and
+;; not before: an older jolt ignores it, as it ignores every key it does not
+;; know. Note what that excludes — this key landed in the commit AFTER the one
+;; that moved ffi/write, so no floor catches that particular break: every runtime
+;; with the old argument order skips the key. Pinning the toolchain is the answer
+;; there. The floor is for the breaks that come after a reader exists on both
+;; sides, which is the reason to add it now rather than at the next one.
 (defn- version-parts
   "The leading numeric components of a version string, as a vector of longs.
   Tolerates a `v` prefix and reads each component's numeric PREFIX, stopping at


### PR DESCRIPTION
Documentation only — comments and markdown, no functional change. Follow-up to
#804.

## The overclaim

The `:jolt/min-version` write-up, in both places it appears, says the floor
turns the `ffi/write` argument-order change into a message:

> `ffi/write`'s argument order moved in this release, and the old and new
> spellings are both integers, so an older runtime writes to the wrong place and
> reports nothing — **the exact failure a declared floor turns into a message.**

It does not, and cannot. The key is honoured by the jolt that **reads** it, and
`:jolt/min-version` landed in a commit *after* the one that moved the arguments:

```
$ git merge-base --is-ancestor 30a2c6a8 d4e92a43 && echo yes
yes
```

- `30a2c6a8` — *Give jolt.ffi arenas, and babashka.ffi's names for the rest* (#802), which moved `ffi/write`
- `d4e92a43` — *Let a deps.edn declare the oldest jolt it works on* (#804), which added the key

Both are tagged `v0.8.0`. So every runtime old enough to take the offset first is
too old to parse `:jolt/min-version` and skips it. Declaring `"0.8.0"` does not
turn that break into a refusal — you get the untreated failure, a misdirected
write or a namespace that will not load. Pinning the toolchain is the answer for
that one.

The floor is still worth having, for the reason it was added: it catches the
*next* break of that shape, where a reader exists on both sides of the change.
This just stops the docs from promising it retroactively covers this one.

## What changed

- `jolt-core/jolt/deps.clj` — the comment block above `version-parts`.
- `CHANGELOG.md` — the 0.8.0 `:jolt/min-version` entry. Also reorders it so
  "a library is the natural declarer" comes *after* the caveat, putting the
  limitation before the advice rather than inside it.

## Verification

`deps.clj` is in `jolt-core`, which is baked into the seed, so a change there
normally needs `make remint`. This one is comments only:

```
make selfhost   mint: 0 form(s) skipped
                self-host fixpoint: rebuild == checked-in seed
```

The rebuilt seed is byte-identical to the checked-in one, so no re-mint is
needed and no compiled behaviour can have changed.