### PR TITLE
-M with nothing to run is a REPL; caught load errors no longer pin the source position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`-M` with nothing to run starts a REPL.** `jolt -M:test` where no selected
+  alias declares `:main-opts` and the command line adds none used to exit 1
+  with `alias(es) [:test] have no :main-opts`. `-M` is `clojure.main`, and
+  `clojure.main` with no arguments is a REPL — `clj -M:dev` is how a REPL over
+  an alias's extra deps is started — so jolt does the same now, over the
+  project resolved with those aliases. `:main-opts ["-r"]` (or `--repl`) asks
+  for one explicitly, as on the JVM. A `:main-opts` form jolt does not take
+  says which it does: `-m NS`, `-e EXPR`, `-r`, or a script file.
+
+### Fixed
+
+- **A caught load error no longer misplaces every later error.** The
+  `at file:line:col` line under an uncaught error is the top-level form that
+  was evaluating, and a file load deliberately left that position on its
+  failing form when it threw, so the report named the file that failed. When
+  the throw was *caught* — a `data_readers.clj` namespace the loader tolerates,
+  a `require` inside a `try` — the position stayed put anyway, and every later,
+  unrelated error was reported at it: a CLI argument error came out `at
+  …/clj_time/core.clj:254:1`, the form whose Joda class the clj-time data-reader
+  load had stumbled on. A file load now binds the position around the whole
+  load, and the failing form's position travels with the throw itself (recorded
+  by the innermost load it crosses, before the stack unwinds), which the report
+  reads back — so a propagating load error is placed exactly as before, and a
+  caught one leaves nothing behind. `JOLT_DIAG=edn` diagnostics read the same
+  position.
+- **The data-reader load warning says where and what.** `data-reader namespace
+  clj-time.coerce failed to load: Unknown class DateTimeZone` now carries the
+  position the load failed at and the tags that consequently have no reader
+  (`tags #clj-time/date-time will not read`), instead of leaving the reader to
+  find the form and to meet the missing tag later as an unrelated
+  unresolved-var error.
+
 ## [0.8.1] - 2026-09-02
 
 Host classes are provided by declaration now. The runtime no longer carries the

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ $ jolt -e '(/ 1 2)'
 When the current directory has a `deps.edn`, `-e` resolves it first, so the
 expression can require the project's own namespaces and its dependencies.
 `-Sdeps` and `-A` compose with it for a one-off evaluation, and `-M` takes the
