### PR TITLE
Executor follow-ups: interop dispatch, shutdownNow interrupts, and pool growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **A cached pool grows on a handoff that failed, not on a queue that is deep.**
+  The JVM's rule is that a cached pool starts a thread when offering the task to a
+  `SynchronousQueue` fails, and it fails only when no worker is at the handoff point
+  to take it. jolt has an asynchronous queue, so the same test written directly — is
+  the depth above the idle count — says yes in a case the JVM's never sees: a worker
+  that is *running*, or that is queued behind the producer on the very mutex the
+  producer holds, is a worker about to take the task, and counts as idle in neither.
+  A producer in a tight loop wins that mutex race most of the time, so the pool grew
+  threads which then contended for the same mutex and slowed the workers down
+  further.
+
+  Making the dispatcher above 2.4x faster made this visible by making the producer
+  faster: the same 200k no-op burst went from 7 workers to 25-37 and from 8.9µs a
+  task to 10.6µs, while one worker ran the identical tasks at 1.8µs. The pool was
+  paying for threads that were in its way.
+
+  The decision is now made the way the JVM makes it — **offer first**. When the
+  depth test says grow, the enqueue drops the mutex, yields, and asks again: a worker
+  that was one acquisition away from the task now has it and there is nothing to grow
+  for, while a pool whose workers are all blocked still has the task sitting there
+  and grows. The yield is paid only on the path that was about to fork a thread for
+  ~80µs, and a pool at its maximum (every fixed pool, always) skips the whole thing.
+
+  | 200k tasks through `.execute` | before | after | JVM |
+  |---|---|---|---|
+  | single-thread pool | 4.3 µs | **1.7 µs** | 9.1 µs |
+  | fixed pool of 4 | 7.3 µs | **5.8 µs** | 2.8 µs |
+  | four producers, one cached pool | 11.0 µs | **9.5 µs** | 2.2 µs |
+  | submit + get round trip | 15.8 µs | **9.8 µs** | 7.2 µs |
+  | cached pool | 8.9 µs (7 threads) | 9.0 µs (11-13) | 5.2 µs (8) |
+
+  The 64-blocking-task row still reaches exactly 64 workers, which is the property
+  this rule exists to keep: growth answers a pool that cannot make progress, and
+  declines a pool that is merely busy.
+
 - **A `.method` call on a host object stops walking the whole dispatch chain
   first.** The `.method` dispatcher resolves a call by trying an ordered list of
   arms, and the arm that answers for a host shim — a queue, a stream, a socket, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **A `.method` call on a host object stops walking the whole dispatch chain
