### PR TITLE
Reset the tail-site slot per top-level form; CLI entries start in user; balance hotscaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`tags #clj-time/date-time will not read`), instead of leaving the reader to
   find the form and to meet the missing tag later as an unrelated
   unresolved-var error.
+- **A returned call no longer haunts a top-level throw.** The trace under an
+  error thrown at the top level of a file being loaded — or of a `-e`, a
+  `load-string`, a REPL input — opened with a frame from a fn that had returned
+  long before: `jolt.main/drop-end-of-options` under a `run -m` whose namespace
+  failed to load, a helper's tail call from the fn that called `require`, a
+  macro's helper when the expansion threw. The tail-site slot the reporter reads
+  holds the last tail call made, and nothing tail-calls a top-level form, so
+  the slot is cleared when one starts to compile and again when its compiled
+  code starts to run.
+- **Every CLI entry starts in `user`.** The built image bakes `jolt.main` and
+  loading a namespace leaves it current, so a bare `jolt -e '(str *ns*)'`
+  printed `jolt.main`, a REPL `(defn h …)` landed as `#'jolt.main/h` under a
+  prompt that said `user`, and `-main` under `run -m` ran in `jolt.main`.
+  `clojure.main` starts every entry in `user`; jolt does too now, and the REPL
+  prompt names whatever namespace is current, as `clojure.main`'s does.
 
 ## [0.8.1] - 2026-09-02
 

