### PR TITLE
Default zone: TZ, a registered provider, else UTC; core reads no system files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The default time zone is the machine's.** `TimeZone/getDefault`,
   `Calendar/getInstance`, a `SimpleDateFormat` with no zone set, the deprecated
   `Date` constructor and getters, `java.sql.Date.valueOf` and `toLocalDate` all
-  answered UTC where the JVM answers the machine's zone (`TZ`, then
-  `/etc/localtime`, then `/etc/timezone`). They read that zone's clock now, the
-  same zone jolt.time's `ZoneId/systemDefault` names, so a date formatted by
+  answered UTC where the JVM answers the machine's zone. They read one default
+  zone now: `TZ` from the process's environment, else what a provider
+  registered through `jolt.host/set-default-zone-provider!` answers, else UTC.
+  Core reads no system file for this — which zone a machine is in lives in
+  `/etc/localtime` or `/etc/timezone`, and looking there is I/O the program
+  never asked for; jolt.time knows how, and registers its `ZoneId/systemDefault`
+  lookup as the provider when it loads, so with the library a date formatted by
   core and one formatted through java.time agree. `.setTimeZone` on a
   `SimpleDateFormat` is honored: `z` renders the zone's short name (`EST`),
   `Z` its RFC 822 offset, `X`/`XX`/`XXX` its ISO offset, and a zone-less

--- a/host/chez/java/inst-time.ss
+++ b/host/chez/java/inst-time.ss
@@ -583,35 +583,35 @@
                 (> (tz-offset-ms self (ms-of d))
                    (* 1000 (tz-raw-offset-seconds (tz-id self))))))))
 