+  first.** The `.method` dispatcher resolves a call by trying an ordered list of
+  arms, and the arm that answers for a host shim — a queue, a stream, a socket, an
+  executor, a `Path`, anything with a `jhost` method table — is the LAST one. So
+  every interop call on one of those was resolved by calling nine arms above it and
+  being told "not mine" nine times, before the two hashtable lookups that had the
+  answer all along.
+
+  That is 316ns of the 492ns a call took, measured on a shim method whose whole
+  body is one `vector-ref`, and every host object in the runtime paid it:
+
+  | | before | after |
+  |---|---|---|
+  | `.size` on an `ArrayBlockingQueue` (dispatch and nothing else) | 492 ns | **198 ns** |
+  | `.peek` (dispatch + the queue's mutex) | 603 ns | 287 ns |
+  | `.offer`+`.poll` | 1852 ns | 935 ns |
+  | `.put`+`.take` | 2011 ns | 1204 ns |
+
+  A shortcut ahead of the chain answers exactly what the bottom arm would have
+  answered for a table HIT, and 'pass for everything else, so the chain still
+  decides every other case in the same order it did. It is armed once every
+  built-in arm has registered and **stands down by itself** if that ever changes:
+  the baseline is the number of arms below the jhost tier at arming time, so a user
+  override (`jolt.host/extend-class!`) or any arm a library adds below that tier
+  puts every call back on the full chain — which is the only way an arm written to
+  intercept a host object keeps intercepting it. `.getClass` (the universal arm
+  owns it) and `java.nio.file.Path` (the one tag whose methods live in an arm
+  above rather than in a table, and which says so out loud now) are excluded.
+
+  This is why an `ArrayBlockingQueue` looked 22x slower than the JVM's: the queue
+  was not the problem, the road to it was.
+
 - **An executor enqueue wakes one worker, not all of them (#819).** The pool's
   workers and its `awaitTermination` waited on ONE condition, so every enqueue
   broadcast to every waiter: with 130 idle workers, one task woke all 130, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,9 +257,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     rest" ran the rest: a caller shutting a pool down hard because its work had
     become irrelevant got every queued task executed anyway, and an empty list
     claiming nothing had been pending. The returned procedures are callable, so a
-    caller can still run one itself, as `.run` lets them on the JVM. What jolt still
-    cannot do is the other half — interrupting the tasks already RUNNING, which
-    needs the workers to carry an interrupt flag a shutdown can set.
+    caller can still run one itself, as `.run` lets them on the JVM.
+  - **`shutdownNow` also interrupts the tasks already running.** Every worker now
+    carries an interrupt flag — the same box its `(Thread/currentThread)` hands out,
+    so the two spellings are one flag — and `shutdownNow` sets them all and pokes
+    the waits, so a task parked in `Thread/sleep`, a channel op, a blocking queue or
+    a `Future.get` is thrown out with `InterruptedException` exactly where the JVM
+    throws one. Plain `shutdown` still interrupts nothing, and a worker's flag is
+    cleared before it takes its next task, so an interrupt aimed at one task cannot
+    land on the next (both checked against reference Clojure). A task in a
+    computation the runtime cannot see — a tight loop, a blocking FFI call — still
+    runs to the end; the JVM's interrupt is no different.
   - **`close` blocks until the pool has terminated**, as the JVM's has since 19.
     It used to return the moment the flag was set, so the one spelling of shutdown
     that promises the work is finished when it returns was the one that did not

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1850,6 +1850,38 @@
   (jolt-throw (jolt-host-throwable
                "java.util.concurrent.RejectedExecutionException"
                "task rejected from executor: it is shut down")))
+;; GROWING ON A HANDOFF THAT FAILED, which is the JVM's rule and not the one a
+;; queue-depth test gives you on its own.
+;;
+;; A cached pool grows there when offering the task to a SynchronousQueue fails,
+;; and it fails only when no worker is at the handoff point to take it. jolt has an
+;; asynchronous queue, so the same test written directly — is the depth above the
+;; idle count — answers yes in a case the JVM's never sees: a worker that is
+;; running, or is queued behind the producer on this very mutex, is a worker about
+;; to take the task, and it counts as idle in neither. A producer in a tight loop
+;; wins that mutex race most of the time, so the depth outruns the idle count for
+;; reasons that have nothing to do with the pool being short of workers, and the
+;; pool grows threads which then contend for the same mutex and slow the workers
+;; down further — the feedback the wake fix removed one source of, arriving by
+;; another road.
+;;
+;; Measured, once the dispatch shortcut made the producer 2.4x faster and made it
+;; worse: 200k no-op tasks peaked at 25-37 workers and cost 10.6us each, against 7
+;; workers and 8.9us before the producer sped up. A single-worker pool ran the same
+;; tasks at 1.8us. The pool was paying for threads that were in its way.
+;;
+;; So the decision is made the way the JVM makes it: OFFER FIRST. When the depth
+;; test says grow, the enqueue drops the mutex, yields the CPU to whoever wants it,
+;; and asks again. A worker that was one mutex acquisition away from this task now
+;; has it, and there is nothing to grow for; a pool whose workers are all blocked
+;; still has the task sitting there, and grows. The yield costs a syscall on the
+;; path that was about to fork a thread for ~80us, and nothing at all on the path
+;; that was not.
+(define (executor-grow? st)
+  (jolt-with-mutex (vector-ref st 2)
+    (and (not (vector-ref st 0))
+         (fx>? (vector-ref st 10) (vector-ref st 9))
+         (executor-claim-worker! st))))
 (define (executor-enqueue! self job)
   (let* ((st (jhost-state self))
          (action (jolt-with-mutex (vector-ref st 2)
@@ -1866,16 +1898,24 @@
                       ;; miss.
                       (when (fx>? (vector-ref st 9) 0)
                         (jolt-cv-signal-one! (vector-ref st 3)))
-                      ;; Grow if this task has no idle worker waiting to take it.
-                      (if (and (fx>? (vector-ref st 10) (vector-ref st 9))
-                               (executor-claim-worker! st))
-                          'spawn
+                      ;; No idle worker waiting to take this task — which is a
+                      ;; reason to grow only if it is still true once the workers
+                      ;; have had their turn at the mutex, and only if there is
+                      ;; room to grow at all. A pool at its maximum (every fixed
+                      ;; pool, always) must not pay the yield to be told what its
+                      ;; own size already says: that check costs a fixed pool
+                      ;; nothing and it was costing it 0.9us a task without it.
+                      (if (and (fx<? (vector-ref st 4) (vector-ref st 7))
+                               (fx>? (vector-ref st 10) (vector-ref st 9)))
+                          'offer
                           #f))))))
-    ;; Both of these happen with the mutex RELEASED: a fork takes ~80us and the
-    ;; queue cannot be shut for that long, and a throw has no business unwinding
-    ;; through a lock region it does not need to hold.
+    ;; All of these happen with the mutex RELEASED: a fork takes ~80us and the
+    ;; queue cannot be shut for that long, a yield holding it would hand the CPU on
+    ;; while keeping the workers out, and a throw has no business unwinding through
+    ;; a lock region it does not need to hold.
     (case action
-      ((spawn) (executor-spawn-worker! st))
+      ((offer) (thread-yield!)
+               (when (executor-grow? st) (executor-spawn-worker! st)))
       ((reject) (executor-reject-task! st))
       (else (void)))))
 (let ((single (lambda _ (make-executor 1)))

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -1561,9 +1561,11 @@
         (cons "cancel" (lambda (self . _) #f))))
 ;; executor-service state: #(shutdown? queue-box queue-mutex task-cond
 ;; live-workers advisory-queue-capacity core-workers max-workers keep-alive-ms
-;; idle-workers queue-depth term-cond) — the capacity is #f except for a
-;; ThreadPoolExecutor built with an ArrayBlockingQueue; .getQueue's view subtracts
-;; the live depth from it.
+;; idle-workers queue-depth term-cond worker-interrupt-boxes) — the capacity is #f
+;; except for a ThreadPoolExecutor built with an ArrayBlockingQueue; .getQueue's
+;; view subtracts the live depth from it. The last slot is one interrupt flag per
+;; live worker, which is what lets shutdownNow reach a task that is already
+;; running (see executor-shutdown-now!).
 ;;
 ;; TWO CONDITIONS, one mutex. task-cond carries "a task is queued, or the pool is
 ;; shutting down" to the WORKERS, which are threads; term-cond carries "shut down
@@ -1620,7 +1622,7 @@
 (define (make-executor* core-n max-n keep-alive-ms cap)
   (let ((self (make-jhost "executor-service"
                           (vector #f (box (cons '() '())) (make-mutex) (make-condition) 0
-                                  cap core-n max-n keep-alive-ms 0 0 (make-condition)))))
+                                  cap core-n max-n keep-alive-ms 0 0 (make-condition) '()))))
     (let ((st (jhost-state self)))
       ;; The core workers, eagerly. Above core, a worker appears when a task
       ;; arrives with nobody idle to take it, and not before: a cached pool that
@@ -1656,14 +1658,25 @@
 ;; never run is a failure the caller has to see (the JVM's own answer to a thread
 ;; it cannot create is to reject the task, not to queue it silently).
 (define (executor-spawn-worker! st)
-  (guard (e (#t (let ((none-left? (jolt-with-mutex (vector-ref st 2)
-                                    (vector-set! st 4 (fx- (vector-ref st 4) 1))
-                                    (jolt-cv-wake! (vector-ref st 11))
-                                    (fx=? 0 (vector-ref st 4)))))
-                  (when none-left? (raise e)))))
-    (fork-thread (lambda ()
-      (*txn* #f)      ; worker must not inherit the creating thread's txn
-      (executor-worker-loop st)))))
+  ;; The worker's interrupt flag, made and REGISTERED here rather than by the
+  ;; thread itself: a shutdownNow landing between the claim and the new thread's
+  ;; first instruction has to find this worker, and a flag the worker allocates on
+  ;; arrival is not there to be found. It is the same box the worker adopts as its
+  ;; own, so a task's (Thread/currentThread) .isInterrupted and the pool's shutdown
+  ;; are ONE flag — the shape future-call and Thread.start already use.
+  (let ((ibox (box #f)))
+    (jolt-with-mutex (vector-ref st 2)
+      (vector-set! st 12 (cons ibox (vector-ref st 12))))
+    (guard (e (#t (let ((none-left? (jolt-with-mutex (vector-ref st 2)
+                                      (vector-set! st 12 (remq ibox (vector-ref st 12)))
+                                      (vector-set! st 4 (fx- (vector-ref st 4) 1))
+                                      (jolt-cv-wake! (vector-ref st 11))
+                                      (fx=? 0 (vector-ref st 4)))))
+                    (when none-left? (raise e)))))
+      (fork-thread (lambda ()
+        (*txn* #f)      ; worker must not inherit the creating thread's txn
+        (adopt-interrupt-box! ibox)
+        (executor-worker-loop st ibox))))))
 
 ;; Dequeue, with the mutex held. Callers test queue-depth first.
 (define (executor-dequeue! st)
@@ -1699,7 +1712,8 @@
 ;; decrementing under one hold makes the two orders the only two: an enqueue
 ;; before it sees this worker idle and waiting (and needs no new one, because the
 ;; wake sends it back to the queue), one after sees the count without it.
-(define (executor-worker-exit! st)
+(define (executor-worker-exit! st ibox)
+  (vector-set! st 12 (remq ibox (vector-ref st 12)))
   (vector-set! st 4 (fx- (vector-ref st 4) 1))
   ;; Announced on term-cond only, and only to a waiter that can care: what
   ;; awaitTermination waits for is live 0 with the pool shut down, so a keep-alive
@@ -1716,14 +1730,19 @@
 ;; woke every idle worker for one task resumes the losers waiting for what is LEFT
 ;; of their keep-alive rather than restarting it — the same reason Thread.join and
 ;; the waits above carry deadlines rather than durations.
-(define (executor-take-job! st)
+(define (executor-take-job! st ibox)
   (let poll ((deadline #f))
-    (cond ((fx>? (vector-ref st 10) 0) (executor-dequeue! st))
-          ((vector-ref st 0) (executor-worker-exit! st))   ; shutdown + drained
+    (cond ((fx>? (vector-ref st 10) 0)
+           ;; Taking a task CLEARS the flag, unless the pool is stopping: an
+           ;; interrupt aimed at the last task is not for this one, and the JVM's
+           ;; runWorker clears it at the same point and for the same reason.
+           (set-box! ibox #f)
+           (executor-dequeue! st))
+          ((vector-ref st 0) (executor-worker-exit! st ibox))   ; shutdown + drained
           ((and (vector-ref st 8) (fx>? (vector-ref st 4) (vector-ref st 6)))
            (let ((dl (or deadline (+ (now-millis) (vector-ref st 8)))))
              (if (>= (now-millis) dl)
-                 (executor-worker-exit! st)                ; idle past keep-alive
+                 (executor-worker-exit! st ibox)               ; idle past keep-alive
                  (begin (executor-idle-wait! st (jolt-millis->time dl))
                         (poll dl)))))
           (else (executor-idle-wait! st #f) (poll deadline)))))
@@ -1737,13 +1756,13 @@
 ;; worker for free, because a live count below max with a task waiting is exactly
 ;; what the growth rule starts one on (the JVM replaces an abruptly-dead worker
 ;; too, for the same reason).
-(define (executor-worker-loop st)
-  (guard (e (#t (jolt-with-mutex (vector-ref st 2) (executor-worker-exit! st))
+(define (executor-worker-loop st ibox)
+  (guard (e (#t (jolt-with-mutex (vector-ref st 2) (executor-worker-exit! st ibox))
                 (guard (_ (#t #f))
                   (display "Exception in executor worker:\n" (current-error-port))
                   (jolt-report-throwable e (current-error-port)))))
     (let loop ()
-      (let ((job (jolt-with-mutex (vector-ref st 2) (executor-take-job! st))))
+      (let ((job (jolt-with-mutex (vector-ref st 2) (executor-take-job! st ibox))))
         (when job (job) (loop))))))
 
 ;; shutdown: stop accepting, let what is queued drain.
@@ -1767,11 +1786,24 @@
 ;; returned rather than discarded: the returned procedures are callable, and calling
 ;; one runs that task on the caller's thread, the same recovery .run gives there.
 ;;
-;; What jolt CANNOT do is the other half of shutdownNow, interrupting the tasks
-;; already running: the workers do not carry an interrupt flag for a shutdown to
-;; set, so a task in Thread/sleep or a blocking read keeps going. The JVM
-;; interrupts those threads. Tracked; a worker would have to adopt an interrupt box
-;; the way Thread.start does.
+;; The other half of shutdownNow is INTERRUPTING the tasks already running, and it
+;; does that too: every live worker carries an interrupt flag (executor-spawn-worker!
+;; above), so a task parked in Thread/sleep, a channel op, a blocking queue or a
+;; Future.get is thrown out of it with InterruptedException, exactly as the JVM
+;; throws one there. The flag first and the poke second, which is the order every
+;; interrupt in this runtime uses: the flag is what a woken waiter reads, and a wake
+;; that arrives before it is set says nothing.
+;;
+;; A task in a computation the runtime cannot see — a tight loop, a blocking FFI
+;; call — still runs to the end. The JVM's interrupt is no different: it unblocks
+;; the waits it knows about and sets a flag for everything else to notice.
+(define (executor-interrupt-workers! st)
+  (let ((boxes (jolt-with-mutex (vector-ref st 2) (vector-ref st 12))))
+    (for-each (lambda (b) (set-box! b #t)) boxes)
+    ;; poked OUTSIDE the queue mutex: waking a wait takes the waiter's own mutex,
+    ;; and a task blocked on something that wants this pool's mutex would deadlock
+    ;; against a poke that held it.
+    (for-each jolt-interrupt-wake-waits! boxes)))
 (define (executor-drain-queue! st)
   (let* ((q (unbox (vector-ref st 1)))
          (jobs (append (car q) (reverse (cdr q)))))
@@ -1786,6 +1818,7 @@
                      (jolt-cv-wake! (vector-ref st 3))
                      (jolt-cv-wake! (vector-ref st 11))
                      jobs))))
+    (executor-interrupt-workers! st)
     (apply jolt-vector dropped)))
 
 ;; The wait awaitTermination and close share. DEADLINE #f waits for as long as it

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -160,6 +160,35 @@
        (list->cseq (if asc keep (reverse keep)))))
     (else (dispatch-miss obj method rest))))
 
+;; Tags an arm ABOVE the jhost tier claims for itself. Only java.nio.file's Path is
+;; one today (nio-path? is a jhost with that tag, and its arm sits at 42), and it
+;; has no method table of its own, so the shortcut below would already miss it —
+;; this says so out loud instead, because the day someone gives that tag a table is
+;; the day a silent shortcut would take the arm's methods away from it.
+(define jhost-early-arm-tags (make-hashtable string-hash string=?))
+(define (register-early-arm-tag! tag) (hashtable-set! jhost-early-arm-tags tag #t))
+
+;; The shortcut record-method-dispatch arms itself with (records-dispatch.ss, where
+;; the conditions it is sound under are written out). It answers exactly what the
+;; arm below answers for a table HIT and nothing else: a miss, a tag some arm above
+;; claims, or .getClass — which the universal getclass arm owns, and which one
+;; table (java.lang.Class's own) also defines — all say 'pass and take the chain.
+;; The two guards are tested AFTER the table hit, not before it: a miss has to walk
+;; the chain either way, and the tags an arm above claims have no table at all, so
+;; ordering it this way keeps the common call down to the two lookups the arm below
+;; would have done anyway.
+(define (jhost-table-fast-arm obj method-name rest-args)
+  (if (jhost? obj)
+      (let* ((tag (jhost-tag obj))
+             (mh (hashtable-ref host-methods-tbl tag #f))
+             (f (and mh (hashtable-ref mh method-name #f))))
+        (if (and f
+                 (not (string=? method-name "getClass"))
+                 (not (hashtable-ref jhost-early-arm-tags tag #f)))
+            (apply f obj (if (jolt-nil? rest-args) '() (seq->list rest-args)))
+            'pass))
+      'pass))
+
 (register-method-arm! arm-priority-host-type
   (lambda (obj method-name rest-args)
     (cond

--- a/host/chez/java/nio-file.ss
+++ b/host/chez/java/nio-file.ss
@@ -237,6 +237,9 @@
   (register-class-statics! "java.nio.file.FileSystems" fs-statics))
 
 ;; nio-path method dispatch (priority above the jfile arm).
+;; A Path is a jhost, so it is the one tag whose methods live above the jhost tier
+;; rather than in a method table. Declared, so the jhost shortcut leaves it alone.
+(register-early-arm-tag! "nio-path")
 (register-method-arm! arm-priority-nio-path
   (lambda (obj method-name rest-args)
     (if (nio-path? obj)

--- a/host/chez/records-dispatch.ss
+++ b/host/chez/records-dispatch.ss
@@ -331,7 +331,13 @@
 ;; string/keyword/symbol/Object-method surface). A host shim / library registers
 ;; an arm with register-method-arm! instead of set!-wrapping the dispatcher.
 (define method-dispatch-arms '())   ; list of (priority . arm), ascending priority
+;; How many arms sit BELOW the jhost tier. The fast path at the bottom of this
+;; file is only sound while that number is the one it was installed against — see
+;; install-jhost-fast-arm!.
+(define method-arms-below-host-type 0)
 (define (register-method-arm! priority arm)
+  (when (< priority arm-priority-host-type)
+    (set! method-arms-below-host-type (fx+ method-arms-below-host-type 1)))
   (set! method-dispatch-arms
     (let ins ((as method-dispatch-arms))
       (cond ((null? as) (list (cons priority arm)))
@@ -356,12 +362,45 @@
 (define arm-priority-nio-path 42)     ; java.nio.file.Path methods (above jfile)
 (define arm-priority-htable 43)       ; tagged htable method registry
 (define arm-priority-host-type 44)    ; jhost/number/string per-type dispatch
+;; THE JHOST SHORTCUT. A .method call on a host shim — a queue, a stream, a socket,
+;; an executor, a Path — is resolved by the arm at the BOTTOM of the chain, so it
+;; used to be found by calling every arm above it first and being told 'pass nine
+;; times. That cost 316ns of the 492ns an interop call took, measured on a shim
+;; method whose whole body is one vector-ref, and it is paid by every host object
+;; in the runtime: an ArrayBlockingQueue put+take pair went from 2011ns to 974ns
+;; with it removed.
+;;
+;; The shortcut answers only what the bottom arm would have answered identically —
+;; a receiver that is a jhost, a method its own tag's table defines, and nothing
+;; above claiming it — so the chain still decides everything else, in order.
+;; jolt-nil-safe: it returns 'pass for a miss, never #f, because #f is a legal
+;; RESULT and a miss that read as one would run the method twice.
+;;
+;; INSTALLED, not compiled in, and self-disabling. It lives in java/host-static.ss
+;; (which owns the tables) and is armed once every built-in arm has registered;
+;; the baseline is the number of arms below the jhost tier at that moment, and the
+;; shortcut steps aside the moment that number changes. So a user override
+;; (jolt.host/extend-class!, priority 1, registered lazily) or any arm a library
+;; adds below the tier puts every call back on the full chain, which is the only
+;; way an arm that was written to intercept a jhost keeps intercepting it.
+(define jhost-fast-arm #f)
+(define jhost-fast-arm-baseline -1)
+(define (install-jhost-fast-arm! f)
+  (set! jhost-fast-arm f)
+  (set! jhost-fast-arm-baseline method-arms-below-host-type))
+
 (define (record-method-dispatch obj method-name rest-args)
-  (let loop ((as method-dispatch-arms))
-    (if (null? as)
-        (record-method-dispatch-base obj method-name rest-args)
-        (let ((r ((cdar as) obj method-name rest-args)))
-          (if (eq? r 'pass) (loop (cdr as)) r)))))
+  (let ((r (if (and jhost-fast-arm
+                    (fx=? method-arms-below-host-type jhost-fast-arm-baseline))
+               (jhost-fast-arm obj method-name rest-args)
+               'pass)))
+    (if (eq? r 'pass)
+        (let loop ((as method-dispatch-arms))
+          (if (null? as)
+              (record-method-dispatch-base obj method-name rest-args)
+              (let ((r ((cdar as) obj method-name rest-args)))
+                (if (eq? r 'pass) (loop (cdr as)) r))))
+        r)))
 
 ;; Strings are the most common interop receiver in library code (honeysql's
 ;; format path alone is .charAt/.length/.indexOf/.toString per entity), and the

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -1678,6 +1678,14 @@
 ;; a lookup resolves against is the final one.
 (load "host/chez/java/class-extensions.ss")
 
+;; Arm the jhost shortcut in the .method dispatcher, now that every built-in arm
+;; has registered. It captures the arm count below the jhost tier as its baseline
+;; and stands down whenever that changes, so this has to run after the LAST
+;; built-in registration and before any library one — which is here: the seam that
+;; lets a library add an arm (class-extensions.ss, and jolt.host/extend-class!
+;; through it) is loaded above and registers nothing until it is called.
+(install-jhost-fast-arm! jhost-table-fast-arm)
+
 ;; Native stack traces: jv$ns$name -> source registry + continuation frame walk +
 ;; uncaught-throwable renderer. After the printers/equality it relies on.
 (load "host/chez/source-registry.ss")

--- a/host/gambit/records-gambit.ss
+++ b/host/gambit/records-gambit.ss
@@ -2231,7 +2231,12 @@
 
 (define method-dispatch-arms '())
 
+(define method-arms-below-host-type 0)
+
 (define (register-method-arm! priority arm)
+  (when (< priority arm-priority-host-type)
+    (set! method-arms-below-host-type
+      (fx+ method-arms-below-host-type 1)))
   (set! method-dispatch-arms
     (let ins ((as method-dispatch-arms))
       (cond
@@ -2259,12 +2264,28 @@
 
 (define arm-priority-host-type 44)
 
+(define jhost-fast-arm #f)
+
+(define jhost-fast-arm-baseline -1)
+
+(define (install-jhost-fast-arm! f)
+  (set! jhost-fast-arm f)
+  (set! jhost-fast-arm-baseline method-arms-below-host-type))
+
 (define (record-method-dispatch obj method-name rest-args)
-  (let loop ((as method-dispatch-arms))
-    (if (null? as)
-        (record-method-dispatch-base obj method-name rest-args)
-        (let ((r ((cdar as) obj method-name rest-args)))
-          (if (eq? r 'pass) (loop (cdr as)) r)))))
+  (let ((r (if (and jhost-fast-arm
+                    (fx=?
+                      method-arms-below-host-type
+                      jhost-fast-arm-baseline))
+               (jhost-fast-arm obj method-name rest-args)
+               'pass)))
+    (if (eq? r 'pass)
+        (let loop ((as method-dispatch-arms))
+          (if (null? as)
+              (record-method-dispatch-base obj method-name rest-args)
+              (let ((r ((cdar as) obj method-name rest-args)))
+                (if (eq? r 'pass) (loop (cdr as)) r))))
+        r)))
 
 (register-method-arm!
   arm-priority-string

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1259,6 +1259,18 @@
   ;; close BLOCKS until the work is done, which is what makes it usable as the
   ;; closing half of with-open
   {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1) done (atom nil)] (.execute ex (fn [] (Thread/sleep 300) (reset! done :ran))) (.close ex) [@done (.isTerminated ex)])" :expected "[:ran true]"}
+  ;; shutdownNow INTERRUPTS the tasks already running: a task parked in
+  ;; Thread/sleep (or a channel op, or a blocking queue) is thrown out of it with
+  ;; InterruptedException, which is what makes the method a hard stop rather than a
+  ;; polite one. Reference Clojure answers exactly this.
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1) started (promise) out (promise)] (.execute ex (fn [] (deliver started true) (deliver out (try (Thread/sleep 30000) :slept (catch InterruptedException e :interrupted))))) (deref started 5000 :timeout) (Thread/sleep 100) (.shutdownNow ex) [(deref out 5000 :timeout) (.awaitTermination ex 10 java.util.concurrent.TimeUnit/SECONDS)])" :expected "[:interrupted true]"}
+  ;; and plain shutdown does NOT — a running task is left to finish
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1) started (promise) out (promise)] (.execute ex (fn [] (deliver started true) (deliver out (try (Thread/sleep 400) :slept (catch InterruptedException e :interrupted))))) (deref started 5000 :timeout) (.shutdown ex) [(deref out 5000 :timeout) (.awaitTermination ex 10 java.util.concurrent.TimeUnit/SECONDS)])" :expected "[:slept true]"}
+  ;; the interrupt reaches a submitted task's Future as the cause, like any throw
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1) started (promise) f (.submit ex (fn [] (deliver started true) (Thread/sleep 30000) :slept))] (deref started 5000 :timeout) (Thread/sleep 100) (.shutdownNow ex) (try (.get f 5000 java.util.concurrent.TimeUnit/MILLISECONDS) :no-throw (catch java.util.concurrent.ExecutionException e (.getSimpleName (class (ex-cause e))))))" :expected "\"InterruptedException\""}
+  ;; and a worker's flag does not leak from one task to the next: a task that
+  ;; interrupts itself does not hand the interrupt to whoever runs there next
+  {:suite "executor-shutdown" :expr "(let [ex (java.util.concurrent.Executors/newFixedThreadPool 1)] (.get (.submit ex (fn [] (.interrupt (Thread/currentThread)) :self))) (let [r (.get (.submit ex (fn [] (Thread/interrupted))))] (.shutdownNow ex) r))" :expected "false"}
   ;; shutdownNow DROPS what is queued and hands it back, instead of answering an
   ;; empty list and running it all anyway. The first task is known to be running
   ;; before the five are queued, so the count is not a race.

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -1102,6 +1102,14 @@
   {:suite "class-extensions" :expr "(do (jolt.host/extend-class! \"java.io.File\" {:methods {\"shout\" (fn [self] (.toUpperCase (.getPath self)))}}) (.shout (java.io.File. \"a/b\")))" :expected "\"A/B\""}
   ;; the default tier only fills gaps — it cannot take a method the shim answers
   {:suite "class-extensions" :expr "(do (jolt.host/extend-class! \"java.io.File\" {:methods {\"getPath\" (fn [self] \"hijacked\")}}) (.getPath (java.io.File. \"a/b\")))" :expected "\"a/b\""}
+  ;; A HOST SHIM's method table is answered by a shortcut ahead of the arm chain
+  ;; (records-dispatch.ss), and that shortcut has to stand down the moment an
+  ;; override arm exists — or an :override would silently stop overriding the whole
+  ;; jhost surface. Registering one here disarms it for the rest of this process,
+  ;; which is the point: the row after this one still reads a table method, through
+  ;; the full chain. remainingCapacity, because nothing else in this file calls it.
+  {:suite "class-extensions" :expr "(let [q (java.util.concurrent.ArrayBlockingQueue. 4)] (.put q 1) (let [before (.remainingCapacity q)] (jolt.host/extend-class! \"java.util.concurrent.ArrayBlockingQueue\" {:methods {\"remainingCapacity\" (fn [_] :overridden)} :override true}) [before (.remainingCapacity q)]))" :expected "[3 :overridden]"}
+  {:suite "class-extensions" :expr "(let [q (java.util.concurrent.ArrayBlockingQueue. 4)] (.put q :a) (.put q :b) [(.size q) (.take q) (.peek q)])" :expected "[2 :a :b]"}
   ;; …and :override does, for every caller in the process
   {:suite "class-extensions" :expr "(do (jolt.host/extend-class! \"java.io.File\" {:methods {\"getPath\" (fn [self] \"overridden\")} :override true}) (.getPath (java.io.File. \"a/b\")))" :expected "\"overridden\""}
   ;; a registration on a SUPERCLASS answers for a subclass receiver (class graph)


### PR DESCRIPTION
Stacked on #820 — **review that one first**; this PR's base is its branch, and its
diff is only the commits above it.

All three of #820's follow-ups, fixed. Each one's stated cause turned out to be
wrong, and each real cause was found by measuring rather than reasoning — which is
the thread running through this PR.

## 1. The `ArrayBlockingQueue` gap: the queue was fine, the road to it was not

#820 said the 22x came from `jolt-cv-wake!`'s global mutex and hashtable. Priced by
stubbing each suspect out, those are ~150 ns of a 2000 ns put+take pair. The probe
that pointed at them is dominated by park/unpark scheduling — removing work from it
made it read *slower*.

Measured on one thread with a queue that is never empty and never full, so nothing
parks: **2000 ns → 1025 ns** (JVM: 45 ns). Half of it was **interop dispatch**. The
`.method` dispatcher tries an ordered list of arms and the arm that answers for a
host shim is the LAST one, so every call on a queue, stream, socket or executor was
resolved by calling nine arms above it first — 316 ns of 492 ns, paid by every host
object in the runtime.

| | before | after |
|---|---|---|
| `.size` (dispatch, nothing else) | 492 ns | **198 ns** |
| `.peek` (+ the queue's mutex) | 603 ns | 287 ns |
| `.offer` + `.poll` | 1852 ns | 935 ns |
| `.put` + `.take` | 2011 ns | 1204 ns |

A shortcut ahead of the chain answers exactly what the bottom arm would have
answered for a table hit, `'pass` for everything else. It is armed after the last
built-in arm registers and **stands down by itself** when the arm count below the
jhost tier changes, so `jolt.host/extend-class!` or any library arm below that tier
puts every call back on the full chain — the only way an arm written to intercept a
host object keeps intercepting it. A unit row registers an override and watches the
shortcut give way. `.getClass` and `java.nio.file.Path` are excluded, both because
something above the tier owns the name or the tag.

## 2. `shutdownNow` interrupts the tasks already running

Every worker carries an interrupt flag, made and registered by the spawner *before*
the fork (so a `shutdownNow` landing between the claim and the thread's first
instruction still finds it) and adopted by the worker, so a task's
`(Thread/currentThread)` `.isInterrupted` and the pool's shutdown are one flag.
`shutdownNow` sets them all and then pokes the waits — flag first, poke second —
with the pokes outside the queue mutex, since waking a wait takes the waiter's own.

| | jolt | JVM |
|---|---|---|
| `shutdownNow` interrupts a sleeping task | `[:interrupted true]` | same |
| plain `shutdown` does not | `[:slept true]` | same |
| a submitted task's `Future` sees the cause | `"InterruptedException"` | same |
| the flag does not leak to the next task | `false` | same |

## 3. Contention: it was the growth rule, not the mutex

#820 said this needed queue striping. It did not. **The dispatch fix above made it
worse**, which is what exposed the real cause: a faster producer runs further ahead
of the workers, and the growth rule read that as "the pool is short of workers". The
same 200k burst went from 7 threads to 25-37 and from 8.9 µs a task to 10.6 µs —
while a single-worker pool ran the identical tasks at 1.8 µs. The pool was paying
for threads that were in its way.

The JVM grows when an offer to a `SynchronousQueue` fails, and it fails only when no
worker is at the handoff to take it. jolt's asynchronous queue makes the direct test
— depth above idle — say yes in a case the JVM's never sees: a worker that is
running, or queued behind the producer on the very mutex the producer holds, is
about to take the task and counts as idle in neither.

So the enqueue now **offers first**: when the depth test says grow, it drops the
mutex, yields, and asks again. A worker one acquisition away from the task now has
it; a pool whose workers are all blocked still has the task sitting there, and grows.
The yield is paid only on the path that was about to fork a thread for ~80 µs, and
not at all by a pool at its maximum — every fixed pool, always, which without that
early-out cost a single-thread executor 0.9 µs a task.

200k tasks through `.execute`, against the tip of #820:

| | before | after | JVM |
|---|---|---|---|
| single-thread pool | 4.3 µs | **1.7 µs** | 9.1 µs |
| fixed pool of 4 | 7.3 µs | **5.8 µs** | 2.8 µs |
| four producers, one cached pool | 11.0 µs | **9.5 µs** | 2.2 µs |
| submit + get round trip | 15.8 µs | **9.8 µs** | 7.2 µs |
| cached pool | 8.9 µs | 9.0 µs | 5.2 µs |
| peak threads for that burst | 7 | 11-13 | 8 |

The 64-blocking-task row still reaches exactly 64 workers, which is the property the
rule exists to keep: growth answers a pool that cannot make progress and declines one
that is merely busy. What is left on the contended row is the single queue mutex
itself — striping it is a real design change (it gives up the global FIFO a
single-thread executor's ordering depends on), and it is now the *only* thing left in
that number rather than a guess about it.

## Tests

Six new unit rows (four `executor-shutdown`, two `class-extensions`); the four
interrupt rows all render what reference JVM Clojure renders for the same expression.

Gates, every one matching its baseline: `unit` 1594/1594, `corpus` 0 new divergences,
`documented`, `flow`, `threadsafety`, `smoke` 192/0, `sci` 417/424, `cts` 5987 pass /
139 fail / 3 error, `lockcheck`, `parkcheck`, `gambitgencheck` (the regenerated
`records-gambit.ss` is in here — that gate is what caught the first CI failure).