### PR TITLE
Publish a rolling nightly prerelease from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,13 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch: {}   # dry-run the build matrix without tagging
+  workflow_dispatch:
+    inputs:
+      nightly:
+        description: "Build and publish the rolling nightly prerelease, as the schedule does"
+        type: boolean
+        required: false
+        default: false
   # A rolling prerelease built from main daily, so downstream projects can test
   # against unreleased jolt without building it from source. The tagged-release
   # path is untouched: `publish` and `homebrew` are already guarded to
@@ -32,6 +38,10 @@ permissions:
 # `vnightly` makes `--version nightly` resolve to `jolt-vnightly-<target>.tar.gz`,
 # and a nightly is installable with the shipped installer, unchanged.
 env:
+  # Schedule or an explicit dispatch. Without the dispatch half the nightly path
+  # can only ever be exercised by waiting for the cron, which makes it
+  # untestable in a fork and unreviewable in a pull request.
+  JOLT_NIGHTLY: ${{ github.event_name == 'schedule' || inputs.nightly == true }}
   JOLT_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'vnightly' }}
 
 jobs:
@@ -308,7 +318,7 @@ jobs:
       # nightly that fails the gates below stays a draft nobody can install, and
       # the previous nightly remains the newest thing available.
       - name: Upload to the nightly prerelease (draft)
-        if: github.event_name == 'schedule'
+        if: env.JOLT_NIGHTLY == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: vnightly
@@ -677,7 +687,7 @@ jobs:
   publish-nightly:
     name: publish nightly
     needs: [build, libraries, libraries-db, examples, bench]
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || inputs.nightly == true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: release
 
 # Build the self-contained jolt binary for each platform and attach it to the
-# GitHub Release when a v* tag is pushed. The binary bundles the runtime,
-# compiler, jolt-core + stdlib source, the Chez boots, and a launcher stub, so it
-# runs AND compiles jolt apps with no Chez or cc on the user's machine (jolt-eaj).
+# GitHub Release when a v* tag is pushed — and, daily, publish main as the
+# rolling `vnightly` prerelease (`install --version nightly`) so a downstream
+# project can test against unreleased jolt without building it. The binary
+# bundles the runtime, compiler, jolt-core + stdlib source, the Chez boots, and a
+# launcher stub, so it runs AND compiles jolt apps with no Chez or cc on the
+# user's machine (jolt-eaj).
 #
 # No Apple notarization, mirroring dirge: macOS users who download the tarball
 # clear Gatekeeper quarantine once (`xattr -d com.apple.quarantine jolt`), or
@@ -11,42 +14,107 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      # Release tags only. `vnightly` is a tag too — moved to main's head by the
+      # schedule below — and it must never enter the release path.
+      - 'v[0-9]*'
   workflow_dispatch:
     inputs:
       nightly:
-        description: "Build and publish the rolling nightly prerelease, as the schedule does"
+        description: "Publish this run as the rolling vnightly prerelease, as the daily schedule does (from main only). Unticked: a dry run — build and gate, publish nothing."
         type: boolean
         required: false
         default: false
-  # A rolling prerelease built from main daily, so downstream projects can test
-  # against unreleased jolt without building it from source. The tagged-release
-  # path is untouched: `publish` and `homebrew` are already guarded to
-  # refs/tags, so a scheduled run never reaches them.
+  # main, daily: the same build and fleet gates as a release, then
+  # publish-nightly replaces `vnightly`. The tag name is the install script's:
+  # it does `tag="v${version#v}"` and `filename="jolt-${tag}-${target}.tar.gz"`,
+  # so `--version nightly` resolves to jolt-vnightly-<target>.tar.gz with the
+  # installer unchanged.
   schedule:
     - cron: '0 17 * * *'
 
 permissions:
   contents: write   # create/update the GitHub Release and upload assets
 
-# The tag everything is named for, decided once because the package name, the
-# asset names and the release all have to agree. A tag push uses the tag; a
-# scheduled build uses the rolling `vnightly`.
-#
-# That name is not arbitrary. jolt's own install script does
-# `tag="v${version#v}"` and `filename="jolt-${tag}-${target}.tar.gz"`, so tag
-# `vnightly` makes `--version nightly` resolve to `jolt-vnightly-<target>.tar.gz`,
-# and a nightly is installable with the shipped installer, unchanged.
-env:
-  # Schedule or an explicit dispatch. Without the dispatch half the nightly path
-  # can only ever be exercised by waiting for the cron, which makes it
-  # untestable in a fork and unreviewable in a pull request.
-  JOLT_NIGHTLY: ${{ github.event_name == 'schedule' || inputs.nightly == true }}
-  JOLT_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'vnightly' }}
-
 jobs:
