### PR TITLE
Stop forwarding JOLT_PWD to children; model the classes typed.clojure names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   child's environment map asked for it and keeps it. An installed binary never
   exports the variable, which is why the same program passed under one and
   failed under a source checkout.
+- **`clojure.lang.Agent`, `AMapEntry`, `ChunkBuffer`, `IAtom`, `IAtom2`,
+  `IBlockingDeref`, `IChunk`, `IMapEntry`, `Reduced` and `Volatile` resolve.**
+  typed.clojure's core annotations name all ten, and its `override-classes`
+  stopped at the first: `Could not resolve class: clojure.lang.ChunkBuffer`.
+  Each is in the class graph under its JVM supers now, so `resolve`, `import`,
+  `Class/forName`, `bases`, `supers`, `.isInterface`, `.getModifiers` and
+  `instance?` agree: an atom is an `IAtom2`, a promise and a future are
+  `IBlockingDeref`, a reduced box is an `IDeref` and reports
+  `clojure.lang.Reduced` (it was `:object`), `MapEntry` extends `AMapEntry`
+  which is an `IMapEntry`, and a chunk buffer is `Counted` and answers `count`.
+  Three general faults came out with them. Protocol dispatch never consulted
+  the class a value reports through a class arm, so `extend-protocol` on
+  `clojure.lang.Volatile`, `Agent`, `Delay`, `Ref` or a promise's class — or on
+  `IDeref` for any of them — threw `No method`; dispatch now reads the same
+  class `instance?` does, and the hand-kept list of derefable values that
+  answered `instance?` for `IDeref`/`IRef`/`IPending` is gone in favour of the
+  graph. A class registered with no supers was read as unregistered, and a `$`
+  in its name then made it a fn, so `(supers java.util.Map$Entry)` and the
+  promise and future reify classes reported the `AFunction` chain, `Fn`
+  included. And `Class/forName` rejected every interface `resolve` accepts
+  (`"clojure.lang.IDeref"`) because it consulted a narrower table; it answers
+  for every modeled class now, under its full name only. `chunk` still seals
+  into a vector rather than an `ArrayChunk`, so nothing is an `IChunk`
+  (known-divergences).
 - **`Character/isLetter`, `isDigit`, `isLetterOrDigit`, `isUpperCase` and
   `isLowerCase` classify all of Unicode.** They were ASCII range checks, so
   `(Character/isLetter \é)` and `(Character/isUpperCase \É)` were false where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A child process no longer inherits `JOLT_PWD`.** `bin/jolt` exports the
+  user's directory in `JOLT_PWD` before changing into its checkout, and a
+  spawned child's environment was seeded from the parent's, so a child jolt
+  started with `:dir` at another project took its user.dir from the variable
+  rather than from its own working directory: `(slurp "README.md")` under
+  `:dir` answered the parent's README. The variable is the launcher's message
+  to the process it started, and the child's directory is whatever the spawn
+  set, so `ProcessBuilder`, `jolt.process` and `clojure.java.shell` now start
+  every child without it — a child jolt, directly under `:dir` or behind a
+  shell's `cd`, reads its own project. A caller that puts `JOLT_PWD` in the
+  child's environment map asked for it and keeps it. An installed binary never
+  exports the variable, which is why the same program passed under one and
+  failed under a source checkout.
 - **`Character/isLetter`, `isDigit`, `isLetterOrDigit`, `isUpperCase` and
   `isLowerCase` classify all of Unicode.** They were ASCII range checks, so
   `(Character/isLetter \é)` and `(Character/isUpperCase \É)` were false where

