### PR TITLE
clojure.core.async.flow, with :io processes on fibers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`clojure.core.async.flow`, with `:io` processes on fibers.** core.async's
+  flow library — a flow is a directed graph of processes communicating over
+  channels, with the topology, thread execution, lifecycle, monitoring and error
+  handling factored out of your step functions and centralized in the graph — now
+  ships in the stdlib. The four namespaces (`clojure.core.async.flow`, `.flow.spi`,
+  `.flow.impl`, `.flow.impl.graph`) are upstream's sources unmodified, so they
+  track the library rather than reimplementing it, and upstream's own
+  `flow_test.clj` passes.
+
+  ```clojure
+  (require '[clojure.core.async.flow :as flow])
+  (def g (flow/create-flow
+          {:procs {:src {:proc (flow/process #'source) :args {:n 5}}
+                   :dbl {:proc (flow/process #'doubler)}}
+           :conns [[[:src :out] [:dbl :in]]]}))
+  (flow/start g)
+  (flow/resume g)
+  ```
+
+  What jolt supplies underneath is `clojure.core.async.impl.dispatch/executor-for`,
+  the workload -> Executor mapping flow runs its processes on, and it maps the
+  tags the way `clojure.core.async/thread-call` already does:
+
+  - **`:io` is a fiber.** A flow process's loop is mostly channel ops, which park
+    and free their carrier, so an `:io` process costs a stack rather than an OS
+    thread. 200 of them run on four carriers; against a bounded pool, everything
+    past the worker count never started at all — silently, with no error and no
+    message ever reaching those processes. `clojure.core.async/fiber-execute` is
+    the spawn behind it, deliberately leaner than `fiber-spawn`: an
+    `Executor.execute` returns void, so there is nobody to hand a result channel
+    to and none is allocated.
+  - **`:mixed` is a thread per task**, because a `:mixed` step may block somewhere
+    the runtime cannot see (`Thread/sleep`, a raw fd, a blocking FFI call) and
+    that would pin a carrier. One per task and not a pool because a flow process
+    runs for the life of the flow, so pooling buys no reuse.
+  - **`:compute` is a pooled executor**, the one case that runs a short task per
+    message rather than one per process.
+
 - **`jolt.ffi`: babashka.ffi's bare `:&`, one binding for every tail shape
   (#803).** `:&` already declared a variadic C function, but only in the
   *declared-tail* form — `[:int :int :& :int]`, the tail fixed when the binding
@@ -108,6 +146,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and every answer they gave before. The buffer keeps nothing alive: using one
   after the memory is released reads freed memory, the same rule babashka.ffi
   states for its own.
+
+### Fixed
+
+- **`deref` of a `java.util.concurrent.Future`.** `@fut` raised "deref:
+  unsupported reference type" for a `FutureTask` and for what an
+  `ExecutorService.submit` hands back. Neither is `IDeref` on the JVM either —
+  `clojure.core/deref` falls *through* to `deref-future` for anything that is not,
+  which is `.get`, and for the timed arity `.get(ms, MILLISECONDS)` with a
+  `TimeoutException` answered by the timeout value rather than thrown. Both
+  arities now work, so `@(.submit pool f)` and `(deref fut 100 :timeout)` do what
+  they do on the JVM.
+
+- **`Future.get` reports a task's throw as an `ExecutionException`.** The raw
+  throw used to come straight back out, so a caller catching
+  `ExecutionException` — which is what the JVM makes them catch — caught nothing,
+  and `.getCause` had nothing to read. The original is now the cause, so
+  `ex-cause` and `.getCause` both reach it. This is the same wrap a clojure
+  `future` already did on deref; the two now agree.
+
+- **`instance?` on the executor and future shims.** `java.util.concurrent`'s
+  executor/future interfaces had no rows in the class graph at all, so an
+  `ExecutorService` reported `(class x)` as `:object` and answered **false** to
+  `(instance? java.util.concurrent.Executor x)`. That is the exact seam
+  core.async.flow tests a user-supplied `:io-exec`/`:mixed-exec`/`:compute-exec`
+  through, so a real jolt executor was rejected as "not an Executor". `Executor`,
+  `ExecutorService`, `ThreadPoolExecutor`, `Future`, `RunnableFuture` and
+  `FutureTask` are now in the graph and the shims report their real classes. The
+  graph is consulted only by `instance?`/`class`, so naming it costs a shim value
+  nothing to construct or call.
+
+- **`Thread(Runnable)` accepts a `FutureTask`.** `.start` invoked its target
+  directly, and a `FutureTask` is a shim value rather than a procedure, so
+  `(.start (Thread. a-future-task))` hung instead of running the task. It goes
+  through the same `Runnable` conversion the executors use now — which is what
+  the class graph above already claims, a `FutureTask` being a `Runnable`.
 
 ## [0.8.0] - 2026-08-31
 

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscali
   inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck hostprops statlayout lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
   gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
   systemstreams \
-  certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety
+  certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety flow
 TEST-GATES := submodules selfhost ci
 
 GATE-RECEIPT := target/gate-receipt
@@ -607,6 +607,14 @@ ffi:
 # watchdog thread and FAILS on a deadline instead of wedging the run.
 continuations:
 	@bin/jolt run test/chez/continuations-test.clj
+
+# clojure.core.async.flow: the graph end to end (start/pause/resume/ping/inject,
+# the error channel, casts) and the j.u.c seams under it — deref of a Future,
+# ExecutionException out of .get, instance? Executor, and the workload -> carrier
+# mapping. The scale row is the one that would regress silently: :io processes
+# run on fibers, so 200 of them do not need 200 threads.
+flow:
+	@bin/jolt run test/chez/flow-test.clj
 
 # Transients: mutable backing, snapshot on persistent!, and linear-time builds.
 transient:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ doubles, `BigDecimal` with `M` literals and `with-precision`), lazy and infinite
 sequences, transducers, destructuring, multimethods with hierarchies,
 protocols/records (`deftype`/`defrecord`/`reify`/`extend-protocol`), metadata,
 namespaces, atoms, refs/STM (`ref`/`dosync`/`alter`/`commute`),
-`future`/`promise`/`agent`/`pmap`, `clojure.core.async`, runtime
+`future`/`promise`/`agent`/`pmap`, `clojure.core.async` (and `.flow`), runtime
 `eval`/`load-string`/`defmacro`, and the full reader (`#()`, `#_`, `#?`, tagged
 literals, `#"…"`) all behave as on the JVM. `=` is category-aware
 (`(= 3 3.0)` ⇒ `false`) and `==` is value-equality, as in Clojure. The genuine

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -682,6 +682,33 @@
 (jch-register-supers! "java.lang.Comparable" '())
 (jch-register-supers! "java.lang.Runnable" '())
 (jch-register-supers! "java.util.concurrent.Callable" '())
+;; java.util.concurrent's executor/future interfaces. The shims for these
+;; (concurrency.ss) had no rows at all, so an ExecutorService reported (class x)
+;; => :object and answered FALSE to (instance? java.util.concurrent.Executor x) —
+;; which is the seam core.async.flow tests a user-supplied :io-exec through, so a
+;; real jolt executor was rejected as "not an Executor". The graph is consulted
+;; only by instance?/class (host-static-classes.ss), so naming it costs a shim
+;; value nothing to construct or call.
+(jch-register-supers! "java.util.concurrent.Executor" '())
+(jch-mark-interface! "java.util.concurrent.Executor")
+(jch-register-supers! "java.util.concurrent.ExecutorService"
+                      '("java.util.concurrent.Executor"))
+(jch-mark-interface! "java.util.concurrent.ExecutorService")
+(jch-register-supers! "java.util.concurrent.AbstractExecutorService"
+                      '("java.util.concurrent.ExecutorService" "java.util.concurrent.Executor"))
+(jch-register-supers! "java.util.concurrent.ThreadPoolExecutor"
+                      '("java.util.concurrent.AbstractExecutorService"
+                        "java.util.concurrent.ExecutorService" "java.util.concurrent.Executor"))
+(jch-register-supers! "java.util.concurrent.Future" '())
+(jch-mark-interface! "java.util.concurrent.Future")
+(jch-register-supers! "java.util.concurrent.RunnableFuture"
+                      '("java.util.concurrent.Future" "java.lang.Runnable"))
+(jch-mark-interface! "java.util.concurrent.RunnableFuture")
+;; FutureTask is the class Executors' pools hand back from submit, and the one
+;; core.async.flow's futurize constructs directly.
+(jch-register-supers! "java.util.concurrent.FutureTask"
+                      '("java.util.concurrent.RunnableFuture"
+                        "java.util.concurrent.Future" "java.lang.Runnable"))
 ;; java.time temporal interfaces — base abstractions the concrete time classes implement
 (jch-register-supers! "java.time.temporal.TemporalAccessor" '())
 (jch-mark-interface! "java.time.temporal.TemporalAccessor")
@@ -752,6 +779,11 @@
   '(("user-thread" . "java.lang.Thread")
     ("abq" . "java.util.concurrent.ArrayBlockingQueue")
     ("future-task" . "java.util.concurrent.FutureTask")
+    ;; Executors' pools are ThreadPoolExecutors on the JVM too, and what their
+    ;; submit returns is a FutureTask — the same class the "future-task" tag
+    ;; models, which is why two tags share one FQN here (as the writer tags do).
+    ("executor-service" . "java.util.concurrent.ThreadPoolExecutor")
+    ("j-future" . "java.util.concurrent.FutureTask")
     ("instant" . "java.time.Instant")
     ("local-date" . "java.time.LocalDate")
     ("local-time" . "java.time.LocalTime")

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -126,6 +126,17 @@
            (jolt-cv-wake! (jolt-future-cv f))))))
     f))
 
+;; Wrap a task's captured throw in an ExecutionException, the original as the
+;; cause so ex-cause and .getCause both reach it. One helper for every place a
+;; task's throw surfaces — a clojure `future`'s deref just below, and the .get of
+;; either Future shim (the ExecutorService's and FutureTask's, further down) —
+;; because the JVM makes a caller catch ExecutionException at all of them.
+(define (task-execution-exception e)
+  (let ((cause (jolt-unwrap-throw e)))
+    (jolt-host-throwable "java.util.concurrent.ExecutionException"
+                         (jolt-str-render-one cause)
+                         cause)))
+
 ;; Final value of a settled future (called OUTSIDE the lock): wrap a captured
 ;; throw in an ExecutionException (JVM semantics), signal a cancellation, else
 ;; the value. The original exception is stored as the cause so ex-cause works.
@@ -139,10 +150,7 @@
      (jolt-throw (jolt-host-throwable "java.util.concurrent.CancellationException"
                                       "Future cancelled")))
     ((jolt-future-ok? f) (jolt-future-payload f))
