### PR TITLE
Executors/newCachedThreadPool grows on demand, as on the JVM (#819)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`Executors/newCachedThreadPool` grows on demand (#819).** It was a fixed pool
+  of 32 workers. A burst of more than 32 concurrent tasks queued behind the ones
+  already running — invisible while tasks are short, and a deadlock when they are
+  not: 32 tasks that block waiting for the 33rd (a fan-out whose children hand
+  their results back through a channel, say) never let it start, with no error and
+  nothing in the code to suggest a ceiling. The pool now has the JVM's shape —
+  core 0, max `Integer/MAX_VALUE`, 60s keep-alive — so nothing is forked until a
+  task arrives, a task that no idle worker is waiting to take starts one, and a
+  worker retires after 60 seconds idle.
+
+  It is still a POOL, which is what keeps that unbounded maximum from meaning a
+  thread per task: 2000 trivial tasks submitted back to back peak at **4** workers
+  on an idle 8-core box (5000 of them, 3), because the handful that keep up with
+  them are idle again by the time the next one lands. How far it grows is a
+  property of how far the producer runs ahead of the workers — the same 2000-task
+  burst pinned to a single core peaks at 136 — and of the tasks themselves: 1000
+  tasks that each sleep 50ms do reach 558 workers. Which is the JVM's own answer to
+  the same bursts, measured on the same box against reference Clojure: 13 workers
+  for the 2000 trivial tasks, 697 for the 1000 sleepers, and the same 64 for the
+  64 blocking ones. The unbounded growth is concurrency, not churn.
+
+  `newVirtualThreadPerTaskExecutor` maps to the same pool, being equally unbounded
+  on the JVM; a pooled thread stands in for a fresh virtual one, which nothing
+  here can tell apart. `newWorkStealingPool` stays a fixed pool, because a
+  `ForkJoinPool` is sized at `availableProcessors` on the JVM too. `newFixedThreadPool`
+  and `newSingleThreadExecutor` are unchanged: every worker eager, none retired,
+  and for the single-thread pool the submission ORDER that depends on there being
+  exactly one worker forever.
+
+  `ThreadPoolExecutor.`'s `corePoolSize`, `maximumPoolSize` and `keepAliveTime`
+  now all reach the pool it builds — the core workers eager, the rest on demand up
+  to max, and the above-core ones retired after keepAlive. Before, it was a fixed
+  pool of `maximumPoolSize` and the keep-alive was discarded. One divergence
+  remains, in the direction of the caller's stated maximum: the JVM grows past
+  core only once the work queue is FULL, so a `ThreadPoolExecutor` with an
+  unbounded queue never passes core there, while jolt (which has one unbounded
+  queue per pool) grows on the same no-idle-worker test as a cached pool.
+
+  `.getPoolSize`, `.getActiveCount`, `.getCorePoolSize` and `.getMaximumPoolSize`
+  are new, so a caller can see the pool grow and retire — and so the tests can
+  assert it without counting threads by hand.
+
 - **`deref` of a `java.util.concurrent.Future`.** `@fut` raised "deref:
   unsupported reference type" for a `FutureTask` and for what an
   `ExecutorService.submit` hands back. Neither is `IDeref` on the JVM either —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after the memory is released reads freed memory, the same rule babashka.ffi
   states for its own.
 
+### Performance
+
+- **An executor enqueue wakes one worker, not all of them (#819).** The pool's
+  workers and its `awaitTermination` waited on ONE condition, so every enqueue
+  broadcast to every waiter: with 130 idle workers, one task woke all 130, and
+  129 of them took the queue mutex, found the task already claimed, and parked
+  again. Fire-and-forget cost **152µs per no-op task** that way, against 3.2µs on
+  reference Clojure, and the herd fed back into the growth rule — workers that
+  slow to return look like workers that are not coming, so a 200k-task burst grew
+  the pool to 134 threads and 131MB, which made the herd bigger still.
+
+  Task and termination now have a condition each. An enqueue signals exactly one
+  parked worker (`jolt-cv-signal-one!`, locks.ss, where the two preconditions it
+  needs are written out), and none at all when none is parked — a worker re-reads
+  the queue before it parks, under the same mutex, so there is no wake to miss.
+  A worker retiring on keep-alive wakes nobody unless the pool is shutting down or
+  it is the last one out. Shutdown still broadcasts, on both conditions: that news
+  is for every worker.
+
+  The broadcast is older than the growing pool and cost something all along — a
+  fixed 32-worker pool woke 32 — so this is a **3x improvement on 0.8.0** as well
+  as a 17x one on the growing pool before the split. Dispatching a no-op task
+  through `.execute`, same box:
+
+  | | µs/task | threads |
+  |---|---|---|
+  | 0.8.0: fixed 32-worker pool, one condition | 26.5 | 32 |
+  | growing pool, one condition | 152 | 134 |
+  | growing pool, one worker signalled | **8.9** | 7 |
+  | reference JVM Clojure | 5.2 | 8 |
+
+  and the rest of the shapes, jolt against reference Clojure on that box:
+
+  | | jolt | JVM |
+  |---|---|---|
+  | 4 producers, one pool | 11 µs/task (was 80) | 2.2 µs |
+  | single-thread pool | 4.3 µs | 9.1 µs |
+  | submit + get round trip | 12.0 µs | 7.2 µs |
+  | 256 threads created | 21 ms | 22 ms |
+
+  The pool now grows to the same handful of threads the JVM's does for the same
+  work. What is left between the two is one mutex and one park/unpark per handoff
+  where a `SynchronousQueue` transfers without either: it costs jolt 1.7x on a
+  single producer, and it is most of the gap with four producers on one pool,
+  where the JVM's queue stripes and jolt's one mutex convoys.
+
 ### Fixed
 
 - **`Executors/newCachedThreadPool` grows on demand (#819).** It was a fixed pool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are new, so a caller can see the pool grow and retire — and so the tests can
   assert it without counting threads by hand.
 
+- **The three spellings of executor shutdown do what they say (#819).** Found
+  while measuring the pool above, all three verified against reference JVM Clojure
+  on Java 21:
+
+  - **A `submit` or `execute` after shutdown is REJECTED** with
+    `RejectedExecutionException` (a `RuntimeException`, catchable as either), which
+    is what the JVM's default `AbortPolicy` does. jolt used to accept the task and
+    queue it — a promise the pool cannot keep, because its workers leave as soon as
+    the queue they are draining runs dry. The task then ran only if a worker
+    happened to still be there, and otherwise sat in the queue for good, with a
+    `Future` whose `.get` waits forever and an `isTerminated` answering false about
+    a pool that has nothing left to run it. The check is made under the queue mutex,
+    so a task that gets in ahead of the flag is enqueued while a worker is still
+    live, and a worker drains the queue before it leaves.
+  - **`shutdownNow` drops the queued tasks and hands them back**, which is the
+    whole difference between it and `shutdown`. It used to answer an empty vector
+    and leave the queue to drain, so the method that exists to say "do not run the
+    rest" ran the rest: a caller shutting a pool down hard because its work had
+    become irrelevant got every queued task executed anyway, and an empty list
+    claiming nothing had been pending. The returned procedures are callable, so a
+    caller can still run one itself, as `.run` lets them on the JVM. What jolt still
+    cannot do is the other half — interrupting the tasks already RUNNING, which
+    needs the workers to carry an interrupt flag a shutdown can set.
+  - **`close` blocks until the pool has terminated**, as the JVM's has since 19.
+    It used to return the moment the flag was set, so the one spelling of shutdown
+    that promises the work is finished when it returns was the one that did not
+    wait, and `(with-open [ex …] …)` left its tasks running behind it.
+
+  A worker that dies for any reason other than its task throwing (nothing does
+  that today) now hands its slot back before it goes, instead of leaving
+  `live-workers` counting a thread that is gone — which would have left
+  `isTerminated` false forever and `awaitTermination` waiting out its deadline on a
+  finished pool. The next enqueue starts a replacement, because a live count below
+  max with a task waiting is what the growth rule spawns on.
+
 - **`deref` of a `java.util.concurrent.Future`.** `@fut` raised "deref:
   unsupported reference type" for a `FutureTask` and for what an
   `ExecutorService.submit` hands back. Neither is `IDeref` on the JVM either —

--- a/bench/README.md
+++ b/bench/README.md
@@ -53,6 +53,15 @@ absolute reference.
 | `char-scan` | walking a string one code point at a time via `.charAt`, with the `int`/`long`/`unchecked-*` casts hinted Clojure puts around it, incl. a `case`-dispatched character state machine | numeric cast fast paths, `.charAt` on a proven string, `case` over small ints | honeysql `alphanumeric?` |
 | `sorted-access` | reads a collection's structure can answer without walking: `count`/`drop` on a vector seq, `rseq`, `first` on a sorted map/set | shape-answered reads (Counted / IDrop / leftmost-node), not traversal | — |
 | `nth-access` | `nth` on a vector, small and large, and with a default — the constant cost of an indexed read | `Indexed`-first ordering in `jolt-nth` ahead of the extension-type probes | — |
+| `executors` | `java.util.concurrent` dispatch: fire-and-forget at a cached pool faster than it can drain, submit/get round trips, growth to 64 blocking tasks, and four producers on one pool | the RUNTIME rather than a pass — the executor's queue, its wake rule and its growth rule (`host/chez/java/concurrency.ss`) | — |
+
+`executors` is the one row that is not about a compiler pass. It is here because
+nothing else in the suite measures concurrency throughput, and the cost it watches
+is real: an enqueue that woke every idle worker instead of one took a no-op task
+from 8.9µs to 152µs and the pool from 7 threads to 134, with every correctness
+gate still green. Concurrency numbers are noisier than the rest — the four-producer
+phase is a fight over one mutex on however many cores the machine has — so read a
+move here with more suspicion than usual, and re-run it alone on both sides.
 
 ## Scorecard
 

--- a/bench/executors.clj
+++ b/bench/executors.clj
@@ -1,0 +1,104 @@
+;; executors — java.util.concurrent dispatch: what it costs to get a task onto a
+;; worker and, for the submit shapes, the result back. The four phases are the four
+;; ways a pool is asked to do that, and they fail differently:
+;;
+;;   drain      fire-and-forget onto a cached pool, faster than the workers can
+;;              clear it. Measures the enqueue, the wake, and the growth rule under
+;;              a producer that outruns them — the shape where a pool that wakes
+;;              every idle worker per task, or grows one per queued task, collapses.
+;;   round-trip submit and wait, one at a time. The handoff both ways, with no
+;;              queue depth to hide behind: park, unpark, and the future's latch.
+;;   ramp       tasks that block until the last one has started, so the pool must
+;;              actually reach that many threads. Thread creation, plus the growth
+;;              decision on the one workload that genuinely needs it.
+;;   contended  four producers on one pool: how much of the queue's mutex is left
+;;              after they have finished fighting over it.
+;;
+;; Not a compiler-pass benchmark — the cost is in the runtime's queue and wakes
+;; (host/chez/java/concurrency.ss), and the suite is where the runtime's hot paths
+;; get watched. It is here because nothing else in the suite measures concurrency
+;; throughput, and a 17x regression in it once passed every correctness gate.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh executors 60000
+(ns executors
+  (:import [java.util.concurrent Executors TimeUnit CountDownLatch Callable]))
+
+;; n trivial tasks at a growing pool, drained through shutdown/awaitTermination so
+;; that nothing per-task is added to the measurement but the dispatch itself.
+(defn drain [n]
+  (let [ex (Executors/newCachedThreadPool)
+        c (atom 0)
+        f (fn [] (swap! c inc))]
+    (.execute ex f)                                     ; one worker up first
+    (dotimes [_ n] (.execute ex f))
+    (.shutdown ex)
+    (.awaitTermination ex 120 TimeUnit/SECONDS)
+    @c))
+
+;; submit one, wait for its value, repeat: a full handoff each way per task.
+(defn round-trip [n]
+  (let [ex (Executors/newCachedThreadPool)
+        one (fn [] 1)
+        total (loop [i 0 acc 0]
+                (if (< i n)
+                  (recur (inc i) (+ acc (long (.get (.submit ex ^Callable one)))))
+                  acc))]
+    (.shutdownNow ex)
+    total))
+
+;; k tasks that each block until the last of them has started, so the pool has to
+;; grow to k threads before the latch can fall.
+(defn ramp [k]
+  (let [ex (Executors/newCachedThreadPool)
+        latch (CountDownLatch. k)
+        go (promise)]
+    (dotimes [_ k] (.execute ex (fn [] (.countDown latch) (deref go 60000 :timeout))))
+    (.await latch 60 TimeUnit/SECONDS)
+    (deliver go true)
+    (.shutdown ex)
+    (.awaitTermination ex 60 TimeUnit/SECONDS)
+    k))
+
+;; p producer threads sharing one pool, released together.
+(defn contended [n p]
+  (let [ex (Executors/newCachedThreadPool)
+        c (atom 0)
+        f (fn [] (swap! c inc))
+        per (quot n p)
+        start (CountDownLatch. 1)
+        done (CountDownLatch. p)
+        ts (mapv (fn [_] (Thread. (fn []
+                                    (.await start)
+                                    (dotimes [_ per] (.execute ex f))
+                                    (.countDown done))))
+                 (range p))]
+    (.execute ex f)
+    (doseq [t ts] (.start t))
+    (.countDown start)
+    (.await done)
+    (.shutdown ex)
+    (.awaitTermination ex 120 TimeUnit/SECONDS)
+    @c))
+
+(defn run [n]
+  (+ (drain n)
+     (round-trip (quot n 20))
+     (ramp 64)
+     (contended n 4)))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 60000)]
+    (dotimes [_ 2] (run (quot n 4)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "executors n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -61,7 +61,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 char-scan:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 char-scan:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14 executors:60000"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1560,60 +1560,214 @@
         (cons "isCancelled" (lambda (self) #f))
         (cons "cancel" (lambda (self . _) #f))))
 ;; executor-service state: #(shutdown? queue-box queue-mutex queue-cond
-;; worker-count advisory-queue-capacity)  — the capacity is #f except for a
-;; ThreadPoolExecutor built with an ArrayBlockingQueue; .getQueue's view
-;; subtracts the live depth from it.
+;; live-workers advisory-queue-capacity core-workers max-workers keep-alive-ms
+;; idle-workers queue-depth) — the capacity is #f except for a ThreadPoolExecutor
+;; built with an ArrayBlockingQueue; .getQueue's view subtracts the live depth
+;; from it.
 ;; queue-box holds a pair (out . in) — out is the dequeue head-list, in is the
 ;; enqueue tail-list (reversed). Enqueue conses onto in (O(1)); dequeue pops from
-;; out, reversing in into out when out is empty (amortized O(1)).
-(define (make-executor n-workers . cap)
-  (let ((self (make-jhost "executor-service" (vector #f (box (cons '() '())) (make-mutex) (make-condition) n-workers
-                                                     (if (null? cap) #f (car cap))))))
+;; out, reversing in into out when out is empty (amortized O(1)). queue-depth is
+;; that pair's length, maintained rather than walked: the growth decision below
+;; reads it on every enqueue.
+;;
+;; A POOL THAT GROWS, because two of the factories on the JVM have no fixed size
+;; at all. The shape is java.util.concurrent.ThreadPoolExecutor's, with the three
+;; numbers that decide when a thread is created and when one is retired:
+;;
+;;   core-workers   forked at construction and never retired.
+;;   max-workers    the ceiling live-workers may grow to.
+;;   keep-alive-ms  how long a worker ABOVE core may sit idle before it exits,
+;;                  or #f for a pool whose workers never expire.
+;;
+;; A fixed pool is core = max, keep-alive #f — every worker eager, none retired,
+;; which is what newFixedThreadPool and newSingleThreadExecutor were already and
+;; still are (single-thread submission ORDER depends on it: one worker, forever).
+;; Eager is jolt's own and predates this: the JVM creates even CORE threads on
+;; demand, so a fixed pool's getPoolSize is 0 there until the first task. Forking
+;; them up front costs the threads the caller named and nothing more, and it is
+;; the behaviour every pool here has had, so it stays.
+;;
+;; newCachedThreadPool is core 0, max unbounded, keep-alive 60s — the JVM's own
+;; (0, Integer.MAX_VALUE, 60L, SECONDS), and newVirtualThreadPerTaskExecutor gets
+;; the same pool.
+;;
+;; WHEN A THREAD IS CREATED is the part worth stating exactly, because the JVM
+;; expresses it through a data structure jolt does not have. There, a cached pool
+;; hands tasks over a SynchronousQueue, whose offer succeeds only if a worker is
+;; already parked in a take; when it fails the executor starts a thread. So the
+;; rule is "a task that no idle worker is waiting to accept starts one", and that
+;; is what executor-enqueue! tests directly: queue-depth > idle-workers, decided
+;; under the queue mutex, so an idle worker cannot have claimed the task between
+;; the test and the fork. Tasks still go through the one unbounded queue either
+;; way, which is why the test is a depth against a count rather than a handoff.
+(define executor-unbounded-workers 2147483647)   ; Integer.MAX_VALUE, as the JVM passes
+(define cached-pool-keep-alive-ms 60000)         ; 60L, TimeUnit.SECONDS, as the JVM passes
+(define (make-executor* core-n max-n keep-alive-ms cap)
+  (let ((self (make-jhost "executor-service"
+                          (vector #f (box (cons '() '())) (make-mutex) (make-condition) 0
+                                  cap core-n max-n keep-alive-ms 0 0))))
     (let ((st (jhost-state self)))
-      (let spawn ((k n-workers))
-        (when (> k 0)
-          (fork-thread (lambda ()
-            (*txn* #f)      ; worker must not inherit the creating thread's txn
-            (let loop ()
-              (let ((job (jolt-with-mutex (vector-ref st 2)
-                           (let poll ()
-                             (let ((q (unbox (vector-ref st 1))))
-                               (cond ((pair? (car q))
-                                      (let ((out (car q)))
-                                        (set-car! q (cdr out))
-                                        (car out)))
-                                     ((pair? (cdr q))
-                                      (set-car! q (reverse (cdr q)))
-                                      (set-cdr! q '())
-                                      (let ((out (car q)))
-                                        (set-car! q (cdr out))
-                                        (car out)))
-                                     ((vector-ref st 0) #f)   ; shutdown + empty -> exit
-                                     (else (jolt-condition-wait (vector-ref st 3) (vector-ref st 2)) (poll))))))))
-                (if job
-                    (begin (job) (loop))
-                    (jolt-with-mutex (vector-ref st 2)
-                      (vector-set! st 4 (fx- (vector-ref st 4) 1))
-                      (jolt-cv-wake! (vector-ref st 3))))))))
-          (spawn (- k 1))))
+      ;; The core workers, eagerly. Above core, a worker appears when a task
+      ;; arrives with nobody idle to take it, and not before: a cached pool that
+      ;; is never used costs no threads.
+      (let spawn ((k core-n))
+        (when (fx>? k 0)
+          (when (jolt-with-mutex (vector-ref st 2) (executor-claim-worker! st))
+            (executor-spawn-worker! st))
+          (spawn (fx- k 1))))
       self)))
+;; A fixed pool: n eager workers that never retire, and the advisory capacity a
+;; ThreadPoolExecutor's queue argument contributes to .getQueue's view.
+(define (make-executor n-workers . cap)
+  (make-executor* n-workers n-workers #f (if (null? cap) #f (car cap))))
+;; newCachedThreadPool / newVirtualThreadPerTaskExecutor.
+(define (make-cached-executor)
+  (make-executor* 0 executor-unbounded-workers cached-pool-keep-alive-ms #f))
+
+;; Claim a worker slot, or answer #f because the pool is at max. Called with the
+;; queue mutex HELD, and the slot is claimed BEFORE the fork rather than counted
+;; by the new thread on arrival: live-workers is what isTerminated and
+;; awaitTermination read, so a count that dipped between the decision and the
+;; thread's first instruction would report a pool terminated while a task it
+;; accepted was still on its way to a worker. It is also what keeps two
+;; concurrent enqueues from both spawning past max.
+(define (executor-claim-worker! st)
+  (and (fx<? (vector-ref st 4) (vector-ref st 7))
+       (begin (vector-set! st 4 (fx+ (vector-ref st 4) 1)) #t)))
+;; Fork the thread for a slot already claimed, OUTSIDE the mutex. A fork that
+;; fails gives the slot back; whether that is the caller's problem depends on
+;; whether anything is left to run the task — with other workers live it waits
+;; for one of them, with none it would wait forever, and a submit whose task can
+;; never run is a failure the caller has to see (the JVM's own answer to a thread
+;; it cannot create is to reject the task, not to queue it silently).
+(define (executor-spawn-worker! st)
+  (guard (e (#t (let ((none-left? (jolt-with-mutex (vector-ref st 2)
+                                    (vector-set! st 4 (fx- (vector-ref st 4) 1))
+                                    (jolt-cv-wake! (vector-ref st 3))
+                                    (fx=? 0 (vector-ref st 4)))))
+                  (when none-left? (raise e)))))
+    (fork-thread (lambda ()
+      (*txn* #f)      ; worker must not inherit the creating thread's txn
+      (executor-worker-loop st)))))
+
+;; Dequeue, with the mutex held. Callers test queue-depth first.
+(define (executor-dequeue! st)
+  (let ((q (unbox (vector-ref st 1))))
+    (when (null? (car q))                       ; amortized reverse of the tail
+      (set-car! q (reverse (cdr q)))
+      (set-cdr! q '()))
+    (let ((out (car q)))
+      (set-car! q (cdr out))
+      (vector-set! st 10 (fx- (vector-ref st 10) 1))
+      (car out))))
+;; Park until something changes: a task arrives, the pool shuts down, or (for a
+;; worker above core) the keep-alive deadline passes. The idle count is raised
+;; before the wait releases the mutex and dropped after it retakes it, so the
+;; growth test in executor-enqueue! sees exactly the workers that are available
+;; to take a task.
+(define (executor-idle-wait! st abs-time)
+  (vector-set! st 9 (fx+ (vector-ref st 9) 1))
+  (if abs-time
+      (jolt-condition-wait (vector-ref st 3) (vector-ref st 2) abs-time)
+      (jolt-condition-wait (vector-ref st 3) (vector-ref st 2)))
+  (vector-set! st 9 (fx- (vector-ref st 9) 1)))
+;; Leave the pool: drop out of the live count and announce it, since
+;; awaitTermination waits on exactly this reaching zero. Answers #f, the "no job,
+;; you are done" answer executor-take-job! returns.
+;;
+;; UNDER THE SAME MUTEX HOLD AS THE DECISION TO GO, which is the whole reason it
+;; is a procedure and not two lines in the worker loop. Released in between, the
+;; count says a worker is live for a moment after it has stopped taking work, and
+;; an enqueue in that moment reads it and declines to grow — with max reached it
+;; declines for good, and the task waits for a worker that has already left. A TPE
+;; of (0, 1, 0ms) strands a task that way on the first idle gap. Deciding and
+;; decrementing under one hold makes the two orders the only two: an enqueue
+;; before it sees this worker idle and waiting (and needs no new one, because the
+;; wake sends it back to the queue), one after sees the count without it.
+(define (executor-worker-exit! st)
+  (vector-set! st 4 (fx- (vector-ref st 4) 1))
+  ;; Announced only to the waiter that can care, which is awaitTermination
+  ;; (isTerminated polls): it wants live 0 with the pool shut down, so a
+  ;; keep-alive retirement in a RUNNING pool needs to wake nobody. Every wake
+  ;; here is a broadcast to every idle worker, and the retirements come in a
+  ;; crowd — a burst that grew the pool to 558 retires all 558 sixty seconds
+  ;; later, which would otherwise be 558 broadcasts to a shrinking crowd.
+  (when (or (vector-ref st 0) (fx=? 0 (vector-ref st 4)))
+    (jolt-cv-wake! (vector-ref st 3)))
+  #f)
+;; The next task for this worker, or #f meaning it has exited — because the pool
+;; is shut down and drained, or because this worker is above core and has been
+;; idle for keep-alive. Runs with the mutex held, and only ever exits with the
+;; queue empty, so no task is left with nobody to run it.
+;;
+;; The keep-alive deadline is absolute and survives the loop, so a broadcast that
+;; woke every idle worker for one task resumes the losers waiting for what is LEFT
+;; of their keep-alive rather than restarting it — the same reason Thread.join and
+;; the waits above carry deadlines rather than durations.
+(define (executor-take-job! st)
+  (let poll ((deadline #f))
+    (cond ((fx>? (vector-ref st 10) 0) (executor-dequeue! st))
+          ((vector-ref st 0) (executor-worker-exit! st))   ; shutdown + drained
+          ((and (vector-ref st 8) (fx>? (vector-ref st 4) (vector-ref st 6)))
+           (let ((dl (or deadline (+ (now-millis) (vector-ref st 8)))))
+             (if (>= (now-millis) dl)
+                 (executor-worker-exit! st)                ; idle past keep-alive
+                 (begin (executor-idle-wait! st (jolt-millis->time dl))
+                        (poll dl)))))
+          (else (executor-idle-wait! st #f) (poll deadline)))))
+(define (executor-worker-loop st)
+  (let loop ()
+    (let ((job (jolt-with-mutex (vector-ref st 2) (executor-take-job! st))))
+      (when job (job) (loop)))))
+
 (define (executor-enqueue! self job)
   (let ((st (jhost-state self)))
-    (jolt-with-mutex (vector-ref st 2)
-      (let ((q (unbox (vector-ref st 1))))
-        (set-cdr! q (cons job (cdr q))))
-      (jolt-cv-wake! (vector-ref st 3)))))
+    (when (jolt-with-mutex (vector-ref st 2)
+            (let ((q (unbox (vector-ref st 1))))
+              (set-cdr! q (cons job (cdr q))))
+            (vector-set! st 10 (fx+ (vector-ref st 10) 1))
+            (jolt-cv-wake! (vector-ref st 3))
+            ;; Grow if this task has no idle worker waiting to take it. Not after
+            ;; shutdown: a task enqueued then is one jolt keeps rather than
+            ;; rejects (the divergence noted above), and starting a thread for it
+            ;; would also resurrect a pool that had reached termination.
+            (and (not (vector-ref st 0))
+                 (fx>? (vector-ref st 10) (vector-ref st 9))
+                 (executor-claim-worker! st)))
+      (executor-spawn-worker! st))))
 (let ((single (lambda _ (make-executor 1)))
       (fixed  (lambda (n . _) (make-executor (max 1 (jnum->exact n)))))
-      ;; per-task / cached / virtual: enough workers to not serialize; a generous
-      ;; fixed pool preserves concurrency without unbounded thread growth.
-      (many   (lambda _ (make-executor 32))))
+      ;; cached / virtual-thread-per-task: the two factories that are UNBOUNDED on
+      ;; the JVM. A cached pool is (0, Integer.MAX_VALUE, 60s, SynchronousQueue)
+      ;; there, and a virtual thread per task is a thread per task with no pool at
+      ;; all; both answer a burst of n concurrent tasks with n carriers. These were
+      ;; one fixed 32-worker pool, which meant task 33 of a burst did not start
+      ;; until an earlier one finished — invisible while tasks are short, and a
+      ;; deadlock when they are not: 32 tasks that block waiting for the 33rd (a
+      ;; fan-out whose children hand results back through a channel, say) never let
+      ;; it run. Growing on demand takes that ceiling away.
+      ;;
+      ;; A grown worker is REUSED for a later task and retired after 60s idle, so a
+      ;; steady stream of short tasks costs a thread or two rather than one per
+      ;; task, and a burst that has passed does not leave its threads behind. That
+      ;; is exactly a cached pool; for the virtual-thread executor it is a
+      ;; substitution — a pooled thread for a fresh virtual one, which nothing here
+      ;; can tell apart, since jolt has no thread-locals and a task's identity is
+      ;; its own.
+      (cached (lambda _ (make-cached-executor)))
+      ;; newWorkStealingPool is NOT one of those and stays a fixed pool: a
+      ;; ForkJoinPool is sized at availableProcessors, because work stealing is for
+      ;; CPU-bound tasks that would only contend if there were more of them than
+      ;; cores. It does grow past that, but only to REPLACE a worker the JVM can
+      ;; see is blocked in a join, which is a thing jolt cannot see; a flat 32 sits
+      ;; between the two bounds and errs toward not stranding a blocking task.
+      (stealing (lambda _ (make-executor 32))))
   (for-each (lambda (nm) (register-class-statics! nm
               (list (cons "newSingleThreadExecutor" single)
                     (cons "newSingleThreadScheduledExecutor" single)
                     (cons "newFixedThreadPool" fixed) (cons "newScheduledThreadPool" fixed)
-                    (cons "newVirtualThreadPerTaskExecutor" many)
-                    (cons "newCachedThreadPool" many) (cons "newWorkStealingPool" many))))
+                    (cons "newVirtualThreadPerTaskExecutor" cached)
+                    (cons "newCachedThreadPool" cached) (cons "newWorkStealingPool" stealing))))
             '("Executors" "java.util.concurrent.Executors")))
 (register-host-methods! "executor-service"
   (list (cons "submit" (lambda (self thunk)
@@ -1636,8 +1790,8 @@
         (cons "close" (lambda (self) (let ((st (jhost-state self)))
           (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) jolt-nil))
         (cons "isShutdown" (lambda (self) (vector-ref (jhost-state self) 0)))
-        (cons "isTerminated" (lambda (self) (let* ((st (jhost-state self)) (q (unbox (vector-ref st 1))))
-          (and (vector-ref st 0) (null? (car q)) (null? (cdr q)) (fx=? 0 (vector-ref st 4))))))
+        (cons "isTerminated" (lambda (self) (let ((st (jhost-state self)))
+          (and (vector-ref st 0) (fx=? 0 (vector-ref st 10)) (fx=? 0 (vector-ref st 4))))))
         ;; (timeout, unit) on the JVM. The unit used to be dropped and the amount read
         ;; as milliseconds outright, so (.awaitTermination ex 5 TimeUnit/SECONDS)
         ;; waited five MILLISECONDS and reported the pool still running.
@@ -1824,24 +1978,35 @@
       x))
 
 ;; ThreadPoolExecutor ctor: (core max keepAlive unit [queue] [factory]
-;; [handler]) — workers sized by maximumPoolSize (with an unbounded internal
-;; queue, threads past core would never spawn; max preserves the concurrency
-;; the caller asked for). keepAlive/factory/handler are accepted and ignored.
+;; [handler]) — core, max and keepAlive all reach the pool now that the pool can
+;; grow and retire; factory and handler are accepted and ignored. The workers up
+;; to core are eager, the rest appear as tasks arrive with nobody idle, and an
+;; above-core worker retires after keepAlive.
+;;
+;; WHEN a thread past core appears is the one place this still diverges, and it
+;; diverges in the direction of the caller's stated maximum: the JVM grows only
+;; once the work queue is FULL, so a TPE with an unbounded queue never passes
+;; core at all, and jolt has one unbounded queue for every pool. Growing on the
+;; handoff test instead means max means what it says. The pool is at least 1 for
+;; the same reason as newFixedThreadPool: a pool with no worker runs nothing.
 (for-each (lambda (nm) (register-class-ctor! nm
             (lambda (core-n max-n . rest)
-              (let ((q (and (>= (length rest) 3) (abq? (list-ref rest 2)) (list-ref rest 2))))
-                (make-executor (max 1 (jnum->exact max-n))
-                               (and q (vector-ref (jhost-state q) 0)))))))
+              (let* ((q (and (>= (length rest) 3) (abq? (list-ref rest 2)) (list-ref rest 2)))
+                     (max-n (max 1 (jnum->exact max-n)))
+                     (core-n (min max-n (max 0 (jnum->exact core-n))))
+                     ;; #f only when the ctor was called without them at all; a
+                     ;; keepAlive of 0 is the JVM's "retire the moment you are
+                     ;; idle" and stays 0.
+                     (keep (and (>= (length rest) 2) (tu->ms (car rest) (cadr rest)))))
+                (make-executor* core-n max-n keep
+                                (and q (vector-ref (jhost-state q) 0)))))))
           '("ThreadPoolExecutor" "java.util.concurrent.ThreadPoolExecutor"))
 ;; .getQueue answers a live VIEW of the executor's internal queue — size reads
 ;; the real depth, remainingCapacity subtracts it from the advisory capacity
 ;; (Integer/MAX_VALUE without one). Honest for monitoring; not the caller's
 ;; ArrayBlockingQueue instance, which the executor does not use.
 (define (executor-queue-depth ex)
-  (let ((st (jhost-state ex)))
-    (jolt-with-mutex (vector-ref st 2)
-      (let ((q (unbox (vector-ref st 1))))
-        (fx+ (length (car q)) (length (cdr q)))))))
+  (vector-ref (jhost-state ex) 10))
 (register-host-methods! "executor-queue-view"
   (list (cons "size" (lambda (self) (executor-queue-depth (vector-ref (jhost-state self) 0))))
         (cons "isEmpty" (lambda (self) (fx=? 0 (executor-queue-depth (vector-ref (jhost-state self) 0)))))
@@ -1851,7 +2016,19 @@
             (if cap (max 0 (- cap (executor-queue-depth ex))) 2147483647))))
         (cons "toString" (lambda (self) "ExecutorQueueView"))))
 (register-host-methods! "executor-service"
-  (list (cons "getQueue" (lambda (self) (make-jhost "executor-queue-view" (vector self))))))
+  (list (cons "getQueue" (lambda (self) (make-jhost "executor-queue-view" (vector self))))
+        ;; ThreadPoolExecutor's size accessors, which are how a caller (and the
+        ;; test suite) can see the pool grow and retire at all. getActiveCount is
+        ;; documented as approximate on the JVM and is approximate here for the
+        ;; same reason: it is a live count read without stopping the pool.
+        ;; getMaximumPoolSize of a cached pool answers Integer/MAX_VALUE, which is
+        ;; the number the JVM's own newCachedThreadPool passes.
+        (cons "getPoolSize" (lambda (self) (vector-ref (jhost-state self) 4)))
+        (cons "getActiveCount" (lambda (self)
+          (let ((st (jhost-state self)))
+            (max 0 (fx- (vector-ref st 4) (vector-ref st 9))))))
+        (cons "getCorePoolSize" (lambda (self) (vector-ref (jhost-state self) 6)))
+        (cons "getMaximumPoolSize" (lambda (self) (vector-ref (jhost-state self) 7)))))
 
 ;; java.util.concurrent.locks.ReentrantLock — a reentrant mutual-exclusion lock.
 ;; State: #(monitor), one MONITOR record of its own (make-monitor above), not the

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1559,11 +1559,26 @@
         (cons "isDone" (lambda (self) (vector-ref (jhost-state self) 0)))
         (cons "isCancelled" (lambda (self) #f))
         (cons "cancel" (lambda (self . _) #f))))
-;; executor-service state: #(shutdown? queue-box queue-mutex queue-cond
+;; executor-service state: #(shutdown? queue-box queue-mutex task-cond
 ;; live-workers advisory-queue-capacity core-workers max-workers keep-alive-ms
-;; idle-workers queue-depth) — the capacity is #f except for a ThreadPoolExecutor
-;; built with an ArrayBlockingQueue; .getQueue's view subtracts the live depth
-;; from it.
+;; idle-workers queue-depth term-cond) — the capacity is #f except for a
+;; ThreadPoolExecutor built with an ArrayBlockingQueue; .getQueue's view subtracts
+;; the live depth from it.
+;;
+;; TWO CONDITIONS, one mutex. task-cond carries "a task is queued, or the pool is
+;; shutting down" to the WORKERS, which are threads; term-cond carries "shut down
+;; and the last worker is gone" to awaitTermination, which a fiber can reach. They
+;; were one condition, and an enqueue therefore broadcast to every waiter on it:
+;; with 130 idle workers, one task woke all 130, and 129 of them took the queue
+;; mutex, found the task already claimed and parked again. Fire-and-forget cost
+;; 152us per no-op task that way, against 5.2us on the JVM (and 26.5us with the
+;; fixed 32-worker pool this replaced, which woke 32), and the herd fed the
+;; growth rule below — workers that slow to return look like workers that are not
+;; coming, so a 200k-task burst grew the pool to 134 threads, which made the herd
+;; bigger still. Split, an enqueue signals exactly ONE worker (jolt-cv-signal-one!,
+;; locks.ss, where the preconditions this relies on are written out): the same
+;; no-op task costs 8.9us and the same burst needs 7 threads, which is the pool the
+;; JVM grows for it too.
 ;; queue-box holds a pair (out . in) — out is the dequeue head-list, in is the
 ;; enqueue tail-list (reversed). Enqueue conses onto in (O(1)); dequeue pops from
 ;; out, reversing in into out when out is empty (amortized O(1)). queue-depth is
@@ -1605,7 +1620,7 @@
 (define (make-executor* core-n max-n keep-alive-ms cap)
   (let ((self (make-jhost "executor-service"
                           (vector #f (box (cons '() '())) (make-mutex) (make-condition) 0
-                                  cap core-n max-n keep-alive-ms 0 0))))
+                                  cap core-n max-n keep-alive-ms 0 0 (make-condition)))))
     (let ((st (jhost-state self)))
       ;; The core workers, eagerly. Above core, a worker appears when a task
       ;; arrives with nobody idle to take it, and not before: a cached pool that
@@ -1643,7 +1658,7 @@
 (define (executor-spawn-worker! st)
   (guard (e (#t (let ((none-left? (jolt-with-mutex (vector-ref st 2)
                                     (vector-set! st 4 (fx- (vector-ref st 4) 1))
-                                    (jolt-cv-wake! (vector-ref st 3))
+                                    (jolt-cv-wake! (vector-ref st 11))
                                     (fx=? 0 (vector-ref st 4)))))
                   (when none-left? (raise e)))))
     (fork-thread (lambda ()
@@ -1686,14 +1701,11 @@
 ;; wake sends it back to the queue), one after sees the count without it.
 (define (executor-worker-exit! st)
   (vector-set! st 4 (fx- (vector-ref st 4) 1))
-  ;; Announced only to the waiter that can care, which is awaitTermination
-  ;; (isTerminated polls): it wants live 0 with the pool shut down, so a
-  ;; keep-alive retirement in a RUNNING pool needs to wake nobody. Every wake
-  ;; here is a broadcast to every idle worker, and the retirements come in a
-  ;; crowd — a burst that grew the pool to 558 retires all 558 sixty seconds
-  ;; later, which would otherwise be 558 broadcasts to a shrinking crowd.
+  ;; Announced on term-cond only, and only to a waiter that can care: what
+  ;; awaitTermination waits for is live 0 with the pool shut down, so a keep-alive
+  ;; retirement in a RUNNING pool wakes nobody at all. (isTerminated polls.)
   (when (or (vector-ref st 0) (fx=? 0 (vector-ref st 4)))
-    (jolt-cv-wake! (vector-ref st 3)))
+    (jolt-cv-wake! (vector-ref st 11)))
   #f)
 ;; The next task for this worker, or #f meaning it has exited — because the pool
 ;; is shut down and drained, or because this worker is above core and has been
@@ -1720,13 +1732,25 @@
     (let ((job (jolt-with-mutex (vector-ref st 2) (executor-take-job! st))))
       (when job (job) (loop)))))
 
+;; shutdown / shutdownNow / close, which differ only in what they RETURN here.
+(define (executor-shutdown! st)
+  (vector-set! st 0 #t)
+  (jolt-with-mutex (vector-ref st 2)
+    (jolt-cv-wake! (vector-ref st 3))       ; every idle worker: leave
+    (jolt-cv-wake! (vector-ref st 11))))    ; awaitTermination: re-read the flag
+
 (define (executor-enqueue! self job)
   (let ((st (jhost-state self)))
     (when (jolt-with-mutex (vector-ref st 2)
             (let ((q (unbox (vector-ref st 1))))
               (set-cdr! q (cons job (cdr q))))
             (vector-set! st 10 (fx+ (vector-ref st 10) 1))
-            (jolt-cv-wake! (vector-ref st 3))
+            ;; One task, one taker: signal a single parked worker, and none at all
+            ;; when none is parked — a worker that is running or waiting on this
+            ;; mutex re-reads the queue before it parks, under this same hold, so
+            ;; there is no wake for it to miss.
+            (when (fx>? (vector-ref st 9) 0)
+              (jolt-cv-signal-one! (vector-ref st 3)))
             ;; Grow if this task has no idle worker waiting to take it. Not after
             ;; shutdown: a task enqueued then is one jolt keeps rather than
             ;; rejects (the divergence noted above), and starting a thread for it
@@ -1783,12 +1807,15 @@
                               (jolt-report-throwable e (current-error-port)))))
                 (jolt-invoke thunk)))))
           jolt-nil)))
-        (cons "shutdown" (lambda (self) (let ((st (jhost-state self)))
-          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) jolt-nil))
-        (cons "shutdownNow" (lambda (self) (let ((st (jhost-state self)))
-          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) (jolt-vector)))
-        (cons "close" (lambda (self) (let ((st (jhost-state self)))
-          (vector-set! st 0 #t) (jolt-with-mutex (vector-ref st 2) (jolt-cv-wake! (vector-ref st 3)))) jolt-nil))
+        ;; Shutdown wakes BOTH conditions, and every waiter on each: task-cond so
+        ;; that all the idle workers see the flag and leave (the one place a
+        ;; broadcast there is the point — the news is for all of them, not for
+        ;; whichever one a signal would pick), term-cond because a pool with no
+        ;; live worker is already terminated and awaitTermination has to re-read
+        ;; the flag to find out.
+        (cons "shutdown" (lambda (self) (executor-shutdown! (jhost-state self)) jolt-nil))
+        (cons "shutdownNow" (lambda (self) (executor-shutdown! (jhost-state self)) (jolt-vector)))
+        (cons "close" (lambda (self) (executor-shutdown! (jhost-state self)) jolt-nil))
         (cons "isShutdown" (lambda (self) (vector-ref (jhost-state self) 0)))
         (cons "isTerminated" (lambda (self) (let ((st (jhost-state self)))
           (and (vector-ref st 0) (fx=? 0 (vector-ref st 10)) (fx=? 0 (vector-ref st 4))))))
@@ -1802,11 +1829,13 @@
             ;; outside it in 10-100ms steps, because sleeping while HOLDING the mutex
             ;; starves the worker exit it waits for. A condition wait releases the
             ;; mutex atomically with blocking, so it needs neither the poll nor the
-            ;; care: the workers already broadcast this condition as each one exits,
-            ;; and shutdown broadcasts it too. It also stops a fiber calling this from
-            ;; sleeping its carrier in 100ms chunks.
+            ;; care: the workers already broadcast term-cond as each one exits, and
+            ;; shutdown broadcasts it too. It also stops a fiber calling this from
+            ;; sleeping its carrier in 100ms chunks. term-cond and not task-cond: a
+            ;; wait that can belong to a FIBER must not sit on the condition the
+            ;; enqueue path signals one thread on.
             (jolt-cv-wait-interruptibly "ExecutorService.awaitTermination"
-                                        (vector-ref st 2) (vector-ref st 3) deadline
+                                        (vector-ref st 2) (vector-ref st 11) deadline
               (lambda (timed-out?)
                 (cond ((and (vector-ref st 0) (fx=? 0 (vector-ref st 4))) #t)
                       (timed-out? #f)

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1727,38 +1727,124 @@
                  (begin (executor-idle-wait! st (jolt-millis->time dl))
                         (poll dl)))))
           (else (executor-idle-wait! st #f) (poll deadline)))))
+;; A worker that dies must not take the pool's accounting with it. Everything a
+;; TASK can throw is already caught at the task (submit's future keeps it, execute
+;; reports it), so reaching this handler means the queue mechanics threw — which
+;; nothing in them does today. Unhandled, it would leave live-workers counting a
+;; thread that is gone: isTerminated would never answer true and awaitTermination
+;; would wait out its whole deadline on a pool that is finished. The bookkeeping
+;; here is the same one a retiring worker does, and the next enqueue replaces the
+;; worker for free, because a live count below max with a task waiting is exactly
+;; what the growth rule starts one on (the JVM replaces an abruptly-dead worker
+;; too, for the same reason).
 (define (executor-worker-loop st)
-  (let loop ()
-    (let ((job (jolt-with-mutex (vector-ref st 2) (executor-take-job! st))))
-      (when job (job) (loop)))))
+  (guard (e (#t (jolt-with-mutex (vector-ref st 2) (executor-worker-exit! st))
+                (guard (_ (#t #f))
+                  (display "Exception in executor worker:\n" (current-error-port))
+                  (jolt-report-throwable e (current-error-port)))))
+    (let loop ()
+      (let ((job (jolt-with-mutex (vector-ref st 2) (executor-take-job! st))))
+        (when job (job) (loop))))))
 
-;; shutdown / shutdownNow / close, which differ only in what they RETURN here.
+;; shutdown: stop accepting, let what is queued drain.
 (define (executor-shutdown! st)
   (vector-set! st 0 #t)
   (jolt-with-mutex (vector-ref st 2)
     (jolt-cv-wake! (vector-ref st 3))       ; every idle worker: leave
     (jolt-cv-wake! (vector-ref st 11))))    ; awaitTermination: re-read the flag
 
+;; shutdownNow: stop accepting AND drop what is queued, answering the dropped
+;; tasks in queue order — which is the whole difference between the two methods and
+;; the whole point of this one. It used to set the flag, answer an empty vector, and
+;; leave the queue to drain, so the method that exists to say "do not run the rest"
+;; ran the rest: a caller shutting a pool down hard because its work had become
+;; irrelevant (a cancelled request, a failing import) got every queued task
+;; executed anyway, and an empty list claiming nothing had been pending.
+;;
+;; A dropped task's Future never completes, so a .get on it waits forever. That is
+;; the JVM's behaviour too — the tasks it hands back are the pending FutureTasks
+;; themselves, and nothing runs them unless the caller does — which is why they are
+;; returned rather than discarded: the returned procedures are callable, and calling
+;; one runs that task on the caller's thread, the same recovery .run gives there.
+;;
+;; What jolt CANNOT do is the other half of shutdownNow, interrupting the tasks
+;; already running: the workers do not carry an interrupt flag for a shutdown to
+;; set, so a task in Thread/sleep or a blocking read keeps going. The JVM
+;; interrupts those threads. Tracked; a worker would have to adopt an interrupt box
+;; the way Thread.start does.
+(define (executor-drain-queue! st)
+  (let* ((q (unbox (vector-ref st 1)))
+         (jobs (append (car q) (reverse (cdr q)))))
+    (set-car! q '())
+    (set-cdr! q '())
+    (vector-set! st 10 0)
+    jobs))
+(define (executor-shutdown-now! st)
+  (vector-set! st 0 #t)
+  (let ((dropped (jolt-with-mutex (vector-ref st 2)
+                   (let ((jobs (executor-drain-queue! st)))
+                     (jolt-cv-wake! (vector-ref st 3))
+                     (jolt-cv-wake! (vector-ref st 11))
+                     jobs))))
+    (apply jolt-vector dropped)))
+
+;; The wait awaitTermination and close share. DEADLINE #f waits for as long as it
+;; takes, which is what close does.
+(define (executor-await-termination st deadline)
+  (jolt-cv-wait-interruptibly "ExecutorService.awaitTermination"
+                              (vector-ref st 2) (vector-ref st 11) deadline
+    (lambda (timed-out?)
+      (cond ((and (vector-ref st 0) (fx=? 0 (vector-ref st 4))) #t)
+            (timed-out? #f)
+            (else jolt-cv-again)))))
+
+;; A submit or execute after shutdown is REJECTED, as on the JVM, whose default
+;; handler is AbortPolicy. jolt used to accept it and queue it, which is a promise
+;; the pool cannot keep: the workers leave as soon as the queue they are draining
+;; runs dry, so the task ran only if one happened to still be there, and otherwise
+;; sat in the queue for good — with a Future whose .get waits forever and an
+;; isTerminated that answers false about a pool with nothing left to run it. A
+;; throw at the submit says the same thing the JVM says, at the only point where
+;; the caller can still do something about it.
+;;
+;; Decided under the queue mutex, which is what makes the answer honest either way:
+;; shutdown sets the flag and then takes this mutex, so a task that gets in ahead of
+;; the flag is enqueued with a worker still live, and a worker drains the queue
+;; before it leaves (executor-take-job! reads the depth before it reads the flag).
+;; Checked outside, the window between reading the flag and enqueueing is exactly
+;; the one where the task can be both accepted and abandoned.
+(define (executor-reject-task! st)
+  (jolt-throw (jolt-host-throwable
+               "java.util.concurrent.RejectedExecutionException"
+               "task rejected from executor: it is shut down")))
 (define (executor-enqueue! self job)
-  (let ((st (jhost-state self)))
-    (when (jolt-with-mutex (vector-ref st 2)
-            (let ((q (unbox (vector-ref st 1))))
-              (set-cdr! q (cons job (cdr q))))
-            (vector-set! st 10 (fx+ (vector-ref st 10) 1))
-            ;; One task, one taker: signal a single parked worker, and none at all
-            ;; when none is parked — a worker that is running or waiting on this
-            ;; mutex re-reads the queue before it parks, under this same hold, so
-            ;; there is no wake for it to miss.
-            (when (fx>? (vector-ref st 9) 0)
-              (jolt-cv-signal-one! (vector-ref st 3)))
-            ;; Grow if this task has no idle worker waiting to take it. Not after
-            ;; shutdown: a task enqueued then is one jolt keeps rather than
-            ;; rejects (the divergence noted above), and starting a thread for it
-            ;; would also resurrect a pool that had reached termination.
-            (and (not (vector-ref st 0))
-                 (fx>? (vector-ref st 10) (vector-ref st 9))
-                 (executor-claim-worker! st)))
-      (executor-spawn-worker! st))))
+  (let* ((st (jhost-state self))
+         (action (jolt-with-mutex (vector-ref st 2)
+                   (cond
+                     ((vector-ref st 0) 'reject)
+                     (else
+                      (let ((q (unbox (vector-ref st 1))))
+                        (set-cdr! q (cons job (cdr q))))
+                      (vector-set! st 10 (fx+ (vector-ref st 10) 1))
+                      ;; One task, one taker: signal a single parked worker, and
+                      ;; none at all when none is parked — a worker that is running
+                      ;; or waiting on this mutex re-reads the queue before it
+                      ;; parks, under this same hold, so there is no wake for it to
+                      ;; miss.
+                      (when (fx>? (vector-ref st 9) 0)
+                        (jolt-cv-signal-one! (vector-ref st 3)))
+                      ;; Grow if this task has no idle worker waiting to take it.
+                      (if (and (fx>? (vector-ref st 10) (vector-ref st 9))
+                               (executor-claim-worker! st))
+                          'spawn
+                          #f))))))
+    ;; Both of these happen with the mutex RELEASED: a fork takes ~80us and the
+    ;; queue cannot be shut for that long, and a throw has no business unwinding
+    ;; through a lock region it does not need to hold.
+    (case action
+      ((spawn) (executor-spawn-worker! st))
+      ((reject) (executor-reject-task! st))
+      (else (void)))))
 (let ((single (lambda _ (make-executor 1)))
       (fixed  (lambda (n . _) (make-executor (max 1 (jnum->exact n)))))
       ;; cached / virtual-thread-per-task: the two factories that are UNBOUNDED on
@@ -1814,32 +1900,37 @@
         ;; live worker is already terminated and awaitTermination has to re-read
         ;; the flag to find out.
         (cons "shutdown" (lambda (self) (executor-shutdown! (jhost-state self)) jolt-nil))
-        (cons "shutdownNow" (lambda (self) (executor-shutdown! (jhost-state self)) (jolt-vector)))
-        (cons "close" (lambda (self) (executor-shutdown! (jhost-state self)) jolt-nil))
+        (cons "shutdownNow" (lambda (self) (executor-shutdown-now! (jhost-state self))))
+        ;; close is shutdown plus an unbounded awaitTermination, and it BLOCKS —
+        ;; "blocks until all tasks have completed execution", as the JVM has it
+        ;; since 19. It used to return the moment the flag was set, so the one
+        ;; spelling of shutdown that promises the work is finished when it returns
+        ;; was the one that did not wait: (with-open [ex …] …) left its tasks
+        ;; running behind it and the body's cleanup ran against a live pool.
+        (cons "close" (lambda (self)
+          (let ((st (jhost-state self)))
+            (executor-shutdown! st)
+            (executor-await-termination st #f))
+          jolt-nil))
         (cons "isShutdown" (lambda (self) (vector-ref (jhost-state self) 0)))
         (cons "isTerminated" (lambda (self) (let ((st (jhost-state self)))
           (and (vector-ref st 0) (fx=? 0 (vector-ref st 10)) (fx=? 0 (vector-ref st 4))))))
         ;; (timeout, unit) on the JVM. The unit used to be dropped and the amount read
         ;; as milliseconds outright, so (.awaitTermination ex 5 TimeUnit/SECONDS)
         ;; waited five MILLISECONDS and reported the pool still running.
+        ;; A WAIT AND NOT A POLL (executor-await-termination above). This used to
+        ;; check under the mutex and sleep outside it in 10-100ms steps, because
+        ;; sleeping while HOLDING the mutex starves the worker exit it waits for. A
+        ;; condition wait releases the mutex atomically with blocking, so it needs
+        ;; neither the poll nor the care: the workers already broadcast term-cond as
+        ;; each one exits, and shutdown broadcasts it too. It also stops a fiber
+        ;; calling this from sleeping its carrier in 100ms chunks. term-cond and not
+        ;; task-cond: a wait that can belong to a FIBER must not sit on the
+        ;; condition the enqueue path signals one thread on.
         (cons "awaitTermination" (lambda (self ms . rest)
-          (let* ((st (jhost-state self))
-                 (deadline (+ (now-millis) (tu->ms ms (if (null? rest) #f (car rest))))))
-            ;; A WAIT AND NOT A POLL. This used to check under the mutex and sleep
-            ;; outside it in 10-100ms steps, because sleeping while HOLDING the mutex
-            ;; starves the worker exit it waits for. A condition wait releases the
-            ;; mutex atomically with blocking, so it needs neither the poll nor the
-            ;; care: the workers already broadcast term-cond as each one exits, and
-            ;; shutdown broadcasts it too. It also stops a fiber calling this from
-            ;; sleeping its carrier in 100ms chunks. term-cond and not task-cond: a
-            ;; wait that can belong to a FIBER must not sit on the condition the
-            ;; enqueue path signals one thread on.
-            (jolt-cv-wait-interruptibly "ExecutorService.awaitTermination"
-                                        (vector-ref st 2) (vector-ref st 11) deadline
-              (lambda (timed-out?)
-                (cond ((and (vector-ref st 0) (fx=? 0 (vector-ref st 4))) #t)
-                      (timed-out? #f)
-                      (else jolt-cv-again)))))))))
+          (executor-await-termination
+            (jhost-state self)
+            (+ (now-millis) (tu->ms ms (if (null? rest) #f (car rest)))))))))
 
 ;; --- ArrayBlockingQueue / FutureTask / ThreadPoolExecutor --------------------
 ;; The construction Grain's SQLite write coordinator does directly:

--- a/host/chez/locks.ss
+++ b/host/chez/locks.ss
@@ -352,6 +352,36 @@
   (let ((fs (jolt-cv-take-waiters! cv)))
     (unless (null? fs) (for-each sa-fiber-resume fs))))
 
+;; (jolt-cv-signal-one! cv) — wake exactly ONE thread waiting on cv, with mu held.
+;;
+;; The narrow counterpart of jolt-cv-wake!, for a condition that carries a QUEUE of
+;; interchangeable items to a crowd of interchangeable waiters: one item arrives,
+;; one waiter can take it, and any of them will do. The executor's task condition is
+;; that and is the only one in the runtime (java/concurrency.ss).
+;;
+;; The two preconditions, both of which that condition meets and neither of which
+;; the caller can be trusted to remember, so they are stated where the call is:
+;;
+;;   NO FIBER MAY WAIT ON cv. There is no fiber half here — a parked fiber lives in
+;;   a table this does not read, so signalling would leave it parked. The executor's
+;;   workers are threads, and jolt-condition-wait REFUSES on a fiber, so the pool
+;;   cannot acquire a fiber waiter by accident; the pool's other waiters (its
+;;   awaitTermination, which a fiber can reach) wait on a second condition of their
+;;   own and are woken with jolt-cv-wake!.
+;;
+;;   EVERY WAITER MUST WANT THE SAME THING. Broadcast is the default for the reason
+;;   given above — when the state is true for only one waiter, the waker cannot pick
+;;   which — and a signal here is right only because they are all waiting for "a
+;;   task, any task", so the one that wakes can always use what arrived.
+;;
+;; What it buys, measured on the pool it was written for: an enqueue used to
+;; broadcast, so a pool with 130 idle workers woke all 130 for one task, 129 of
+;; which took the queue mutex, found the task gone and parked again. Dispatching a
+;; no-op task cost 152us of that; signalling one took it to 8.9us, and the pool it
+;; needs for the same work from 134 threads to 7. Reference JVM Clojure dispatches
+;; the same task in 5.2us.
+(define (jolt-cv-signal-one! cv) (condition-signal cv))
+
 ;; Absolute epoch millis -> the absolute time object Chez's condition-wait wants.
 ;; Floored to an exact integer first: make-time will not take a flonum field, and a
 ;; deadline arriving as one is a caller's arithmetic, not something to trust.

--- a/stdlib/clojure/core/async/impl/dispatch.clj
+++ b/stdlib/clojure/core/async/impl/dispatch.clj
@@ -27,10 +27,11 @@
              not a pool because a flow process's task is its whole lifetime —
              pooling buys no reuse, while a bounded pool silently strands every
              process past the worker count.
-    :compute a pooled executor. Unlike the other two this runs one SHORT task per
+    :compute a cached pool. Unlike the other two this runs one SHORT task per
              message (flow futurizes a :compute step per call and waits on it), so
-             thread reuse is the whole point and bounded parallelism is right for
-             CPU-bound work."
+             thread reuse is the whole point: a stream of :compute calls is served
+             by the handful of workers that keep up with it, and a burst grows the
+             pool rather than queueing behind a fixed ceiling."
   (:require [clojure.core.async :as async])
   (:import [java.util.concurrent Executors Executor]))
 
@@ -48,8 +49,9 @@
     (execute [_ r]
       (.start (Thread. r (str "async-mixed-" (swap! thread-counter inc)))))))
 
-;; Lazy: constructing a pool forks its workers, and merely loading this namespace
-;; must not cost a thread.
+;; Lazy: a flow that never runs a :compute step never builds the pool. (A cached
+;; pool forks no worker until a task arrives, so this no longer costs a thread at
+;; load either way.)
 (def ^:private compute-executor (delay (Executors/newCachedThreadPool)))
 
 (defn executor-for

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1198,6 +1198,56 @@
   {:suite "threads" :expr "(let [ex (java.util.concurrent.Executors/newSingleThreadExecutor)] (.submit ex (fn [] (Thread/sleep 200))) (.shutdown ex) (.awaitTermination ex 10 java.util.concurrent.TimeUnit/SECONDS))" :expected "true"}
   ;; a bounded Future/get throws TimeoutException instead of waiting out the task
   {:suite "threads" :expr "(let [ex (java.util.concurrent.Executors/newSingleThreadExecutor) f (.submit ex (fn [] (Thread/sleep 30000)))] (try (.get f 50 java.util.concurrent.TimeUnit/MILLISECONDS) :no-throw (catch Throwable e :timeout)))" :expected ":timeout"}
+  ;; A CACHED POOL GROWS. These are the properties of Executors/newCachedThreadPool
+  ;; that a fixed pool of any size does not have, so each one is a size-independent
+  ;; statement rather than a count to update when a number changes.
+  ;;
+  ;; The first five expected values were read off reference JVM Clojure running the
+  ;; same expression, so those are conformance rows in substance. They live in the
+  ;; host unit file and not the corpus because they are timing-shaped — a corpus row
+  ;; is a value, and \"how many threads by now\" is not one. The last three are
+  ;; jolt's own: a fiber is not a JVM thing at all, the ThreadPoolExecutor row
+  ;; leaves out the queue argument the JVM ctor requires (jolt supplies its own
+  ;; unbounded one, and grows past core on the no-idle-worker test rather than on a
+  ;; full queue), and the fixed-pool row records the eager core threads.
+  ;;
+  ;; Nothing is forked until a task arrives, and max is the JVM's own
+  ;; Integer/MAX_VALUE.
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newCachedThreadPool)] [(.getPoolSize ex) (.getCorePoolSize ex) (.getMaximumPoolSize ex)])" :expected "[0 0 2147483647]"}
+  ;; 64 tasks that all block until the last one has started: a pool with any fixed
+  ;; ceiling below 64 never gets there, whatever the ceiling is.
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newCachedThreadPool) n 64 latch (java.util.concurrent.CountDownLatch. n) go (promise)] (dotimes [_ n] (.execute ex (fn [] (.countDown latch) (deref go 20000 :timeout)))) (let [started (.await latch 20 java.util.concurrent.TimeUnit/SECONDS) grown (.getPoolSize ex)] (deliver go true) (.shutdown ex) [started grown (.awaitTermination ex 20 java.util.concurrent.TimeUnit/SECONDS)]))" :expected "[true 64 true]"}
+  ;; The shape that used to deadlock: a task that submits a task and waits on it,
+  ;; 40 deep in parallel — 80 workers at once, which no 32-worker pool reaches.
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newCachedThreadPool) outer (mapv (fn [i] (.submit ex (fn [] (+ i (.get (.submit ex (fn [] 100))))))) (range 40))] (reduce + (map (fn [f] (.get f)) outer)))" :expected "4780"}
+  ;; and it is a POOL: 20 tasks submitted one at a time, each waited out before the
+  ;; next, are served by a worker or two rather than by 20 — the growth above is
+  ;; concurrency, not churn. Not exactly one, because a worker that has just
+  ;; finished a task may not be back at the queue when the next submit tests for an
+  ;; idle worker; reference Clojure answers 3 to this same expression, for the same
+  ;; race against its SynchronousQueue handoff.
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newCachedThreadPool)] (dotimes [_ 20] (.get (.submit ex (fn [] 1)))) (< (.getPoolSize ex) 5))" :expected "true"}
+  ;; A burst of 2000 short tasks: every one runs, the pool drains and terminates,
+  ;; and it is served by the workers that keep up with the burst rather than by one
+  ;; thread per task. The bound on the peak is deliberately loose — the growth test
+  ;; is \"no idle worker to take this task\", so how far the pool actually grows
+  ;; depends on how far the producer runs ahead of the workers, which is a property
+  ;; of the machine: 4 workers on an idle 8-core box, 136 pinned to one core (and
+  ;; 13 on reference Clojure, which grows on the same rule).
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newCachedThreadPool) c (atom 0) peak (atom 0)] (dotimes [_ 2000] (.execute ex (fn [] (swap! c inc))) (swap! peak max (.getPoolSize ex))) (.shutdown ex) [(.awaitTermination ex 30 java.util.concurrent.TimeUnit/SECONDS) @c (< @peak 1000)])" :expected "[true 2000 true]"}
+  ;; Growth reached from a FIBER: .execute on a fiber's carrier forks the new
+  ;; worker, and that worker must not inherit the fiber context — a worker that
+  ;; thought it was a fiber would refuse the condition wait it lives in. 20 fibers,
+  ;; each handing the pool a task and waiting on its promise.
+  {:suite "cached-pool" :expr "(do (require '[clojure.core.async :as a]) (let [ex (java.util.concurrent.Executors/newCachedThreadPool) out (a/chan 20)] (dotimes [i 20] (a/io-thread (let [p (promise)] (.execute ex (fn [] (deliver p i))) (a/>!! out (deref p 5000 :timeout))))) (= (set (repeatedly 20 (fn [] (a/<!! out)))) (set (range 20)))))" :expected "true"}
+  ;; A ThreadPoolExecutor's core, max and keepAlive all reach the pool: it grows to
+  ;; max on demand and retires the grown workers after keepAlive, keeping core.
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.ThreadPoolExecutor. 1 6 100 java.util.concurrent.TimeUnit/MILLISECONDS) latch (java.util.concurrent.CountDownLatch. 6) go (promise)] (dotimes [_ 6] (.execute ex (fn [] (.countDown latch) (deref go 20000 :timeout)))) (let [started (.await latch 20 java.util.concurrent.TimeUnit/SECONDS) grown (.getPoolSize ex)] (deliver go true) (Thread/sleep 1000) [started grown (.getPoolSize ex) (.getActiveCount ex)]))" :expected "[true 6 1 0]"}
+  ;; A fixed pool is still fixed: every worker eager, none retired, max = core.
+  ;; Eager is jolt's, and unchanged by the growth work: the JVM creates even core
+  ;; threads on demand, so getPoolSize there is 0 until the first task. Which is
+  ;; why this is a host unit case and not a corpus row.
+  {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 3)] (Thread/sleep 300) [(.getPoolSize ex) (.getCorePoolSize ex) (.getMaximumPoolSize ex)])" :expected "[3 3 3]"}
   {:suite "telemetry" :expr "(clojure.string/starts-with? (jolt.host/scheme-version) \"Chez Scheme\")" :expected "true"}
   {:suite "telemetry" :expr "(let [m (jolt.host/machine-type)] [(string? m) (pos? (count m))])" :expected "[true true]"}
   ;; bytes-allocated reads the LIVE heap, so it only has to grow across an

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1248,6 +1248,21 @@
   ;; threads on demand, so getPoolSize there is 0 until the first task. Which is
   ;; why this is a host unit case and not a corpus row.
   {:suite "cached-pool" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 3)] (Thread/sleep 300) [(.getPoolSize ex) (.getCorePoolSize ex) (.getMaximumPoolSize ex)])" :expected "[3 3 3]"}
+  ;; SHUTDOWN, the three spellings, each of which was quietly not doing what its
+  ;; name says. All four expected values are reference JVM Clojure's, read off the
+  ;; same expressions on Java 21.
+  ;;
+  ;; A submit after shutdown is REJECTED rather than queued-and-abandoned.
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newSingleThreadExecutor)] (.shutdown ex) (try (.submit ex (fn [] 1)) :no-throw (catch java.util.concurrent.RejectedExecutionException e :rejected)))" :expected ":rejected"}
+  ;; and so is an execute, catchable as the RuntimeException it is on the JVM
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newCachedThreadPool)] (.shutdown ex) (try (.execute ex (fn [] 1)) :no-throw (catch RuntimeException e :rejected)))" :expected ":rejected"}
+  ;; close BLOCKS until the work is done, which is what makes it usable as the
+  ;; closing half of with-open
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1) done (atom nil)] (.execute ex (fn [] (Thread/sleep 300) (reset! done :ran))) (.close ex) [@done (.isTerminated ex)])" :expected "[:ran true]"}
+  ;; shutdownNow DROPS what is queued and hands it back, instead of answering an
+  ;; empty list and running it all anyway. The first task is known to be running
+  ;; before the five are queued, so the count is not a race.
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1) started (promise) go (promise) ran (atom 0)] (.execute ex (fn [] (deliver started true) (deref go 5000 :timeout))) (deref started 5000 :timeout) (dotimes [_ 5] (.execute ex (fn [] (swap! ran inc)))) (let [returned (.shutdownNow ex)] (deliver go true) [(count returned) @ran (.awaitTermination ex 10 java.util.concurrent.TimeUnit/SECONDS)]))" :expected "[5 0 true]"}
   {:suite "telemetry" :expr "(clojure.string/starts-with? (jolt.host/scheme-version) \"Chez Scheme\")" :expected "true"}
   {:suite "telemetry" :expr "(let [m (jolt.host/machine-type)] [(string? m) (pos? (count m))])" :expected "[true true]"}
   ;; bytes-allocated reads the LIVE heap, so it only has to grow across an


### PR DESCRIPTION
Closes #819.

`Executors/newCachedThreadPool` was a fixed pool of 32 workers, so a burst wider
than 32 concurrent tasks queued behind the ones already running — invisible while
tasks are short, and a deadlock when they are not: 32 tasks blocking on the 33rd
never let it start, with no error and nothing in the code to suggest a ceiling.

The executor now has `ThreadPoolExecutor`'s shape — core workers, a max to grow to,
and a keep-alive after which an above-core worker retires. Growth is decided under
the queue mutex as `queue-depth > idle-workers`, which is the `SynchronousQueue`
handoff the JVM expresses through its queue type; the exit decision and the
live-count decrement happen under one hold, so an enqueue can never read a worker
as live after it has stopped taking work.

- **cached / virtual-thread-per-task**: `(0, Integer.MAX_VALUE, 60s)`, the JVM's own
  numbers. Nothing forked until a task arrives.
- **fixed / single-thread**: unchanged — core = max, eager, never retired (the
  single-thread pool's submission order depends on exactly one worker, forever).
- **work-stealing**: still fixed, a `ForkJoinPool` being core-count-bounded there too.
- **`ThreadPoolExecutor.`**: core, max and keepAlive all reach the pool now; the ctor
  used to size a fixed pool by max and discard the keep-alive.
- **new**: `.getPoolSize`, `.getActiveCount`, `.getCorePoolSize`, `.getMaximumPoolSize`,
  so the growth and the retirement are observable rather than inferred.

## Latent issues this turned up, and fixed

**An enqueue woke every worker, not one.** Workers and `awaitTermination` shared one
condition, so each task broadcast to all waiters: with 130 idle workers, one task woke
130, and 129 took the mutex, found nothing and re-parked. It also fed the growth rule,
so a 200k burst reached 134 threads and 131MB. Task and termination now have a
condition each and an enqueue signals exactly one parked worker (`jolt-cv-signal-one!`,
with its two preconditions written into `locks.ss`). The broadcast predates this branch,
so this is a 3x improvement on 0.8.0 as well as a 17x one on the growing pool.

**The three spellings of shutdown did not do what they say** — each verified against
reference JVM Clojure on Java 21 before changing anything:

- a `submit`/`execute` after shutdown was queued and abandoned (its `.get` waits
  forever); now `RejectedExecutionException`, decided under the queue mutex so a task
  that beats the flag still runs;
- `shutdownNow` answered an empty vector and ran the queue anyway — the method that
  exists to say "do not run the rest" ran the rest; now drops the queued tasks and
  returns them (callable, like the JVM's Runnables). Interrupting *running* tasks is
  still missing and is marked in the source;
- `close` returned the moment the flag was set, so `(with-open [ex …] …)` left its
  tasks running; now blocks until terminated, as the JVM's has since 19.

A worker that dies for any reason other than its task throwing also no longer leaks
its slot, which would have hung `awaitTermination` on a finished pool.

## Measured

200k no-op tasks through `.execute`, same box, against reference Clojure on Java 21:

| | jolt | JVM |
|---|---|---|
| cached pool | 8.9 µs/task (peak 7 threads) | 5.2 µs (peak 8) |
| 4 producers, one pool | 11 µs/task | 2.2 µs |
| single-thread pool | 4.3 µs | 9.1 µs |
| submit + get round trip | 12 µs | 7.2 µs |
| 256 threads created | 21 ms | 22 ms |

and for the pool itself: 152 µs/task and 134 threads before the wake fix, 26.5 µs and
32 threads on 0.8.0. What is left between jolt and the JVM is one mutex and one
park/unpark per handoff where a `SynchronousQueue` transfers without either.

A `bench/executors` row is added so this is watched: nothing in the suite measured
dispatch, and the 17x regression above passed every correctness gate.

## Tests

Twelve new unit rows (`cached-pool`, `executor-shutdown`); nine of them render exactly
what reference JVM Clojure renders for the same expression. The rest are jolt's own
(a fiber reaching the growth path; the `ThreadPoolExecutor` arity the JVM ctor does not
have; the eager core threads).

Gates: `unit`, `flow`, `smoke` (192/0), `corpus` (0 new divergences), `documented`,
`threadsafety`, `fibers`, `gosm`, `asynctimer`, `interruptnest`, `sci`, `cts` (matches
baseline), `lockcheck`, `parkcheck`.

## Known follow-ups

- `ArrayBlockingQueue` put/take is 8.5 µs against the JVM's 0.39 µs. The cost is
  `jolt-cv-wake!` taking a global mutex and hashtable on every operation to check for
  parked fibers; a fast path there touches every wake in the runtime and wants its own
  issue.
- `shutdownNow` cannot interrupt running tasks — the workers carry no interrupt flag.
- Multi-producer contention needs queue striping or per-worker handoff slots.