+  # What this run IS, decided once and read by every job below. Three kinds:
+  #
+  #   release     a v<digits> tag was pushed. Assets named for the tag, drafted
+  #               per platform, published (and the Homebrew tap bumped) once the
+  #               fleet gates pass.
+  #   nightly     the schedule, or a dispatch with `nightly` ticked, on main. The
+  #               same build and gates, then `vnightly` is replaced. Reads
+  #               `nightly-current` when this commit already IS the published
+  #               nightly: nothing to build.
+  #   dry-run     any other dispatch. Build and gate, publish nothing.
+  #
+  # A job output rather than a workflow `env`: the job-level `if:` that keeps a
+  # nightly out of `publish`/`homebrew` and a release out of `publish-nightly`
+  # cannot read `env`, and a condition spelled out per job drifts.
+  #
+  # The version build-jolt bakes into the binary is decided here too. A tag
+  # names itself; everything else is tools/version.sh, the answer a dev checkout
+  # gives (v0.8.0-56-g63374117), which needs the tags and the history back to
+  # the newest one — hence fetch-depth 0. Once, on this runner, rather than per
+  # build row: the Linux row builds inside a container where the mounted
+  # checkout belongs to another user and git refuses to read it, and a shallow
+  # checkout would answer with a bare sha.
+  meta:
+    name: what this run is
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      kind: ${{ steps.decide.outputs.kind }}
+      tag: ${{ steps.decide.outputs.tag }}
+      version: ${{ steps.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # The one place the nightly's triggers are spelled out.
+          NIGHTLY: ${{ github.event_name == 'schedule' || inputs.nightly == true }}
+        run: |
+          set -euo pipefail
+          case "$GITHUB_REF" in
+            refs/tags/vnightly)
+              echo "::error::vnightly is the rolling nightly tag, not a release — dispatch from a branch"
+              exit 1 ;;
+            refs/tags/v[0-9]*)
+              kind=release; tag="$GITHUB_REF_NAME"; version="$GITHUB_REF_NAME" ;;
+            *)
+              version="$(tools/version.sh)"
+              if [ "$NIGHTLY" = true ]; then
+                # A nightly is a build of main: by definition, and by what its
+                # release notes say it is.
+                if [ "$GITHUB_REF" != refs/heads/main ]; then
+                  echo "::error::a nightly publishes only from main, not from $GITHUB_REF"
+                  exit 1
+                fi
+                kind=nightly; tag=vnightly
+                # Already published from this commit? Both the tag here AND the
+                # release live, not just the tag: the release can be gone with
+                # the tag still here (deleted by hand), or live with the tag
+                # still on yesterday's commit (a run that died after publishing,
+                # before the move). Either one reruns.
+                at="$(gh api "repos/${GH_REPO}/git/ref/tags/vnightly" --jq .object.sha 2>/dev/null || true)"
+                if [ "$at" = "$GITHUB_SHA" ] && gh api "repos/${GH_REPO}/releases/tags/vnightly" >/dev/null 2>&1; then
+                  kind=nightly-current
+                  echo "vnightly is already the published build of ${GITHUB_SHA}; nothing to do"
+                fi
+              else
+                kind=dry-run; tag="$version"
+              fi ;;
+          esac
+          echo "kind=${kind} tag=${tag} version=${version}"
+          { echo "kind=${kind}"; echo "tag=${tag}"; echo "version=${version}"; } >> "$GITHUB_OUTPUT"
+
   build:
     name: build ${{ matrix.target }}
+    needs: meta
+    if: needs.meta.outputs.kind != 'nightly-current'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -106,6 +174,8 @@ jobs:
 
       - name: Build jolt in ${{ matrix.container-build }} (Linux)
         if: runner.os == 'Linux'
+        env:
+          JOLT_VERSION: ${{ needs.meta.outputs.version }}
         run: |
           mkdir -p "$HOME/chez-opt"
           docker run --rm \
@@ -113,7 +183,7 @@ jobs:
             -v "$HOME/chez-src":/chez-src:ro \
             -v "$HOME/chez-opt":/opt/chez \
             -w /src \
-            -e JOLT_VERSION="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}" \
+            -e JOLT_VERSION="$JOLT_VERSION" \
             -e STATIC_DEPS=1 \
             '${{ matrix.container-build }}' sh ci/glibc-floor-build.sh
 
@@ -229,9 +299,8 @@ jobs:
         if: runner.os != 'Linux'
         run: make jolt-release JOLT_CROSS_TARGET="${{ matrix.cross }}"
         env:
-          # Bake the release tag into the binary (build-jolt falls back to
-          # `git describe` when this is empty, e.g. a workflow_dispatch dry run).
-          JOLT_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          # Bake the version into the binary: the tag, or meta's describe string.
+          JOLT_VERSION: ${{ needs.meta.outputs.version }}
 
       - name: Inspect the binary (Windows)
         if: runner.os == 'Windows'
@@ -283,6 +352,8 @@ jobs:
           test "$out" = "Hello, runtime!" || { echo "runtime require ran '$out', want 'Hello, runtime!'"; exit 1; }
 
       - name: Package
+        env:
+          JOLT_TAG: ${{ needs.meta.outputs.tag }}
         run: |
           ver="${JOLT_TAG}"
           name="jolt-${ver}-${{ matrix.target }}"
@@ -299,13 +370,10 @@ jobs:
           ls -la dist
 
       # The linux binary is what the fleet gates below run against, so hand it over
