### PR TITLE
fix(gate): version-smoke's no-repo case must be outside the repo

### DIFF
--- a/test/version-smoke.sh
+++ b/test/version-smoke.sh
@@ -53,9 +53,16 @@ g tag -d v0.1.0 >/dev/null
 got="$("$script" "$repo")"
 [ "$got" = "dev-g$sha" ] || fail "no release tag: got '$got', want 'dev-g$sha'"
 
-# (e) not a git checkout at all
+# (e) not a git checkout at all. GIT_CEILING_DIRECTORIES is not decoration:
+# make exports TMPDIR into the checkout (.cache/local/tmp, from makes'
+# local.mk), so on a provisioned dev machine this mktemp directory is INSIDE
+# the jolt repo — git discovery walks up out of it and version.sh answers the
+# repo's own version, which is the right answer to a question this case did
+# not mean to ask. The ceiling stops the walk at $tmp, so the case asks about
+# no repo wherever mktemp puts it. CI never saw this: it runs `make CHEZ=...`,
+# which skips provisioning and leaves TMPDIR alone.
 mkdir -p "$tmp/plain"
-got="$("$script" "$tmp/plain")"
+got="$(GIT_CEILING_DIRECTORIES="$tmp" "$script" "$tmp/plain")"
 [ "$got" = "dev" ] || fail "outside git: got '$got', want 'dev'"
 
 # (f) every consumer goes through the script; none re-derives it inline


### PR DESCRIPTION
## `make test` cannot complete on a provisioned dev machine

The full gate stops at `versionsmoke`, and has for as long as the local
toolchain provisioning has been in place:

```
$ make test
...
version-smoke: outside git: got 'v0.8.1-10-ged9bb1d3', want 'dev'
make[2]: *** [Makefile:949: versionsmoke] Error 1
FAILED: ci gate did not complete — targets after the failure never ran,
        so nothing here is evidence the rest of the gate passes.
```

That is `ed9bb1d3`, not a recent regression — it reproduces on any commit.
And because the gate stops at the first failure by design, every target
after `versionsmoke` never ran: `systemstreams`, `certify`, the four
`gambit*` targets, `grenadinecheck`, `fibers`, `gosm`, `asynctimer`,
`interruptnest`, `threadsafety` and `flow`, plus the whole `selfhost`
byte-fixpoint that `make test` exists to add over `make ci`.

## Why

Case (e) of the version smoke asks what `tools/version.sh` answers for a
directory that is not a git checkout, and builds that directory with
`mktemp -d`. But make exports TMPDIR into the checkout itself —
`.cache/makes/local.mk:45`, `export TMPDIR := $(LOCAL-TMP)`, which is
`.cache/local/tmp` — so the directory is *inside* the jolt repo. Git
discovery walks up out of it, finds the repo, and `version.sh` answers the
repo's own version. The case then fails on a correct answer to a question
it did not mean to ask.

It passes when the script is run directly (`bash test/version-smoke.sh`),
because only the make environment redirects TMPDIR. That is also why this
has never been visible in CI: `tests.yml` runs `make CHEZ=/opt/chez/bin/chez
… test`, and an explicit Chez skips the provisioning that sets TMPDIR. So
the target is green on every PR and red on the dev machine the full gate is
specifically for — the one place `make test` is meant to be run.

## The change

`GIT_CEILING_DIRECTORIES="$tmp"` stops git's upward walk at the temp root,
so the case asks about no repo wherever mktemp happens to put it.

`tools/version.sh` is deliberately unchanged. A directory inside a checkout
*is* in a checkout, and answering with the checkout's version was never the
bug — the test's setup was.

## Verification

```
$ make versionsmoke          # before
version-smoke: outside git: got 'v0.8.1-13-g1e65f801', want 'dev'

$ make versionsmoke          # after
version-smoke: ok (release tags only; vnightly at HEAD reads v0.1.0-1-ga7504ad)
```

Checked both ways round: the fixed script still fails case (e) if the
ceiling is removed, and passes with TMPDIR forced to `.cache/local/tmp`.

No CHANGELOG entry — this is gate-only, with no user-visible behavior change.
