### PR TITLE
Scan alias-qualified namespaced maps before namespace loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`jolt build` accepts an alias-qualified namespaced map before the namespace
+  has loaded.** The dependency scanner reads every top-level form before it
+  evaluates the file's `ns` declaration. Scan mode already preserved an
+  unresolved `::alias/keyword` until the real load installed the alias, but
+  `#::alias{:key value}` still tried to resolve it immediately and failed with
+  `Unknown auto-resolved namespace alias`. This prevented a self-contained
+  application using `clojure.core.async.flow` from building because flow's
+  implementation uses `:as-alias flow` and `#::flow{...}`. Namespaced maps now
+  use the same scan-only placeholder rule as auto-resolved keywords; ordinary
+  reads remain strict.
 - **The default time zone is the machine's.** `TimeZone/getDefault`,
   `Calendar/getInstance`, a `SimpleDateFormat` with no zone set, the deprecated
   `Date` constructor and getters, `java.sql.Date.valueOf` and `toLocalDate` all
@@ -296,7 +306,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prompt that said `user`, and `-main` under `run -m` ran in `jolt.main`.
   `clojure.main` starts every entry in `user`; jolt does too now, and the REPL
   prompt names whatever namespace is current, as `clojure.main`'s does.
-
 ## [0.8.1] - 2026-09-02
 
 Host classes are provided by declaration now. The runtime no longer carries the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prompt that said `user`, and `-main` under `run -m` ran in `jolt.main`.
   `clojure.main` starts every entry in `user`; jolt does too now, and the REPL
   prompt names whatever namespace is current, as `clojure.main`'s does.
+
 ## [0.8.1] - 2026-09-02
 
 Host classes are provided by declaration now. The runtime no longer carries the

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -959,8 +959,8 @@ if grep -q 'set-chez-ns! "app.other"' "$aaout.build/flat.ss"; then
   echo "  FAIL: :as-alias pulled app.other into the binary"; exit 1
 fi
 got_aa="$(cd / && "$aaout" 2>&1)"
-if [ "$got_aa" != ":kw :app.other/x :aliased true" ]; then
-  echo "  FAIL: as-alias-app — want ':kw :app.other/x :aliased true', got \`$got_aa\`"; exit 1
+if [ "$got_aa" != ":kw :app.other/x :map 1 :aliased true" ]; then
+  echo "  FAIL: as-alias-app — want ':kw :app.other/x :map 1 :aliased true', got \`$got_aa\`"; exit 1
 fi
 
 # --- split flat source + cached runtime fasl ---------------------------------

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -953,9 +953,18 @@
            (let ((mapns (if auto?
                             (if (string=? nstok "") (chez-current-ns)
                                 (let ((a (chez-resolve-alias (chez-current-ns) nstok)))
-                                  (if a a
-                                      (rdr-error s i2 (string-append
-                                                       "Unknown auto-resolved namespace alias: " nstok)))))
+                                  (cond (a a)
+                                        ;; The build's require/class-provider scans
+                                        ;; read every top-level form before the ns
+                                        ;; declaration has installed its aliases.
+                                        ;; Preserve the alias spelling just as the
+                                        ;; ::alias/keyword reader does below; scan
+                                        ;; mode discards the value after extracting
+                                        ;; dependency names.
+                                        ((rdr-scan-mode) nstok)
+                                        (else
+                                         (rdr-error s i2 (string-append
+                                                          "Unknown auto-resolved namespace alias: " nstok))))))
                             nstok)))
              (let-values (((es next) (rdr-read-seq s (+ k 1) end #\})))
                (values (rdr-make-map (rdr-nsmap-kvs mapns es)) next)))))))))

--- a/test/chez/as-alias-app/src/app/core.clj
+++ b/test/chez/as-alias-app/src/app/core.clj
@@ -3,5 +3,7 @@
 ;; ::o/x resolves through the alias at READ time, so it works without the target
 ;; ever being loaded — the point of :as-alias.
 (def k ::o/x)
+(def m #::o{:x 1})
 (defn -main [& _]
-  (println :kw k :aliased (some? (get (ns-aliases 'app.core) 'o))))
+  (println :kw k :map (get m :app.other/x)
+           :aliased (some? (get (ns-aliases 'app.core) 'o))))


### PR DESCRIPTION
## Summary

Allow `jolt build` dependency scans to read `#::alias{...}` forms before the
file's `ns` declaration has installed the alias. Ordinary reads remain strict.

## Problem

The build scanner reads every top-level form before evaluating `ns`. Its scan
mode already preserves unresolved `::alias/keyword` forms, but the equivalent
alias-qualified namespaced-map form still tries to resolve immediately:

```clojure
(ns app.core
  (:require [app.other :as-alias o]))

(def m #::o{:x 1})
```

Stock `jolt build` fails with:

```text
Unknown auto-resolved namespace alias: o
```

This also prevents a self-contained application using `clojure.core.async.flow`
from building because flow uses `:as-alias flow` and `#::flow{...}`.

## Fix

In scan mode only, preserve the unresolved namespaced-map alias spelling just
as the keyword reader already does. The scanner extracts dependency names and
discards the placeholder value; the real load rereads the form after `ns` has
installed its aliases. Outside scan mode, a missing alias still throws.

## Regression coverage

The existing `as-alias-app` build fixture now includes both `::o/x` and
`#::o{:x 1}`; `build-smoke.sh` checks its extended output. Together they verify
that:

- the standalone build succeeds;
- the alias target is not pulled into the binary; and
- the built binary resolves both forms to `app.other`.

## Red to green evidence

Building the extended fixture with current stock upstream
`jolt-lang/jolt@c35b3676db07a53f99100455d6acd5b8b3f2fe91` fails before source loading:

```text
Unknown auto-resolved namespace alias: o
```

At the branch tip, the same fixture builds and its binary prints:

```text
:kw :app.other/x :map 1 :aliased true
```

## Validation

- current base: `jolt-lang/jolt@c35b3676db07a53f99100455d6acd5b8b3f2fe91`
- branch tip: `d594f6ae6b366d313a7d4f10d2a36665db2ceee4`
- `make -j1 buildsmoke` -- PASS, including `scan-alias-set` and the extended
  `as-alias` fixture
- `make -j1 unit` -- PASS, 1650/1650, including the expanded current
  namespaced-map boundary and namespace suites
- `git diff --check origin/main...HEAD` -- PASS

All Jolt commands ran through Chez Scheme 10.4.1.

## Provenance

The external correctness ledger tracks the original evidence at
https://github.com/chucklehead-dev/jolt-aspect-packs/issues/70. The ledger is
provenance only; understanding or testing this patch does not depend on its
infrastructure.

## Scope

The branch changes one build-scan reader branch, extends the existing
`:as-alias` build fixture, and records the fix in `CHANGELOG.md`. It does not
relax ordinary reader behavior, load the alias target, or add a new harness.