--- a/host/chez/cli-core.ss
+++ b/host/chez/cli-core.ss
@@ -261,6 +261,12 @@
     (else #f)))
 
 (define (jolt-cli-run cli-args prepare-build!)
+  ;; Every entry starts in user, as clojure.main's does. The image bakes jolt.main
+  ;; and jolt.deps at heap build, and loading a namespace leaves it current, so
+  ;; without this a bare -e or a REPL evaluated in jolt.main: (str *ns*) said so,
+  ;; and a REPL def landed as #'jolt.main/x under a prompt that said user. The
+  ;; script driver arrives with user already current; here it costs nothing.
+  (set-chez-ns! "user")
   ;; On the main thread, before anything user code can reach: Chez's exit-handler
   ;; is a thread parameter, so the shutdown-hook wrapper has to be installed on
   ;; the thread that will call (exit), and this is that thread for both CLI

--- a/host/chez/compile-eval.ss
+++ b/host/chez/compile-eval.ss
@@ -119,6 +119,7 @@
   (register-class-statics! "clojure.lang.Compiler" members))
 
 (define (jolt-enter-form! form)
+  (jolt-site-reset!)   ; a top-level form is a root (rt.ss)
   (let ((p (hc-form-position form)))
     (when (pmap? p)
       (jolt-current-source p)
@@ -630,6 +631,9 @@
      (let* ((scm (jolt-analyze-emit-form form ns))
             (cap (jolt-aot-capture)))            ; tee for the AOT cache (loader.ss)
        (when cap (put-string cap scm) (newline cap))
+       ;; the run is a root as much as the compile was: expanding the form ran
+       ;; macros, whose tail sites would otherwise be what a throw here reports.
+       (jolt-site-reset!)
        (if (jolt-ce-trace-frames?)
            (jolt-eval-with-source scm)
            (eval (read (open-input-string scm)) (interaction-environment)))))))

--- a/host/chez/rt.ss
+++ b/host/chez/rt.ss
@@ -442,6 +442,13 @@
 ;; Consumers therefore read the THROW-TIME snapshot (jolt-throw-sitep), and the
 ;; reporter validates it against the callsite table before splicing.
 (define (jolt-site! p) (set-virtual-register! jolt-vreg-site p))
+;; A top-level form is a root: nothing tail-called it, so whatever the slot holds
+;; when one starts is a returned call's residue — the reporter's validator cannot
+;; tell it from a live pair when the innermost live frame is a host fn (the
+;; loader, the eval loop), which registers no callees. compile-eval.ss clears the
+;; slot when a form starts to compile and again when its compiled code starts to
+;; run, since macroexpansion runs user code in between.
+(define (jolt-site-reset!) (set-virtual-register! jolt-vreg-site 0))
 ;; The line to report for the INNERMOST frame. Inside a catch clause that is the
 ;; line the throw came from, snapshotted on the way in; else the pair stashed at
 ;; the raise. Never the live vreg — it can be stale between throws.

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -527,6 +527,37 @@ else
   fails=$((fails + 1))
 fi
 
+# Every CLI entry starts in user, like clojure.main's. The image bakes jolt.main
+# at heap build, and loading a namespace leaves it current, so -e, the REPL and a
+# run's -main all evaluated in jolt.main: a REPL def landed as #'jolt.main/x
+# under a prompt that said user.
+ns_e="$($jolt -e '(defn h [] 1) (println (str *ns*) (str #'"'"'h))' 2>/dev/null)"
+if printf '%s' "$ns_e" | grep -q "^user #'user/h"; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: -e should evaluate in user (got \`$ns_e\`)"
+  fails=$((fails + 1))
+fi
+repl_ns="$(printf '(in-ns (quote foo))\n(str *ns*)\n' | $jolt repl 2>/dev/null)"
+if printf '%s' "$repl_ns" | grep -q '^foo=> "foo"'; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: the REPL prompt should name the current namespace (got \`$repl_ns\`)"
+  fails=$((fails + 1))
+fi
+nsm="$(mktemp -d)"
+mkdir -p "$nsm/src/nsm"
+printf '{:paths ["src"]}\n' > "$nsm/deps.edn"
+printf '(ns nsm.core)\n(defn -main [& _] (println (str *ns*)))\n' > "$nsm/src/nsm/core.clj"
+nsm_out="$(JOLT_PWD="$nsm" $jolt run -m nsm.core 2>/dev/null | tail -1)"
+if [ "$nsm_out" = "user" ]; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: run -m should invoke -main in user (got \`$nsm_out\`)"
+  fails=$((fails + 1))
+fi
+rm -rf "$nsm"
+
 # The runtime's shared side-tables (metadata, the variadic fixed-arity registry)
 # must survive concurrent access: a Chez hashtable is not thread-safe, and
 # unsynchronized mutation corrupts it into a SIGSEGV inside the collector or a

--- a/host/chez/trace-smoke.sh
+++ b/host/chez/trace-smoke.sh
@@ -217,6 +217,64 @@ out_ss="$(run_app app.sitestale)"
 expect_match "sitestale: the thrower is named at its line" "$out_ss" 'app\.sitestale/h (.*src/app/sitestale\.clj:5)'
 expect_no_match "sitestale: the returned fn's site is rejected" "$out_ss" 'app\.sitestale/g'
 
+# A top-level form is a root. The site vreg holds the LAST tail site executed,
+# and only tail sites write it — so when a loaded file throws at its top level,
+# which nothing tail-called, the raise-time stash is whatever the previous call
+# left behind: helper's `str` tail here, long returned. The validator cannot
+# reject it either, because the innermost live frame is the loader itself, a
+# host fn that registers no callees. Each form-at-a-time entry — the loader,
+# -e, load-string, the REPL — clears the slot when a form starts (jolt-site-reset!).
+cat > "$work/src/app/topres.clj" <<'EOF'
+(ns app.topres)
+(defn helper [] (str "a" "b"))
+(defn -main [& _]
+  (helper)
+  (require 'app.topboom)
+  (println "unreachable"))
+EOF
+cat > "$work/src/app/topboom.clj" <<'EOF'
+(ns app.topboom)
+(throw (ex-info "top" {}))
+EOF
+echo "trace smoke: a returned tail site cannot haunt a throw at a loaded file's top level"
+out_tr="$(run_app app.topres)"
+expect_match "topres: the location is the throwing form" "$out_tr" 'at .*src/app/topboom\.clj:2:1'
+expect_match "topres: the loading caller is named at its require line" "$out_tr" 'app\.topres/-main (.*src/app/topres\.clj:5)'
+expect_no_match "topres: the returned helper is not resurrected" "$out_tr" 'app\.topres/helper'
+# The form's COMPILE is a root too: macroexpansion runs user code, and mk's
+# `apply` tail is what the slot held when the expanded throw ran — cleared again
+# between the expansion and the run.
+cat > "$work/src/app/macboom.clj" <<'EOF'
+(ns app.macboom)
+(defn mk [] (apply list ['throw (list 'ex-info "mac" {})]))
+(defmacro m [] (mk))
+(m)
+EOF
+cat > "$work/src/app/macmain.clj" <<'EOF'
+(ns app.macmain)
+(defn -main [& _]
+  (require 'app.macboom)
+  (println "unreachable"))
+EOF
+echo "trace smoke: macroexpansion's tail sites cannot haunt the expanded form's run"
+out_mr="$(run_app app.macmain)"
+expect_match "macres: the loading caller is named" "$out_mr" 'app\.macmain/-main (.*src/app/macmain\.clj:3)'
+expect_no_match "macres: the expander's helper is not resurrected" "$out_mr" 'app\.macboom/mk'
+# The same rule at the other form-at-a-time entries.
+run_e() { ( cd "$work" && "$joltabs" -e "$1" 2>&1 ); }
+out_e="$(run_e '(defn h [] (str 1)) (h) (throw (ex-info "x" {}))')"
+expect_match "-e: the throw is reported" "$out_e" 'Unhandled exception: x'
+expect_no_match "-e: a returned fn is not resurrected" "$out_e" '^ *[a-z.]*/h$'
+out_ls="$(run_e '(load-string "(defn h2 [] (str 1)) (h2) (throw (ex-info \"y\" {}))")')"
+expect_match "load-string: the throw is reported" "$out_ls" 'Unhandled exception: y'
+expect_no_match "load-string: a returned fn is not resurrected" "$out_ls" '^ *[a-z.]*/h2$'
+out_repl="$( ( cd "$work" && printf '(defn h3 [] (str 1))\n(h3)\n(throw (ex-info "z" {}))\n' | "$joltabs" repl 2>&1 ) )"
+expect_match "repl: the throw is reported" "$out_repl" 'error: z'
+expect_no_match "repl: a returned fn is not resurrected" "$out_repl" '^ *[a-z.]*/h3$'
+# and the positive dual: a throw INSIDE an evaluated fn still names it
+out_repl2="$( ( cd "$work" && printf '(defn t [] (throw (ex-info "q" {})))\n(t)\n' | "$joltabs" repl 2>&1 ) )"
+expect_match "repl: a throw inside an evaluated fn names it" "$out_repl2" '^ *[a-z.]*/t$'
+
 # R2: a HOST fault (no jolt-throw anywhere — a bad primitive-array index) is
 # captured by the cli's with-exception-handler while the frames are live, so
 # the trace still names the fn and its exact line.

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -470,7 +470,7 @@
   ;; accumulated buffer is a complete form. Returns the (possibly multi-line)
   ;; buffer, or nil on EOF at the primary prompt.
   (loop [buf nil]
-    (print (if buf "... " "user=> ")) (flush)
+    (print (if buf "... " (str (ns-name *ns*) "=> "))) (flush)
     (let [line (read-line)]
       (cond
         (nil? line) buf                                 ; EOF: nil at primary, partial mid-form

--- a/test/hotpath_scaling_test.clj
+++ b/test/hotpath_scaling_test.clj
@@ -2,8 +2,9 @@
 ;; StringTokenizer, ns-publics/refer, and set/intersection must not scale
 ;; worse than linearly (or must be independent of a dimension they used to
 ;; scale with). One file, one boot: each section is the same in-process
-;; judgment as read_scaling_test.clj — best-of-3, only ratios, sized so a
-;; REGRESSED implementation still finishes and fails rather than hanging.
+;; judgment as read_scaling_test.clj — best-of-5 over alternating arms, only
+;; ratios, sized so a REGRESSED implementation still finishes and fails rather
+;; than hanging.
 ;;
 ;; What each section pins (all were real, found in the 2026-08 structural
 ;; sweep):
@@ -25,10 +26,13 @@
             [clojure.set :as set]
             [clojure.core.async :as async]))
 
+;; Milliseconds as a double, from the nanosecond clock: a row whose small arm
+;; takes a millisecond or two is otherwise quantized to 1 or 2, and its ratio
+;; to 5.0 or 10.0 — which is where the timeout row's noise came from.
 (defn- timed [f]
-  (let [t (System/currentTimeMillis)
+  (let [t (System/nanoTime)
         v (f)]
-    [(- (System/currentTimeMillis) t) v]))
+    [(/ (- (System/nanoTime) t) 1e6) v]))
 
 (defn- best-of [k f]
   (reduce min (map first (repeatedly k #(timed f)))))
@@ -36,13 +40,40 @@
 (def ^:private failures (atom 0))
 
 (defn- judge [label t1 t4 ceiling detail]
-  (let [t1 (max 1 t1)
+  (let [t1 (max 0.05 t1)
         ratio (double (/ t4 t1))]
-    (println (format "hotpath %-9s %4dms vs %4dms, ratio %6.2f (ceiling %.1f)"
+    (println (format "hotpath %-9s %7.1fms vs %7.1fms, ratio %6.2f (ceiling %.1f)"
                      label t1 t4 ratio (double ceiling)))
     (when (> ratio ceiling)
       (println (str "FAIL hotpath " label ": " detail))
       (swap! failures inc))))
+
+;; Two arms measured together: best-of-5 each, the runs ALTERNATING arms so a
+;; contended stretch of a shared CI runner lands on both. Measured separately,
+;; a short arm nearly always finds one clean run and a long arm often does not,
+;; which reads as the long arm being superlinear — the deque row read 8.33 on a
+;; 4-vs-16 expectation that way, then the tokenizer row 8.50. A miss is measured
+;; once more before it counts; a regression misses twice.
+(defn- judge-thunks [label fa fb ceiling detail]
+  (let [measure (fn []
+                  (let [ts (doall (repeatedly 5 #(vector (first (timed fa)) (first (timed fb)))))]
+                    [(reduce min (map first ts)) (reduce min (map second ts))]))
+        [ta tb] (measure)
+        ratio (double (/ tb (max 0.05 ta)))]
+    (if (<= ratio ceiling)
+      (judge label ta tb ceiling detail)
+      (do (println (format "hotpath %-9s %7.1fms vs %7.1fms, ratio %6.2f — over %.1f, measuring again"
+                           label ta tb ratio (double ceiling)))
+          (let [[ua ub] (measure)] (judge label ua ub ceiling detail))))))
+
+;; A scaling row: f1 drains the base size, f4 four times it. The arms are
+;; balanced to the SAME wall time for a linear implementation — f1 runs 4×reps
+;; times, f4 reps times — so the ratio reads ~1 for linear and ~4 for quadratic
+;; (the ceiling sits at 2), and contention inflates both arms alike rather than
+;; only the longer one. The big arm's total work is what "still finishes when
+;; regressed" is sized around, and it is unchanged: reps drains of 4n.
+(defn- judge-scaling [label f1 f4 reps ceiling detail]
+  (judge-thunks label #(dotimes [_ (* 4 reps)] (f1)) #(dotimes [_ reps] (f4)) ceiling detail))
 
 ;; --- split with a positive limit ---------------------------------------------
 (defn- split-drain [n]
@@ -77,27 +108,29 @@
     (println "FAIL hotpath: wrong results from a fixed path")
     (System/exit 1))
 
-  ;; Each timed arm repeats its drain 4x: the deque small arm measured ~3ms,
-  ;; under the CI noise floor, and read 8.33 against the 8.0 ceiling on a
-  ;; shared runner (a regressed shifting impl sits ~16). Repetition grows the
-  ;; measurement without growing n, so a quadratic regression's per-drain cost
-  ;; — what "still finishes when broken" was sized around — is unchanged.
+  ;; 4 drains of 4n against 16 drains of n: a linear drain reads ~1, a
+  ;; quadratic one ~4 (a regressed shifting deque sat at 16 on a 4-vs-16
+  ;; expectation, which is 4 here). The base arm alone measured ~3ms, under the
+  ;; CI noise floor; the repetition grows the measurement without growing n.
   (let [n1 4000]
-    (judge "split" (best-of 3 #(dotimes [_ 4] (split-drain n1))) (best-of 3 #(dotimes [_ 4] (split-drain (* 4 n1)))) 8.0
+    (judge-scaling "split" #(split-drain n1) #(split-drain (* 4 n1)) 4 2.0
            "re-split is recomputing (length out) per part again (natives-str.ss)")
-    (judge "deque" (best-of 3 #(dotimes [_ 4] (deque-drain n1))) (best-of 3 #(dotimes [_ 4] (deque-drain (* 4 n1)))) 8.0
+    (judge-scaling "deque" #(deque-drain n1) #(deque-drain (* 4 n1)) 4 2.0
            "ArrayDeque front ops are shifting the backing vector again (host-static-classes.ss)")
-    (judge "tokenizer" (best-of 3 #(dotimes [_ 4] (tok-drain n1))) (best-of 3 #(dotimes [_ 4] (tok-drain (* 4 n1)))) 8.0
+    (judge-scaling "tokenizer" #(tok-drain n1) #(tok-drain (* 4 n1)) 4 2.0
            "StringTokenizer is scanning its token list per token again (host-static-classes.ss)"))
 
-  ;; timeout arming: single measurement per size (arming is not idempotent —
-  ;; a second best-of run would arm into a heap pre-loaded by the first, which
-  ;; is fine for a heap but distorts the pre/post comparison), far-future
-  ;; deadlines so nothing fires mid-measure.
+  ;; timeout arming: a plain 1-vs-4 row, not a balanced one. Arming is not
+  ;; idempotent — every run arms into the heap the earlier runs filled — and
+  ;; repeating the small arm 4x would make it the SAME 4k inserts as the big
+  ;; arm, so a regressed linear insert would read 1. Best-of over the growing
+  ;; heap is sound the other way round: a heap costs log n more per run, a
+  ;; regressed list costs n more, so a miss re-measured only reads worse. Each
+  ;; run gets its own far-future deadline band so nothing fires mid-measure.
   (let [k 2000
-        [t1 _] (timed #(arm-timeouts k 3600000))
-        [t4 _] (timed #(arm-timeouts (* 4 k) 7200000))]
-    (judge "timeout" t1 t4 8.0
+        band (atom 0)
+        arm (fn [n] #(arm-timeouts n (+ 3600000 (* 200000 (swap! band inc)))))]
+    (judge-thunks "timeout" (arm k) (arm (* 4 k)) 8.0
            "timeout-insert! is walking the pending list per arm again (async.ss)"))
 
   ;; ns-publics shape independence: a tiny namespace's ns-publics must not get
@@ -116,14 +149,9 @@
   ;; intersection shape independence: big ∩ small vs small ∩ big.
   (let [big (set (range 100000))
         small #{1 2 3}
-        reps 200
-        t-bs (best-of 3 #(dotimes [_ reps] (set/intersection big small)))
-        t-sb (max 1 (best-of 3 #(dotimes [_ reps] (set/intersection small big))))
-        ratio (double (/ t-bs t-sb))]
-    (println (format "hotpath set-shape %4dms vs %4dms, ratio %6.2f (ceiling 5.0)" t-bs t-sb ratio))
-    (when (> ratio 5.0)
-      (println "FAIL hotpath set-shape: intersection is walking its larger argument (set.clj)")
-      (swap! failures inc)))
+        reps 200]
+    (judge-thunks "set-shape" #(dotimes [_ reps] (set/intersection small big)) #(dotimes [_ reps] (set/intersection big small)) 5.0
+           "intersection is walking its larger argument (set.clj)"))
 
   ;; protocol-count shape independence: a record collection op looks for a
   ;; declared impl before falling back to the record behaviour, and that lookup
@@ -157,10 +185,8 @@
                          (contains? one :x) (contains? many :x))
             (println "FAIL hotpath proto-shape: record ops answered wrong")
             (System/exit 1))
-        probe (fn [r] #(dotimes [_ reps] (do (count r) (contains? r :x) (seq r))))
-        t1 (max 1 (best-of 3 (probe one)))
-        t8 (best-of 3 (probe many))]
-    (judge "proto-shape" t1 t8 3.0
+        probe (fn [r] #(dotimes [_ reps] (do (count r) (contains? r :x) (seq r))))]
+    (judge-thunks "proto-shape" (probe one) (probe many) 3.0
            "record collection ops are re-walking the type's protocol table (find-method-any-protocol, protocols.ss) — 8 protocols cost more than 1"))
 
   (if (pos? @failures)


### PR DESCRIPTION
"Follow-up to #825.\n\nA throw at the top level of a file being loaded (or of a `-e`, a `load-string`, a REPL input) opened its trace with a fn that had returned long before — `jolt.main/drop-end-of-options` under a `run -m` whose namespace failed to load, a helper's tail call from the fn that called `require`, a macro's helper when the expansion threw. The tail-site slot holds the last tail call made and nothing tail-calls a top-level form, so the raise-time stash was residue the validator cannot reject when the innermost live frame is the loader. The slot is cleared when a form starts to compile and again when its code starts to run.\n\nFound on the way: the built image evaluates `-e`, the REPL and a run's `-main` in `jolt.main`, not `user` (`(str *ns*)` said so; a REPL `defn` landed as `#'jolt.main/h` under a `user=>` prompt). `jolt-cli-run` now sets `user` on entry and the prompt names the current namespace.\n\nAlso: the `hotscaling` gate failed the pull_request run of #825 at 8.50 vs 8.0 on the tokenizer row and passed the push run of the same commit. The arms are balanced to equal wall time now, alternated inside best-of-5, re-measured once on a miss, and timed in nanoseconds. Under ten CPU hogs the old file failed 6/6 runs, this one 0/6; a deliberately quadratic drain still fails.\n\nGates: trace smoke +11 cases (the five negatives red on 0.8.1, positive duals green on both), cli smoke +3 (red on 0.8.1), full `make test` green (ci 97 targets, test 3).\n"