-    (else (let ((cause (jolt-unwrap-throw (jolt-future-payload f))))
-            (jolt-throw (jolt-host-throwable "java.util.concurrent.ExecutionException"
-                          (jolt-str-render-one cause)
-                          cause))))))
+    (else (jolt-throw (task-execution-exception (jolt-future-payload f))))))
 
 ;; jolt-cv-wait and not a bare condition-wait, here and at every other wait in this
 ;; file: @a-future from a go block used to block the fiber's CARRIER, so every other
@@ -1509,15 +1517,8 @@
 ;; Future.get reports a task's throw as an ExecutionException wrapping it, on the
 ;; JVM and here — the raw throw used to come straight back out, so a caller
 ;; catching ExecutionException (what the JVM makes them catch) caught nothing and
-;; .getCause had nothing to read. The original is the cause, so ex-cause and
-;; .getCause both reach it. This is the same wrap jolt-future-finish does for a
-;; clojure `future`; the two now agree.
-(define (task-execution-exception e)
-  (let ((cause (jolt-unwrap-throw e)))
-    (jolt-host-throwable "java.util.concurrent.ExecutionException"
-                         (jolt-str-render-one cause)
-                         cause)))
-
+;; .getCause had nothing to read. task-execution-exception (above) is the wrap,
+;; the same one a clojure `future` already did on deref; the two now agree.
 ;; j-future state: #(done? result error mutex condition)
 (define (make-j-future) (make-jhost "j-future" (vector #f jolt-nil #f (make-mutex) (make-condition))))
 (define (j-future-complete! self thunk)

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -702,6 +702,24 @@
        (if (null? opts) (jolt-agent-state x) (jolt-throw (deref-cast-error x opts))))
       ((jolt-delay? x)
        (if (null? opts) (jolt-delay-force x) (jolt-throw (deref-cast-error x opts))))
+      ;; java.util.concurrent.Future — a FutureTask, and what an ExecutorService's
+      ;; submit hands back. Neither is IDeref on the JVM either; clojure.core/deref
+      ;; falls THROUGH to deref-future for anything that is not, which is .get, and
+      ;; for the timed arity .get(ms, MILLISECONDS) with a TimeoutException answered
+      ;; by the timeout value rather than thrown. Without this arm @a-future-task
+      ;; raised "deref: unsupported reference type", so @(.submit pool f) — and
+      ;; core.async.flow's own @(flow/inject …) and @(futurize …) — did not work.
+      ;; The ms goes through tu-args->ms so the timed arity normalizes its amount
+      ;; exactly as the .get(timeout, unit) overload does.
+      ;;
+      ;; ONE jhost? test and then the tag, rather than an arm per shim: every deref
+      ;; of an ATOM falls past this whole cond to %pre-conc-deref, so what the
+      ;; common case pays for these two shims is a single record-type predicate.
+      ((and (jhost? x) (future-shim-get* x))
+       => (lambda (get*)
+            (if (null? opts)
+                (get* x #f future-timeout-throw)
+                (get* x (tu-args->ms (list (car opts))) (lambda () (cadr opts))))))
       ;; a record/reify implementing clojure.lang.IDeref: @x calls its `deref`
       ;; method with the value itself as the leading `this`. The timed arity
       ;; passes its opts through — (deref r ms val) reaches the IBlockingDeref
@@ -1398,7 +1416,11 @@
               (guard (e (#t (guard (_ (#t #f))
                               (display "Exception in Thread body:\n" (current-error-port))
                               (jolt-report-throwable e (current-error-port)))))
-                (let ((th (vector-ref st 0))) (when th (jolt-invoke th))))
+                ;; runnable->thunk and not a bare jolt-invoke: Thread(Runnable)
+                ;; accepts any Runnable on the JVM, and a FutureTask is one (it is
+                ;; registered as such in the class graph). Invoking it directly
+                ;; hung — a FutureTask is a shim value, not a procedure.
+                (let ((th (vector-ref st 0))) (when th (jolt-invoke (runnable->thunk th)))))
               (jolt-with-mutex (vector-ref st 2)
                  (vector-set! st 1 #t)
                  (jolt-cv-wake! (vector-ref st 3)))))
@@ -1484,6 +1506,18 @@
 ;; code relies on that ordering (claxon dispatches handlers on a single-thread
 ;; executor and a later empty task acts as a barrier). submit returns a Future
 ;; whose .get waits for the result (re-raising the task's throw, like the JVM).
+;; Future.get reports a task's throw as an ExecutionException wrapping it, on the
+;; JVM and here — the raw throw used to come straight back out, so a caller
+;; catching ExecutionException (what the JVM makes them catch) caught nothing and
+;; .getCause had nothing to read. The original is the cause, so ex-cause and
+;; .getCause both reach it. This is the same wrap jolt-future-finish does for a
+;; clojure `future`; the two now agree.
+(define (task-execution-exception e)
+  (let ((cause (jolt-unwrap-throw e)))
+    (jolt-host-throwable "java.util.concurrent.ExecutionException"
+                         (jolt-str-render-one cause)
+                         cause)))
+
 ;; j-future state: #(done? result error mutex condition)
 (define (make-j-future) (make-jhost "j-future" (vector #f jolt-nil #f (make-mutex) (make-condition))))
 (define (j-future-complete! self thunk)
@@ -1493,25 +1527,34 @@
         (unless (vector-ref st 2) (vector-set! st 1 r))
         (vector-set! st 0 #t)
         (jolt-cv-wake! (vector-ref st 4))))))
+(define (j-future? x) (and (jhost? x) (string=? (jhost-tag x) "j-future")))
+;; get() waits for the task; get(timeout, unit) gives up at the deadline and throws
+;; TimeoutException, like the JVM. The timeout used to be discarded, so the bounded
+;; overload waited forever on a task that never finished.
+;;
+;; ON-TIMEOUT is what a missed deadline produces. Future.get throws there;
+;; `deref` with a timeout value returns it instead (Clojure's deref-future
+;; swallows exactly TimeoutException), so both spellings share one wait rather
+;; than one of them catching what the other just threw.
+(define (j-future-get* self ms on-timeout)
+  (let* ((st (jhost-state self))
+         (done (jolt-cv-wait-interruptibly "Future.get"
+                             (vector-ref st 3) (vector-ref st 4)
+                             (and ms (ms->deadline-millis ms))
+                 (lambda (timed-out?)
+                   (cond ((vector-ref st 0) #t)
+                         (timed-out? #f)
+                         (else jolt-cv-again))))))
+    (cond ((not done) (on-timeout))
+          ((vector-ref st 2) (jolt-throw (task-execution-exception (vector-ref st 2))))
+          (else (vector-ref st 1)))))
+(define (future-timeout-throw)
+  (jolt-throw (jolt-host-throwable "java.util.concurrent.TimeoutException"
+                                   "timed out waiting for the task")))
+(define (j-future-get self . args)
+  (j-future-get* self (tu-args->ms args) future-timeout-throw))
 (register-host-methods! "j-future"
-  ;; get() waits for the task; get(timeout, unit) gives up at the deadline and throws
-  ;; TimeoutException, like the JVM. The timeout used to be discarded, so the bounded
-  ;; overload waited forever on a task that never finished.
-  (list (cons "get" (lambda (self . args)
-          (let* ((st (jhost-state self))
-                 (ms (tu-args->ms args))
-                 (done (jolt-cv-wait-interruptibly "Future.get"
-                                     (vector-ref st 3) (vector-ref st 4)
-                                     (and ms (ms->deadline-millis ms))
-                         (lambda (timed-out?)
-                           (cond ((vector-ref st 0) #t)
-                                 (timed-out? #f)
-                                 (else jolt-cv-again))))))
-            (cond ((not done)
-                   (jolt-throw (jolt-host-throwable "java.util.concurrent.TimeoutException"
-                                                    "timed out waiting for the task")))
-                  ((vector-ref st 2) (jolt-throw (vector-ref st 2)))
-                  (else (vector-ref st 1))))))
+  (list (cons "get" j-future-get)
         (cons "isDone" (lambda (self) (vector-ref (jhost-state self) 0)))
         (cons "isCancelled" (lambda (self) #f))
         (cons "cancel" (lambda (self . _) #f))))
@@ -1731,25 +1774,35 @@
             (lambda (thunk . rest)
               (make-future-task thunk (pair? rest) (if (pair? rest) (car rest) jolt-nil)))))
           '("FutureTask" "java.util.concurrent.FutureTask"))
+(define (future-task-get* self ms on-timeout)
+  (let* ((st (jhost-state self))
+         (r (jolt-cv-wait-interruptibly "FutureTask.get"
+                          (vector-ref st 5) (vector-ref st 6)
+                          (and ms (ms->deadline-millis ms))
+              (lambda (timed-out?)
+                (cond ((memq (vector-ref st 0) '(done cancelled)) (vector-ref st 0))
+                      (timed-out? #f)
+                      (else jolt-cv-again))))))
+    (cond ((not r) (on-timeout))
+          ((eq? r 'cancelled)
+           (jolt-throw (jolt-host-throwable "java.util.concurrent.CancellationException"
+                                            "task was cancelled")))
+          ((vector-ref st 4) (jolt-throw (task-execution-exception (vector-ref st 4))))
+          (else (vector-ref st 3)))))
+(define (future-task-get self . args)
+  (future-task-get* self (tu-args->ms args) future-timeout-throw))
+
+;; The get* of a Future-shaped shim value, or #f. Both spellings of the deref
+;; arity go through it: ms #f waits forever (Future.get()), an ms with a timeout
+;; thunk is the bounded overload.
+(define (future-shim-get* x)
+  (let ((tag (jhost-tag x)))
+    (cond ((string=? tag "future-task") future-task-get*)
+          ((string=? tag "j-future") j-future-get*)
+          (else #f))))
 (register-host-methods! "future-task"
   (list (cons "run" (lambda (self) (future-task-run! self)))
-        (cons "get" (lambda (self . args)
-          (let* ((st (jhost-state self))
-                 (ms (tu-args->ms args))
-                 (r (jolt-cv-wait-interruptibly "FutureTask.get"
-                                  (vector-ref st 5) (vector-ref st 6)
-                                  (and ms (ms->deadline-millis ms))
-                      (lambda (timed-out?)
-                        (cond ((memq (vector-ref st 0) '(done cancelled)) (vector-ref st 0))
-                              (timed-out? #f)
-                              (else jolt-cv-again))))))
-            (cond ((not r) (jolt-throw (jolt-host-throwable "java.util.concurrent.TimeoutException"
-                                                            "timed out waiting for the task")))
-                  ((eq? r 'cancelled)
-                   (jolt-throw (jolt-host-throwable "java.util.concurrent.CancellationException"
-                                                    "task was cancelled")))
-                  ((vector-ref st 4) (jolt-throw (vector-ref st 4)))
-                  (else (vector-ref st 3))))))
+        (cons "get" future-task-get)
         (cons "isDone" (lambda (self) (and (memq (vector-ref (jhost-state self) 0) '(done cancelled)) #t)))
         (cons "isCancelled" (lambda (self) (eq? (vector-ref (jhost-state self) 0) 'cancelled)))
         (cons "cancel" (lambda (self . _)

--- a/host/chez/java/fibers-async.ss
+++ b/host/chez/java/fibers-async.ss
@@ -232,6 +232,31 @@
 (cca-def! "<!!" (lambda (ch) (if (jolt-current-fiber) (jolt-fiber-<! ch) (jolt-async-take ch))))
 (cca-def! ">!!" (lambda (ch v) (if (jolt-current-fiber) (jolt-fiber->! ch v) (jolt-async-give ch v))))
 
+;; (fiber-execute runnable) -> nil. Run RUNNABLE on a fiber and forget it: no
+;; result channel, no join. This is the spawn behind the :io Executor that
+;; clojure.core.async.impl.dispatch hands to core.async.flow, and it is
+;; deliberately leaner than fiber-spawn — a flow process never reads the channel
+;; fiber-spawn would allocate, and the executor contract (java.util.concurrent
+;; .Executor/execute returns void) has nothing to hand one to.
+;;
+;; Uncaught throws are REPORTED and swallowed, matching the executor-service
+;; shim's `execute` (concurrency.ss) rather than fiber-spawn's convey-to-channel:
+;; nobody is holding a channel to convey to. runnable->thunk accepts a FutureTask
+;; (what futurize submits) as well as a plain thunk, so the two executors take the
+;; same arguments.
+(define (async-fiber-execute r)
+  (let ((thunk (runnable->thunk r)))
+    (sa-fiber-spawn
+     (lambda ()
+       (*txn* #f)
+       (guard (e (#t (async-report-uncaught! "fiber-execute task" e)))
+         (jolt-invoke thunk))))
+    ;; a carrier may not exist yet on the very first spawn (fiber-spawn's own
+    ;; postlude does this too) — without it the fiber sits ready and unrun.
+    (jolt-fiber-ensure-carrier!)
+    jolt-nil))
+(cca-def! "fiber-execute" async-fiber-execute)
+
 ;; Install the alts! fiber-await hook (see async.ss).
 (set! jolt-fiber-alt-await-fn jolt-fiber-alt-await)
 

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -18,6 +18,11 @@ babashka.process
 babashka.process.pprint
 babashka.tasks
 clojure.core.async
+clojure.core.async.flow
+clojure.core.async.flow.impl
+clojure.core.async.flow.impl.graph
+clojure.core.async.flow.spi
+clojure.core.async.impl.dispatch
 clojure.core.async.lab
 clojure.core.protocols
 clojure.core.rrb-vector

--- a/stdlib/clojure/core/async.clj
+++ b/stdlib/clojure/core/async.clj
@@ -2,9 +2,11 @@
 ;;
 ;; The primitives (chan, <!, >!, <!!, >!!, close!, put!, take!, offer!, timeout,
 ;; promise-chan, buffer/dropping-buffer/sliding-buffer, thread, go-spawn,
-;; fiber-spawn) are provided natively (host/chez/java/async.ss); everything but
-;; fiber-spawn (which is io-thread's carrier — see thread-call below) runs on real
-;; OS threads. go and go-loop
+;; fiber-spawn, fiber-execute) are provided natively (host/chez/java/async.ss);
+;; everything but the two fiber ones (fiber-spawn is io-thread's carrier — see
+;; thread-call below; fiber-execute is the same spawn without a result channel,
+;; behind clojure.core.async.impl.dispatch's :io Executor) runs on real OS
+;; threads. go and go-loop
 ;; are NOT: they are defined below, because the pass that picks a park's
 ;; representation per site needs &env, macroexpand and resolve. This overlay
 ;; adds the portable dataflow operators — alts!, pipe, pipeline, split, reduce,

--- a/stdlib/clojure/core/async/flow.clj
+++ b/stdlib/clojure/core/async/flow.clj
@@ -7,9 +7,10 @@
 ;;   You must not remove this notice, or any other, from this software.
 
 ;; Upstream core.async's flow library, carried UNMODIFIED — this file and its
-;; three siblings (flow/spi.clj, flow/impl.clj, flow/impl/graph.clj) are byte-for-
-;; byte the sources from the dev-flow-alpha branch (42dbd51, 2026-06-12), which is
-;; where flow lives; it was removed from core.async master in c63dfee. Keeping
+;; three siblings (flow/spi.clj, flow/impl.clj, flow/impl/graph.clj) are the
+;; sources from the dev-flow-alpha branch (42dbd51, 2026-06-12), which is where
+;; flow lives; it was removed from core.async master in c63dfee. The siblings are
+;; byte for byte, and so is this file apart from this header comment. Keeping
 ;; them verbatim is the point: flow tracks upstream rather than being reimplemented
 ;; here, and upstream's own flow_test.clj is part of the gate (test/chez/flow-test.clj).
 ;;

--- a/stdlib/clojure/core/async/flow.clj
+++ b/stdlib/clojure/core/async/flow.clj
@@ -1,0 +1,358 @@
+;;   Copyright (c) Rich Hickey and contributors. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+;; Upstream core.async's flow library, carried UNMODIFIED — this file and its
+;; three siblings (flow/spi.clj, flow/impl.clj, flow/impl/graph.clj) are byte-for-
+;; byte the sources from the dev-flow-alpha branch (42dbd51, 2026-06-12), which is
+;; where flow lives; it was removed from core.async master in c63dfee. Keeping
+;; them verbatim is the point: flow tracks upstream rather than being reimplemented
+;; here, and upstream's own flow_test.clj is part of the gate (test/chez/flow-test.clj).
+;;
+;; Everything jolt supplies sits underneath, in clojure.core.async.impl.dispatch:
+;; the workload -> Executor mapping flow runs its processes on, where :io is a
+;; fiber (a process's loop is channel ops, which park), :mixed a thread per task,
+;; and :compute a pool. Nothing in these four files knows that.
+
+(ns ^{:author "Rich Hickey"}
+  clojure.core.async.flow
+  "
+  Note - Alpha, work-in-progress, names and other details are in flux 
+
+  A library for building concurrent, event driven data processing
+  flows out of communication-free functions, while centralizing
+  control, reporting, execution and error handling. Built on core.async.
+
+  The top-level construct is the flow, comprising:
+  a set of processes (generally, threads) - concurrent activities
+  a set of channels flowing data into and out of the processes
+  a set of channels for centralized control, reporting, error-handling,
+    and execution of the processes
+
+  The flow library itself constructs processes, channels and flows. The
+  user provides configuration data and process logic (step-fns) that
+  specify how the flow should work.
+
+  A flow is constructed from flow configuration data which defines a
+  directed graph of processes and the connections between
+  them. Processes describe their I/O requirements and the
+  flow (library) itself creates channels and passes them to the
+  processes that requested them. See 'create-flow' for the
+  details. The flow configuration provides a centralized place for
+  policy decisions regarding process settings, threading, buffering etc.
+
+  Flow also provides a subsystem for broadcast communication of
+  out-of-band messages without explicit connections or
+  declarations. This could for example be used to communicate the
+  passage of (real or virtual) time. Broadcast messages are associated
+  with (otherwise undeclared) signal-ids, and will be received by
+  processes selecting those ids. Broadcasts messages will arrive along
+  with messages from process inputs, so signal-ids must not conflict
+  with any process input-id. Thus namespaced keywords, UUIDs etc or
+  tuples thereof are recommended as signal-ids. See process
+  describe/transform and inject below for details.
+  
+  It is expected that applications will rarely define instances of the
+  process protocol but instead use the API function 'process' that
+  implements the process protocol in terms of calls to ordinary
+  functions (step-fns) that might include no communication or
+  core.async code. In this way the library helps you achieve a strict
+  separation of your application logic from its execution,
+  communication, lifecycle, error handling and monitoring.
+
+  Note that at several points the library calls upon the user to
+  supply ids for processes, inputs, outputs etc. These should be
+  keywords. When a namespaced keyword is required it is explicitly
+  stated. This documentation refers to various keywords utilized by
+  the library itself as ::flow/xyz, where ::flow is an alias for
+  clojure.core.async.flow
+
+  Flows support the Clojure 'datafy' protocol to support
+  observability. See also the 'ping' and 'ping-proc' fns for a live
+  view of processes.
+
+  A process is represented in the flow definition by an implementation
+  of spi/ProcLauncher that starts it. See the spi docs for
+  details."
+
+  (:require
+   [clojure.core.async.flow.impl :as impl]
+   [clojure.core.async.flow.impl.graph :as g]))
+
+(set! *warn-on-reflection* true)
+
+(defn create-flow
+  "Creates a flow from the supplied configuration: a map containing the
+  keys :procs and :conns, and optionally :mixed-exec/:io-exec/:compute-exec
+
+  :procs - a map of pid->proc-def
+  where proc-def is a map with keys :proc, :args, :chan-opts
+
+  :proc - a function that starts a process
+  :args - a map of param->val which will be passed to the process ctor
+  :chan-opts - a map of io-id->{:keys [buf-or-n xform]},
+               where io-id is an input/output name, and buf-or-n
+               and xform have their meanings per core.async/chan
+               the default for inputs and outputs is {:buf-or-n 10}
+  
+  :conns - a collection of [[from-pid outid] [to-pid inid]] tuples.
+
+  Inputs and outputs support multiple connections. When an output is
+  connected multiple times every connection will get every message, as
+  per a core.async/mult. Note that non-multed outputs do not have
+  corresponding channels and thus any chan-opts will be ignored.
+
+  Broadcast signals are conveyed to a process via a channel with an
+  async/sliding-buffer of size 100, thus signals not handled in a
+  timely manner will be dropped in favor of later arriving signals.
+  
+  :mixed-exec/:io-exec/:compute-exec -> Executor
+  These can be used to specify the Executor to use for the
+  corresonding workload, in lieu of the lib defaults.
+
+  N.B. The flow is not started. See 'start'"
+  [config] (impl/create-flow config))
+
+(defn start
+  "starts the entire flow from init values. The processes start paused.
+  Call 'resume' or 'resume-proc' to start flow.  Returns a map with keys:
+  
+  :report-chan - a core.async chan for reading.'ping' responses
+  will show up here, as will any explicit ::flow/report outputs
+  from :transform
+  
+  :error-chan - a core.async chan for reading. Any (and only)
+  exceptions thrown anywhere on any thread inside a flow will appear
+  in maps sent here. There will at least be a ::flow/ex entry with the
+  exception, and may be additional keys for pid, state, status etc
+  depending on the context of the error."
+  [g] (g/start g))
+
+(defn stop
+  "shuts down the flow, stopping all procsesses and closing the error
+  and report channels. The flow can be started again"
+  [g] (g/stop g))
+
+(defn pause
+  "pauses a running flow"
+  [g] (g/pause g))
+
+(defn resume
+  "resumes a paused flow"
+  [g] (g/resume g))
+
+(defn ping
+  "pings all processes, returning a map of pid -> proc status and
+  state, for those procs that reply within timeout-ms (default 1000).
+  The value at ::flow/state is that returned by the proc's
+  :ping-map-fn (see process)."
+  [g & {:keys [timeout-ms] :or {timeout-ms 1000}}]
+  (g/ping g timeout-ms))
+
+(defn pause-proc
+  "pauses a process"
+  [g pid] (g/pause-proc g pid))
+
+(defn resume-proc
+  "resumes a process"
+  [g pid] (g/resume-proc g pid))
+
+(defn ping-proc
+  "like ping, but just pings the specified process"
+  [g pid & {:keys [timeout-ms] :or {timeout-ms 1000}}]
+  (g/ping-proc g pid timeout-ms))
+  
+(defn inject
+  "asynchronously puts the messages on the channel corresponding to
+  the input or output of the process, returning a future that will
+  complete when done. You can broadcast messages on a signal using the
+  special coord [::flow/cast a-signal-id]. Note that signals cannot be
+  sent to a particular process."
+  [g [pid io-id :as coord] msgs] (g/inject g coord msgs))
+
+(defn process
+  "Given a function of four arities (0-3), aka the 'step-fn',
+  returns a launcher that creates a process compliant with the process
+  protocol (see the spi/ProcLauncher doc).
+
+  The possible arities for the step-fn are
+
+  0 - 'describe',   () -> description
+  1 - 'init',       (arg-map) -> initial-state
+  2 - 'transition', (state transition) -> state'
+  3 - 'transform',  (state input msg) -> [state' output-map]
+
+  This is the core facility for defining the logic for processes via
+  ordinary functions. Using a var holding a fn as the 'step-fn' is the
+  preferred method for defining a proc, as it enables
+  hot-code-reloading of the proc logic in a flow, and better names in
+  datafy.
+
+  arity 0 - 'describe', () -> description
+  where description is a map with possible keys:
+  :params :ins and :outs, each of which in turn is a map of keyword to doc string
+  :signal-select - a predicate of a signal-id. Messages on approved
+                   signals will appear in the transform arity (see below)
+                   For the simple case of enumerated signal-ids, use a set,
+                   e.g. #{:this/signal :that/signal}
+                   If no :signal-select is provided, no signals will be received
+  :ping-map-fn - (state) -> ping-map. Defaults to identity. Given the state,
+                 should return a (preferably all data) map, which is conveyed
+                 under ::flow/state in ping/ping-proc replies.
+  :workload with possible values of :mixed :io :compute.
+  All entries in the describe return map are optional.
+  
+  :params describes the initial arguments to setup the state for the function.
+  :ins enumerates the process input[s], for which the flow will create channels
+  :outs enumerates the process output[s], for which the flow _may_ create channels.
+  :workload - describes the nature of the workload, one of :mixed :io or :compute
+          an :io workload should not do extended computation
+          a :compute workload should never block
+  
+  No io-id key may be present in both :ins and :outs, allowing for a
+  uniform channel coordinate system of [:process-id :channel-id]. The
+  ins/outs/params returned will be the ins/outs/params of the
+  process. describe may be called by users to understand how to use
+  the proc. It will also be called by the impl in order to discover
+  what channels are needed.
+
+  arity 1 - 'init', (arg-map) -> initial-state
+  
+  The init arity will be called once by the process to establish any initial
+  state. The arg-map will be a map of param->val, as supplied in the
+  flow def. The key ::flow/pid will be added, mapped to the pid
+  associated with the process (useful e.g. if the process wants to
+  refer to itself in reply-to coordinates). 
+
+  Optionally, a returned init state may contain the
+  keys ::flow/in-ports and/or ::flow/out-ports. These should be maps
+  of cid -> a core.async.channel. The cids must not conflict with the
+  in/out ids. These channels will become part of the input/output set
+  of the process, but are not otherwise visible/resolvable within the
+  flow. Ports are a way to allow data to enter or exit the flow from
+  outside of it. Use :transition to coordinate the lifecycle of these
+  external channels.
+
+  Optionally, _any_ returned state, whether from init, transition
+  or transform, may contain the key ::flow/input-filter, a predicate
+  of cid. Only inputs (including in-ports) satisfying the predicate
+  will be part of the next channel read set. In the absence of this
+  predicate all inputs are read.
+
+  arity 2 - 'transition', (state transition) -> state'
+
+  The transition arity will be called when the process makes a state
+  transition, transition being one of ::flow/resume, ::flow/pause
+  or ::flow/stop
+
+  With this a process impl can track changes and coordinate
+  resources, especially cleaning up any resources on :stop, since the
+  process will no longer be used following that. See the SPI for
+  details. state' will be the state supplied to subsequent calls.
+
+  arity 3 - 'transform', (state in-or-signal-id msg) -> [state' output]
+  where output is a map of outid->[msgs*]
+
+  The transform arity will be called every time a message arrives at
+  any of the inputs or signals (selected via :signal-select in
+  describe), identified by the id. Output can be sent to none, any or
+  all of the :outs enumerated, and/or an input named by a [pid in-id]
+  coord tuple (e.g. for reply-to), and/or to the ::flow/report
+  output.
+
+  You can broadcast output to all processes selecting a signal via
+  the special coord [::flow/cast a-signal-id] Note that signals cannot
+  be sent to a particular process.
+
+  A step need not output at all (output or msgs can be empty/nil),
+  however an output _message_ may never be nil (per core.async
+  channels). state' will be the state supplied to subsequent calls.
+
+  process also accepts an option map with keys:
+  :workload - one of :mixed, :io or :compute
+  :compute-timeout-ms - if :workload is :compute, this timeout (default 5000 msec)
+                will be used when getting the return from the future - see below
+
+  A :workload supplied as an option to process will override
+  any :workload returned by the :describe fn of the process. If neither
+  are provded the default is :mixed.
+
+  In the :workload context of :mixed or :io, this dictates the type of
+  thread in which the process loop will run, _including its calls to
+  transform_. 
+
+  When :io is specified, transform should not do extensive computation.
+
+  When :compute is specified, each call to transform will be run in a
+  separate thread. The process loop will run in an :io context (since
+  it no longer directly calls transform, all it does is I/O) and it
+  will submit transform to the :compute executor then await (blocking,
+  for compute-timeout-ms) the completion of the future returned by the
+  executor. If the future times out it will be reported
+  on ::flow/error.
+
+  When :compute is specified transform must not block!"
+  ([step-fn] (process step-fn nil))
+  ([step-fn {:keys [workload compute-timeout-ms] :as opts}]
+   (impl/proc step-fn opts)))
+
+(defn map->step
+  "given a map of functions corresponding to step fn arities (see
+  'process'), returns a step fn suitable for passing to 'process'. You
+  can use this map form to compose the proc logic from disparate
+  functions or to leverage the optionality of some of the entry
+  points.
+
+  The keys in the map are:
+  :describe, arity 0 - required
+  :init, arity 1 - optional, but should be provided if 'describe' returns :params.
+  :transition, arity 2 - optional
+  :transform, arity 3 - required"
+  [{:keys [describe init transition transform]}]
+  (assert (and describe transform) "must provide :describe and :transform")
+  (fn
+    ([] (describe))
+    ([arg-map] (when init (init arg-map)))
+    ([state trans] (if transition (transition state trans) state))
+    ([state input msg] (transform state input msg))))
+
+(defn lift*->step
+  "given a fn f taking one arg and returning a collection of non-nil
+  values, creates a step fn as needed by process, with one input
+  and one output (named :in and :out), and no state."
+  [f]
+  (fn
+    ([] {:ins {:in (str "the argument to " f)}
+         :outs {:out (str "the return of " f)}})
+    ([arg-map] nil)
+    ([state transition] nil)
+    ([state input msg] [nil {:out (f msg)}])))
+
+(defn lift1->step
+  "like lift*->step except taking a fn returning one value, which when
+  nil will yield no output."
+  [f]
+  (fn
+    ([] {:ins {:in (str "the argument to " f)}
+         :outs {:out (str "the return of " f)}})
+    ([arg-map] nil)
+    ([state transition] nil)
+    ([state input msg] [nil (when-some [m (f msg)] {:out (vector m)})])))
+
+(defn futurize
+  "Takes a fn f and returns a fn that takes the same arguments as f
+  and immediately returns a future, having started a thread for the
+  indicated workload, or via the supplied executor, that invokes f
+  with those args and completes that future with its return.
+
+  futurize accepts kwarg options:
+  :exec - one of the workloads :mixed, :io, :compute
+          or a j.u.c.Executor object,
+          default :mixed"
+  [f & {:keys [exec]
+        :or {exec :mixed} :as opts}]
+  (impl/futurize f (assoc opts :exec exec)))

--- a/stdlib/clojure/core/async/flow/impl.clj
+++ b/stdlib/clojure/core/async/flow/impl.clj
@@ -1,0 +1,323 @@
+;;   Copyright (c) Rich Hickey and contributors. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+(ns clojure.core.async.flow.impl
+  (:require [clojure.core.async :as async]
+            [clojure.core.async.flow :as-alias flow]
+            [clojure.core.async.flow.spi :as spi]
+            [clojure.core.async.flow.impl.graph :as graph]
+            [clojure.core.async.impl.dispatch :as disp]
+            [clojure.walk :as walk]
+            [clojure.datafy :as datafy])
+  (:import [java.util.concurrent Future Executor TimeUnit FutureTask]
+           [java.util.concurrent.locks ReentrantLock]))
+
+(set! *warn-on-reflection* true)
+
+(defn datafy [x]
+  (condp instance? x
+    clojure.lang.Fn (-> x str symbol)
+    Executor (str x)
+    clojure.lang.Var (symbol x)
+    (datafy/datafy x)))
+
+(defn futurize [f {:keys [exec]}]
+  (fn [& args]
+    (let [^Executor e (if (instance? Executor exec)
+                        exec
+                        (disp/executor-for exec))
+          fut (FutureTask. #(apply f args))]
+      (.execute e fut)
+      fut)))
+
+(defn prep-proc [ret pid {:keys [proc, args, chan-opts] :or {chan-opts {}}}]
+  (let [{:keys [ins outs signal-select]} (spi/describe proc)
+        copts (fn [cs]
+                (zipmap (keys cs) (map #(chan-opts %) (keys cs))))
+        inopts (copts ins)
+        outopts (copts outs)]
+    (when (or (some (partial contains? inopts) (keys outopts))
+              (some (partial contains? outopts) (keys inopts)))
+      (throw (ex-info ":ins and :outs cannot share ids within a process"
+                      {:pid pid :ins (keys inopts) :outs (keys outopts)})))
+    (assoc ret pid {:pid pid :proc proc :ins inopts :outs outopts :args args :signal-select signal-select})))
+
+(defn create-flow
+  "see lib ns for docs"
+  [{:keys [procs conns mixed-exec io-exec compute-exec]}]
+  (let [lock (ReentrantLock.)
+        chans (atom nil)
+        execs {:mixed mixed-exec :io io-exec :compute compute-exec}
+        _ (assert (every? #(or (nil? %) (instance? Executor %)) (vals execs))
+                  "mixed-exe, io-exec and compute-exec must be Executors")
+        pdescs (reduce-kv prep-proc {} procs)
+        allopts (fn [iok] (into {} (mapcat #(map (fn [[k opts]] [[(:pid %) k] opts]) (iok %)) (vals pdescs))))
+        inopts (allopts :ins)
+        outopts (allopts :outs)
+        set-conj (fnil conj #{})
+        ;;out-coord->#{in-coords}
+        conn-map (reduce (fn [ret [out in :as conn]]
+                           (if (and (contains? outopts out)
+                                    (contains? inopts in))
+                             (update ret out set-conj in)
+                             (throw (ex-info "invalid connection" {:conn conn}))))
+                         {} conns)
+        running-chans #(or (deref chans) (throw (Exception. "flow not running")))
+        send-command (fn sc
+                       ([cmap]
+                        (let [{:keys [control]} (running-chans)]
+                          (async/>!! control cmap)))
+                       ([command to] (sc #::flow{:command command :to to})))
+        handle-ping (fn [to timeout-ms]
+                      (let [reply-chan (async/chan (count procs))
+                            ret-chan (async/take (if (= to ::flow/all) (count procs) 1) reply-chan)
+                            timeout (async/timeout timeout-ms)
+                            _ (send-command #::flow{:command ::flow/ping, :to to, :reply-chan reply-chan})
+                            ret (loop [ret nil]
+                                  (let [[{::flow/keys [pid] :as m} c] (async/alts!! [ret-chan timeout])]
+                                    (if (some? m)
+                                      (recur (assoc ret pid m))
+                                      ret)))]
+                        (if (= to ::flow/all) ret (-> ret vals first))))]
+    (reify
+      clojure.core.protocols/Datafiable
+      (datafy [_]
+        (walk/postwalk datafy {:procs procs, :conns conns, :execs execs
+                               :chans (select-keys @chans [:ins :outs :error :report])}))
+
+      clojure.core.async.flow.impl.graph.Graph
+      (start [_]
+        (.lock lock)
+        (try
+          (if-let [{:keys [report error]} @chans]
+            {:report-chan report :error-chan error :already-running true}
+            (let [control-chan (async/chan 10)
+                  control-mult (async/mult control-chan)
+                  report-chan (async/chan (async/sliding-buffer 100))
+                  error-chan (async/chan (async/sliding-buffer 100))
+                  make-chan (fn [[[pid cid]{:keys [buf-or-n xform]}]]
+                              (if xform
+                                (async/chan
+                                 buf-or-n xform
+                                 (fn [ex]
+                                   (async/put! error-chan
+                                               #::flow{:ex ex, :pid pid, :cid cid, :xform xform})
+                                   nil))
+                                (async/chan (or buf-or-n 10))))
+                  in-chans (zipmap (keys inopts) (map make-chan inopts))
+                  needs-mult? (fn [out ins]
+                                (or (< 1 (count ins))
+                                    (= (first out) (ffirst ins))))
+                  out-chans (zipmap (keys outopts)
+                                    (map (fn [[coord opts :as co]]
+                                           (let [conns (conn-map coord)]
+                                             (cond
+                                               (empty? conns) nil
+                                               (needs-mult? coord conns) (make-chan co)
+                                               ;;direct connect 1:1
+                                               :else (in-chans (first conns))))) 
+                                         outopts))                 
+                  ;;pid->{:select :chan}
+                  castees (reduce (fn [ret {:keys [pid signal-select]}]
+                                    (assoc ret pid
+                                           {:select signal-select
+                                            :chan (async/chan (async/sliding-buffer 100))}))
+                                     {} (vals pdescs))
+                  cast (fn [sigid msgs]
+                         (doseq [{:keys [select chan]} (vals castees)]
+                           (when (and select (select sigid))
+                             (doseq [m msgs]
+                               (async/>!! chan [sigid m])))))
+                  ;;mults
+                  _  (doseq [[out ins] conn-map]
+                       (when (needs-mult? out ins)
+                         (let [m (async/mult (out-chans out))]
+                           (doseq [in ins]
+                             (async/tap m (in-chans in))))))
+                  write-chan #(if-let [[_ c] (or (find in-chans %) (find out-chans %))]
+                                c
+                                (throw (ex-info "can't resolve channel with io-id" {:io-id %})))
+                  resolver (reify spi/Resolver
+                             (get-write-chan [_ coord]
+                               (write-chan coord))
+                             (get-exec [_ context] (or (execs context) (disp/executor-for context))))
+                  start-proc
+                  (fn [{:keys [pid proc args ins outs]}]
+                    (try
+                      (let [chan-map (fn [ks coll] (zipmap (keys ks) (map #(coll [pid %]) (keys ks))))
+                            control-tap (async/chan 10)]
+                        (async/tap control-mult control-tap)
+                        (spi/start proc {:pid pid :args (assoc args ::flow/pid pid)
+                                         :resolver resolver :cast cast
+                                         :ins (assoc (chan-map ins in-chans)
+                                                     ::flow/control control-tap
+                                                     ::flow/casts (-> pid castees :chan))
+                                         :outs (assoc (chan-map outs out-chans)
+                                                      ::flow/error error-chan
+                                                      ::flow/report report-chan)}))
+                      (catch Throwable ex
+                        (async/>!! control-chan #::flow{:command ::flow/stop :to ::flow/all})
+                        (throw ex))))]
+              (doseq [p (vals pdescs)]
+                (start-proc p))
+              ;;the only connection to a running flow is via channels
+              (reset! chans {:control control-chan :resolver resolver :cast cast
+                             :report report-chan, :error error-chan
+                             :ins in-chans, :outs out-chans})
+              {:report-chan report-chan :error-chan error-chan}))
+          (finally (.unlock lock))))
+      (stop [_]
+        (.lock lock)
+        (try
+          (when-let [{:keys [report error]} @chans]
+            (send-command ::flow/stop ::flow/all)
+            (async/close! error)
+            (async/close! report)
+            (reset! chans nil)
+            true)
+          (finally (.unlock lock))))
+      (pause [_] (send-command ::flow/pause ::flow/all))
+      (resume [_] (send-command ::flow/resume ::flow/all))
+      (ping [_ timeout-ms] (handle-ping ::flow/all timeout-ms))
+      (pause-proc [_ pid] (send-command ::flow/pause pid))
+      (resume-proc [_ pid] (send-command ::flow/resume pid))
+      (ping-proc [_ pid timeout-ms] (handle-ping pid timeout-ms))         
+      (inject [_ [target id :as coord] msgs]
+        (let [{:keys [resolver cast]} (running-chans)
+              do-io (if (= target ::flow/cast)
+                      #(cast id msgs)
+                      (let [chan (spi/get-write-chan resolver coord)]
+                        #(doseq [m msgs]
+                           (async/>!! chan m))))]
+          ((futurize do-io {:exec :io})))))))
+
+(defn handle-command
+  [pid pong status cmd]
+  (let [transition #::flow{:stop :exit, :resume :running, :pause :paused}
+        {::flow/keys [to command reply-chan]} cmd]
+    (if (#{::flow/all pid} to)
+      (do
+        (when (= command ::flow/ping) (pong reply-chan))
+        (or (transition command) status))
+      status)))
+
+(defn handle-transition
+  "when transition, returns maybe new state"
+  [transition status nstatus state]
+  (if (not= status nstatus)
+    (transition state (case nstatus
+                            :exit ::flow/stop
+                            :running ::flow/resume
+                            :paused ::flow/pause))
+    state))
+
+(defn send-outputs [status state outputs outs resolver control handle-command transition cast]
+  (loop [nstatus status, nstate state, outputs (seq outputs)]
+    (if (or (nil? outputs) (= nstatus :exit))
+      [nstatus nstate]
+      (let [[output msgs] (first outputs)]
+        (if (and (vector? output) (= (first output) ::flow/cast))
+          (do (cast (second output) msgs)
+              (recur nstatus nstate (next outputs)))
+          (if-let [outc (or (outs output) (spi/get-write-chan resolver output))]
+            (let [[nstatus nstate]
+                  (loop [nstatus nstatus, nstate nstate, msgs (seq msgs)]
+                    (if (or (nil? msgs) (= nstatus :exit))
+                      [nstatus nstate]
+                      (let [[v c] (async/alts!!
+                                   [control [outc (first msgs)]]
+                                   :priority true)]
+                        (if (= c control)
+                          (let [nnstatus (handle-command nstatus v)
+                                nnstate (handle-transition transition nstatus nnstatus nstate)]
+                            (recur nnstatus nnstate msgs))
+                          (recur nstatus nstate (next msgs))))))]
+              (recur nstatus nstate (next outputs)))
+            (recur nstatus nstate  (next outputs))))))))
+
+(defn proc
+  "see lib ns for docs"
+  [step {:keys [workload compute-timeout-ms] :or {compute-timeout-ms 5000}}]
+  (let [{:keys [params ins ping-map-fn] :or {ping-map-fn identity} :as desc} (step)
+        workload (or workload (:workload desc) :mixed)]
+    ;;(assert (or (not params) init) "must have :init if :params")
+    (reify
+      clojure.core.protocols/Datafiable
+      (datafy [_]
+        (let [{:keys [params ins outs]} desc]
+          (walk/postwalk datafy {:step step :desc desc})))
+      spi/ProcLauncher
+      (describe [_] desc)
+      (start [_ {:keys [pid args ins outs resolver cast]}]
+        (assert (or (not params) args) "must provide :args if :params")
+        (let [transform (if (= workload :compute)
+                          #(.get ^Future ((futurize step {:exec (spi/get-exec resolver :compute)}) %1 %2 %3)
+                                 compute-timeout-ms TimeUnit/MILLISECONDS)
+                          step)
+              exs (spi/get-exec resolver (if (= workload :mixed) :mixed :io))
+              state (step args)
+              ins (into (or ins {}) (::flow/in-ports state))
+              outs (into (or outs {}) (::flow/out-ports state))
+              io-id (zipmap (concat (vals ins) (vals outs)) (concat (keys ins) (keys outs)))
+              control (::flow/control ins)
+              casts (::flow/casts ins)
+              read-ins (dissoc ins ::flow/control ::flow/casts)
+              run
+              #(loop [status :paused, state state, count 0, read-ins read-ins]
+                 (let [pong (fn [c]
+                              (let [pins (dissoc ins ::flow/control ::flow/casts)
+                                    pouts (dissoc outs ::flow/error ::flow/report)]
+                                (async/>!! c (assoc (walk/postwalk datafy
+                                                     #::flow{:pid pid, :status status
+                                                             :count count
+                                                             :ins pins :outs pouts})
+                                                    ::flow/state (ping-map-fn state)))))
+                       handle-command (partial handle-command pid pong)
+                       [nstatus nstate count read-ins]
+                       (try
+                         (if (= status :paused)
+                           (let [nstatus (handle-command status (async/<!! control))
+                                 nstate (handle-transition step status nstatus state)]
+                             [nstatus nstate count read-ins])
+                           ;;:running
+                           (let [ ;;TODO rotate/randomize after control per normal alts?
+                                 read-chans (let [ipred (or (::flow/input-filter state) identity)]
+                                              (reduce-kv (fn [ret cid chan]
+                                                           (if (ipred cid)
+                                                             (conj ret chan)
+                                                             ret))
+                                                         [control casts] read-ins))
+                                 [msg c] (async/alts!! read-chans :priority true)
+                                 cid (io-id c)]
+                             (if (= c control)
+                               (let [nstatus (handle-command status msg)
+                                     nstate (handle-transition step status nstatus state)]
+                                 [nstatus nstate count read-ins])
+                               (try
+                                 (let [[nstate outputs]
+                                       (if (= c casts) ;;[sigid msg]
+                                         (transform state (first msg) (second msg))
+                                         (transform state cid msg))
+                                       [nstatus nstate]
+                                       (send-outputs status nstate outputs outs
+                                                     resolver control handle-command step cast)]
+                                   [nstatus nstate (inc count) (if (some? msg)
+                                                                 read-ins
+                                                                 (dissoc read-ins cid))])
+                                 (catch Throwable ex
+                                   (async/>!! (outs ::flow/error)
+                                              #::flow{:pid pid, :status status, :state state,
+                                                      :count (inc count), :cid cid, :msg msg :op :step, :ex ex})
+                                   [status state count read-ins])))))
+                         (catch Throwable ex
+                           (async/>!! (outs ::flow/error)
+                                      #::flow{:pid pid, :status status, :state state, :count (inc count), :ex ex})
+                           [status state count read-ins]))]
+                   (when-not (= nstatus :exit) ;;fall out
+                     (recur nstatus nstate (long count) read-ins))))]
+          ((futurize run {:exec exs})))))))

--- a/stdlib/clojure/core/async/flow/impl/graph.clj
+++ b/stdlib/clojure/core/async/flow/impl/graph.clj
@@ -1,0 +1,28 @@
+;;   Copyright (c) Rich Hickey and contributors. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+(ns clojure.core.async.flow.impl.graph)
+
+(defprotocol Graph
+  (start [g] "starts the entire graph from init values. The processes start paused. 
+              Call resume-all or resume-proc to start flow.
+              returns {:report-chan -  a core.async chan for reading 
+                       :error-chan - a core.async chan for reading}")
+  (stop [g] "shuts down the graph, stopping all procs, can be started again")
+  (pause [g] "pauses a running graph")
+  (resume [g] "resumes a paused graph")
+  (ping [g timeout-ms] "pings all processes, which will put their status and state on the report channel")
+
+  (pause-proc [g pid] "pauses a process")
+  (resume-proc [g pid] "resumes a process")
+  (ping-proc [g pid timeout-ms] "pings the process, which will put its status and state on the report channel")
+  (command-proc [g pid cmd-id more-kvs] "synchronously sends a process-specific command with the given id 
+                                         and additional kvs to the process")
+  
+  (inject [g [pid io-id] msgs] "synchronously puts the messages on the channel 
+                         corresponding to the input or output of the process"))

--- a/stdlib/clojure/core/async/flow/spi.clj
+++ b/stdlib/clojure/core/async/flow/spi.clj
@@ -1,0 +1,95 @@
+;;   Copyright (c) Rich Hickey and contributors. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+(ns clojure.core.async.flow.spi)
+
+(defprotocol ProcLauncher
+  "Note - defining a ProcLauncher is an advanced feature and should not
+  be needed for ordinary use of the library. This protocol is for
+  creating new types of Processes that are not possible to create
+  with ::flow/process.
+  
+  A ProcLauncher is a constructor for a process, a thread of activity.
+  It has two functions - to describe the parameters and input/output
+  requirements of the process and to start it. The launcher should
+  acquire no resources, nor retain any connection to the started
+  process. A launcher may be called upon to start a process more than
+  once, and should start a new process each time start is called.
+  
+  The process launched process must obey the following:
+
+  It must have 2 logical statuses, :paused and :running. In
+  the :paused status operation is suspended and no output is
+  produced.
+
+  When the process starts it must be :paused
+
+  Whenever it is reading or writing to any channel a process must use
+  alts!! and include a read of the ::flow/control channel, giving it
+  priority.
+
+  Command messages sent over the ::flow/control channel have the keys:
+  ::flow/to - either ::flow/all or a process id
+  ::flow/command - ::flow/stop|pause|resume|ping or process-specific
+  
+  It must act upon any, and only, control messages whose ::flow/to key is its pid or ::flow/all
+  It must act upon the following values of ::flow/command:
+
+  ::flow/stop - all resources should be cleaned up and any thread(s)
+     should exit ordinarily - there will be no more subsequent use
+     of the process.
+  ::flow/pause - enter the :paused status
+  ::flow/resume - enter the :running status and resume processing
+  ::flow/ping - emit a ping message (format TBD) to
+     the ::flow/report channel containing at least its pid and status
+
+  A process can define and respond to other commands in its own namespace.
+
+  A process should not transmit channel objects (use [pid io-id] data
+  coordinates instead) A process should not close channels
+
+  Finally, if a process encounters an error it must report it on the
+  ::flow/error channel (format TBD) and attempt to continue, though it
+  may subsequently get a ::flow/stop command it must respect"
+  
+  (describe [p]
+    "returns a map with keys - :params, :ins and :outs,
+  each of which in turn is a map of keyword to docstring
+
+  :params describes the initial arguments to setup the state for the process
+  :ins enumerates the input[s], for which the graph will create channels
+  :outs enumerates the output[s], for which the graph may create channels.
+
+  describe may be called by users to understand how to use the
+  proc. It will also be called by the impl in order to discover what
+  channels are needed.")
+  
+  (start [p {:keys [pid args ins outs resolver]}]
+    "return ignored, called for the
+  effect of starting the process (typically, starting its thread)
+
+  where:
+
+  :pid - the id of the process in the graph, so that e.g. it can refer to itself in control, reporting etc
+  :args - a map of param->val,  as supplied in the graph def
+  :ins - a map of in-id->readable-channel, plus the ::flow/control channel
+  :outs - a map of out-id->writeable-channel, plus the ::flow/error and ::flow/report channels
+          N.B. outputs may be nil if not connected
+  :resolver - an impl of spi/Resolver, which can be used to find
+              channels given their logical [pid cid] coordinates, as well as to
+              obtain Executors corresponding to the
+              logical :mixed/:io/:compute contexts"))
+
+(defprotocol Resolver
+  (get-write-chan [_ coord]
+    "Given a tuple of [pid cid], returns a core.async chan to
+    write to or nil (in which case the output should be dropped,
+    e.g. nothing is connected).")
+  (get-exec [_ context]
+    "returns the Executor for the given context, one
+     of :mixed, :io, :compute"))

--- a/stdlib/clojure/core/async/impl/dispatch.clj
+++ b/stdlib/clojure/core/async/impl/dispatch.clj
@@ -1,0 +1,72 @@
+;;   Copyright (c) Rich Hickey and contributors. All rights reserved.
+;;   The use and distribution terms for this software are covered by the
+;;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;;   which can be found in the file epl-v10.html at the root of this distribution.
+;;   By using this software in any fashion, you are agreeing to be bound by
+;;   the terms of this license.
+;;   You must not remove this notice, or any other, from this software.
+
+(ns ^{:skip-wiki true} clojure.core.async.impl.dispatch
+  "The workload -> Executor mapping core.async.flow runs its processes on.
+
+  Upstream this namespace is also core.async's own go-block dispatcher; on jolt
+  the channel runtime is Scheme (host/chez/java/async.ss) and dispatches itself,
+  so what remains here is the executor registry flow asks for by workload tag.
+
+  The three tags mean what they mean for clojure.core.async/thread-call, and get
+  the same carriers:
+
+    :io      a fiber. Blocking-shaped I/O that the runtime can see — channel ops,
+             jolt.socket reads, subprocess pipes — PARKS and frees its carrier, so
+             a flow can hold far more :io processes than there are threads, and
+             each costs a stack rather than an OS thread. A flow process's loop is
+             mostly channel ops, which is exactly this shape.
+    :mixed   a real thread, one per task. A :mixed step may block somewhere the
+             runtime cannot see (Thread/sleep, a raw fd, a blocking FFI call), and
+             that pins a fiber's carrier; a thread is the escape. One per task and
+             not a pool because a flow process's task is its whole lifetime —
+             pooling buys no reuse, while a bounded pool silently strands every
+             process past the worker count.
+    :compute a pooled executor. Unlike the other two this runs one SHORT task per
+             message (flow futurizes a :compute step per call and waits on it), so
+             thread reuse is the whole point and bounded parallelism is right for
+             CPU-bound work."
+  (:require [clojure.core.async :as async])
+  (:import [java.util.concurrent Executors Executor]))
+
+;; Fire-and-forget onto a fiber. clojure.core.async/fiber-execute is the lean
+;; spawn behind this: no result channel, because Executor/execute returns void
+;; and there would be nobody to hand one to.
+(def ^:private io-executor
+  (reify Executor
+    (execute [_ r] (async/fiber-execute r))))
+
+(def ^:private thread-counter (atom 0))
+
+(def ^:private mixed-executor
+  (reify Executor
+    (execute [_ r]
+      (.start (Thread. r (str "async-mixed-" (swap! thread-counter inc)))))))
+
+;; Lazy: constructing a pool forks its workers, and merely loading this namespace
+;; must not cost a thread.
+(def ^:private compute-executor (delay (Executors/newCachedThreadPool)))
+
+(defn executor-for
+  "Given a workload tag, returns the Executor for it. The tags are :io, :compute
+  and :mixed; :core-async-dispatch is accepted as an alias for :mixed, as
+  upstream. Throws on any other tag."
+  ^Executor [workload]
+  (case workload
+    :io io-executor
+    (:mixed :core-async-dispatch) mixed-executor
+    :compute @compute-executor
+    (throw (IllegalArgumentException.
+            (str "Invalid workload " (pr-str workload)
+                 " — expected :io, :compute or :mixed")))))
+
+(defn exec
+  "Runs Runnable r on the executor for the given workload tag."
+  [r workload]
+  (.execute (executor-for workload) r)
+  nil)

--- a/test/chez/flow-test.clj
+++ b/test/chez/flow-test.clj
@@ -1,0 +1,192 @@
+;; clojure.core.async.flow gate — the flow graph end to end on jolt, plus the
+;; java.util.concurrent seams it stands on (deref of a Future, ExecutionException
+;; from .get, instance? Executor, and the workload -> carrier mapping in
+;; clojure.core.async.impl.dispatch).
+;;
+;; Run: bin/jolt run test/chez/flow-test.clj
+(ns flow-test
+  (:require [clojure.core.async :as async]
+            [clojure.core.async.flow :as flow]
+            [clojure.core.async.impl.dispatch :as dispatch]
+            [jolt.fibers :as fib])
+  (:import [java.util.concurrent Executor ExecutorService Future FutureTask
+            Executors TimeUnit ExecutionException]))
+
+(def failures (atom []))
+
+;; announce BEFORE evaluating and flush: a check that parks and is never resumed
+;; must name itself in the log rather than hang silently.
+(defmacro check-eq [label got want]
+  `(do
+     (print (str "  .. " ~label "\n"))
+     (flush)
+     (let [g# (try ~got (catch Throwable t# [:threw (ex-message t#)])) w# ~want]
+       (when-not (= g# w#)
+         (swap! failures conj (str ~label ": want " (pr-str w#) " got " (pr-str g#)))))))
+
+;; --- the j.u.c seams --------------------------------------------------------
+
+(def pool (Executors/newCachedThreadPool))
+
+(check-eq "ExecutorService is an Executor" (instance? Executor pool) true)
+(check-eq "ExecutorService is an ExecutorService" (instance? ExecutorService pool) true)
+(check-eq "FutureTask is a Future" (instance? Future (FutureTask. (fn [] 1))) true)
+(check-eq "FutureTask is a Runnable" (instance? Runnable (FutureTask. (fn [] 1))) true)
+(check-eq "submit's Future is a Future" (instance? Future (.submit pool (fn [] 1))) true)
+
+;; deref of a Future — clojure.core/deref falls through to deref-future for
+;; anything that is not IDeref, which neither of these is on the JVM either.
+(check-eq "deref a submitted Future" @(.submit pool (fn [] 42)) 42)
+(check-eq "deref a FutureTask"
+          (let [ft (FutureTask. (fn [] 7))] (.execute pool ft) @ft) 7)
+(check-eq "timed deref that completes" (deref (.submit pool (fn [] :v)) 2000 :timeout) :v)
+(check-eq "timed deref that expires"
+          (deref (.submit pool (fn [] (Thread/sleep 3000) :late)) 100 :timeout) :timeout)
+
+;; a task's throw comes back as ExecutionException wrapping it (ASYNC-275)
+(check-eq "get wraps a throw in ExecutionException"
+          (try (.get (.submit pool (fn [] (throw (ex-info "boom" {})))) 2000 TimeUnit/MILLISECONDS)
+               :no-throw
+               (catch ExecutionException e (ex-message (ex-cause e))))
+          "boom")
+(check-eq "deref wraps a throw too"
+          (try @(.submit pool (fn [] (throw (ex-info "bang" {}))))
+               :no-throw
+               (catch ExecutionException e (ex-message (ex-cause e))))
+          "bang")
+
+;; Thread(Runnable) accepts a FutureTask, which is a Runnable
+(check-eq "Thread runs a FutureTask"
+          (let [ft (FutureTask. (fn [] 5)) t (Thread. ft)]
+            (.start t) (.join t) @ft)
+          5)
+
+;; --- the workload -> executor mapping ---------------------------------------
+
+(doseq [w [:io :mixed :compute :core-async-dispatch]]
+  (check-eq (str "executor-for " w " is an Executor")
+            (instance? Executor (dispatch/executor-for w)) true))
+(check-eq "executor-for rejects an unknown tag"
+          (try (dispatch/executor-for :nope) :no-throw (catch Throwable _ :threw))
+          :threw)
+(check-eq "executor-for is stable per tag"
+          (identical? (dispatch/executor-for :io) (dispatch/executor-for :io)) true)
+
+;; :io really is a fiber — the task reports whether it is running on one.
+(check-eq ":io runs its task on a fiber"
+          (let [p (promise)]
+            (.execute (dispatch/executor-for :io)
+                      (fn [] (deliver p (fib/in-fiber?))))
+            (deref p 2000 :timeout))
+          true)
+(check-eq ":mixed runs its task on a thread, not a fiber"
+          (let [p (promise)]
+            (.execute (dispatch/executor-for :mixed)
+                      (fn [] (deliver p (fib/in-fiber?))))
+            (deref p 2000 :timeout))
+          false)
+
+;; --- a flow, end to end -----------------------------------------------------
+
+(def collected (atom []))
+
+(defn source
+  ([] {:params {:n "how many"} :outs {:out "the numbers"}})
+  ([{:keys [n]}]
+   (let [c (async/chan 16)]
+     (async/thread (dotimes [i n] (async/>!! c (inc i))))
+     {::flow/in-ports {:nums c}}))
+  ([state _transition] state)
+  ([state _in msg] [state {:out [msg]}]))
+
+(defn doubler
+  ([] {:ins {:in "numbers"} :outs {:out "doubled"} :signal-select #{:tick}})
+  ([_] {})
+  ([state _transition] state)
+  ([state in msg]
+   (when (= msg 3) (throw (ex-info "boom on 3" {:msg msg})))
+   [state {:out [(if (= in :tick) [:tick msg] (* 2 msg))]}]))
+
+(defn sink
+  ([] {:ins {:in "doubled"}})
+  ([_] {})
+  ([state _transition] state)
+  ([state _in msg] (swap! collected conj msg) [state nil]))
+
+(def g (flow/create-flow
+        {:procs {:src {:proc (flow/process #'source) :args {:n 5}}
+                 :dbl {:proc (flow/process #'doubler)}
+                 :snk {:proc (flow/process #'sink)}}
+         :conns [[[:src :out] [:dbl :in]]
+                 [[:dbl :out] [:snk :in]]]}))
+
+(def chans (flow/start g))
+(check-eq "start returns the report and error channels"
+          (every? some? [(:report-chan chans) (:error-chan chans)]) true)
+(flow/resume g)
+(Thread/sleep 800)
+
+;; 3 throws, so 1 2 4 5 double through and 3 goes to the error channel
+(check-eq "messages flow through the graph" (sort @collected) [2 4 8 10])
+(check-eq "a throwing step reports on the error channel"
+          (let [[v _] (async/alts!! [(:error-chan chans) (async/timeout 500)])]
+            [(::flow/pid v) (ex-message (::flow/ex v))])
+          [:dbl "boom on 3"])
+(check-eq "the process survived its step throwing"
+          (::flow/status (flow/ping-proc g :dbl)) :running)
+
+(check-eq "ping reaches every process" (sort (keys (flow/ping g))) [:dbl :snk :src])
+(check-eq "ping-proc reports a count" (::flow/count (flow/ping-proc g :snk)) 4)
+
+(flow/pause g)
+(check-eq "pause takes" (::flow/status (flow/ping-proc g :snk)) :paused)
+(flow/resume g)
+(check-eq "resume takes" (::flow/status (flow/ping-proc g :snk)) :running)
+
+;; inject returns a Future, which deref waits on
+(check-eq "inject puts a message on an input"
+          (do @(flow/inject g [:dbl :in] [100])
+              (Thread/sleep 300)
+              (some #{200} @collected))
+          200)
+(check-eq "inject casts to a signal-selecting process"
+          (do @(flow/inject g [::flow/cast :tick] [:ping])
+              (Thread/sleep 300)
+              (some #{[:tick :ping]} @collected))
+          [:tick :ping])
+
+(check-eq "the flow datafies" (map? (clojure.datafy/datafy g)) true)
+(check-eq "stop takes" (do (flow/stop g) true) true)
+
+;; --- scale: more :io processes than there are carriers or pool workers ------
+;; The point of putting :io on fibers. Each process holds its carrier only while
+;; running, so the count here is bounded by memory rather than by threads; with a
+;; bounded thread pool everything past the worker count never started at all.
+
+(def reached (atom #{}))
+
+(defn counter-node
+  ([] {:params {:id "id"} :ins {:in "x"} :workload :io})
+  ([{:keys [id]}] {:id id})
+  ([state _transition] state)
+  ([{:keys [id] :as state} _in _msg] (swap! reached conj id) [state nil]))
+
+(let [n 200
+      pids (map #(keyword (str "p" %)) (range n))
+      big (flow/create-flow
+           {:procs (into {} (map (fn [p] [p {:proc (flow/process #'counter-node)
+                                             :args {:id p}}])
+                                 pids))
+            :conns []})]
+  (flow/start big)
+  (flow/resume big)
+  (doseq [p pids] @(flow/inject big [p :in] [1]))
+  (Thread/sleep 2000)
+  (check-eq "200 :io processes all ran" (count @reached) n)
+  (flow/stop big))
+
+(if (empty? @failures)
+  (do (println "FLOW-TEST OK") (flush) (System/exit 0))
+  (do (doseq [f @failures] (println "FAIL:" f))
+      (flush)
+      (System/exit 1)))


### PR DESCRIPTION
Ships core.async's **flow** library — a directed graph of processes communicating over channels, with topology, execution, lifecycle, monitoring and error handling factored out of the step functions and centralized in the graph.

## The library

The four namespaces (`clojure.core.async.flow`, `.flow.spi`, `.flow.impl`, `.flow.impl.graph`) are **upstream's sources carried unmodified**, from the [`dev-flow-alpha`](https://github.com/clojure/core.async/tree/dev-flow-alpha) branch (`42dbd51`) where flow lives — it was removed from core.async master in `c63dfee`. Keeping them verbatim is the point: flow tracks upstream instead of being reimplemented here, and upstream's own `flow_test.clj` runs as part of the new gate (7/7 assertions, including the ASYNC-275 regression).

```clojure
(require '[clojure.core.async.flow :as flow])
(def g (flow/create-flow
        {:procs {:src {:proc (flow/process #'source) :args {:n 5}}
                 :dbl {:proc (flow/process #'doubler)}}
         :conns [[[:src :out] [:dbl :in]]]}))
(flow/start g)
(flow/resume g)
```

## What jolt supplies underneath

`clojure.core.async.impl.dispatch/executor-for` — the workload → Executor mapping flow runs its processes on, mapped the way `clojure.core.async/thread-call` already maps the same tags:

| tag | carrier | why |
|---|---|---|
| `:io` | a **fiber** | A flow process's loop is mostly channel ops, which park and free their carrier, so an `:io` process costs a stack rather than an OS thread. 200 of them run on four carriers. Against a bounded pool everything past the worker count **never started at all** — silently, no error, no message ever reaching those processes. |
| `:mixed` | a thread per task | A `:mixed` step may block somewhere the runtime cannot see (`Thread/sleep`, a raw fd, a blocking FFI call), and that pins a carrier. Not a pool: a flow process runs for the life of the flow, so pooling buys no reuse. |
| `:compute` | a pooled executor | The one case that runs a short task per message rather than one per process, so reuse is the whole point. |

`clojure.core.async/fiber-execute` is the spawn behind `:io`, deliberately leaner than `fiber-spawn`: `Executor.execute` returns void, so there is nobody to hand a result channel to and none is allocated.

## Four j.u.c seams fixed

All of these were broken independently of flow:

- **`deref` of a `Future`** raised `"deref: unsupported reference type"` for a `FutureTask` and for what `ExecutorService.submit` returns. Neither is `IDeref` on the JVM either — `clojure.core/deref` falls *through* to `deref-future` for anything that is not. Both arities work now, the timed one answering a `TimeoutException` with the timeout value rather than throwing.
- **`Future.get` let a task's throw come straight back out**, so a caller catching `ExecutionException` (what the JVM makes them catch) caught nothing and `.getCause` had nothing to read. The original is the cause now, matching the wrap a clojure `future` already did on deref.
- **`instance?` on the executor/future shims.** j.u.c's executor and future interfaces had no rows in the class graph, so an `ExecutorService` reported `(class x)` as `:object` and answered **false** to `(instance? java.util.concurrent.Executor x)` — the exact seam flow tests a user-supplied `:io-exec` through, so a real jolt executor was rejected as "not an Executor". The graph is read only by `instance?`/`class`, so naming it costs a shim value nothing to construct or call.
- **`Thread(Runnable)` hung on a `FutureTask`** — `.start` invoked its target directly, and a `FutureTask` is a shim value, not a procedure.

## Gate

New `make flow` (`test/chez/flow-test.clj`), added to `CI-GATES`: the graph end to end (start/pause/resume/ping/inject, the error channel, casts), the four seams above, the `:io`-is-a-fiber / `:mixed`-is-a-thread assertions, and the 200-process scale row that would otherwise regress silently.

Gates run locally, all green: `flow` `unit` `corpus` `documented` `certify` (108/108 known divergences, **0 new, 0 stale**) `selfhost` `smoke` `sci` `stdlibfasl` `fibers` `gosm` `asynctimer` `interruptnest` `threadsafety` `continuations` `adaptercheck` `portcheck` `hostprops` `readmecheck` `gambitgencheck`, plus a full `make jolt-release` — the five new namespaces compile to embedded fasls and load from them with zero source compiles.