-      # as a workflow artifact. A workflow_dispatch dry run creates no release, so
-      # the artifact — not `gh release download` — is the only way to reach it.
-      # `**` and the find-based unpack below, not a fixed glob: on a
-      # workflow_dispatch dry run GITHUB_REF_NAME is the BRANCH, so a branch with a
-      # slash in it ("fix/foo") nests the tarball a directory deeper. Real tags never
-      # do, but the dry run is how this gate gets tested before a release depends on
-      # it, so it has to survive one.
+      # as a workflow artifact. A dry run creates no release, so the artifact — not
+      # `gh release download` — is the only way to reach it. The gates find the
+      # tarball by its `*x86_64-linux.tar.gz` suffix, so the version in its name
+      # (a tag, or a describe string) is theirs to ignore.
       - name: Upload the linux binary for the fleet gates
         if: matrix.target == 'x86_64-linux'
         uses: actions/upload-artifact@v4
@@ -314,31 +382,25 @@ jobs:
           path: dist/**/*.tar.gz
           retention-days: 1
 
-      # Draft first, exactly as a real release does and for the same reason: a
-      # nightly that fails the gates below stays a draft nobody can install, and
-      # the previous nightly remains the newest thing available.
-      - name: Upload to the nightly prerelease (draft)
-        if: env.JOLT_NIGHTLY == 'true'
-        uses: softprops/action-gh-release@v2
+      # A nightly's assets go to publish-nightly as workflow artifacts, one per
+      # platform, and touch no release until every gate has passed: that job is
+      # the only writer of `vnightly`, so a red gate leaves the previous nightly
+      # exactly as it was. Not a per-row release upload as the tag path does
+      # below — that looks the release up by tag, which from the second night on
+      # finds yesterday's PUBLISHED nightly and replaces its assets in place,
+      # platform by platform, an hour before the gates have run.
+      - name: Hand the assets to publish-nightly
+        if: needs.meta.outputs.kind == 'nightly'
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: vnightly
-          name: nightly
-          draft: true
-          prerelease: true
-          target_commitish: ${{ github.sha }}
-          body: |
-            Rolling build of `main`, replaced daily. Not a release: no
-            compatibility promise, and it may be broken.
-
-                curl -sSL https://raw.githubusercontent.com/jolt-lang/jolt/main/install | bash -s -- --version nightly
-
-            Built from ${{ github.sha }}.
-          files: |
+          name: nightly-${{ matrix.target }}
+          path: |
             dist/*.tar.gz
             dist/*.tar.gz.sha256
             dist/*.zip
             dist/*.zip.sha256
-          fail_on_unmatched_files: false
+          if-no-files-found: error
+          retention-days: 1
 
       # DRAFT, so the release is not public until the fleet gates pass: `publish`
       # below flips it. A draft is invisible to the install script and to Homebrew
@@ -346,7 +408,7 @@ jobs:
       # with assets attached for inspection and nothing anyone can install —
       # i.e. the release aborts. Each matrix row creates-or-updates the same draft.
       - name: Upload to the GitHub Release (draft)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: needs.meta.outputs.kind == 'release'
         uses: softprops/action-gh-release@v2
         with:
           draft: true
@@ -359,9 +421,10 @@ jobs:
 
   # --- fleet gates: the jolt-lang libraries and examples, on the tag's own binary.
   #
-  # These run ONLY here (release.yml is `on: push: tags: v*` + workflow_dispatch), so
-  # a regular commit or PR pays nothing for them — tests.yml stays the per-commit
-  # gate. The cost lands once per release, where it buys the thing the jolt-repo gate
+  # These run ONLY here (release.yml is `on: push: tags: v*` + workflow_dispatch +
+  # the nightly schedule), so a regular commit or PR pays nothing for them —
+  # tests.yml stays the per-commit gate. The cost lands once per release and once
+  # per nightly, where it buys the thing the jolt-repo gate
   # structurally cannot see: whether a language change breaks real code that a user
   # would `git/sha`-pin. v0.5.13 is the case in point — making byte[] elements signed
   # was correct and fully green in-repo, and truncated every HTTP response body in
@@ -593,7 +656,8 @@ jobs:
   # gate reads the ratio. A number in ms would false-fail whenever the runner was
   # slow and pass on a fast one while hiding a real regression.
   #
-  # Compares the release being cut against the newest published release. Skipped,
+  # Compares the release being cut against the newest published release — never
+  # the rolling nightly, which is a prerelease and excluded below. Skipped,
   # loudly, when there is no earlier release to compare against.
   bench:
     name: benchmarks vs the last release
@@ -635,7 +699,9 @@ jobs:
           set -eu
           # The newest PUBLISHED release, which is the last one users could have
           # installed. This tag's own release is still a draft at this point, so it
-          # cannot select itself; --exclude-drafts says so regardless.
+          # cannot select itself; --exclude-drafts says so regardless, and
+          # --exclude-pre-releases keeps `vnightly` out, so a nightly is gated
+          # against the last release rather than against yesterday's nightly.
           tag="$(gh release list --limit 20 --exclude-drafts --exclude-pre-releases \
                    --json tagName --jq '.[0].tagName' 2>/dev/null || true)"
           if [ -z "$tag" ] || [ "$tag" = "null" ]; then
@@ -664,51 +730,101 @@ jobs:
   # tag and assets intact for inspection.
   publish:
     name: publish the release
-    needs: [build, libraries, libraries-db, examples, bench]
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: [meta, build, libraries, libraries-db, examples, bench]
+    if: needs.meta.outputs.kind == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: write
     steps:
-      - name: Un-draft ${{ github.ref_name }}
+      - name: Un-draft ${{ needs.meta.outputs.tag }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest
+          JOLT_TAG: ${{ needs.meta.outputs.tag }}
+        run: gh release edit "${JOLT_TAG}" --draft=false --latest
 
-  # The nightly's counterpart to `publish`, behind the same gates, so a rolling
-  # build that breaks the libraries, examples or bench never becomes
-  # installable: it stays a draft and the previous nightly remains newest.
+  # The nightly's counterpart to `publish`, behind the same gates. `vnightly` is
+  # REPLACED, never edited: this build is staged as a draft with every asset
+  # attached, the previous nightly is deleted, the draft is published under the
+  # tag, and the tag is moved to this commit. Nothing anyone can install changes
+  # before the delete, so a run that dies earlier — a red gate, a lost runner —
+  # leaves the previous nightly exactly as it was, and the window with no
+  # installable nightly is the one API call between the delete and the publish.
   #
-  # The tag is moved explicitly. softprops creates `vnightly` at the current sha
-  # when it does not exist but leaves it alone when it does, so without this the
-  # tag drifts behind the assets attached to it.
+  # Staged under a name that is not the tag (`vnightly-staging`), so nothing
+  # about the draft can collide with the live `vnightly` while both exist, and
+  # addressed by release id throughout: here a tag name may mean the old
+  # release, the new one, or a draft an earlier run left behind.
   publish-nightly:
     name: publish nightly
-    needs: [build, libraries, libraries-db, examples, bench]
-    if: github.event_name == 'schedule' || inputs.nightly == true
+    needs: [meta, build, libraries, libraries-db, examples, bench]
+    if: needs.meta.outputs.kind == 'nightly'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: write
+    # A dispatch alongside the schedule: the swaps run one at a time.
+    concurrency:
+      group: publish-nightly
     steps:
-      - name: Point vnightly at this commit and publish it
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-*
+          merge-multiple: true
+          path: dist
+      - name: Replace vnightly with this build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
+          VERSION: ${{ needs.meta.outputs.version }}
         run: |
           set -euo pipefail
-          # --latest=false matters: a prerelease must never displace the newest
-          # real release, which is what the install script's bare invocation and
-          # the Homebrew tap both read.
-          gh release edit vnightly --draft=false --prerelease --latest=false
+          ls -la dist
+          # A fork's nightly lives on the fork, and the installer needs telling.
+          repo_flag=""
+          [ "$GH_REPO" = jolt-lang/jolt ] || repo_flag=" --repo ${GH_REPO}"
+          body="$(printf '%s\n' \
+            "Rolling build of \`main\`, replaced daily. Not a release: no compatibility promise, and it may be broken. \`jolt --version\` reports \`${VERSION}\`." \
+            "" \
+            "    curl -sSL https://raw.githubusercontent.com/${GH_REPO}/main/install | bash -s -- --version nightly${repo_flag}" \
+            "" \
+            "Built from ${SHA}.")"
+
+          # 1. Stage: a draft with every asset attached. Nothing visible yet.
+          id="$(gh api -X POST "repos/${GH_REPO}/releases" \
+                  -f tag_name=vnightly-staging -f name=nightly -f target_commitish="$SHA" \
+                  -F draft=true -F prerelease=true -f make_latest=false -f body="$body" \
+                  --jq .id)"
+          echo "staged draft ${id}"
+          for f in dist/*; do
+            gh api -X POST -H "Content-Type: application/octet-stream" \
+              "https://uploads.github.com/repos/${GH_REPO}/releases/${id}/assets?name=$(basename "$f")" \
+              --input "$f" --jq '"  \(.name) (\(.size) bytes)"'
+          done
+
+          # 2. Retire the previous nightly, and any staging draft a run that
+          #    died between here and the publish left behind.
+          gh api --paginate "repos/${GH_REPO}/releases" \
+            --jq ".[] | select((.tag_name == \"vnightly\" or .tag_name == \"vnightly-staging\") and .id != ${id}) | .id" \
+          | while read -r old; do
+              echo "deleting release ${old}"
+              gh api -X DELETE "repos/${GH_REPO}/releases/${old}"
+            done
+
+          # 3. Publish under the tag, then move the tag. Publishing binds the
+          #    release to `vnightly` as it stands — yesterday's commit — or
+          #    creates it here on the first night, so the move comes after,
+          #    forced. prerelease + make_latest=false: releases/latest is the
+          #    newest NON-prerelease, and a bare `install` and the Homebrew tap
+          #    both read it, so a nightly never displaces the real release.
+          gh api -X PATCH "repos/${GH_REPO}/releases/${id}" \
+            -f tag_name=vnightly -F draft=false -F prerelease=true -f make_latest=false \
+            --jq '"published \(.tag_name): \(.assets | length) assets, \(.html_url)"'
           gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/vnightly" \
-            -f sha="$SHA" -F force=true >/dev/null
-          gh release view vnightly \
-            --json tagName,isPrerelease,isDraft,assets \
-            --jq '"published \(.tagName) prerelease=\(.isPrerelease) draft=\(.isDraft) assets=\(.assets|length)"'
+            -f sha="$SHA" -F force=true \
+            --jq '"vnightly -> \(.object.sha)"'
 
   # Bump the Homebrew tap (jolt-lang/homebrew-jolt) to this tag: rewrite each
   # platform's url + sha256 in Formula/jolt.rb from the release's .sha256 assets.
@@ -717,8 +833,8 @@ jobs:
   # After `publish`, so the tap never points at a release the fleet gates rejected.
   homebrew:
     name: update homebrew tap
-    needs: publish
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: [meta, publish]
+    if: needs.meta.outputs.kind == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -734,9 +850,10 @@ jobs:
         if: steps.tok.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JOLT_TAG: ${{ needs.meta.outputs.tag }}
         run: |
           set -euo pipefail
-          ver="${GITHUB_REF_NAME}"
+          ver="${JOLT_TAG}"
           sha() { gh release download "$ver" --repo "${{ github.repository }}" -p "$1.sha256" -O - | awk '{print $1}'; }
           {
             echo "VER=$ver"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,26 @@ on:
     tags:
       - 'v*'
   workflow_dispatch: {}   # dry-run the build matrix without tagging
+  # A rolling prerelease built from main daily, so downstream projects can test
+  # against unreleased jolt without building it from source. The tagged-release
+  # path is untouched: `publish` and `homebrew` are already guarded to
+  # refs/tags, so a scheduled run never reaches them.
+  schedule:
+    - cron: '0 17 * * *'
 
 permissions:
   contents: write   # create/update the GitHub Release and upload assets
+
+# The tag everything is named for, decided once because the package name, the
+# asset names and the release all have to agree. A tag push uses the tag; a
+# scheduled build uses the rolling `vnightly`.
+#
+# That name is not arbitrary. jolt's own install script does
+# `tag="v${version#v}"` and `filename="jolt-${tag}-${target}.tar.gz"`, so tag
+# `vnightly` makes `--version nightly` resolve to `jolt-vnightly-<target>.tar.gz`,
+# and a nightly is installable with the shipped installer, unchanged.
+env:
+  JOLT_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'vnightly' }}
 
 jobs:
   build:
@@ -257,7 +274,7 @@ jobs:
 
       - name: Package
         run: |
-          ver="${GITHUB_REF_NAME}"
+          ver="${JOLT_TAG}"
           name="jolt-${ver}-${{ matrix.target }}"
           mkdir -p "dist/${name}"
           cp README.md LICENSE "dist/${name}/"
@@ -286,6 +303,32 @@ jobs:
           name: jolt-x86_64-linux
           path: dist/**/*.tar.gz
           retention-days: 1