--- a/host/chez/java/class-hierarchy.ss
+++ b/host/chez/java/class-hierarchy.ss
@@ -78,11 +78,15 @@
 (define (str-has-dollar? s)
   (let loop ((i 0)) (and (< i (string-length s)) (or (char=? (string-ref s i) #\$) (loop (+ i 1))))))
 
+;; A row registered with NO supers (java.util.Map$Entry, a marker interface) is
+;; still a row: only a name the table has never seen falls to the fn rule. It
+;; used to read an empty row as absent, and a $ in the name then made the
+;; interface a fn — (supers java.util.Map$Entry) answered the AFunction chain.
 (define (jch-direct-supers name)
-  (let ((direct (hashtable-ref jvm-class-parents name '())))
-    (if (pair? direct) direct
-        (if (str-has-dollar? name) '("clojure.lang.AFunction")
-            '()))))
+  (let ((direct (hashtable-ref jvm-class-parents name #f)))
+    (cond (direct direct)
+          ((str-has-dollar? name) '("clojure.lang.AFunction"))
+          (else '()))))
 
 ;; Replace a class's direct supers outright (defrecord re-declares the row its
 ;; deftype half registered). Same cache invalidation as a register.
@@ -269,7 +273,9 @@
             "clojure.lang.Reversible" "clojure.lang.Indexed" "clojure.lang.Counted"
             "clojure.lang.Named" "clojure.lang.Fn" "clojure.lang.IFn"
             "clojure.lang.IPersistentCollection" "clojure.lang.ISeq"
-            "clojure.lang.IChunkedSeq"
+            "clojure.lang.IChunkedSeq" "clojure.lang.IChunk"
+            "clojure.lang.IPending" "clojure.lang.IRef" "clojure.lang.IAtom"
+            "clojure.lang.IAtom2" "clojure.lang.IBlockingDeref" "clojure.lang.IMapEntry"
             "clojure.lang.Associative" "clojure.lang.ILookup"
             "clojure.lang.IPersistentStack" "clojure.lang.IPersistentVector"
             "clojure.lang.IPersistentMap" "clojure.lang.IPersistentSet"
@@ -343,9 +349,12 @@
             "java.time.Year" "java.time.YearMonth" "java.time.zone.ZoneRules"
             "java.time.ZonedDateTime" "java.time.ZoneOffset" "java.util.Base64"
             "java.util.Locale" "java.util.regex.Pattern" "java.util.UUID"
+            ;; clojure.lang's final classes, from their declarations
+            "clojure.lang.ChunkBuffer" "clojure.lang.Volatile" "clojure.lang.Reduced"
             ))
 (for-each jch-mark-abstract!
           '(
+            "clojure.lang.AMapEntry"
             "java.io.InputStream" "java.io.OutputStream" "java.io.Reader"
             "java.io.Writer" "java.lang.Number" "java.lang.VirtualMachineError"
             "java.nio.ByteBuffer" "java.nio.charset.Charset" "java.nio.file.FileSystem"
@@ -459,12 +468,23 @@
 ;; scalars / named / callable
 (jch-register-supers! "clojure.lang.Keyword" '("clojure.lang.IFn" "clojure.lang.Named" "java.lang.Comparable"))
 (jch-register-supers! "clojure.lang.Symbol" '("clojure.lang.IObj" "clojure.lang.IFn" "clojure.lang.Named" "java.lang.Comparable"))
-(jch-register-supers! "clojure.lang.Var" '("clojure.lang.IDeref" "clojure.lang.IFn"))
-;; Atom extends ARef, and ARef implements IRef — so an atom IS an IRef, not just
-;; an IDeref. IRef itself extends IDeref, so IDeref still holds transitively.
-(jch-register-supers! "clojure.lang.Atom" '("clojure.lang.IRef"))
-(jch-register-supers! "clojure.lang.Ref" '("clojure.lang.IRef"))
+;; The reference types extend ARef, which implements IRef — so each IS an IRef,
+;; not just an IDeref (IRef extends IDeref, so that still holds transitively).
+;; An atom is also the IAtom2 swap/reset surface; Ref and Var are callable.
 (jch-register-supers! "clojure.lang.IRef" '("clojure.lang.IDeref"))
+(jch-register-supers! "clojure.lang.IAtom" '())
+(jch-register-supers! "clojure.lang.IAtom2" '("clojure.lang.IAtom"))
+(jch-register-supers! "clojure.lang.Atom" '("clojure.lang.IRef" "clojure.lang.IAtom2"))
+(jch-register-supers! "clojure.lang.Ref" '("clojure.lang.IRef" "clojure.lang.IFn" "java.lang.Comparable"))
+(jch-register-supers! "clojure.lang.Var" '("clojure.lang.IRef" "clojure.lang.IFn"))
+(jch-register-supers! "clojure.lang.Agent" '("clojure.lang.IRef"))
+;; the boxes: Volatile and Reduced are plain derefs, a Delay is a pending one.
+;; IBlockingDeref is the timed deref a promise or future answers (their reify
+;; classes register in concurrency.ss, beside the values that carry them).
+(jch-register-supers! "clojure.lang.IBlockingDeref" '())
+(jch-register-supers! "clojure.lang.Volatile" '("clojure.lang.IDeref"))
+(jch-register-supers! "clojure.lang.Reduced" '("clojure.lang.IDeref"))
+(jch-register-supers! "clojure.lang.Delay" '("clojure.lang.IDeref" "clojure.lang.IPending"))
 (jch-register-supers! "clojure.lang.Ratio" '("java.lang.Number" "java.lang.Comparable"))
 (jch-register-supers! "clojure.lang.BigInt" '("java.lang.Number"))
 (jch-register-supers! "java.lang.String" '("java.lang.CharSequence" "java.lang.Comparable"))
@@ -601,10 +621,18 @@
 (jch-register-supers! "java.util.StringTokenizer" '())
 (jch-register-supers! "java.nio.charset.Charset" '())
 (jch-register-supers! "java.util.Base64" '())
-;; MapEntry is an APersistentVector that also implements java.util.Map.Entry —
-;; libraries (orchard.print) dispatch entries via (instance? java.util.Map$Entry e).
-(jch-register-supers! "clojure.lang.MapEntry" '("clojure.lang.APersistentVector" "java.util.Map$Entry"))
+;; MapEntry extends AMapEntry: an APersistentVector that is also an IMapEntry, the
+;; clojure.lang view of java.util.Map.Entry — so the vector checks and
+;; (instance? java.util.Map$Entry e) (orchard.print) both hold through one chain.
+(jch-register-supers! "clojure.lang.IMapEntry" '("java.util.Map$Entry"))
+(jch-register-supers! "clojure.lang.AMapEntry" '("clojure.lang.APersistentVector" "clojure.lang.IMapEntry"))
+(jch-register-supers! "clojure.lang.MapEntry" '("clojure.lang.AMapEntry"))
 (jch-register-supers! "java.util.Map$Entry" '())
+;; chunk building: a ChunkBuffer is Counted, and IChunk — the block chunk seals
+;; one into on the JVM — is Indexed. jolt seals a chunk into a plain vector, so
+;; nothing here is an IChunk (known-divergences, :seq-type-model).
+(jch-register-supers! "clojure.lang.ChunkBuffer" '("clojure.lang.Counted"))
+(jch-register-supers! "clojure.lang.IChunk" '("clojure.lang.Indexed"))
 (jch-register-supers! "clojure.lang.Namespace" '())
 (jch-register-supers! "java.util.regex.Pattern" '())
 (jch-register-supers! "java.net.URI" '())

--- a/host/chez/java/concurrency.ss
+++ b/host/chez/java/concurrency.ss
@@ -225,6 +225,14 @@
 ;; matches the stable enclosing-fn prefix and pins __0 (rather than :object).
 (register-class-arm! jolt-future? (lambda (f) "clojure.core$future_call$reify__0"))
 (register-class-arm! jolt-promise? (lambda (p) "clojure.core$promise$reify__0"))
+;; ...and what those reifies implement. A row is needed: to the class graph a
+;; $-name with no row is a fn (AFunction), which neither of these is.
+(jch-register-supers! "clojure.core$future_call$reify__0"
+  '("clojure.lang.IDeref" "clojure.lang.IBlockingDeref" "clojure.lang.IPending"
+    "java.util.concurrent.Future"))
+(jch-register-supers! "clojure.core$promise$reify__0"
+  '("clojure.lang.IDeref" "clojure.lang.IBlockingDeref" "clojure.lang.IPending"
+    "clojure.lang.IFn"))
 
 (define (jolt-deliver p v)
   (if (jolt-promise? p)
@@ -2685,29 +2693,14 @@
 (def-var! "jolt.host" "block-sigint" (lambda () (jolt-set-sigint-blocked #t)))
 (def-var! "jolt.host" "park-until-interrupt" jolt-park-until-interrupt)
 
-;; reference types report their JVM classes and answer the IDeref/IRef taxonomy
-;; ((class (agent 1)) is clojure.lang.Agent; derefables are IDeref; the mutable
-;; references — Atom/Ref/Agent/Var — are IRef; Ref and Var are also IFn).
+;; reference types report their JVM classes ((class (agent 1)) is
+;; clojure.lang.Agent). The IDeref/IRef/IPending/IFn/IBlockingDeref answers come
+;; from the class graph's rows for these names (class-hierarchy.ss, and the two
+;; reify rows above): instance? and protocol dispatch both read the class a
+;; value reports and take its ancestry from there, so there is no second list
+;; of "which values are derefable" to keep in step with the graph.
 (register-class-arm! jolt-agent? (lambda (x) "clojure.lang.Agent"))
 (register-class-arm! jolt-delay? (lambda (x) "clojure.lang.Delay"))
 (register-class-arm! (lambda (x) (jvol? x)) (lambda (x) "clojure.lang.Volatile"))
 (register-class-arm! (lambda (x) (var-cell? x)) (lambda (x) "clojure.lang.Var"))
 (register-class-arm! (lambda (x) (and (jhost? x) (string=? (jhost-tag x) "user-thread"))) (lambda (x) "java.lang.Thread"))
-(register-instance-check-arm!
-  (lambda (type-sym val)
-    (if (symbol-t? type-sym)
-        (let ((tn (symbol-t-name type-sym)))
-          (cond
-            ((or (string=? tn "IDeref") (string=? tn "clojure.lang.IDeref"))
-             (if (or (jolt-atom? val) (jolt-ref? val) (jolt-agent? val) (var-cell? val)
-                     (jvol? val) (jolt-delay? val) (jolt-future? val) (jolt-promise? val))
-                 #t 'pass))
-            ((or (string=? tn "IRef") (string=? tn "clojure.lang.IRef"))
-             (if (or (jolt-atom? val) (jolt-ref? val) (jolt-agent? val) (var-cell? val))
-                 #t 'pass))
-            ((or (string=? tn "IFn") (string=? tn "clojure.lang.IFn"))
-             (if (or (jolt-ref? val) (var-cell? val)) #t 'pass))
-            ((or (string=? tn "IPending") (string=? tn "clojure.lang.IPending"))
-             (if (or (jolt-delay? val) (jolt-future? val) (jolt-promise? val)) #t 'pass))
-            (else 'pass)))
-        'pass)))

--- a/host/chez/java/host-class.ss
+++ b/host/chez/java/host-class.ss
@@ -113,6 +113,7 @@
     ((symbol-t? x) "clojure.lang.Symbol")
     ((jolt-atom? x) "clojure.lang.Atom")
     ((jolt-ref? x) "clojure.lang.Ref")
+    ((jolt-reduced? x) "clojure.lang.Reduced")
     ((char? x) "java.lang.Character")
     ((regex-t? x) "java.util.regex.Pattern")
     ;; an anonymous / unregistered fn — like the JVM, where (class #(..)) is a

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -827,9 +827,19 @@
   ;; matches a known class (e.g. "com.acme.String" when "java.lang.String"
   ;; exists). jch-known? does last-segment matching and is NOT used here;
   ;; it lives on for jch-isa?'s suffix matching (round-6 territory).
-  (or (hashtable-ref class-statics-tbl nm #f)
-      (hashtable-ref class-ctors-tbl nm #f)
-      (hashtable-ref jvm-class-parents nm #f)))
+  ;; And a full name only: the statics table is keyed by the short name as
+  ;; well, and jch-known-exact? holds each simple segment (the spelling
+  ;; chez-condition-exc-class hands over), where (Class/forName "String") is a
+  ;; ClassNotFoundException on the JVM. Every class the graph models answers,
+  ;; interfaces included — the set resolve answers for.
+  (and (forname-qualified? nm)
+       (or (hashtable-ref class-statics-tbl nm #f)
+           (hashtable-ref class-ctors-tbl nm #f)
+           (jch-known-exact? nm))))
+(define (forname-qualified? nm)
+  (let loop ((i 0))
+    (and (< i (string-length nm))
+         (or (char=? (string-ref nm i) #\.) (loop (+ i 1))))))
 ;; A namespace with a hyphen munges to an underscore in the package name, so a
 ;; record defined in my-app.core is my_app.core.Foo on the JVM. jolt keeps the
 ;; namespace as written, so a forName of the munged name has to demunge to find

--- a/host/chez/java/natives-array.ss
+++ b/host/chez/java/natives-array.ss
@@ -252,6 +252,9 @@
     (make-pvec out)))
 (define (na-chunk-cons chunk rest)
   (if (fx=? 0 (pvec-count chunk)) rest (cseq-chunked chunk 0 rest)))
+;; the buffer is clojure.lang.ChunkBuffer, a Counted: count reads its fill
+(register-class-arm! jolt-chunkbuf? (lambda (b) "clojure.lang.ChunkBuffer"))
+(register-count-arm! jolt-chunkbuf? (lambda (b) (jolt-chunkbuf-cnt b)))
 
 ;; --- extend the collection dispatchers to see a jolt-array ------------------
 (register-count-arm! jolt-array? (lambda (c) (ja-len (jolt-array-vec c))))

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -326,9 +326,19 @@
 ;; A live mutable Map<String,String>, seeded from the parent environment. jolt's
 ;; babashka.process only calls clear/putAll, but put/get/remove are provided too.
 ;; state: a Scheme string->string hashtable.
+;; The environment a child starts from: the parent's, less JOLT_PWD. That variable
+;; is the launcher's message to THIS process — bin/jolt exports the user's cwd
+;; before cd'ing to its checkout — and a child's cwd is whatever the spawn chose
+;; (proc-effective-dir), so an inherited copy hands a child jolt the PARENT's
+;; project as its user.dir: (slurp "README.md") under :dir read the spawner's
+;; README. A caller that puts JOLT_PWD in the env map asked for it and keeps it.
+;; Both the inherited envp and the seed of ProcessBuilder.environment() come from
+;; here, so there is no spawn shape that forwards it.
+(define (proc-child-env-pairs)
+  (filter (lambda (p) (not (string=? (car p) "JOLT_PWD"))) (all-env-pairs)))
 (define (make-proc-env-map)
   (let ((h (make-hashtable string-hash string=?)))
-    (for-each (lambda (p) (hashtable-set! h (car p) (cdr p))) (all-env-pairs))
+    (for-each (lambda (p) (hashtable-set! h (car p) (cdr p))) (proc-child-env-pairs))
     (make-jhost "jolt-env-map" h)))
 (define (proc-env-map? x) (and (jhost? x) (string=? (jhost-tag x) "jolt-env-map")))
 (define (proc-env-map-pairs em)
@@ -753,7 +763,7 @@
         (let* ((argv (proc-marshal-argv (list "/bin/sh" "-c" sh-cmd)))
                (envp (proc-marshal-argv
                       (map (lambda (p) (string-append (car p) "=" (cdr p)))
-                           (all-env-pairs))))
+                           (proc-child-env-pairs))))
                ;; attrp is NULL, so the child inherits this thread's signal mask —
                ;; which must carry none of jolt's own blocking (concurrency.ss).
                (rc (jolt-with-empty-sigmask

--- a/host/chez/protocols.ss
+++ b/host/chez/protocols.ss
@@ -429,6 +429,18 @@
         ;; a namespace value is clojure.lang.Namespace — (class *ns*) already says
         ;; so, and clojure.datafy extends Datafiable to it.
         ((jns? obj) (jch-tags "clojure.lang.Namespace"))
+        ;; anything else that reports a modeled class — an agent, a volatile, a
+        ;; delay, a future, a promise, a reduced box, a chunk buffer, a ref —
+        ;; dispatches as that class and its ancestry: the class arms name it
+        ;; (host-class.ss) and the graph carries its supers, so an extension on
+        ;; clojure.lang.Volatile, or on IDeref for any of them, reaches the
+        ;; value. The same class instance? reads. A value naming no modeled
+        ;; class stays a plain Object; this is the last arm, so only values
+        ;; every arm above declined pay for the lookup. jolt-class-name is the
+        ;; java host layer's (host-class.ss, loaded after this file); the Gambit
+        ;; runtime shares this file and shims it to answer no class (rt-core.ss).
+        ((let ((n (jolt-class-name obj))) (and (string? n) (jch-known-exact? n) n))
+         => jch-tags)
         (else '("Object"))))
 
 

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1303,7 +1303,10 @@ fi
 # single check, "FAIL: jolt.process" with nothing under it is all the gate says, and
 # the reason — the exception — is exactly what was thrown away.
 process_log="$(mktemp)"
-$jolt run test/chez/process-test.clj >"$process_log" 2>&1 || true
+# JOLT_EXE names the jolt under test for the cases that spawn a child jolt, so a
+# built binary tests itself rather than whatever `jolt` is on PATH.
+JOLT_EXE="$(cd "$(dirname "$jolt_bin")" && pwd)/$(basename "$jolt_bin")" \
+  $jolt run test/chez/process-test.clj >"$process_log" 2>&1 || true
 process_out="$(cat "$process_log")"
 if printf '%s' "$process_out" | grep -q 'PROCESS-TEST OK'; then
   pass=$((pass + 1))

--- a/host/gambit/records-gambit.ss
+++ b/host/gambit/records-gambit.ss
@@ -1544,6 +1544,9 @@
      (jch-tags (jolt-ex-info-record-class-name obj)))
     ((jolt-atom? obj) (jch-tags "clojure.lang.Atom"))
     ((jns? obj) (jch-tags "clojure.lang.Namespace"))
+    ((let ((n (jolt-class-name obj)))
+       (and (string? n) (jch-known-exact? n) n)) =>
+     jch-tags)
     (else '("Object"))))
 
 (define (make-deftype-ctor name-sym field-kws . rest-args)

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -812,6 +812,11 @@
     (cond ((null? rs) #f)
           (((caar rs) x) ((cdar rs) x))
           (else (loop (cdr rs))))))
+;; The class a value reports. This host has no class model, so the answer is no
+;; class: jolt-object-repr below prints the value plainly, and the last arm of
+;; value-host-tags (records-gambit.ss, from host/chez/protocols.ss) leaves it a
+;; plain Object — the same outcomes the guarded call used to reach by raising.
+(define (jolt-class-name x) #f)
 (define (jolt-object-repr x readable?)
   (let ((cls (guard (e (#t #f)) (jolt-class-name x)))
         (content (guard (e (#t #f)) (jolt-object-content x))))

--- a/test/chez/process-test.clj
+++ b/test/chez/process-test.clj
@@ -94,6 +94,34 @@
 (let [sub (fs/create-temp-dir {:prefix "jp-dir-"})]
   (check-eq "dir set" (str/trim (:out (sh ["pwd"] {:dir (str sub)}))) (str sub))
   (fs/delete-tree sub))
+;; JOLT_PWD is the launcher's message to THIS process — bin/jolt exports the user's
+;; cwd before cd'ing to its checkout. A child's cwd is whatever the spawn chose, so
+;; the variable is never forwarded: a child jolt reads user.dir from its own cwd
+;; instead of inheriting the parent's project. A caller that puts it in the env map
+;; asked for it and gets it.
+(check-eq "JOLT_PWD is not forwarded"
+          (str/trim (:out (sh ["sh" "-c" "echo ${JOLT_PWD-unset}"]))) "unset")
+(check-eq "JOLT_PWD is not forwarded through :extra-env"
+          (str/trim (:out (sh ["sh" "-c" "echo ${JOLT_PWD-unset}"] {:extra-env {"JP_Y" "1"}}))) "unset")
+(check-eq "an explicit JOLT_PWD is honored"
+          (str/trim (:out (sh ["sh" "-c" "echo $JOLT_PWD"] {:extra-env {"JOLT_PWD" "/explicit"}}))) "/explicit")
+;; End to end, in the shape a test harness takes: this process's own directory
+;; has a README.md (the jolt checkout's), and a child jolt rooted at another
+;; project — one with its own README.md — must read THAT one, whether it is put
+;; there by :dir or by a shell's cd. The wrong answer is the parent's README, a
+;; different text rather than a missing file. The child is the jolt under test:
+;; smoke.sh hands it down in JOLT_EXE, and bin/jolt exports the same.
+(let [sub (fs/create-temp-dir {:prefix "jp-proj-"})
+      exe (or (System/getenv "JOLT_EXE") (some-> (fs/which "jolt") str) "jolt-not-found:set-JOLT_EXE")
+      expr "(print (slurp \"README.md\"))"]
+  (spit (str sub "/README.md") "PROJECT-README-MARKER")
+  (check-eq "the parent's own README is not the project's"
+            (str/includes? (slurp "README.md") "PROJECT-README-MARKER") false)
+  (check-eq "a child jolt under :dir reads its own project"
+            (:out (sh [exe "-e" expr] {:dir (str sub)})) "PROJECT-README-MARKER")
+  (check-eq "a child jolt behind a cd reads its own project"
+            (:out (sh ["sh" "-c" (str "cd '" sub "' && '" exe "' -e '" expr "'")])) "PROJECT-README-MARKER")
+  (fs/delete-tree sub))
 
 ;; ProcessBuilder.start throws (like the JVM) when the program can't be resolved,
 ;; with a "No such file" message — not a shell "not found" after spawning

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -2391,4 +2391,29 @@
   ;; collect when multiple threads are active"; the adapter retries and then
   ;; degrades to a no-op instead.
   {:suite "concurrency" :expr "(let [stop (atom false) f (future (loop [] (when-not @stop (recur))))] (try (do (jolt.host/gc-full!) :ok) (finally (reset! stop true))))" :expected ":ok"}
+  ;; The clojure.lang reference, box, entry and chunk classes typed.ann.clojure
+  ;; annotates: each resolves, sits in the class graph under its JVM supers, and
+  ;; names the jolt value that implements it — so instance?, supers, protocol
+  ;; dispatch and Class/forName all answer from the one graph.
+  {:suite "class-lattice" :expr "(vec (remove (comp some? resolve) '[clojure.lang.Agent clojure.lang.AMapEntry clojure.lang.ChunkBuffer clojure.lang.IAtom clojure.lang.IAtom2 clojure.lang.IBlockingDeref clojure.lang.IChunk clojure.lang.IMapEntry clojure.lang.Reduced clojure.lang.Volatile]))" :expected "[]"}
+  {:suite "class-lattice" :expr "(class (reduced 1))" :expected "clojure.lang.Reduced"}
+  {:suite "class-lattice" :expr "(instance? clojure.lang.IDeref (reduced 1))" :expected "true"}
+  {:suite "class-lattice" :expr "[(instance? clojure.lang.IAtom (atom 1)) (instance? clojure.lang.IAtom2 (atom 1)) (instance? clojure.lang.IAtom (volatile! 1))]" :expected "[true true false]"}
+  {:suite "class-lattice" :expr "[(instance? clojure.lang.IBlockingDeref (promise)) (instance? clojure.lang.IBlockingDeref (future 1)) (instance? clojure.lang.IBlockingDeref (delay 1)) (instance? clojure.lang.IBlockingDeref (atom 1))]" :expected "[true true false false]"}
+  ;; a promise or future is a reify over the deref interfaces, not a fn: no AFunction/Fn
+  {:suite "class-lattice" :expr "(let [s (set (map #(.getName %) (supers (class (promise)))))] (mapv (partial contains? s) [\"clojure.lang.IBlockingDeref\" \"clojure.lang.IPending\" \"clojure.lang.IFn\" \"clojure.lang.AFunction\" \"clojure.lang.Fn\"]))" :expected "[true true true false false]"}
+  {:suite "class-lattice" :expr "(let [s (set (map #(.getName %) (supers clojure.lang.MapEntry)))] (mapv (partial contains? s) [\"clojure.lang.AMapEntry\" \"clojure.lang.IMapEntry\" \"java.util.Map$Entry\" \"clojure.lang.APersistentVector\" \"clojure.lang.AFunction\"]))" :expected "[true true true true false]"}
+  ;; an interface registered with no supers has none — a $ in its name does not make it a fn
+  {:suite "class-lattice" :expr "(bases java.util.Map$Entry)" :expected ""}
+  {:suite "class-lattice" :expr "[(.getName (.getSuperclass clojure.lang.MapEntry)) (.getName (.getSuperclass clojure.lang.AMapEntry)) (.getSuperclass clojure.lang.IMapEntry)]" :expected "[\"clojure.lang.AMapEntry\" \"clojure.lang.APersistentVector\" nil]"}
+  {:suite "class-lattice" :expr "[(.isInterface clojure.lang.IAtom) (.isInterface clojure.lang.IChunk) (.isInterface clojure.lang.AMapEntry) (bit-and (.getModifiers clojure.lang.AMapEntry) 1024) (bit-and (.getModifiers clojure.lang.ChunkBuffer) 16) (bit-and (.getModifiers clojure.lang.Volatile) 16) (bit-and (.getModifiers clojure.lang.Reduced) 16)]" :expected "[true true false 1024 16 16 16]"}
+  {:suite "class-lattice" :expr "(let [b (chunk-buffer 4)] [(.getName (class b)) (count b) (instance? clojure.lang.Counted b) (do (chunk-append b 1) (chunk-append b 2) (count b))])" :expected "[\"clojure.lang.ChunkBuffer\" 0 true 2]"}
+  ;; protocol dispatch reads the same class the value reports
+  {:suite "class-lattice" :expr "(do (defprotocol PLat (plat [x])) (extend-protocol PLat clojure.lang.Volatile (plat [x] :vol) clojure.lang.Agent (plat [x] :agent) clojure.lang.Reduced (plat [x] :reduced) clojure.lang.Delay (plat [x] :delay) clojure.lang.ChunkBuffer (plat [x] :chunkbuf)) [(plat (volatile! 1)) (plat (agent 1)) (plat (reduced 1)) (plat (delay 1)) (plat (chunk-buffer 1))])" :expected "[:vol :agent :reduced :delay :chunkbuf]"}
+  {:suite "class-lattice" :expr "(do (defprotocol PLatD (platd [x])) (extend-protocol PLatD clojure.lang.IDeref (platd [x] :deref)) [(platd (volatile! 1)) (platd (reduced 1)) (platd (promise)) (platd (ref 1)) (platd #'platd) (platd (agent 1))])" :expected "[:deref :deref :deref :deref :deref :deref]"}
+  {:suite "class-lattice" :expr "[(instance? clojure.lang.IRef #'first) (instance? clojure.lang.IRef (ref 1)) (instance? clojure.lang.IFn (ref 1)) (instance? clojure.lang.IPending (delay 1)) (instance? clojure.lang.IPending (future 1)) (instance? clojure.lang.IPending (atom 1))]" :expected "[true true true true true false]"}
+  {:suite "class-lattice" :expr "(do (import 'clojure.lang.Volatile) (instance? Volatile (volatile! 1)))" :expected "true"}
+  ;; Class/forName answers for every class resolve does — interfaces included — and
+  ;; only for a fully qualified name, as on the JVM.
+  {:suite "class-lattice" :expr "[(.getName (Class/forName \"clojure.lang.IDeref\")) (.getName (Class/forName \"clojure.lang.IAtom\")) (try (Class/forName \"IDeref\") :found (catch ClassNotFoundException _ :not-found)) (try (Class/forName \"String\") :found (catch ClassNotFoundException _ :not-found))]" :expected "[\"clojure.lang.IDeref\" \"clojure.lang.IAtom\" :not-found :not-found]"}
 ]

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -821,7 +821,18 @@
    :check {:expr "(contains? (set (map #(.getName %) (.getMethods String))) \"substring\")"
            :jvm "true"
            :jolt "false"}
-   :note "A class whose methods jolt models as a cond rather than a table under-reports; a member that IS registered reports its JVM class (java.lang.reflect.Method/Field/Constructor) and prints like one. getMethod raises NoSuchMethodException only for a name no registry has."}]
+   :note "A class whose methods jolt models as a cond rather than a table under-reports; a member that IS registered reports its JVM class (java.lang.reflect.Method/Field/Constructor) and prints like one. getMethod raises NoSuchMethodException only for a name no registry has."}
+  ;; chunk seals a ChunkBuffer into a plain vector where the JVM builds an
+  ;; ArrayChunk, an IChunk. Every consumer — chunk-cons, chunk-first, nth —
+  ;; reads the Indexed block it is, so only the class differs. IChunk itself
+  ;; resolves and is an Indexed interface, as on the JVM; nothing jolt makes is one.
+  {:category :seq-type-model
+   :behavior "(instance? clojure.lang.IChunk (chunk (chunk-buffer 1)))"
+   :jvm "true — an ArrayChunk"
+   :jolt "false — a PersistentVector"
+   :check {:expr "(instance? clojure.lang.IChunk (chunk (chunk-buffer 1)))"
+           :jvm "true"
+           :jolt "false"}}]
  :entries
  [;; Wherever a syntax-quote's CONSTRUCTION CODE becomes a value rather than
   ;; being compiled — a nested backtick, a quoted one, a macro's argument —


### PR DESCRIPTION
"Two fixes surfaced by running a test harness and typed.clojure against a source checkout.\n\n**JOLT_PWD leaked into children.** `bin/jolt` exports the user's cwd in `JOLT_PWD` and cd's into the checkout; process.ss seeded every child's environment from the parent's, so a child jolt started with `:dir` at another project took its user.dir from the variable and `(slurp \"README.md\")` answered the parent's README. A built binary never exports it, which is why the same harness passed under homebrew 0.8.1 and failed under the checkout. The spawn seam now drops the variable from the inherited envp and from the `ProcessBuilder.environment()` seed; an explicit entry in the env map is kept. `test/chez/process-test.clj` covers the invariant (not forwarded, not forwarded through `:extra-env`, explicit entry honored) and the end-to-end shape: a child jolt rooted at a project with its own README reads that one, under `:dir` and behind a shell `cd`. smoke.sh hands the binary under test down in `JOLT_EXE` so a built jolt tests itself.\n\n**Ten `clojure.lang` classes did not resolve.** typed.ann.clojure's `override-classes` stopped at `ChunkBuffer`; the full missing set was Agent, AMapEntry, ChunkBuffer, IAtom, IAtom2, IBlockingDeref, IChunk, IMapEntry, Reduced, Volatile. All ten are in the class graph under their JVM supers (modifiers and superclass edges checked against a JDK oracle), `(class (reduced 1))` is `clojure.lang.Reduced` rather than `:object`, and a chunk buffer is `Counted`. Shaking them out fixed three general things:\n- protocol dispatch never consulted the class arms, so `extend-protocol` on Volatile/Agent/Delay/Ref or a promise's class, or on IDeref for any of them, threw `No method`; dispatch now reads the class a value reports, and the hand instance arm in concurrency.ss is gone in favour of the graph\n- a registered-empty row with a `$` in its name was read as a fn, so `(supers java.util.Map$Entry)` and the promise/future reify classes reported the AFunction chain\n- `Class/forName` rejected every interface `resolve` accepts and accepted short names the JVM rejects\n\nThe Gambit runtime shares protocols.ss and has no class model, so its rt-core.ss shims `jolt-class-name` to answer no class (records-gambit.ss regenerated). `chunk` still seals into a vector, not an ArrayChunk; recorded in known-divergences with a machine check. `supers` answers `#{}` where the JVM answers `nil` for a class with no ancestry (seed edit, jolt-xp7e).\n\nGates: `make test`, `make documented`, the 16 new unit rows also evaluated on the JVM.\n"