### PR TITLE
Supply the babashka.fs built-in :bb promises, and stop a project shadowing it

### DIFF
--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -65,6 +65,42 @@
     (fold-left (lambda (s r) (string-append s " \"" r "\"")) "" ldr-install-roots)
     ")"))
 
+;; --- namespaces Jolt provides the way babashka provides a built-in ----------
+;; Jolt's reader matches :bb (reader.ss rdr-features), which a .cljc library
+;; reads as "this host defines that itself". Two things follow, and jolt owes
+;; both.
+;;
+;; It has to DEFINE what the :bb branch skips. babashka.fs writes list-dir as
+;; #?(:bb nil :default (defn list-dir …)) because babashka supplies it natively,
+;; so on jolt the var stayed declared and unbound and list-dirs / modified-since
+;; / path-seq failed at the call. A supplement is an ordinary install-root
+;; namespace loaded immediately after the one it completes — where babashka's
+;; built-in would already be. It is the namespace-level counterpart of
+;; :jolt/provides for classes.
+;;
+;; And a copy of one of these on a project's roots must not shadow jolt's. Such
+;; a copy is source written to be INERT here: babashka.fs 0.4.18 has no forward
+;; declaration, so its list-dirs fails to compile at all. A built binary already
+;; resolves jolt's copy first (install sources are embedded, and resolve-on-roots
+;; probes those before any root), so resolving these from the install roots is
+;; what keeps source mode answering the same file as the binary. babashka does
+;; not let a classpath copy shadow a built-in either.
+(define ldr-ns-supplements '(("babashka.fs" . "jolt.bb.fs")))
+(define (ldr-supplement-of name)
+  (cond ((assoc name ldr-ns-supplements) => cdr) (else #f)))
+;; Matched as a namespace PREFIX so a child (babashka/process/pprint) travels
+;; with its parent.
+(define ldr-builtin-ns-rels '("babashka/fs" "babashka/process"))
+(define (ldr-builtin-ns-rel? rel)
+  (let loop ((bs ldr-builtin-ns-rels))
+    (and (pair? bs)
+         (let* ((b (car bs)) (bn (string-length b)))
+           (or (and (>= (string-length rel) bn)
+                    (string=? (substring rel 0 bn) b)
+                    (or (fx=? (string-length rel) bn)
+                        (char=? (string-ref rel bn) #\/)))
+               (loop (cdr bs)))))))
+
 ;; --- data readers (#tag literals) -------------------------------------------
 ;; A project's data_readers.{jolt,clj,cljc} at a source root maps a tag symbol to a
 ;; qualified reader fn (e.g. {time/date time-literals.data-readers/date}). We
@@ -290,17 +326,22 @@
   (define (embedded-key? k)
     (let ((v (hashtable-ref embedded-resources k #f)))
       (or (string? v) (bytevector? v))))
+  (define (on-roots roots)
+    (let loop ((roots roots))
+      (and (pair? roots)
+           (or (let ext ((es ldr-source-exts))
+                 (and (pair? es)
+                      (let ((f (string-append (car roots) "/" rel (car es))))
+                        (if (file-exists? f) f (ext (cdr es))))))
+               (loop (cdr roots))))))
   (or (let loop ((es ldr-source-exts))
         (and (pair? es)
              (let ((k (string-append rel (car es))))
                (if (embedded-key? k) k (loop (cdr es))))))
-      (let loop ((roots source-roots))
-        (and (pair? roots)
-             (or (let ext ((es ldr-source-exts))
-                   (and (pair? es)
-                        (let ((f (string-append (car roots) "/" rel (car es))))
-                          (if (file-exists? f) f (ext (cdr es))))))
-                 (loop (cdr roots)))))))
+      ;; a namespace jolt provides as a host built-in resolves to jolt's copy
+      ;; before a project root's — see ldr-builtin-ns-rels
+      (and (ldr-builtin-ns-rel? rel) (on-roots ldr-install-roots))
+      (on-roots source-roots)))
 
 ;; Read a namespace source. An embedded key (resolve-on-roots above, or the
 ;; build driver's app-order entries) reads its baked string; everything else is
@@ -1859,7 +1900,12 @@
            (lambda () (set-chez-ns! saved)))   ; the current ns is thread-local
          ;; the hook feeds `jolt build`, which needs the SOURCE path; an
          ;; artifact-only namespace has none to give.
-         (ns-loaded-hook name (or file art))))
+         (ns-loaded-hook name (or file art))
+         ;; then the built-in supplement, if this namespace has one. It runs
+         ;; AFTER the load and after the mark, so its own require of the
+         ;; namespace it completes is the no-op a cycle would otherwise be.
+         (cond ((ldr-supplement-of name)
+                => (lambda (sup) (load-namespace sup))))))
       ;; No source file but the namespace exists in memory (AOT'd into a built
       ;; binary): it's already defined — mark loaded and move on.
       ((ns-has-vars? name)

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1006,6 +1006,27 @@ else
   fails=$((fails + 1))
 fi
 
+# A project root must not shadow a namespace Jolt provides as a host built-in.
+# Jolt's reader matches :bb, so a copy of babashka.fs pulled in as a dependency
+# is source written to be inert here (0.4.18 guards list-dir behind
+# `#?(:bb nil …)` and its list-dirs then fails to compile). A built binary
+# already resolves Jolt's copy first because install sources are embedded; this
+# asserts source mode answers the same file. The decoy would load fine on its
+# own — it is Jolt's copy winning that makes list-dir resolve.
+bbs_jolt="$(cd "$(dirname "$jolt_bin")" && pwd)/$(basename "$jolt_bin")"
+bbshadow="$(mktemp -d)"; mkdir -p "$bbshadow/src/babashka"
+printf '(ns babashka.fs)\n(def marker :decoy)\n' > "$bbshadow/src/babashka/fs.cljc"
+printf '{:paths ["src"]}\n' > "$bbshadow/deps.edn"
+bbs_out="$(cd "$bbshadow" && JOLT_NO_DEVCACHE=1 "$bbs_jolt" -e '(do (require (quote babashka.fs)) [(nil? (resolve (quote babashka.fs/marker))) (boolean (some-> (resolve (quote babashka.fs/list-dir)) deref fn?))])' 2>&1 | tail -1)"
+if [ "$bbs_out" = '[true true]' ]; then
+  pass=$((pass + 1))
+else
+  echo "  FAIL: a project root shadowed babashka.fs"
+  echo "    want \`[true true]\` got \`$bbs_out\`"
+  fails=$((fails + 1))
+fi
+rm -rf "$bbshadow"
+
 # jolt.fs — the stdlib file-system API against a scratch temp dir (glob, copy-tree,
 # move, mtime round-trip, which). The file self-checks and prints one marker.
 fs_out="$($jolt run test/chez/fs-test.clj 2>/dev/null)"

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -51,6 +51,7 @@ grenadine.lock
 grenadine.repo
 grenadine.runtime
 grenadine.source
+jolt.bb.fs
 jolt.continuations
 jolt.fibers
 jolt.fs

--- a/stdlib/jolt/bb/fs.clj
+++ b/stdlib/jolt/bb/fs.clj
@@ -1,0 +1,45 @@
+(ns jolt.bb.fs
+  "The babashka.fs built-ins Jolt supplies.
+
+  Jolt's reader matches `:bb`, and a .cljc library reads that as a promise that
+  the host defines the guarded var itself — babashka.fs writes `list-dir` as
+  `#?(:bb nil :default (defn list-dir ...))` because babashka provides it
+  natively and cannot expose java.nio's DirectoryStream to interpreted code.
+  Jolt has to keep the same promise, or the var stays declared and unbound and
+  `list-dirs`, `modified-since` and `path-seq` fail at the call rather than at
+  the load. Jolt's host does shim DirectoryStream, so this is the JVM
+  implementation, interned where babashka's built-in would already be.
+
+  The loader loads this namespace immediately after babashka.fs
+  (`ldr-ns-supplements`); nothing requires it directly."
+  (:require [babashka.fs]))
+
+(defn- directory-stream
+  ([dir]
+   (java.nio.file.Files/newDirectoryStream (babashka.fs/path dir)))
+  ([dir glob-or-accept]
+   (if (string? glob-or-accept)
+     (java.nio.file.Files/newDirectoryStream (babashka.fs/path dir) (str glob-or-accept))
+     (java.nio.file.Files/newDirectoryStream
+       (babashka.fs/path dir)
+       (reify java.nio.file.DirectoryStream$Filter
+         (accept [_ entry] (boolean (glob-or-accept entry))))))))
+
+(defn list-dir
+  "Returns a vector of all paths in `dir`. For descending into subdirectories
+  use `glob`. `glob-or-accept` is a glob string such as \"*.edn\" or a
+  `(fn accept [path]) -> truthy`."
+  ([dir]
+   (with-open [stream (directory-stream dir)]
+     (vec stream)))
+  ([dir glob-or-accept]
+   (with-open [stream (directory-stream dir glob-or-accept)]
+     (vec stream))))
+
+;; babashka.fs already declares the var (its own list-dirs and path-seq refer to
+;; it), so this fills the root the :bb branch left empty.
+(intern 'babashka.fs
+        (with-meta 'list-dir
+          {:doc (:doc (meta #'list-dir))
+           :arglists '([dir] [dir glob-or-accept])})
+        list-dir)

--- a/stdlib/jolt/fs.clj
+++ b/stdlib/jolt/fs.clj
@@ -11,27 +11,6 @@
 
 ;; zip / gzip need java.util.zip, which Jolt does not shim yet — keep them out
 ;; of the public surface rather than exposing operations that fail.
-;; list-dir is defined below: the vendored source leaves it to babashka's
-;; built-in on a :bb host, and Jolt's reader takes the :bb branch.
-(import-vars babashka.fs :exclude #{zip unzip gzip gunzip list-dir})
-
-(defn- directory-stream
-  ([dir] (java.nio.file.Files/newDirectoryStream (babashka.fs/path dir)))
-  ([dir glob-or-accept]
-   (if (string? glob-or-accept)
-     (java.nio.file.Files/newDirectoryStream (babashka.fs/path dir) glob-or-accept)
-     (java.nio.file.Files/newDirectoryStream
-       (babashka.fs/path dir)
-       (reify java.nio.file.DirectoryStream$Filter
-         (accept [_ entry] (boolean (glob-or-accept entry))))))))
-
-(defn list-dir
-  "Returns a vector of all paths in `dir`. For descending into subdirectories
-  use `glob`. `glob-or-accept` is a glob string such as \"*.edn\" or a
-  `(fn accept [path]) -> truthy`."
-  ([dir]
-   (with-open [stream (directory-stream dir)]
-     (vec stream)))
-  ([dir glob-or-accept]
-   (with-open [stream (directory-stream dir glob-or-accept)]
-     (vec stream))))
+;; list-dir comes through with the rest: the vendored source leaves it to the
+;; host on a :bb host, and jolt.bb.fs is where Jolt supplies it.
+(import-vars babashka.fs :exclude #{zip unzip gzip gunzip})

--- a/test/chez/fs-test.clj
+++ b/test/chez/fs-test.clj
@@ -1,7 +1,8 @@
 ;; jolt.fs gate — exercises the public file-system API against a scratch temp dir.
 ;; Run: bin/jolt run test/chez/fs-test.clj (smoke.sh greps for "FS-TEST OK").
 (ns fs-test
-  (:require [jolt.fs :as fs]))
+  (:require [babashka.fs]
+            [jolt.fs :as fs]))
 
 (def failures (atom []))
 (defn check [label got want]
@@ -41,6 +42,19 @@
 
 ;; listing + glob (Path results)
 (check "list-dir count" (count (fs/list-dir (fs/path root "d1"))) 3)
+;; list-dir is the var babashka.fs leaves to the host on a :bb reader (jolt.bb.fs
+;; fills it), so both spellings and both arities are gated, along with the two
+;; callers that broke when the root was empty: list-dirs and modified-since.
+(check "list-dir glob" (mapv fs/file-name (fs/list-dir (fs/path root "d1") "*.clj"))
+       ["one.clj"])
+(check "list-dir accept fn"
+       (count (fs/list-dir (fs/path root "d1") (fn [p] (fs/directory? p)))) 1)
+(check "babashka.fs/list-dir is bound"
+       (count (babashka.fs/list-dir (fs/path root "d1"))) 3)
+(check "list-dirs across roots"
+       (sort (mapv fs/file-name (fs/list-dirs [(fs/path root "d1") (fs/path root "d1" "d2")] "*.clj")))
+       ["one.clj" "two.clj"])
+(check "modified-since" (>= (count (fs/modified-since root [(fs/path root "d1")])) 0) true)
 (check "glob *" (mapv fs/file-name (sort-by str (fs/glob (fs/path root "d1") "*.clj")))
        ["one.clj"])
 (check "glob **" (sort (mapv fs/file-name (fs/glob root "**.clj")))


### PR DESCRIPTION
Stacked on #838.

jolt's reader matches `:bb`, which a .cljc library reads as "this host defines that itself". babashka.fs writes `list-dir` as `#?(:bb nil :default (defn …))` because babashka provides it natively and cannot hand `DirectoryStream` to interpreted code.

jolt kept the reader half of that bargain and not the other half. The var stayed declared and unbound, so `babashka.fs/list-dirs`, `babashka.fs/modified-since` (via `path-seq`) and every external caller of `babashka.fs/list-dir` failed at the call — and so did `jolt.fs/list-dirs` and `jolt.fs/modified-since` through the re-export. `jolt.fs` had its own private copy of the implementation, which is the only reason `jolt.fs/list-dir` worked at all.

`jolt.bb.fs` holds that implementation now and interns it where babashka's built-in would be; the loader loads it immediately after the namespace it completes (`ldr-ns-supplements`, the namespace-level counterpart of `:jolt/provides` for classes). `jolt.fs` drops its copy and re-exports the one definition.

The other half is that a copy of babashka.fs on a project's roots must not shadow jolt's. Such a copy is source written to be inert here — 0.4.18 has no forward declaration, so its `list-dirs` does not compile and `(require 'babashka.fs)` fails outright, which is how this was found (a project pulling babashka/fs 0.4.18 from Maven). A built binary already resolves jolt's copy first, because install sources are embedded and `resolve-on-roots` probes those before any root; resolving these from the install roots is what makes source mode answer the same file as the binary. babashka does not let a classpath copy shadow a built-in either.

Closes jolt-jcdu.

Gate: `make test` green (ci 97 targets, test 3 targets). New coverage: five rows in `test/chez/fs-test.clj` (both spellings, both arities, `list-dirs`, `modified-since`) and a smoke case planting a decoy `babashka.fs` on a project root — red `[false false]`, green `[true true]`.

Note on the alternative: babashka.process took the other route in 0.7.12 — a jolt-lang fork with a `:jolt` arm. That is still the right shape for a branch whose body differs; this one is a var the host simply owes, and the supplement keeps `vendor/fs` tracking upstream.