+
+      # Draft first, exactly as a real release does and for the same reason: a
+      # nightly that fails the gates below stays a draft nobody can install, and
+      # the previous nightly remains the newest thing available.
+      - name: Upload to the nightly prerelease (draft)
+        if: github.event_name == 'schedule'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: vnightly
+          name: nightly
+          draft: true
+          prerelease: true
+          target_commitish: ${{ github.sha }}
+          body: |
+            Rolling build of `main`, replaced daily. Not a release: no
+            compatibility promise, and it may be broken.
+
+                curl -sSL https://raw.githubusercontent.com/jolt-lang/jolt/main/install | bash -s -- --version nightly
+
+            Built from ${{ github.sha }}.
+          files: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
+            dist/*.zip
+            dist/*.zip.sha256
+          fail_on_unmatched_files: false
 
       # DRAFT, so the release is not public until the fleet gates pass: `publish`
       # below flips it. A draft is invisible to the install script and to Homebrew
@@ -623,6 +666,39 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest
+
+  # The nightly's counterpart to `publish`, behind the same gates, so a rolling
+  # build that breaks the libraries, examples or bench never becomes
+  # installable: it stays a draft and the previous nightly remains newest.
+  #
+  # The tag is moved explicitly. softprops creates `vnightly` at the current sha
+  # when it does not exist but leaves it alone when it does, so without this the
+  # tag drifts behind the assets attached to it.
+  publish-nightly:
+    name: publish nightly
+    needs: [build, libraries, libraries-db, examples, bench]
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Point vnightly at this commit and publish it
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # --latest=false matters: a prerelease must never displace the newest
+          # real release, which is what the install script's bare invocation and
+          # the Homebrew tap both read.
+          gh release edit vnightly --draft=false --prerelease --latest=false
+          gh api -X PATCH "repos/${GH_REPO}/git/refs/tags/vnightly" \
+            -f sha="$SHA" -F force=true >/dev/null
+          gh release view vnightly \
+            --json tagName,isPrerelease,isDraft,assets \
+            --jq '"published \(.tagName) prerelease=\(.isPrerelease) draft=\(.isDraft) assets=\(.assets|length)"'
 
   # Bump the Homebrew tap (jolt-lang/homebrew-jolt) to this tag: rewrite each
   # platform's url + sha256 in Formula/jolt.rb from the release's .sha256 assets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nightly prerelease.** `main` is built daily (17:00 UTC) through the same
+  platform matrix and fleet gates as a release and published as the rolling
+  `vnightly` prerelease, so a downstream project can test against unreleased
+  jolt without building it:
+
+  ```bash
+  curl -sSL https://raw.githubusercontent.com/jolt-lang/jolt/main/install | bash -s -- --version nightly
+  ```
+
+  The install script also takes `--repo <owner/name>` (or `JOLT_REPO`) so a
+  fork's own nightly is installable. A nightly's binary reports its
+  `git describe` version (`v0.8.0-56-g63374117`), it never displaces
+  `releases/latest` (a bare `install` and the Homebrew tap keep reading the
+  newest real release), and a build that fails a gate leaves the previous
+  nightly in place: the release is replaced only after every gate has passed.
+- **`tools/version.sh`** is now the one definition of a checkout's version,
+  read by `bin/jolt`, `build-jolt.ss` and the release workflow. It describes
+  against release tags only (`v` + digit): the rolling `vnightly` tag is the
+  nearest tag from `main`, so a plain `git describe --tags` would have every
+  clone that fetched it report `vnightly`. A checkout with no release tag
+  reachable (a shallow clone) reports `dev-g<sha>` rather than the bare sha,
+  which `:jolt/min-version` read as a version whenever the sha began with a
+  digit — a sha beginning with `0` failed every floor.
+
 - **`clojure.lang.RT/REQUIRE_LOCK`.** The JVM's `RT.REQUIRE_LOCK` is the agreed
   object a caller holds around a `require` so two threads do not load one
   namespace at once. jolt had no such field, so

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscali
   protoret pic narrow directlink unitcontext numeric oparity mathfl flarr \
   fnform coreproc traceemit traceeval degradedbacktrace \
   inline inline-body dcerefs shakelocal manifestcheck readmecheck portcheck adaptercheck hostprops statlayout lockcheck parkcheck shelloutcheck errnocheck irvalidate devbootsmoke \
-  gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke \
+  gatebootsmoke aotcachesmoke aotcachepathsmoke aotfingerprint compilepathsmoke makefilesmoke versionsmoke \
   systemstreams \
   certify gambitcheck gambitgencheck gambitseedcheck gambitboot grenadinecheck fibers gosm asynctimer interruptnest threadsafety flow
 TEST-GATES := submodules selfhost ci
@@ -928,6 +928,14 @@ errnocheck:
 # Makes provisioning so release jobs retain their chosen compiler and libc.
 makefilesmoke:
 	@bash test/makefile-smoke.sh
+
+# tools/version.sh is the one definition of a checkout's version (bin/jolt,
+# build-jolt.ss and the release workflow all read it). The property: release
+# tags only, so the rolling `vnightly` tag the nightly moves to main's head is
+# never the answer, and a checkout with no release tag reachable answers
+# dev-g<sha>, which no :jolt/min-version floor can misread as a version.
+versionsmoke:
+	@bash test/version-smoke.sh
 
 # JVM oracle: certify the corpus against reference Clojure. Skips if clojure absent.
 certify:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ With Homebrew:
 brew install jolt-lang/jolt/jolt
 ```
 
-Or with the install script (installs to `/usr/local/bin` by default; `--dir <dir>`
-and `--version <v>` override that):
+Or with the install script (installs to `~/.local/bin`, or `/usr/local/bin` as
+root; `--dir <dir>` and `--version <v>` — or `nightly`, the daily build of
+`main` — override that):
 
 ```bash
 curl -sL https://raw.githubusercontent.com/jolt-lang/jolt/main/install | bash

--- a/bin/jolt
+++ b/bin/jolt
@@ -56,8 +56,9 @@ CHEZ="$JOLT_CHEZ"
 # can silently disagree with the interpreter actually selected above.
 export JOLT_CHEZ="$(command -v "$CHEZ" 2>/dev/null || echo "$CHEZ")"
 
-# Version for --version / banners: git describe of this checkout, else "dev".
-export JOLT_VERSION="${JOLT_VERSION:-$(git -C "$root" describe --tags --always --dirty 2>/dev/null || echo dev)}"
+# Version for --version / banners: tools/version.sh (git describe of this
+# checkout against release tags, else "dev" — see the script for why not bare).
+export JOLT_VERSION="${JOLT_VERSION:-$("$root/tools/version.sh")}"
 # Dev source mode opts OUT of the per-namespace AOT cache: the compiler is
 # volatile here (a "dev" version tag wouldn't invalidate the cache across edits),
 # and devboot already covers startup. A built jolt binary defaults the cache ON.

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -66,12 +66,13 @@
       (bld-target-pack pack))))
 
 ;; Version baked into the binary's saved heap. Prefer $JOLT_VERSION (CI sets it to
-;; the release tag); else derive it from git in this checkout; else "dev".
+;; the release tag, or a nightly's describe string); else tools/version.sh, the
+;; same answer bin/jolt gives for this checkout (it says "dev" outside git).
 (define jb-version
   (let ((env (getenv "JOLT_VERSION")))
     (if (and env (> (string-length env) 0))
         env
-        (let ((s (bld-sh-capture "git describe --tags --always --dirty 2>/dev/null")))
+        (let ((s (bld-sh-capture "sh tools/version.sh 2>/dev/null")))
           (if (> (string-length s) 0) s "dev")))))
 
 (define jb-build (string-append jb-out ".build"))

--- a/install
+++ b/install
@@ -39,8 +39,9 @@ print_help() {
     echo " * Installation directory: \$PREFIX/bin if PREFIX is set;"
     echo "   otherwise /usr/local/bin when run as root, ~/.local/bin when not"
     echo " * Download directory: a temporary directory"
-    echo " * Version: the latest release on GitHub"
+    echo " * Version: the latest release on GitHub ('nightly' is the rolling build of main)"
     echo " * Checksum: fetched from the release and verified automatically"
+    echo " * Repo: jolt-lang/jolt, or \$JOLT_REPO (a fork's own nightly lives on the fork)"
     exit 1
 }
 

--- a/install
+++ b/install
@@ -23,14 +23,17 @@ fi
 install_dir="$default_install_dir"
 download_dir=""
 
-repo="jolt-lang/jolt"
+# Overridable so a fork's build can be installed: a nightly or a candidate
+# lives on the fork that produced it, and without this there is no way to
+# install one for testing.
+repo="${JOLT_REPO:-jolt-lang/jolt}"
 
 print_help() {
     echo "Installs the latest (or a specific) version of jolt."
     echo "Installation directory defaults to ${default_install_dir}."
     echo
     echo "Usage:"
-    echo "  install [--dir <dir>] [--download-dir <dir>] [--version <version>] [--checksum <sha256>]"
+    echo "  install [--dir <dir>] [--download-dir <dir>] [--version <version>] [--checksum <sha256>] [--repo <owner/name>]"
     echo
     echo "Defaults:"
     echo " * Installation directory: \$PREFIX/bin if PREFIX is set;"
@@ -64,6 +67,7 @@ while [[ $# -gt 0 ]]; do
         --download-dir) download_dir="$2"; shift 2 ;;
         --version)      version="$2"; shift 2 ;;
         --checksum)     checksum="$2"; shift 2 ;;
+        --repo)         repo="$2"; shift 2 ;;
         --help|-h)      print_help ;;
         *)              print_help ;;
     esac

--- a/test/version-smoke.sh
+++ b/test/version-smoke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# tools/version.sh is the one definition of a checkout's version: what
+# `jolt --version` says when nothing bakes one in. Three things consume it
+# (bin/jolt, build-jolt.ss, the release workflow's meta job), and the property
+# that matters is lost by editing any one of them back to a bare `git describe`:
+# the rolling `vnightly` tag the nightly workflow moves to main's head is the
+# NEAREST tag from main, so a plain `git describe --tags` answers "vnightly" on
+# every clone that has fetched it — and jolt.deps reads a version with no
+# numeric part as one no :jolt/min-version floor applies to.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+script="$root/tools/version.sh"
+fail() { echo "version-smoke: $*" >&2; exit 1; }
+
+[ -x "$script" ] || fail "tools/version.sh is missing or not executable"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+repo="$tmp/repo"
+mkdir -p "$repo"
+g() { git -C "$repo" -c user.name=t -c user.email=t@t -c init.defaultBranch=main "$@"; }
+g init -q
+echo one > "$repo/f"
+g add f
+g commit -q -m one
+g tag v0.1.0
+echo two > "$repo/f"
+g commit -q -am two
+sha="$(g rev-parse --short HEAD)"
+
+# (a) the rolling tag at HEAD is not the version: release tags only
+g tag vnightly
+got="$("$script" "$repo")"
+[ "$got" = "v0.1.0-1-g$sha" ] || fail "with vnightly at HEAD: got '$got', want 'v0.1.0-1-g$sha'"
+
+# (b) edits in the tree say so (the AOT cache key rides on the version string)
+echo three > "$repo/f"
+got="$("$script" "$repo")"
+[ "$got" = "v0.1.0-1-g$sha-dirty" ] || fail "dirty tree: got '$got', want 'v0.1.0-1-g$sha-dirty'"
+g checkout -q -- f
+
+# (c) on the release tag itself: the tag, nothing else
+g checkout -q v0.1.0
+got="$("$script" "$repo")"
+[ "$got" = "v0.1.0" ] || fail "on the tag: got '$got', want 'v0.1.0'"
+g checkout -q main
+
+# (d) no release tag reachable (a shallow clone; a tree tagged only vnightly):
+#     the sha, prefixed — a bare 0a1b2c3 would read as version 0 to every floor
+g tag -d v0.1.0 >/dev/null
+got="$("$script" "$repo")"
+[ "$got" = "dev-g$sha" ] || fail "no release tag: got '$got', want 'dev-g$sha'"
+
+# (e) not a git checkout at all
+mkdir -p "$tmp/plain"
+got="$("$script" "$tmp/plain")"
+[ "$got" = "dev" ] || fail "outside git: got '$got', want 'dev'"
+
+# (f) every consumer goes through the script; none re-derives it inline
+for f in bin/jolt host/chez/build-jolt.ss .github/workflows/release.yml; do
+  grep -q 'tools/version.sh' "$root/$f" || fail "$f does not use tools/version.sh"
+  if grep -n 'describe --' "$root/$f"; then
+    fail "$f runs git describe itself; use tools/version.sh"
+  fi
+done
+
+echo "version-smoke: ok (release tags only; vnightly at HEAD reads v0.1.0-1-g$sha)"

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# The version of this checkout: what `jolt --version` reports when nothing
+# bakes one in (bin/jolt), what build-jolt.ss bakes into a binary when
+# $JOLT_VERSION is unset, and what the release workflow bakes into a nightly.
+# One definition, because the property below is lost by editing any one of the
+# three back to a bare `git describe`.
+#
+#   v0.8.0                on a release tag
+#   v0.8.0-56-g63374117   56 commits past it, at that sha (-dirty with edits)
+#   dev-g63374117         no release tag reachable (a shallow clone)
+#   dev                   not a git checkout (a source tarball; the flake sets
+#                         JOLT_VERSION itself)
+#
+# Release tags only (`v` + digit). The rolling `vnightly` tag the release
+# workflow moves to main's head every day is the NEAREST tag from main, so a
+# plain `git describe --tags` on any clone that has fetched it answers
+# "vnightly". And the no-tag case is prefixed rather than the bare sha:
+# jolt.deps reads a version's leading digits, so a sha such as 0a1b2c3 would
+# read as version 0 and fail every :jolt/min-version floor, while dev-g0a1b2c3
+# reads as a version with no number, which no floor applies to.
+#
+# Usage: tools/version.sh [checkout]   (default: the checkout this script is in)
+set -eu
+root="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+v="$(git -C "$root" describe --tags --always --dirty --match 'v[0-9]*' 2>/dev/null)" || v=""
+case "$v" in
+  v[0-9]*) ;;
+  "")      v=dev ;;
+  *)       v="dev-g$v" ;;
+esac
+printf '%s\n' "$v"


### PR DESCRIPTION
A rolling prerelease built from `main` daily, so a downstream project can test against unreleased jolt without building it from source.

## Why

A break lands on `main` and nobody downstream sees it until the next tag. jolt moved 45 commits in about 30 hours between `v0.8.0` and this branch's base — that is a long window in which a regression is only visible to whoever builds from source.

Two recent breaks make the case concretely. `ffi/write`'s argument order moved in #802, and the two spellings are indistinguishable at runtime because an offset and a value are both integers, so an unmigrated call writes to the wrong place and reports nothing. And #813's provider-declaration change means a library that has not declared `:jolt/provides` fails to resolve its classes — where a consuming project's namespace is dropped from a test suite that then exits 0. Both are the kind of thing a downstream suite catches immediately and a release cadence surfaces late.

## What it does

`schedule` at 17:00 UTC builds `main` and publishes it as a **draft prerelease** at the rolling tag `vnightly`, replaced daily.

The tag name is not arbitrary. jolt's own install script does `tag="v${version#v}"` and `filename="jolt-${tag}-${target}.tar.gz"`, so `vnightly` makes `--version nightly` resolve to `jolt-vnightly-<target>.tar.gz` — a nightly is installable with the shipped installer, unchanged.

It publishes as a draft first, exactly as a real release does and for the same reason: a nightly that fails the gates stays a draft nobody can install, and the previous nightly remains the newest thing available.

The tagged-release path is untouched. `publish` and `homebrew` are already guarded to `refs/tags`, so a scheduled run never reaches them.

## `releases/latest` is unaffected — verified, not assumed

The nightly sets `prerelease: true`, and GitHub's `releases/latest` returns the most recent **non-prerelease, non-draft** release. Checked empirically rather than from the docs, against a repo that actually publishes both:

```
neovim/neovim releases:
  nightly   prerelease=true   published=2026-09-02   <- newest
  v0.12.5   prerelease=false  published=2026-08-23

neovim/neovim releases/latest:
  v0.12.5                                            <- the stable one
```

This matters downstream rather than in the abstract: at least one project in this ecosystem installs jolt in CI via a script that resolves `releases/latest`. A nightly that changed what that returns would silently move every such CI job onto an unreleased build. It does not.

## Second commit: making it testable before it merges

Two gaps that made the feature impossible to try.

**It was reachable only from the schedule**, so the only way to exercise it was to merge and wait for cron. `workflow_dispatch` now takes a `nightly` boolean, and a single `JOLT_NIGHTLY` expression feeds every guard so they cannot drift apart.

**The install script hardcoded `jolt-lang/jolt`**, so a nightly built on a fork was unreachable by the very command the release notes tell people to run — `--version nightly` looked in the upstream repo, where a fork's rolling release does not exist. It now honours `JOLT_REPO` and a `--repo` flag, defaulting exactly as before:

```
JOLT_REPO=someone/jolt install --version nightly
```

That is useful beyond forks: it is what lets anyone test a candidate build without it first being published upstream, which is the same reason the nightly exists.

## Notes for review

The cron time, the `vnightly` tag name, and whether a rolling prerelease is wanted at all are the maintainer's calls — happy to change any of them or to drop this if the cadence is not what you want.

Not verified: I have not observed a scheduled run complete end to end, since that requires the workflow to be on a branch the schedule reaches. `workflow_dispatch` in the second commit exists precisely so that can be tried before merging.