-same main options on the command line when the selected aliases declare none:
+same main options on the command line when the selected aliases declare none
+(none at all starts a REPL, like `clj -M:dev`):
 
 ```bash
 jolt -Sdeps '{:paths ["src" "test"]}' -e "(require 'my.app-test 'clojure.test)
@@ -161,9 +162,8 @@ failing the query, so `jolt -A:test:dev -Spath` and `jolt -Spath -M:test` both
 answer. Under `-Scp` the deps.edn is still read — aliases, `:main-opts` and
 tasks work — but nothing is expanded, so a shared library declared by a
 *dependency* is not loaded (the project's own `:jolt/native` still is).
-`-Sforce`, `-Sthreads`, and `-Jopt` are accepted and ignored: there is no
-classpath cache to force, fetching is serial, and there is no JVM to pass
-options to.
+`-Sforce`, `-Sthreads`, and `-Jopt` are accepted and ignored: no classpath
+cache to force, serial fetching, no JVM to pass options to.
 
 ## Differences from Clojure
 

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -27,7 +27,6 @@
 ;; {:type :symbol :suggestions :ns}; those fields are lifted to the top of the
 ;; diagnostic, alongside the human :message and the current form's :line/:column/
 ;; :file. A plain error still yields {:message ... :line ... :column ...}.
-(define diag-kw-jolt-error (keyword "jolt" "error"))
 (define diag-kw-message (keyword #f "message"))
 (define diag-kw-line (keyword #f "line"))
 (define diag-kw-column (keyword #f "column"))
@@ -38,7 +37,7 @@
     (and e (string? e) (string-ci=? e "edn"))))
 
 ;; Build the EDN diagnostic map for an unwrapped throw value.
-(define (jolt-diagnostic-map v)
+(define (jolt-diagnostic-map raw v)
   (let* ((msg (cond ((jolt-ex-info-record? v)
                      (jolt-str-render-one (jolt-ex-info-record-message v)))
                     ((condition? v)
@@ -47,7 +46,7 @@
          (data (and (jolt-ex-info-record? v) (jolt-ex-info-record-data v)))
          (err (and data (pmap? data) (jolt-get data diag-kw-jolt-error jolt-nil)))
          (base (if (and err (pmap? err)) err (jolt-hash-map)))
-         (pos (jolt-current-source))
+         (pos (or (jolt-throw-source-position raw) (jolt-current-source)))
          (m (jolt-assoc base diag-kw-message msg)))
     (if (pmap? pos)
         ;; The loader's per-top-level-form position FILLS IN only what the
@@ -67,28 +66,6 @@
             m))
         m)))
 
-;; The ":jolt/error" map an analyzer diagnostic carries, or #f. Its presence marks
-;; a COMPILE-time diagnostic: raised while analyzing a form, so the live Chez stack
-;; is the analyzer recursing into it, never the user's program.
-(define (jolt-analyzer-diagnostic v)
-  (let* ((data (and (jolt-ex-info-record? v) (jolt-ex-info-record-data v)))
-         (err (and data (pmap? data) (jolt-get data diag-kw-jolt-error jolt-nil))))
-    (and (pmap? err) err)))
-
-;; "file:line:col" for a diagnostic that carries its own position, else #f — so the
-;; report can name the offending expression rather than the enclosing top-level
-;; form. Same shape jolt-current-source-string renders, so the two are
-;; indistinguishable in the report.
-(define (jolt-diagnostic-location-string err)
-  (let ((line (jolt-get err diag-kw-line jolt-nil))
-        (col (jolt-get err diag-kw-column jolt-nil))
-        (file (jolt-get err diag-kw-file jolt-nil)))
-    (and (not (jolt-nil? line))
-         (string-append
-           (if (jolt-nil? file) "" (string-append (jolt-str-render-one file) ":"))
-           (number->string (jnum->exact line)) ":"
-           (if (jolt-nil? col) "?" (number->string (jnum->exact col)))))))
-
 ;; Render an uncaught jolt throw (any value, not just a Chez condition) to stderr
 ;; and exit non-zero, instead of Chez's opaque "non-condition value" dump. The
 ;; message/ex-data/cause + a mapped Clojure backtrace come from the shared
@@ -100,14 +77,13 @@
     (if (jolt-diag-machine?)
         ;; jolt-pr-readable, not jolt-pr-str: strings must be quoted so the line
         ;; is valid EDN a tool can read back.
-        (begin (display (jolt-pr-readable (jolt-diagnostic-map v)) port) (newline port))
+        (begin (display (jolt-pr-readable (jolt-diagnostic-map raw v)) port) (newline port))
         (let ((diag (jolt-analyzer-diagnostic v)))
           (jolt-render-throwable v port)
-          ;; Where it failed: the diagnostic's own position when it has one (the
-          ;; innermost form the analyzer was in), else the top-level form that was
-          ;; evaluating when this propagated.
-          (let ((loc (or (and diag (jolt-diagnostic-location-string diag))
-                         (jolt-current-source-string))))
+          ;; Where it failed: the diagnostic's own position, the form a file load
+          ;; was at when this crossed it, or the top-level form evaluating now
+          ;; (jolt-throwable-source-string, compile-eval.ss).
+          (let ((loc (jolt-throwable-source-string raw)))
             (when loc (display "  at " port) (display loc port) (newline port)))
           ;; No trace for a compile-time diagnostic. It is raised while ANALYZING,
           ;; so the frames are jolt's own analyzer recursing into the form

--- a/host/chez/compile-eval.ss
+++ b/host/chez/compile-eval.ss
@@ -135,27 +135,86 @@
 ;; A bare set, not a parameterize, because the reporter runs from the CLI's guard —
 ;; OUTSIDE every dynamic binding the failing phase had established. A parameterized
 ;; value is long gone by then; only a sticky one survives the unwind, which is the
-;; same reason jolt-enter-form! sets rather than binds and load-jolt-file* restores
-;; on normal return only. Clears any leftover line/column: they belong to whatever
-;; was last evaluated, in some other file entirely.
+;; same reason jolt-enter-form! sets rather than binds (a file LOAD is different:
+;; its failing form's position travels with the throw — jolt-note-throw-source!
+;; below). Clears any leftover line/column: they belong to whatever was last
+;; evaluated, in some other file entirely.
 (define (jolt-enter-file! path)
   (when (string? path)
     (jolt-current-source (jolt-hash-map hc-kw-file path))))
 
 ;; "file:line:col" for a form position, bare "file" for a file-only one (above), or
-;; #f when nothing is set.
+;; #f for anything else.
+(define (jolt-source-position-string p)
+  (and (pmap? p)
+       (let ((line (jolt-get p hc-kw-line jolt-nil))
+             (col  (jolt-get p hc-kw-column jolt-nil))
+             (file (jolt-get p hc-kw-file jolt-nil)))
+         (if (jolt-nil? line)
+             (and (string? file) file)
+             (string-append
+               (if (jolt-nil? file) "" (string-append file ":"))
+               (number->string line) ":"
+               (if (jolt-nil? col) "?" (number->string col)))))))
 (define (jolt-current-source-string)
-  (let ((p (jolt-current-source)))
-    (and (pmap? p)
-         (let ((line (jolt-get p hc-kw-line jolt-nil))
-               (col  (jolt-get p hc-kw-column jolt-nil))
-               (file (jolt-get p hc-kw-file jolt-nil)))
-           (if (jolt-nil? line)
-               (and (string? file) file)
-               (string-append
-                 (if (jolt-nil? file) "" (string-append file ":"))
-                 (number->string line) ":"
-                 (if (jolt-nil? col) "?" (number->string col))))))))
+  (jolt-source-position-string (jolt-current-source)))
+
+;; --- where a throwable happened -----------------------------------------
+;; jolt-current-source answers what is evaluating NOW. A throw that crosses a
+;; file load unwinds to the requiring form, and load-jolt-file* (loader.ss) binds
+;; the position around the file, so it unwinds too; the report still wants the
+;; form that FAILED, so that position travels with the throw instead. The
+;; innermost load a raise passes through records (raised-object . position)
+;; here — from its exception handler, before the stack unwinds — and the report
+;; asks for it back by the object's identity. A throw caught on the way leaves a
+;; record nobody asks for, and blames nothing on that file afterwards: while the
+;; position simply stayed put on a throw, a data_readers namespace that failed
+;; on a Joda class put "at .../clj_time/core.clj:254:1" under every later,
+;; unrelated error in the process, the CLI's own argument errors included.
+(define jolt-throw-source (make-thread-parameter #f))
+(define (jolt-note-throw-source! raw)
+  (let ((cur (jolt-throw-source)))
+    (unless (and cur (eq? (car cur) raw))
+      (jolt-throw-source (cons raw (jolt-current-source))))))
+;; The position `raw` was thrown at, as a pmap, or #f.
+(define (jolt-throw-source-position raw)
+  (let ((cur (jolt-throw-source)))
+    (and cur (eq? (car cur) raw) (cdr cur))))
+
+;; The ":jolt/error" map an analyzer diagnostic carries, or #f. Its presence marks
+;; a COMPILE-time diagnostic: raised while analyzing a form, so the live Chez stack
+;; is the analyzer recursing into it, never the user's program.
+(define diag-kw-jolt-error (keyword "jolt" "error"))
+(define (jolt-analyzer-diagnostic v)
+  (let* ((data (and (jolt-ex-info-record? v) (jolt-ex-info-record-data v)))
+         (err (and data (pmap? data) (jolt-get data diag-kw-jolt-error jolt-nil))))
+    (and (pmap? err) err)))
+
+;; "file:line:col" for a diagnostic that carries its own position, else #f — so a
+;; report can name the offending expression rather than the enclosing top-level
+;; form. Same shape jolt-source-position-string renders, so the two are
+;; indistinguishable in the report.
+(define (jolt-diagnostic-location-string err)
+  (let ((line (jolt-get err hc-kw-line jolt-nil))
+        (col (jolt-get err hc-kw-column jolt-nil))
+        (file (jolt-get err hc-kw-file jolt-nil)))
+    (and (not (jolt-nil? line))
+         (string-append
+           (if (jolt-nil? file) "" (string-append (jolt-str-render-one file) ":"))
+           (number->string (jnum->exact line)) ":"
+           (if (jolt-nil? col) "?" (number->string (jnum->exact col)))))))
+
+;; "file:line:col" where the throwable `raw` happened, in the order a report
+;; should trust: the analyzer diagnostic's own position (the innermost form it
+;; failed in), the position the throw crossed a file load at, then whatever is
+;; evaluating now (a -e form, a build phase's file) — or #f. One answer for the
+;; uncaught reporter (cli-core.ss) and for a load the loader catches and warns
+;; about (a data_readers namespace).
+(define (jolt-throwable-source-string raw)
+  (let ((diag (jolt-analyzer-diagnostic (jolt-unwrap-throw raw))))
+    (or (and diag (jolt-diagnostic-location-string diag))
+        (jolt-source-position-string (jolt-throw-source-position raw))
+        (jolt-current-source-string))))
 
 ;; The spine ALWAYS runs with the full clojure.core prelude loaded, so a clojure.*
 ;; ref must lower to var-deref (resolved from the prelude), not trip the emitter's

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -380,11 +380,51 @@ check "-e - reads the expression from stdin" "main1" \
       "$(printf "(require 'appmain) (appmain/-main)" | JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" -e - 2>&1 | tail -1)"
 check "- runs a stdin program against the project" "main1" \
       "$(printf "(require 'appmain) (appmain/-main)" | JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" - 2>&1 | tail -1)"
-out="$(runfull -M)"
-case "$out" in
-  *"have no :main-opts"*) check "bare -M with nothing to run errors" ok ok ;;
-  *) check "bare -M with nothing to run errors" "no-main-opts error" "$(printf '%s' "$out" | head -1)" ;;
-esac
+# -M is clojure.main: with no :main-opts anywhere and nothing on the command
+# line it starts a REPL (`clj -M:dev` is how a REPL over an alias's deps is
+# started), and -r / --repl ask for one explicitly. Resolved WITH the alias:
+# libc is on the roots only through :dev. Piped stdin drives the REPL.
+repl() { expr="$1"; shift; printf '%s\n' "$expr" | JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" "$@" 2>&1; }
+replcheck() { # label expected-fragment out
+  case "$3" in
+    *"$2"*) check "$1" ok ok ;;
+    *) check "$1" "$2" "$(printf '%s' "$3" | head -3)" ;;
+  esac
+}
+replcheck "bare -M with nothing to run starts a REPL" "user=> 3" "$(repl '(+ 1 2)' -M)"
+replcheck "-M:alias without :main-opts starts a REPL over the alias" "libc C" \
+          "$(repl "(require 'appc) (appc/-main)" -M:dev)"
+replcheck ":main-opts [\"-r\"] starts a REPL" "user=> 42" "$(repl '(+ 40 2)' -M:r1)"
+replcheck "-M:alias -r starts a REPL over the alias" "libc C" \
+          "$(repl "(require 'appc) (appc/-main)" -M:dev --repl)"
+# an option jolt's clojure.main does not take says what it does take
+replcheck "unsupported :main-opts names the accepted forms" "accepted: -m NS, -e EXPR, -r, or a script FILE" \
+          "$(runfull -M:bad)"
+
+# A data_readers entry whose namespace fails to load is a WARNING (the project
+# still loads), and the warning has to be actionable: which namespace, why,
+# WHERE it failed, and which tags are now unreadable. And the position the
+# failed load was at must not stick: it used to blame every later, unrelated
+# error on that file ("at .../clj_time/core.clj:254:1" under a CLI arg error).
+RB="$root/test/chez/deps-alias/rdrbroken"
+runrb() { JOLT_PWD="$RB" JOLT_QUIET=1 "$JOLT" "$@" 2>&1; }
+after_report() { printf '%s\n' "$1" | sed -n '/^Unhandled exception/,$p'; }
+warning_block() { printf '%s\n' "$1" | sed '/^Unhandled exception/,$d'; }
+out="$(runrb -X:x)"
+replcheck "data-reader load warning names the namespace and cause" \
+          "data-reader namespace rb.rdr failed to load: Unknown class NoSuchHostClass" "$out"
+replcheck "data-reader load warning says where it failed" "rb/rdr.clj:3:" "$(warning_block "$out")"
+replcheck "data-reader load warning names the tags it takes down" "#rb/up" "$out"
+replcheck "the CLI's own error still reports after the warning" "No function to execute" "$out"
+check "a caught data-reader load leaves no stale 'at' location" "0" \
+      "$(after_report "$out" | grep -c '^  at ')"
+# same leak through a require caught in user code
+out="$(runrb run -m rb.app)"
+replcheck "an error after a caught require is reported" "after a caught load" "$out"
+check "a caught require leaves no stale 'at' location" "0" "$(after_report "$out" | grep -c '^  at ')"
+# …while a load error that PROPAGATES still names the form that failed
+out="$(runrb run -m rb.boom)"
+replcheck "a propagating load error names its form" "rb/boom.clj:3:1" "$(after_report "$out")"
 
 # -X: :exec-fn / :exec-args from the alias, k v overrides, a trailing map, an
 # explicit ns/fn argument, and :ns-aliases qualification

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -202,22 +202,40 @@
                  (pmap-fold m (lambda (k v a) (cons k (cons v a))) '()))))
       (set! data-readers-active #t)
       ;; eagerly load each reader fn's namespace so the rewritten call resolves.
+      ;; Tolerant — a data_readers entry must not kill the project load — but a
+      ;; failure is reported in full (ldr-warn-reader-ns-failed!), or the miss
+      ;; surfaces later as an unrelated unresolved-var error at first #tag read.
       (pmap-fold m (lambda (k v a)
                      (when (and (symbol-t? v) (symbol-t-ns v) (not (jolt-nil? (symbol-t-ns v))))
-                       ;; tolerant — a data_readers entry must not kill the project
-                       ;; load — but say WHICH reader ns failed and why, or the
-                       ;; miss surfaces later as an unrelated unresolved-var error
-                       ;; at first #tag read.
-                       (guard (e (#t (display
-                                      (string-append "jolt: warning: data-reader namespace "
-                                                     (symbol-t-ns v) " failed to load: "
-                                                     (guard (_ (#t "(unprintable error)"))
-                                                       ((var-deref "jolt.host" "condition-message") e))
-                                                     "\n")
-                                      (current-error-port))))
+                       (guard (e (#t (ldr-warn-reader-ns-failed! (symbol-t-ns v) e m)))
                          (load-namespace (symbol-t-ns v))))
                      a)
                  #f)))))
+
+;; The warning for a data_readers namespace that failed to load — everything the
+;; reader needs to act on it: which namespace, why, WHERE it failed (the throw's
+;; own position, in the shape the uncaught report uses), and which tags of the
+;; file now have no reader. The load's position does not outlive the warning:
+;; load-jolt-file* unwinds it, so the next error in the process is not reported
+;; "at" this namespace's failing form.
+(define (ldr-warn-reader-ns-failed! ns-name e readers)
+  (let ((port (current-error-port))
+        (msg (guard (_ (#t "(unprintable error)"))
+               ((var-deref "jolt.host" "condition-message") e)))
+        (where (jolt-throwable-source-string e))
+        (tags (sort string<?
+                    (pmap-fold readers
+                               (lambda (k v a)
+                                 (if (and (symbol-t? v) (equal? (symbol-t-ns v) ns-name))
+                                     (cons (string-append "#" (jolt-pr-str k)) a)
+                                     a))
+                               '()))))
+    (display (string-append "jolt: warning: data-reader namespace " ns-name
+                            " failed to load: " msg "\n")
+             port)
+    (when where (display (string-append "  at " where "\n") port))
+    (unless (null? tags)
+      (display (string-append "  tags " (jolt-str-join tags) " will not read\n") port))))
 (define (load-data-readers!)
   (for-each
     (lambda (root)
@@ -449,18 +467,22 @@
 ;; Split out so the AOT cache (below) reads source once for both keying and the
 ;; capture load, instead of re-reading inside the loop.
 (define (load-jolt-file* path src)
-  (let* ((end (string-length src))
-         ;; Restore the current-source position on NORMAL return only. Loading a
-         ;; required file advances the position per form; without restoring it, a
-         ;; later error in the requiring file (e.g. a second, missing require in
-         ;; the same ns form) would be blamed on the last form of the dependency
-         ;; that just loaded. On a throw we intentionally do NOT restore, so the
-         ;; error keeps the failing form's own position instead of unwinding to
-         ;; the requiring form — the report then points at the file that failed.
-         (saved-source (jolt-current-source)))
+  (let ((end (string-length src)))
     ;; parameterize (not a bare set!) so a require nested in this file's ns form
     ;; restores path when control returns to the rest of this file.
     (parameterize ((rdr-source-file path)    ; list forms read here carry :file = path
+                   ;; The current-source position too: loading a file advances it
+                   ;; per form, and the requiring file's next error (a second,
+                   ;; missing require in the same ns form) must not be blamed on
+                   ;; the dependency's last form. Bound around the WHOLE load, so a
+                   ;; throw restores it as well — the failing form's position
+                   ;; travels with the throw instead (the handler below), which is
+                   ;; what the uncaught report prints. Restoring on a normal
+                   ;; return only, as this used to, left a throw that was CAUGHT
+                   ;; (a data_readers namespace the loader tolerates, a require
+                   ;; in a try) pinning the position on the file that failed, and
+                   ;; every later, unrelated error was reported "at" it.
+                   (jolt-current-source (jolt-current-source))
                    ;; Tee into the AOT capture only while loading the file that
                    ;; capture was opened for. A nested load must not append its
                    ;; forms to the requiring namespace's artifact: that artifact
@@ -479,25 +501,34 @@
                                           (jolt-aot-capture))))
       (ldr-with-file-vars path
         (lambda ()
-          ;; rdr-read-top, not rdr-read-form: a stray close delimiter is a READ
-          ;; ERROR at a file's top level, and only the top-level entry says so.
-          ;; rdr-read-form leaves the position where it found the `)`, and the
-          ;; (> j i) guard below reads no progress as end of input — so one extra
-          ;; paren silently DROPPED the rest of the file and the run exited 0.
-          ;; A test file that lost its whole body that way still looked like a
-          ;; pass. The JVM raises "Unmatched delimiter: )" here (jolt-3amm).
-          (let loop ((i 0))
-            (when (< i end)
-              (let-values (((form j) (rdr-read-top src i end)))
-                (when (> j i)
-                  (unless (rdr-eof? form)
-                    (when (getenv "JOLT_TRACE_LOAD")
-                      (display "  [load-form] " (current-error-port))
-                      (display (jolt-pr-str form) (current-error-port)) (newline (current-error-port)))
-                    (jolt-compile-eval-form (if data-readers-active (ldr-apply-readers form) form)
-                                            (chez-current-ns)))
-                  (loop j))))))))
-    (jolt-current-source saved-source)))
+          ;; The failing form's position, recorded before the stack unwinds (an
+          ;; exception handler runs at the raise; a guard runs after) and keyed
+          ;; by the raised object, so the report can ask for it back. The
+          ;; innermost load records first and outer ones keep its answer.
+          ;; raise-continuable, so a continuable raise (a compiler warning)
+          ;; resumes exactly as it would without this handler.
+          (with-exception-handler
+            (lambda (e) (jolt-note-throw-source! e) (raise-continuable e))
+            (lambda ()
+              ;; rdr-read-top, not rdr-read-form: a stray close delimiter is a
+              ;; READ ERROR at a file's top level, and only the top-level entry
+              ;; says so. rdr-read-form leaves the position where it found the
+              ;; `)`, and the (> j i) guard below reads no progress as end of
+              ;; input — so one extra paren silently DROPPED the rest of the file
+              ;; and the run exited 0. A test file that lost its whole body that
+              ;; way still looked like a pass. The JVM raises "Unmatched
+              ;; delimiter: )" here (jolt-3amm).
+              (let loop ((i 0))
+                (when (< i end)
+                  (let-values (((form j) (rdr-read-top src i end)))
+                    (when (> j i)
+                      (unless (rdr-eof? form)
+                        (when (getenv "JOLT_TRACE_LOAD")
+                          (display "  [load-form] " (current-error-port))
+                          (display (jolt-pr-str form) (current-error-port)) (newline (current-error-port)))
+                        (jolt-compile-eval-form (if data-readers-active (ldr-apply-readers form) form)
+                                                (chez-current-ns)))
+                      (loop j))))))))))))
 
 ;; --- AOT / compile cache for required namespaces ----------------------------
 ;; A disk-backed namespace is recompiled from source on EVERY run (load-jolt-file

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -267,11 +267,18 @@
 ;; with trailing args). The user-supplied extra args are appended, so an alias's
 ;; :main-opts and the command line combine exactly like the clj CLI, which
 ;; prepends the alias's :main-opts to the argv.
+(declare repl-session)
+
 (defn- apply-main-opts [main-opts extra-args]
   (let [opts (concat main-opts extra-args)]
     (cond
       (= "-m" (first opts)) (run-ns (second opts) (drop 2 opts))
       (= "-e" (first opts)) (eval-expr-string (second opts) (drop 2 opts) true)
+      ;; clojure.main -r / --repl: a REPL, the rest as *command-line-args*.
+      (#{"-r" "--repl"} (first opts))
+      (do (push-thread-bindings
+            {#'clojure.core/*command-line-args* (seq (drop-end-of-options (rest opts)))})
+          (repl-session))
       ;; clojure.main: a bare non-option first arg is a script path and the
       ;; rest is *command-line-args* — `jolt -M file.clj a b`, or an alias
       ;; whose :main-opts name a script. Same load shape as `run FILE`.
@@ -282,7 +289,9 @@
             {#'clojure.core/*command-line-args* (seq (drop-end-of-options (rest opts)))})
           (load-file (file-arg (first opts)))
           nil)
-      :else (throw (ex-info (str "unsupported :main-opts " (pr-str (vec opts))) {})))))
+      :else (throw (ex-info (str "unsupported :main-opts " (pr-str (vec opts))
+                                 " (accepted: -m NS, -e EXPR, -r, or a script FILE)")
+                            {:main-opts (vec opts)})))))
 
 (defn- parse-aliases [s]            ; "-M:a:b" / ":a:b" -> [:a :b]
   (let [s (if (str/starts-with? s "-") (subs s 2) s)]
@@ -330,8 +339,10 @@
 ;; -M[:alias…] [main-opts…] — resolve with the aliases (plus any bound by a
 ;; leading -A), then run their :main-opts followed by the command-line ones. With
 ;; no :main-opts anywhere in the selected aliases the command line supplies them
-;; on its own, so a bare `jolt -M -e EXPR` (or `-M -m NS`) works like clj — only
-;; an empty command line with no :main-opts is an error.
+;; on its own, so a bare `jolt -M -e EXPR` (or `-M -m NS`) works like clj. With
+;; nothing to run at all this is clojure.main with no arguments: a REPL over the
+;; resolved project — `clj -M:dev` is how a REPL with an alias's deps is started.
+;; (It used to be an error, "alias(es) [...] have no :main-opts".)
 (defn- cmd-M [arg more]
   (let [aliases (parse-aliases arg)
         {:keys [main-opts] :as resolved} (resolve-current aliases)]
@@ -339,7 +350,7 @@
       (fn []
         (if (or (seq main-opts) (seq more))
           (apply-main-opts main-opts more)
-          (throw (ex-info (str "alias(es) " (pr-str aliases) " have no :main-opts") {})))))))
+          (repl-session))))))
 
 ;; -A:alias… — select the aliases, then run the remaining argv as a command with
 ;; *cli-aliases* bound, so the command's own project resolution (run/path/build/
@@ -470,11 +481,16 @@
         :else       (let [nb (str buf "\n" line)]
                       (if (repl-form-complete? nb) nb (recur nb)))))))
 
+;; `jolt repl`: resolve the project so deps (git libs) are on the roots and
+;; native libs are loaded — same context a run gets, so (require '[some.lib])
+;; works in the REPL — then the session. -M reaches the session directly, with
+;; its aliases already applied.
 (defn- repl []
-  ;; resolve the project so deps (git libs) are on the roots and native libs are
-  ;; loaded — same context a run gets, so (require '[some.lib]) works in the REPL.
   (try (apply-project! (resolve-current))
        (catch :default _ nil))
+  (repl-session))
+
+(defn- repl-session []
   ;; REPL-driven development: trace by default so an uncaught error in evaluated
   ;; code shows a tail-frame backtrace, no JOLT_TRACE needed (JOLT_TRACE=0 opts out).
   (jolt.host/enable-trace!)

--- a/test/chez/deps-alias/app/deps.edn
+++ b/test/chez/deps-alias/app/deps.edn
@@ -15,6 +15,9 @@
   :m2     {:main-opts ["-m" "appmain2"]}
   ;; :main-opts may be an -e expression, not just -m
   :e1     {:main-opts ["-e" "(require 'appmain) (appmain/-main)"]}
+  ;; clojure.main's -r: a REPL, with whatever the alias adds
+  :r1     {:main-opts ["-r"]}
+  :bad    {:main-opts ["--nope"]}
   :time   {:extra-deps {local/timefix {:local/root "../timefix"}}}
   ;; a jolt.time that is on the roots but does not compile
   :timebroken {:extra-deps {local/timebroken {:local/root "../timebroken"}}}

--- a/test/chez/deps-alias/rdrbroken/deps.edn
+++ b/test/chez/deps-alias/rdrbroken/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :aliases {:x {:extra-paths ["src"]}}}

--- a/test/chez/deps-alias/rdrbroken/src/data_readers.clj
+++ b/test/chez/deps-alias/rdrbroken/src/data_readers.clj
@@ -1,0 +1,1 @@
+{rb/up rb.rdr/up}

--- a/test/chez/deps-alias/rdrbroken/src/rb/app.clj
+++ b/test/chez/deps-alias/rdrbroken/src/rb/app.clj
@@ -1,0 +1,5 @@
+(ns rb.app)
+
+(defn -main [& _]
+  (try (require 'rb.rdr) (catch Exception _ nil))
+  (throw (ex-info "after a caught load" {})))

--- a/test/chez/deps-alias/rdrbroken/src/rb/boom.clj
+++ b/test/chez/deps-alias/rdrbroken/src/rb/boom.clj
@@ -1,0 +1,3 @@
+(ns rb.boom)
+
+(throw (ex-info "boom while loading" {}))

--- a/test/chez/deps-alias/rdrbroken/src/rb/rdr.clj
+++ b/test/chez/deps-alias/rdrbroken/src/rb/rdr.clj
@@ -1,0 +1,5 @@
+(ns rb.rdr)
+
+(def zone (NoSuchHostClass/UTC))
+
+(defn up [s] (.toUpperCase s))


### PR DESCRIPTION
"`jolt -M:test:jolt` in a project with clj-time printed\n\n```\njolt: warning: data-reader namespace clj-time.coerce failed to load: Unknown class DateTimeZone\nUnhandled exception: alias(es) [:test :jolt] have no :main-opts\n  ex-data: {}\n  at /Users/…/clj-time-0.15.2.jar.jolt/clj_time/core.clj:254:1\n```\n\nTwo things wrong with that, fixed here.\n\n**`-M` with nothing to run is a REPL.** `-M` is clojure.main, and clojure.main with no args starts a REPL — `clj -M:dev` is how you get a REPL over an alias's deps. jolt threw instead. `cmd-M` now falls through to the REPL session with the aliases already applied; `:main-opts [\"-r\"]` / `--repl` work too. An unsupported `:main-opts` form now says what is accepted.\n\n**A caught load error pinned the source position.** The `at` line is \"the top-level form that was evaluating\", and `load-jolt-file*` deliberately didn't restore it on a throw so a propagating error kept its own position. But the data-reader load was caught (warned and continued), so the position stayed on clj-time's line 254 and every later error in the process — here the CLI's own arg error — was reported at it. Same leak through `(try (require …) (catch …))`.\n\nThe load now binds the position around the whole file (any exit restores it), and the failing form's position travels with the throw: the innermost load a raise crosses records `(raised-object . position)` from an exception handler before the stack unwinds, and the report reads it back by identity (`jolt-throwable-source-string`, one seam for the uncaught reporter, `JOLT_DIAG=edn`, and the loader's warning). A propagating load error is placed exactly as before (`rb.boom` case); a caught one leaves nothing behind.\n\nThe data-reader warning now says where it failed and which tags are dead:\n\n```\njolt: warning: data-reader namespace clj-time.coerce failed to load: Unknown class DateTimeZone\n  at /Users/…/clj_time/core.clj:254:1\n  tags #clj-time/date-time will not read\n```\n\nTests: new `rdrbroken` fixture + 12 cases in deps-alias-smoke (red on v0.8.1: 8 fail; green: 117/117). Full `make test` green.\n\nNoticed but not touched: in source mode the trace under a load error names `jolt.main/drop-end-of-options`, a loop that finished before the require — pre-existing (A/B'd with this change stashed), filed as jolt-492c.\n"