### PR TITLE
fix(adapter): a native iOS build is not Linux either

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A native iOS build no longer reports itself as Linux.** #796 fixed the
+  portable-bytecode half of `sa-os-family` — a `pb` tag names no OS, so the
+  `else` branch called every bytecode build Linux, and it probes the filesystem
+  now. The native half still fell through: Chez's four iOS tags (`a6ios`,
+  `arm64ios`, `ta6ios` and `tarm64ios`, the last documented in `BUILDING` as
+  the iOS cross-target) contain none of `osx`, `macos`, `nt` or `pb`, so all
+  four reached that same `else` and called a Darwin system Linux. iOS is Darwin
+  and `ios` joins the macOS branch, which is the whole fix: that one function is
+  where the host asks what OS this is, so the wrong answer was `SIGCHLD` 17
+  instead of 20, `EAGAIN` 11 instead of 35, `O_NONBLOCK`, `LC_TIME`, the
+  `struct stat` offsets, the chmod and entropy fallbacks and the link libraries,
+  all at once — and, as in #796, `jolt.nrepl` handing Darwin's `socket()` the
+  Linux `SOCK_CLOEXEC`, which cannot bind. `jolt build --target tarm64ios
+  --library` also linked the output with ELF's `-shared` rather than
+  `-dynamiclib -install_name`, because the build's target-side Darwin predicate
+  matched only `osx`; it takes both spellings now. Android needs no such branch
+  and gets none: it has no Chez tag of its own, cross-builds as `tarm64le`, and
+  Bionic is Linux for every constant these select — its divergence is the link
+  libraries, which no tag can express (`tarm64le` is glibc arm64 Linux too) and
+  the target pack owns. The gate pins the iOS and `tarm64le` rows through
+  `sa-os-family-for-tag`, from hosts that are neither.
 - **A child process no longer inherits `JOLT_PWD`.** `bin/jolt` exports the
   user's directory in `JOLT_PWD` before changing into its checkout, and a
   spawned child's environment was seeded from the parent's, so a child jolt

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -85,7 +85,13 @@
 ;; The effective target machine, and whether this is a cross build.
 (define (bld-eff-machine) (or (bld-target) bld-machine))
 (define (bld-cross?) (and (bld-target) (not (string=? (bld-target) bld-machine)) #t))
-(define (bld-tgt-osx?) (bld-contains? (bld-eff-machine) "osx"))
+;; A Darwin target says "osx" OR "ios": Chez's four iOS tags (a6ios, arm64ios,
+;; ta6ios, tarm64ios) name Darwin without saying "osx" — the same vocabulary
+;; sa-os-family-for-tag matches on. Without "ios" here, `jolt build --target
+;; tarm64ios --library` links the output with ELF's -shared instead of
+;; -dynamiclib -install_name, which cannot produce a loadable Darwin dylib.
+(define (bld-tgt-osx?) (or (bld-contains? (bld-eff-machine) "osx")
+                           (bld-contains? (bld-eff-machine) "ios")))
 (define (bld-tgt-nt?) (bld-contains? (bld-eff-machine) "nt"))
 ;; An env override, treating an EMPTY value as absent. A Makefile that exports a
 ;; variable it did not manage to compute exports "" rather than nothing, and ""

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -191,7 +191,17 @@
 ;; there was no way to ask it about a tag. NOT for callers: anything with a tag
 ;; to pass is branching on the tag, which sa-host-tag's contract forbids.
 (define (sa-os-family-for-tag m)
-  (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")) 'macos)
+  ;; "ios" joins the macos branch rather than getting one of its own: iOS is
+  ;; Darwin, so every constant this selects is already the right one, and the
+  ;; three-symbol contract has nowhere else to put it. Chez has four iOS tags
+  ;; (a6ios, arm64ios, ta6ios, tarm64ios; BUILDING documents tarm64ios as the
+  ;; cross-target), and not one of them contains "osx", "macos", "nt" or "pb",
+  ;; so all four reached the else-branch and called a Darwin system Linux.
+  ;; The substring is exact rather than lucky: those four are the only tags in
+  ;; the Chez tree containing "ios", and a tag that contained it by accident
+  ;; would have to be an "osx" tag, which wants 'macos anyway.
+  (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")
+             (sa-tag-contains? m "ios")) 'macos)
         ((or (sa-tag-contains? m "nt") (sa-tag-contains? m "windows")) 'windows)
         ((sa-tag-contains? m "pb") (sa-probed-os-family))
         (else 'linux)))

--- a/host/chez/scheme-adapter-runtime.ss
+++ b/host/chez/scheme-adapter-runtime.ss
@@ -200,6 +200,14 @@
   ;; The substring is exact rather than lucky: those four are the only tags in
   ;; the Chez tree containing "ios", and a tag that contained it by accident
   ;; would have to be an "osx" tag, which wants 'macos anyway.
+  ;;
+  ;; Android takes no branch, and that is not an omission: it has no Chez tag of
+  ;; its own — it cross-builds as tarm64le (tools/cross-compile/README.md) — and
+  ;; Bionic is Linux for every constant this selects, SIGCHLD 17, EAGAIN 11,
+  ;; O_NONBLOCK, SOCK_CLOEXEC and the struct-stat offsets alike. Where Android
+  ;; does diverge is the link libraries (Bionic has no -lrt/-luuid/-ltinfo), and
+  ;; the tag cannot answer that: tarm64le is glibc arm64 Linux too. The target
+  ;; pack owns those flags, which is why they are not derived here.
   (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")
              (sa-tag-contains? m "ios")) 'macos)
         ((or (sa-tag-contains? m "nt") (sa-tag-contains? m "windows")) 'windows)

--- a/test/chez/host-derived-props-test.ss
+++ b/test/chez/host-derived-props-test.ss
@@ -47,6 +47,15 @@
 (row "i3le"      'linux   'i386   'little)
 (row "a6ob"      'linux   'x86-64 #f)   ; unrecognized OS still degrades to linux
 
+;; iOS is Darwin, and its tags say so without saying "osx". Chez has four of
+;; them (a6ios, arm64ios, ta6ios, tarm64ios) and BUILDING documents tarm64ios
+;; as the iOS cross-target. The OS row is what picks SIGCHLD, EAGAIN,
+;; O_NONBLOCK, LC_TIME, the struct-stat offsets and the link libraries, all of
+;; which are Darwin's here. endian is #f for the same reason as the osx tags:
+;; the suffix is not le/be.
+(row "tarm64ios" 'macos   'arm64  #f)
+(row "a6ios"     'macos   'x86-64 #f)
+
 ;; Portable-bytecode tags: pb/pb64l/tpb64l name the threading, word size and
 ;; endianness and deliberately name no OS, and their 64/l fields are not in the
 ;; shape sa-arch-for-tag/sa-endian-for-tag parse either. So all three tag

--- a/test/chez/host-derived-props-test.ss
+++ b/test/chez/host-derived-props-test.ss
@@ -56,6 +56,14 @@
 (row "tarm64ios" 'macos   'arm64  #f)
 (row "a6ios"     'macos   'x86-64 #f)
 
+;; Android is the other cross-target with no tag of its own, and unlike iOS it
+;; needs no branch: it builds as tarm64le (tools/cross-compile/README.md), and
+;; Bionic is Linux for every constant this row picks. Pinned so the answer is a
+;; decision rather than the else-branch's luck. Where Android does diverge is
+;; the link libraries, which this tag cannot express — tarm64le is glibc arm64
+;; Linux too — and which the target pack owns.
+(row "tarm64le"  'linux   'arm64  'little)
+
 ;; Portable-bytecode tags: pb/pb64l/tpb64l name the threading, word size and
 ;; endianness and deliberately name no OS, and their 64/l fields are not in the
 ;; shape sa-arch-for-tag/sa-endian-for-tag parse either. So all three tag


### PR DESCRIPTION
## The gap #796 left

#796 fixed the portable-bytecode half of `sa-os-family`: `pb` tags carry no OS,
so the else-branch called every bytecode build Linux, and the fix probes the
filesystem when the tag has nothing to say.

The native half still falls through. Chez has four iOS machine tags, `a6ios`,
`arm64ios`, `ta6ios` and `tarm64ios`, and `BUILDING` documents `tarm64ios` as
the iOS cross-target. Not one contains `osx`, `macos`, `nt` or `pb`:

```scheme
(define (sa-os-family-for-tag m)
  (cond ((or (sa-tag-contains? m "osx") (sa-tag-contains? m "macos")) 'macos)
        ((or (sa-tag-contains? m "nt")  (sa-tag-contains? m "windows")) 'windows)
        ((sa-tag-contains? m "pb") (sa-probed-os-family))
        (else 'linux)))          ; <- every iOS tag lands here
```

So an iOS build answers `'linux` on a Darwin system.

## Why it matters beyond `os.name`

`sa-os-family` is the single place host logic asks about the OS, so this is
`SIGCHLD` 17 instead of 20, `EAGAIN` 11 instead of 35, `O_NONBLOCK`, `LC_TIME`,
the `struct stat` offsets, the chmod and entropy fallbacks, and the link
libraries in `build.ss`, all at once.

The one that bites first is #796's: `jolt.nrepl` computes `sock-cloexec` as
`0x80000` unless the OS is macOS or Windows, so an iOS build hands Darwin's
`socket()` the Linux-only `SOCK_CLOEXEC` and cannot bind at all.

## The change

`"ios"` joins the macos branch rather than getting a branch of its own. iOS is
Darwin, so every constant above is already the right one, and the contract is
three symbols with nowhere to put a fourth.

The substring is exact rather than lucky. Those four are the only tags in the
Chez tree containing `ios`, checked across `s/*.ss`, `c/*.c`, `configure` and
`BUILDING`, and a tag that contained it by accident would have to be an `osx`
tag, which wants `'macos` anyway.

## Tests

Through `sa-os-family-for-tag`, which #800 split out for exactly this: the rows
can be pinned from a host that is not iOS and cannot be.

```
$ chez --script test/chez/host-derived-props-test.ss     # without the fix
FAIL: tarm64ios -> os macos
FAIL: a6ios -> os macos
host-derived-props: 65 checks, 2 failures

$ chez --script test/chez/host-derived-props-test.ss     # with it
host-derived-props: 65 checks, 0 failures
```

The arch and endian rows for both tags pass either way, so the OS derivation is
the only thing wrong.

`make test` passes on the final tree: `OK: ci gate passed (97 targets)`,
`OK: test gate passed (3 targets)`.

## Verification

Branched from and re-verified against `upstream/main` at `ed9bb1d3`
(2026-09-03), which was still the tip when this was opened. The `ios` tag
enumeration was taken from a Chez v10.4.1 checkout.

Not claimed: I have not run a native `tarm64ios` build end to end, so the
socket consequence above is #796's measurement carried forward through the same
code path, not a fresh reproduction on an iOS target.