-;; The machine's zone, the way TimeZone.getDefault finds it: TZ in the
-;; environment (a leading colon is the POSIX file form, a path is read for its
-;; zoneinfo suffix), else the zone /etc/localtime links to, else /etc/timezone,
-;; else UTC. jolt.time's ZoneId/systemDefault reads the same sources, so core
-;; and the library name one zone. Not cached: a dumped image must not bake a
-;; build machine's zone in, and this is asked on the way into a format, not in
-;; a loop.
-(define (system-tz-id)
+;; The default zone: TZ from the process's own environment (a leading colon is
+;; the POSIX file form; a zoneinfo path is read for the zone name it ends in),
+;; else what a registered provider answers, else UTC. Core reads no system file
+;; for this. Which zone a machine is in lives in /etc/localtime or
+;; /etc/timezone, and looking there is I/O the program never asked for and a
+;; layout assumption core does not make; jolt.time knows how to find it (its
+;; ZoneId/systemDefault) and registers that lookup as the provider when it
+;; loads, so with the library present core and java.time name one zone, and
+;; without it a zone-less format is UTC. Not cached: a dumped image must not
+;; bake a build machine's zone in, and this is asked on the way into a format,
+;; not in a loop.
+(define default-zone-provider #f)
+(def-var! "jolt.host" "set-default-zone-provider!"
+  (lambda (f) (set! default-zone-provider (if (jolt-nil? f) #f f)) jolt-nil))
+(define (tz-env-zone)
   (define (after-zoneinfo p)
     (let ((i (substring-index "zoneinfo/" p)))
       (and i (let ((z (substring p (+ i 9) (string-length p))))
                (and (> (string-length z) 0) z)))))
-  (define (trim s)
-    (let loop ((a 0) (b (string-length s)))
-      (cond ((and (< a b) (char-whitespace? (string-ref s a))) (loop (+ a 1) b))
-            ((and (< a b) (char-whitespace? (string-ref s (- b 1)))) (loop a (- b 1)))
-            (else (substring s a b)))))
-  (or (let ((tz (getenv "TZ")))
-        (and tz (> (string-length tz) 0)
-             (let ((tz (if (char=? (string-ref tz 0) #\:) (substring tz 1 (string-length tz)) tz)))
-               (and (> (string-length tz) 0)
-                    (if (char=? (string-ref tz 0) #\/) (after-zoneinfo tz) tz)))))
-      (guard (e (#t #f))
-        (let ((target (nio-readlink "/etc/localtime")))
-          (and (string? target) (after-zoneinfo target))))
-      (guard (e (#t #f))
-        (and (file-exists? "/etc/timezone")
-             (let ((s (trim (read-file-string "/etc/timezone"))))
-               (and (> (string-length s) 0) s))))
+  (let ((tz (getenv "TZ")))
+    (and tz (> (string-length tz) 0)
+         (let ((tz (if (char=? (string-ref tz 0) #\:) (substring tz 1 (string-length tz)) tz)))
+           (and (> (string-length tz) 0)
+                (if (char=? (string-ref tz 0) #\/) (after-zoneinfo tz) tz))))))
+(define (system-tz-id)
+  (or (tz-env-zone)
+      (and default-zone-provider
+           (let ((z (guard (e (#t #f)) (jolt-invoke default-zone-provider))))
+             (and (string? z) (> (string-length z) 0) z)))
       "UTC"))
 (define (default-timezone) (timezone-of (system-tz-id)))
 ;; The zone's short name at an instant, as SimpleDateFormat's z renders it:

--- a/host/chez/jolt-host-manifest.txt
+++ b/host/chez/jolt-host-manifest.txt
@@ -191,6 +191,7 @@ scheme-eval-string
 scheme-proc
 scheme-version
 seed-callable?
+set-default-zone-provider!
 set-dispatch-macro!
 set-field!
 set-instant-ctor!

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1158,8 +1158,18 @@ else
   fails=$((fails + 1))
 fi
 
-# The default zone is the machine's, as TimeZone.getDefault finds it (TZ,
-# /etc/localtime, /etc/timezone): under a TZ the deprecated Date getters,
+# Core reads no system file for its default zone: with TZ unset and no provider
+# registered it is UTC on every machine; a provider (jolt.time registers its
+# machine-zone lookup) is consulted before that; TZ wins over both.
+tzdefault_out="$(unset TZ; $jolt -e '[(.getID (java.util.TimeZone/getDefault)) (.format (java.text.SimpleDateFormat. "HH:mm zzz") (java.util.Date. 0)) (do (jolt.host/set-default-zone-provider! (fn [] "Asia/Tokyo")) (.getID (java.util.TimeZone/getDefault))) (.format (java.text.SimpleDateFormat. "HH:mm zzz") (java.util.Date. 0))]' 2>&1 | tail -1)"
+if [ "$tzdefault_out" = '["UTC" "00:00 UTC" "Asia/Tokyo" "09:00 JST"]' ]; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: default zone without TZ is UTC, then the provider's: $tzdefault_out"
+  fails=$((fails + 1))
+fi
+
+# TZ names the default zone (the process's own setting): under it the deprecated Date getters,
 # SimpleDateFormat and Calendar read that zone's clock, its short name and
 # offset render, and a zone-less parse lands on the instant it names there.
 tzdef_out="$(TZ=America/New_York $jolt -e '[(.format (java.text.SimpleDateFormat. "yyyy-MM-dd HH:mm zzz Z") (java.util.Date. 1393632000000)) (.getHours (java.util.Date. 1393632000000)) (.getID (java.util.TimeZone/getDefault)) (.get (doto (java.util.Calendar/getInstance) (.setTime (java.util.Date. 1393632000000))) java.util.Calendar/HOUR_OF_DAY) (.getTime (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd HH:mm") "2014-02-28 19:00")) (.getDate (java.util.Date. 114 2 1))]' 2>&1 | tail -1)"

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -84,6 +84,19 @@
    :check :prose
    :why "the JVM's answer is the machine's default locale, so there is no fixed value to record"
    :note "Core has no default locale. Explicit locale ids resolve through the :date-names extension point (:fallback :default): an unregistered id falls back to ROOT rather than throwing."}
+  ;; The default time zone: the JVM's is the machine's (its own tzdata plus the
+  ;; OS's zone setting). Core reads TZ from its environment and otherwise answers
+  ;; UTC — it reads no system file (/etc/localtime, /etc/timezone) on its own;
+  ;; jolt.time knows how to find the machine's zone and registers it through
+  ;; jolt.host/set-default-zone-provider! when it loads, so with the library the
+  ;; two agree. A corpus row cannot pin it: the JVM side is machine-dependent.
+  {:category :host-model
+   :behavior "(.getID (java.util.TimeZone/getDefault))"
+   :jvm "the machine's zone, e.g. \"America/Toronto\""
+   :jolt "TZ when set, else the registered provider's answer (jolt.time: the machine's zone), else \"UTC\""
+   :check :prose
+   :why "the JVM's answer is the machine's default time zone"
+   :note "Core reads no system file for this by design; a library brings the machine's zone."}
   ;; (str lazy-seq) renders the realized seq "(2 3)" rather than the JVM's opaque
   ;; "clojure.lang.LazySeq@<hash>". Deliberately friendlier; left as is.
   {:category :seq-type-model


### PR DESCRIPTION
#832 made the default time zone the machine's, and found it by reading /etc/localtime and /etc/timezone. Core should not do that: it is I/O the program never asked for and assumes a system layout. This narrows core to what it can know on its own and hands the rest to a provider hook.

- Core's default zone is TZ from the process's environment, else what a provider registered through jolt.host/set-default-zone-provider! answers, else UTC. No system file is read.
- jolt-lang/time registers its ZoneId/systemDefault lookup as the provider when it loads (jolt-lang/time#12), so with the library present TimeZone/getDefault, a zone-less SimpleDateFormat and java.time name one zone, and the Selmer/data.json fleet rows still agree. Without the library a zone-less format is UTC.
- Documented in known-divergences (the JVM's default is the machine's zone); smoke pins TZ unset -> UTC, then a registered provider -> its zone, and TZ winning over both.

Still a system dependency, unchanged by this PR and worth a decision: offsets and short names for a named zone (America/New_York) come from libc's tzdata through the tz-primitives probe, and jolt.time reads the same core seam for its own named-zone offsets, keeping a small offset table as its fallback. Making core self-contained there means zone rules become library-supplied data through an extension point, and core alone knows fixed offsets and UTC.
