### PR TITLE
Bake lz4 and zlib into the binary instead of borrowing the machine's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,10 +317,10 @@ jobs:
           echo "exit=$?"
 
       # The prebuilt's whole promise is that it runs with nothing else installed,
-      # and lz4 (the Chez kernel's fasl compressor) is not a system library on
-      # either platform. The macOS binary shipped demanding
-      # /opt/homebrew/opt/lz4/lib/liblz4.1.dylib, which is present only on a Mac
-      # whose owner ran `brew install lz4`: the install script's own
+      # and the Chez kernel's compressors (lz4, zlib) are jolt's to bake in --
+      # lz4 is not a system library on either platform. The macOS binary shipped
+      # demanding /opt/homebrew/opt/lz4/lib/liblz4.1.dylib, which is present only
+      # on a Mac whose owner ran `brew install lz4`: the install script's own
       # `jolt --version` check died with a dyld error for everyone else, and
       # nothing in this workflow noticed. Now it would.
       - name: Assert the binary needs no library the target machine may not have
@@ -335,9 +335,10 @@ jobs:
           else
             readelf -d "$bin" | grep NEEDED || true
             # ncurses/tinfo/uuid are the Linux build's own story (STATIC_DEPS,
-            # and libuuid on top of glibc); lz4 is the one asserted here.
+            # and libuuid on top of glibc); the compression libraries are the
+            # ones jolt bakes in itself, on every platform, so assert those.
             bad="$(readelf -d "$bin" | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p' \
-                   | grep -i lz4 || true)"
+                   | grep -Ei 'lz4|libz\.' || true)"
           fi
           if [ -n "$bad" ]; then
             echo "::error::$bin needs libraries that are not on a stock machine:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           # prebuilt runs on any glibc distro since ~2014 (CentOS 7+, Ubuntu
           # 14.04+, Debian 8+, Amazon Linux 2+) — every >=2.33 symbol the old
           # runner-built binary demanded was a build-host artifact, not a real
-          # API need (#452). Remaining dynamic deps: liblz4/libuuid + glibc.
+          # API need (#452). Remaining dynamic deps: libuuid + glibc.
           - os: ubuntu-latest
             target: x86_64-linux
             shell: bash
@@ -188,7 +188,12 @@ jobs:
             '${{ matrix.container-build }}' sh ci/glibc-floor-build.sh
 
       # --- macOS: Homebrew chezscheme ships `chez` plus the csv kernel dev files
-      # (libkernel.a, scheme.h, *.boot), which is all build-jolt needs. ---
+      # (libkernel.a, scheme.h, *.boot), which is all build-jolt needs — and,
+      # since it vendors lz4 rather than depending on the formula, the matching
+      # liblz4.a next to them. The lz4 keg is only build.ss's fallback source of
+      # a static archive for a Chez that arrived without one: the link names an
+      # archive, never a dylib, so nothing installed here can become a runtime
+      # dependency of the shipped binary (asserted below). ---
       - name: Install Chez Scheme (macOS)
         if: runner.os == 'macOS'
         run: brew install chezscheme lz4
@@ -310,6 +315,36 @@ jobs:
           ntldd target/release/jolt.exe 2>&1 | head -20
           ./target/release/jolt.exe -e '(+ 1 2)'
           echo "exit=$?"
+
+      # The prebuilt's whole promise is that it runs with nothing else installed,
+      # and lz4 (the Chez kernel's fasl compressor) is not a system library on
+      # either platform. The macOS binary shipped demanding
+      # /opt/homebrew/opt/lz4/lib/liblz4.1.dylib, which is present only on a Mac
+      # whose owner ran `brew install lz4`: the install script's own
+      # `jolt --version` check died with a dyld error for everyone else, and
+      # nothing in this workflow noticed. Now it would.
+      - name: Assert the binary needs no library the target machine may not have
+        if: runner.os != 'Windows'
+        run: |
+          bin=target/release/jolt
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            otool -L "$bin"
+            # Every load command must resolve inside the OS itself.
+            bad="$(otool -L "$bin" | tail -n +2 | awk '{print $1}' \
+                   | grep -Ev '^(/usr/lib/|/System/Library/)' || true)"
+          else
+            readelf -d "$bin" | grep NEEDED || true
+            # ncurses/tinfo/uuid are the Linux build's own story (STATIC_DEPS,
+            # and libuuid on top of glibc); lz4 is the one asserted here.
+            bad="$(readelf -d "$bin" | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p' \
+                   | grep -i lz4 || true)"
+          fi
+          if [ -n "$bad" ]; then
+            echo "::error::$bin needs libraries that are not on a stock machine:"
+            echo "$bad"
+            exit 1
+          fi
+          echo "no unexpected dynamic dependencies"
 
       # Sanity: the built binary runs (no Chez needed) and self-reports a value.
       - name: Smoke the binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,27 +47,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A jolt binary no longer needs Homebrew's lz4 to start (macOS).** lz4 is the
-  Chez kernel's fasl compressor, so every binary — jolt itself and anything
-  `jolt build` produces — links it. The macOS link line took it from
+- **A jolt binary carries its own lz4 and zlib, and needs neither at runtime.**
+  They are the Chez kernel's fasl compressors, so every binary — jolt itself and
+  anything `jolt build` produces — links them. The macOS link line took lz4 from
   `$(brew --prefix lz4)/lib`, and a directory holding both a `.dylib` and a `.a`
   gives `-llz4` the dylib, so the released binary demanded
   `/opt/homebrew/opt/lz4/lib/liblz4.1.dylib` off every machine that ran it: on a
   Mac that never ran `brew install lz4` — which is most of them — `curl … | bash`
   died in the install script's own `jolt --version` check with a dyld error.
-  Both platforms now name the static `liblz4.a` that Chez installs next to
-  `libkernel.a`, which is what forces the static choice (Apple's ld has no
+  Every link now names the static `liblz4.a` and `libz.a` that Chez installs next
+  to `libkernel.a`, which is what forces the static choice (Apple's ld has no
   `-Bstatic`); on macOS the brew keg and pkg-config stay as fallbacks for a Chez
-  that installed without one. Linux already resolved that same archive, but
+  that installed without one. Linux already resolved those same archives, but
   through `-L` and search order rather than by name, so a Chez installed without
-  it silently produced a binary with a runtime lz4 dependency; that case now
-  warns. The self-contained jolt carries that archive alongside the Chez kernel
-  it already bundles, so the one link it performs itself — the relink that bakes
-  a `:jolt/native` `:static` archive into an app — takes lz4 from the bundle
-  rather than from the machine the app happens to be built on, and the app it
-  writes has no lz4 dependency either. The release workflow asserts the binary it
-  built needs no library a stock machine lacks, and the install script names the
-  missing library when one fails to load.
+  them silently produced a binary with runtime compression dependencies; that
+  case now warns. The self-contained jolt carries both archives alongside the
+  Chez kernel it already bundles, so the one link it performs itself — the relink
+  that bakes a `:jolt/native` `:static` archive into an app — takes them from the
+  bundle rather than from the machine the app happens to be built on. A built app
+  carries no compression dependency at all: on Linux the smoke's apps come out
+  needing libc and libm and nothing else. The release workflow asserts the binary it built needs no
+  library a stock machine lacks, and the install script names the missing library
+  when one fails to load.
+
+- **A built binary no longer exports the compression symbols it baked in
+  (Linux).** `-rdynamic` puts the executable's symbols in the dynamic table, and
+  the executable is searched before any `dlopen`'d library, so a baked-in
+  `deflate` or `LZ4_decompress_safe` was answering for an FFI-loaded libpng,
+  libssl or libsqlite3 instead of the zlib each was built against. `liblz4.a` and
+  `libz.a` join ncurses on the `--exclude-libs` list, which already existed for
+  the same reason. A `:jolt/native`'s own symbols are still exported, so
+  `(load-shared-object #f)` resolution is unchanged.
 
 - **`java.lang.ThreadLocal` is per-thread again, and the class exists.** The
   value lived in a Chez thread parameter, which a forked thread inherits, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that installed without one. Linux already resolved that same archive, but
   through `-L` and search order rather than by name, so a Chez installed without
   it silently produced a binary with a runtime lz4 dependency; that case now
-  warns. The release workflow asserts the binary it built needs no library a
-  stock machine lacks, and the install script names the missing library when one
-  fails to load.
+  warns. The self-contained jolt carries that archive alongside the Chez kernel
+  it already bundles, so the one link it performs itself — the relink that bakes
+  a `:jolt/native` `:static` archive into an app — takes lz4 from the bundle
+  rather than from the machine the app happens to be built on, and the app it
+  writes has no lz4 dependency either. The release workflow asserts the binary it
+  built needs no library a stock machine lacks, and the install script names the
+  missing library when one fails to load.
 
 - **`java.lang.ThreadLocal` is per-thread again, and the class exists.** The
   value lived in a Chez thread parameter, which a forked thread inherits, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A jolt binary no longer needs Homebrew's lz4 to start (macOS).** lz4 is the
+  Chez kernel's fasl compressor, so every binary — jolt itself and anything
+  `jolt build` produces — links it. The macOS link line took it from
+  `$(brew --prefix lz4)/lib`, and a directory holding both a `.dylib` and a `.a`
+  gives `-llz4` the dylib, so the released binary demanded
+  `/opt/homebrew/opt/lz4/lib/liblz4.1.dylib` off every machine that ran it: on a
+  Mac that never ran `brew install lz4` — which is most of them — `curl … | bash`
+  died in the install script's own `jolt --version` check with a dyld error.
+  Both platforms now name the static `liblz4.a` that Chez installs next to
+  `libkernel.a`, which is what forces the static choice (Apple's ld has no
+  `-Bstatic`); on macOS the brew keg and pkg-config stay as fallbacks for a Chez
+  that installed without one. Linux already resolved that same archive, but
+  through `-L` and search order rather than by name, so a Chez installed without
+  it silently produced a binary with a runtime lz4 dependency; that case now
+  warns. The release workflow asserts the binary it built needs no library a
+  stock machine lacks, and the install script names the missing library when one
+  fails to load.
+
 - **`java.lang.ThreadLocal` is per-thread again, and the class exists.** The
   value lived in a Chez thread parameter, which a forked thread inherits, so a
   child observed the parent's stored value instead of running its own

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -166,15 +166,20 @@
   (let ((memcpy (sa-foreign-procedure \"memcpy\" (u8* uptr uptr) void*)))
     (for-each
       (lambda (spec)
-        (let* ((len (sa-foreign-ref 'unsigned-int (sa-foreign-entry-address (caddr spec)) 0))
-               (bv (make-bytevector len)))
-          (memcpy bv (sa-foreign-entry-address (cadr spec)) len)
-          (register-embedded-bytes! (car spec) bv)))
+        ;; A zero length means the file was absent at jolt-build time — only the
+        ;; lz4 archive can be — so register nothing and let the reader's #f
+        ;; branch handle it. Every other bundle here is always non-empty.
+        (let ((len (sa-foreign-ref 'unsigned-int (sa-foreign-entry-address (caddr spec)) 0)))
+          (when (> len 0)
+            (let ((bv (make-bytevector len)))
+              (memcpy bv (sa-foreign-entry-address (cadr spec)) len)
+              (register-embedded-bytes! (car spec) bv)))))
       '((\"csv/petite.boot\" \"jolt_petite_boot\" \"jolt_petite_boot_len\")
         (\"csv/scheme.boot\" \"jolt_scheme_boot\" \"jolt_scheme_boot_len\")
         (\"stub/launcher\" \"jolt_stub\" \"jolt_stub_len\")
         (\"csv/scheme.h\" \"jolt_scheme_h\" \"jolt_scheme_h_len\")
         (\"csv/libkernel.a\" \"jolt_libkernel_a\" \"jolt_libkernel_a_len\")
+        (\"csv/liblz4.a\" \"jolt_liblz4_a\" \"jolt_liblz4_a_len\")
         (\"stub/launcher.c\" \"jolt_launcher_c\" \"jolt_launcher_c_len\")))))
 
 (suppress-greeting #t)
@@ -642,6 +647,17 @@
     "sed -i.bak -E 's/unsigned char [A-Za-z0-9_]+\\[\\]/unsigned char " name "[]/; "
     "s/unsigned int [A-Za-z0-9_]+_len/unsigned int " name "_len/' '" h "'")))
 
+;; The same header for a file that is not there: main.c's #include and the symbol
+;; still have to exist, and a zero length is how jolt-materialize-bundles! tells
+;; an absent bundle from a real one (it registers nothing, so the reader sees #f
+;; and falls back). Only the lz4 archive is ever optional.
+(define (jb-empty-c-array h name)
+  (let ((p (open-output-file h 'replace)))
+    (put-string p (string-append
+      "unsigned char " name "[] = { 0x00 };\n"
+      "unsigned int " name "_len = 0;\n"))
+    (close-port p)))
+
 (display "build-jolt: embedding boots + stub, linking\n")
 (jb-c-array jb-boot (string-append jb-build "/boot_data.h") "jolt_boot")
 (jb-c-array (string-append (bld-csv-dir) "/petite.boot") (string-append jb-build "/petite_data.h") "jolt_petite_boot")
@@ -653,6 +669,18 @@
 ;; stub, so it relinks (build.ss bld-relink-stub). Needs the system cc at build.
 (jb-c-array (string-append (bld-csv-dir) "/scheme.h") (string-append jb-build "/schemeh_data.h") "jolt_scheme_h")
 (jb-c-array (string-append (bld-csv-dir) "/libkernel.a") (string-append jb-build "/libkernel_data.h") "jolt_libkernel_a")
+;; ...and the static liblz4.a that kernel was built against. That relink is the
+;; one link the distributed jolt performs, and it runs where there is no Chez
+;; install to take an archive from — without this it resolves lz4 off the user's
+;; machine, so an app with a :static native would carry a runtime lz4 dependency
+;; that no other `jolt build` output has. The archive is a couple of hundred KB
+;; next to a ~27M binary.
+(let ((lz4 (bld-lz4-archive)))
+  (if lz4
+      (jb-c-array lz4 (string-append jb-build "/lz4_data.h") "jolt_liblz4_a")
+      ;; Nothing to embed: this jolt was built against a Chez with no archive
+      ;; (bld-link-libs warned then), and the relink degrades to -llz4 as before.
+      (jb-empty-c-array (string-append jb-build "/lz4_data.h") "jolt_liblz4_a")))
 (jb-c-array "host/chez/stub/launcher.c" (string-append jb-build "/launcherc_data.h") "jolt_launcher_c")
 ;; The embedded stdlib fasl blob (one concatenated .so per install-owned ns).
 ;; jb-emit-stdlib-fasls! wrote it during flat.ss emission; it is absent only when
@@ -673,6 +701,7 @@
       "#include \"stub_data.h\"\n"
       "#include \"schemeh_data.h\"\n"
       "#include \"libkernel_data.h\"\n"
+      "#include \"lz4_data.h\"\n"
       "#include \"launcherc_data.h\"\n"
       "#include \"stdlib_fasls_data.h\"\n"
       "int main(int argc, char *argv[]) {\n"

--- a/host/chez/build-jolt.ss
+++ b/host/chez/build-jolt.ss
@@ -167,8 +167,8 @@
     (for-each
       (lambda (spec)
         ;; A zero length means the file was absent at jolt-build time — only the
-        ;; lz4 archive can be — so register nothing and let the reader's #f
-        ;; branch handle it. Every other bundle here is always non-empty.
+        ;; compression archives can be — so register nothing and let the reader's
+        ;; #f branch handle it. Every other bundle here is always non-empty.
         (let ((len (sa-foreign-ref 'unsigned-int (sa-foreign-entry-address (caddr spec)) 0)))
           (when (> len 0)
             (let ((bv (make-bytevector len)))
@@ -180,6 +180,7 @@
         (\"csv/scheme.h\" \"jolt_scheme_h\" \"jolt_scheme_h_len\")
         (\"csv/libkernel.a\" \"jolt_libkernel_a\" \"jolt_libkernel_a_len\")
         (\"csv/liblz4.a\" \"jolt_liblz4_a\" \"jolt_liblz4_a_len\")
+        (\"csv/libz.a\" \"jolt_libz_a\" \"jolt_libz_a_len\")
         (\"stub/launcher.c\" \"jolt_launcher_c\" \"jolt_launcher_c_len\")))))
 
 (suppress-greeting #t)
@@ -650,7 +651,7 @@
 ;; The same header for a file that is not there: main.c's #include and the symbol
 ;; still have to exist, and a zero length is how jolt-materialize-bundles! tells
 ;; an absent bundle from a real one (it registers nothing, so the reader sees #f
-;; and falls back). Only the lz4 archive is ever optional.
+;; and falls back). Only the compression archives are ever optional.
 (define (jb-empty-c-array h name)
   (let ((p (open-output-file h 'replace)))
     (put-string p (string-append
@@ -669,18 +670,24 @@
 ;; stub, so it relinks (build.ss bld-relink-stub). Needs the system cc at build.
 (jb-c-array (string-append (bld-csv-dir) "/scheme.h") (string-append jb-build "/schemeh_data.h") "jolt_scheme_h")
 (jb-c-array (string-append (bld-csv-dir) "/libkernel.a") (string-append jb-build "/libkernel_data.h") "jolt_libkernel_a")
-;; ...and the static liblz4.a that kernel was built against. That relink is the
-;; one link the distributed jolt performs, and it runs where there is no Chez
-;; install to take an archive from — without this it resolves lz4 off the user's
-;; machine, so an app with a :static native would carry a runtime lz4 dependency
-;; that no other `jolt build` output has. The archive is a couple of hundred KB
-;; next to a ~27M binary.
-(let ((lz4 (bld-lz4-archive)))
-  (if lz4
-      (jb-c-array lz4 (string-append jb-build "/lz4_data.h") "jolt_liblz4_a")
-      ;; Nothing to embed: this jolt was built against a Chez with no archive
-      ;; (bld-link-libs warned then), and the relink degrades to -llz4 as before.
-      (jb-empty-c-array (string-append jb-build "/lz4_data.h") "jolt_liblz4_a")))
+;; ...and the static liblz4.a / libz.a that kernel was built against. That relink
+;; is the one link the distributed jolt performs, and it runs where there is no
+;; Chez install to take an archive from — without these it resolves lz4 and zlib
+;; off the user's machine, so an app with a :static native would carry runtime
+;; compression dependencies that no other `jolt build` output has. Together they
+;; are ~300K on a ~27M binary.
+(for-each
+  (lambda (lib)
+    (let ((archive (bld-static-archive lib))
+          (header (string-append jb-build "/" lib "_data.h"))
+          (sym (string-append "jolt_lib" lib "_a")))
+      (if archive
+          (jb-c-array archive header sym)
+          ;; Nothing to embed: this jolt was built against a Chez with no such
+          ;; archive (bld-link-libs warned then), and the relink degrades to -l
+          ;; as before.
+          (jb-empty-c-array header sym))))
+  '("lz4" "z"))
 (jb-c-array "host/chez/stub/launcher.c" (string-append jb-build "/launcherc_data.h") "jolt_launcher_c")
 ;; The embedded stdlib fasl blob (one concatenated .so per install-owned ns).
 ;; jb-emit-stdlib-fasls! wrote it during flat.ss emission; it is absent only when
@@ -702,6 +709,7 @@
       "#include \"schemeh_data.h\"\n"
       "#include \"libkernel_data.h\"\n"
       "#include \"lz4_data.h\"\n"
+      "#include \"z_data.h\"\n"
       "#include \"launcherc_data.h\"\n"
       "#include \"stdlib_fasls_data.h\"\n"
       "int main(int argc, char *argv[]) {\n"

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -265,14 +265,24 @@
 ;; Mac with no Homebrew lz4, which is most of them. lz4 is not a system library
 ;; on either platform, so it has to be baked in: a jolt binary is meant to run
 ;; with nothing else installed.
+
+;; An archive that outranks the search below. The self-contained jolt has no Chez
+;; install to look in, so it carries the archive its own kernel was linked
+;; against and spills it for the one link it still performs (bld-relink-stub).
+(define bld-lz4-override (make-parameter #f))
+
 (define (bld-lz4-archive)
   (let loop ((thunks
-               (cons
+               (cons*
+                 (lambda () (bld-lz4-override))
                  ;; The csv dir the kernel itself comes from. (bld-csv-dir), not
-                 ;; bld-host-csv-dir, for the reason the Linux branch gives below
-                 ;; — though a cross build never reaches here (the pack supplies
-                 ;; its own static lz4 under lib/).
+                 ;; bld-host-csv-dir, for the reason the Linux branch gives below.
+                 ;; A cross build's link never asks (the pack's link-libs carries
+                 ;; its own -llz4, resolved against the static archive under
+                 ;; lib/), but build-jolt does, to embed it — hence the pack path.
                  (lambda () (string-append (bld-csv-dir) "/liblz4.a"))
+                 (lambda () (and (bld-cross?)
+                                 (string-append (bld-target-pack) "/lib/liblz4.a")))
                  ;; macOS only. A distro's static liblz4.a is deliberately NOT
                  ;; searched on Linux: it may well be non-PIC, which would turn
                  ;; today's working `jolt build --library` into a link error
@@ -2022,17 +2032,28 @@
 ;; (native-link) and, on Linux, -rdynamic so the baked-in symbols stay dlsym-
 ;; visible for (load-shared-object #f) + foreign-procedure at startup.
 (define (bld-relink-stub builddir native-link out-path)
-  (let ((h  (string-append builddir "/scheme.h"))
-        (lk (string-append builddir "/libkernel.a"))
-        (lc (string-append builddir "/launcher.c")))
+  (let* ((h  (string-append builddir "/scheme.h"))
+         (lk (string-append builddir "/libkernel.a"))
+         (lc (string-append builddir "/launcher.c"))
+         ;; The bundled lz4 archive, spilled like the kernel: this link runs on a
+         ;; machine with no Chez install, so bld-lz4-archive has nowhere to look
+         ;; and the app would otherwise take whatever lz4 the machine happens to
+         ;; have — a runtime dependency the appended-stub path (the other 99% of
+         ;; builds) does not have, on a binary the user is about to ship. Absent
+         ;; only when the jolt running this was itself built against a Chez that
+         ;; had no archive; then the link falls back to -llz4 as it always did.
+         (lz4 (and (jolt-embedded-bytes "csv/liblz4.a")
+                   (string-append builddir "/liblz4.a"))))
     (jolt-spill-embedded! "csv/scheme.h" h)
     (jolt-spill-embedded! "csv/libkernel.a" lk)
     (jolt-spill-embedded! "stub/launcher.c" lc)
+    (when lz4 (jolt-spill-embedded! "csv/liblz4.a" lz4))
     (display "jolt build: relinking launcher stub with static native libraries\n")
-    (bld-system (string-append
-      "cc -O2 " (bld-export-symbols-flag)
-      "-I'" builddir "' '" lc "' '" lk "' -o '" out-path "' "
-      native-link " " (bld-link-libs)))))
+    (parameterize ((bld-lz4-override lz4))
+      (bld-system (string-append
+        "cc -O2 " (bld-export-symbols-flag)
+        "-I'" builddir "' '" lc "' '" lk "' -o '" out-path "' "
+        native-link " " (bld-link-libs))))))
 
 ;; --- legacy cc link (dev bin/jolt): fresh Chez compile + xxd + cc ------------
 (define (build-with-cc entry-ns out-path mode builddir flat-ss flat-so boot boot-h main-c native-link petite-only?)

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -249,8 +249,75 @@
               (error 'jolt-build (string-append "target pack file missing: " p hint)))))
         '("xpatch" "link-libs")))))
 
-;; Link flags. macOS Homebrew layout for the kernel's lz4/zlib/ncurses deps. The
-;; host branches double as the target flags for a non-cross build (host = target).
+;; The kernel's lz4, as an absolute path to a STATIC archive, or #f when none is
+;; reachable. Chez compiles its bundled lz4 as part of its own build and installs
+;; liblz4.a next to libkernel.a, so the archive matching the kernel this link
+;; bakes in is normally already in the csv dir — on every platform, Homebrew's
+;; chezscheme included (it vendors lz4 too; it does not depend on the lz4
+;; formula). The keg and pkg-config are macOS fallbacks for a Chez that somehow
+;; installed without it.
+;;
+;; Naming the archive by path is what forces the static choice: Apple's ld has no
+;; -Bstatic, and a bare -llz4 pointed at a directory holding both a .dylib and a
+;; .a always takes the .dylib. That is how the released macOS binary came to
+;; demand /opt/homebrew/opt/lz4/lib/liblz4.1.dylib off every machine that ran it
+;; — the install script's own `jolt --version` check died with a dyld error on a
+;; Mac with no Homebrew lz4, which is most of them. lz4 is not a system library
+;; on either platform, so it has to be baked in: a jolt binary is meant to run
+;; with nothing else installed.
+(define (bld-lz4-archive)
+  (let loop ((thunks
+               (cons
+                 ;; The csv dir the kernel itself comes from. (bld-csv-dir), not
+                 ;; bld-host-csv-dir, for the reason the Linux branch gives below
+                 ;; — though a cross build never reaches here (the pack supplies
+                 ;; its own static lz4 under lib/).
+                 (lambda () (string-append (bld-csv-dir) "/liblz4.a"))
+                 ;; macOS only. A distro's static liblz4.a is deliberately NOT
+                 ;; searched on Linux: it may well be non-PIC, which would turn
+                 ;; today's working `jolt build --library` into a link error
+                 ;; ("recompile with -fPIC"). Chez's own archive is built
+                 ;; alongside libkernel.a, which that link already folds into a
+                 ;; shared object, so it carries the same guarantee. Darwin
+                 ;; compiles PIC throughout, so neither fallback has the problem.
+                 (if bld-osx?
+                     (list
+                       (lambda ()
+                         (let ((prefix (bld-sh-capture "brew --prefix lz4 2>/dev/null")))
+                           (and (> (string-length prefix) 0)
+                                (string-append prefix "/lib/liblz4.a"))))
+                       (lambda ()
+                         (let ((libdir (bld-sh-capture "pkg-config --variable=libdir liblz4 2>/dev/null")))
+                           (and (> (string-length libdir) 0)
+                                (string-append libdir "/liblz4.a")))))
+                     '()))))
+    (if (null? thunks)
+        #f
+        (let ((path ((car thunks))))
+          (if (and path (file-exists? path)) path (loop (cdr thunks)))))))
+
+;; No archive anywhere: the link still has to find SOMETHING, and a binary that
+;; needs a dylib beats one that does not link at all. Say so — the result runs
+;; here and nowhere else, which is not what a `jolt build` output is for.
+(define (bld-warn-dynamic-lz4!)
+  (display "jolt build: warning: no static liblz4.a found next to the Chez kernel\n")
+  (display "  — linking lz4 dynamically; the binary will need it on every machine that runs it\n"))
+
+;; The macOS -llz4 fallback: the keg (or pkg-config) at least tells the linker
+;; where the dylib is, which a bare -llz4 on a Mac with no lz4 in /usr/lib cannot.
+(define (bld-osx-lz4-dynamic)
+  (bld-warn-dynamic-lz4!)
+  (let ((prefix (bld-sh-capture "brew --prefix lz4 2>/dev/null")))
+    (if (> (string-length prefix) 0)
+        (string-append "-L" (bld-sh-quote (string-append prefix "/lib")) " -llz4")
+        (let ((pc (bld-sh-capture "pkg-config --libs-only-L liblz4 2>/dev/null")))
+          (if (> (string-length pc) 0)
+              (string-append pc " -llz4")
+              "-llz4")))))
+
+;; Link flags. The kernel's lz4/zlib/ncurses deps, lz4 statically (see above).
+;; The host branches double as the target flags for a non-cross build
+;; (host = target).
 (define (bld-link-libs)
   (cond
     ;; cross: the static lz4/zlib live in the pack (lib/), and the pack's
@@ -261,17 +328,12 @@
      (or (getenv "JOLT_TARGET_LINK_LIBS")
          (string-append "-L" (bld-sh-quote (string-append (bld-target-pack) "/lib")) " "
            (bld-sh-capture (string-append "cat " (bld-sh-quote (string-append (bld-target-pack) "/link-libs")))))))
+    ;; macOS: libz, libncurses, libiconv and Foundation ship with the OS, so they
+    ;; stay dynamic; lz4 does not, so it is named as an archive and baked in.
     (bld-osx?
-     (let ((lz4 (bld-sh-capture "brew --prefix lz4 2>/dev/null")))
-       (if (> (string-length lz4) 0)
-           (string-append "-L" lz4 "/lib -llz4 -lz -lncurses -framework Foundation -liconv -lm")
-           (let ((pc (bld-sh-capture "pkg-config --libs-only-L liblz4 2>/dev/null")))
-             (if (> (string-length pc) 0)
-                 (string-append pc " -llz4 -lz -lncurses -framework Foundation -liconv -lm")
-                 (begin
-                   (display "jolt build: warning: lz4 library path not found via brew or pkg-config")
-                   (display " — linker may not find -llz4\n")
-                   "-llz4 -lz -lncurses -framework Foundation -liconv -lm"))))))
+     (let ((lz4 (bld-lz4-archive)))
+       (string-append (if lz4 (bld-sh-quote lz4) (bld-osx-lz4-dynamic))
+         " -lz -lncurses -framework Foundation -liconv -lm")))
     ;; Windows (ta6nt, MinGW-w64 under MSYS2): the Chez kernel pulls in
     ;; compression, winsock, COM/UUID, and the registry.
     (bld-nt?
@@ -301,7 +363,17 @@
        ;; place, which for a cross build is the TARGET pack, not this host.
        "-L" (bld-sh-quote (bld-csv-dir)) " "
        "-Wl,--exclude-libs,libncurses.a:libncursesw.a:libtinfo.a "
-       "-llz4 -lz -lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt"))))
+       ;; lz4 by archive path rather than -llz4: the -L above already preferred
+       ;; the csv archive over any system liblz4.so, but only as a side effect of
+       ;; search order, so a Chez installed without it silently produced a binary
+       ;; with a runtime lz4 dependency. Naming it says so, and its absence is
+       ;; now a warning rather than silence. Falls back to -llz4 (the -L above,
+       ;; then LIBRARY_PATH, then the system dirs) when there is no archive.
+       (let ((lz4 (bld-lz4-archive)))
+         (if lz4
+             (string-append (bld-sh-quote lz4) " ")
+             (begin (bld-warn-dynamic-lz4!) "-llz4 ")))
+       "-lz -lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt"))))
 
 ;; --- optional built-binary startup profile ----------------------------------
 ;; JOLT_STARTUP_PROFILE=1 reports wall time, process CPU, collections,

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -249,74 +249,86 @@
               (error 'jolt-build (string-append "target pack file missing: " p hint)))))
         '("xpatch" "link-libs")))))
 
-;; The kernel's lz4, as an absolute path to a STATIC archive, or #f when none is
-;; reachable. Chez compiles its bundled lz4 as part of its own build and installs
-;; liblz4.a next to libkernel.a, so the archive matching the kernel this link
-;; bakes in is normally already in the csv dir — on every platform, Homebrew's
-;; chezscheme included (it vendors lz4 too; it does not depend on the lz4
-;; formula). The keg and pkg-config are macOS fallbacks for a Chez that somehow
-;; installed without it.
+;; The kernel's compression libraries — lz4 and zlib — as absolute paths to
+;; STATIC archives, or #f when none is reachable. Chez compiles both as part of
+;; its own build and installs liblz4.a / libz.a next to libkernel.a, so the
+;; archives matching the kernel this link bakes in are normally already in the csv
+;; dir, on every platform — Homebrew's chezscheme included (it vendors them; it
+;; depends on neither formula). The keg and pkg-config are macOS fallbacks for a
+;; Chez that somehow installed without them.
 ;;
-;; Naming the archive by path is what forces the static choice: Apple's ld has no
+;; Naming an archive by path is what forces the static choice: Apple's ld has no
 ;; -Bstatic, and a bare -llz4 pointed at a directory holding both a .dylib and a
 ;; .a always takes the .dylib. That is how the released macOS binary came to
 ;; demand /opt/homebrew/opt/lz4/lib/liblz4.1.dylib off every machine that ran it
 ;; — the install script's own `jolt --version` check died with a dyld error on a
-;; Mac with no Homebrew lz4, which is most of them. lz4 is not a system library
-;; on either platform, so it has to be baked in: a jolt binary is meant to run
-;; with nothing else installed.
+;; Mac with no Homebrew lz4, which is most of them. Neither library has to be a
+;; dependency of anything jolt produces: a jolt binary is meant to run with
+;; nothing else installed, the way a Go binary does.
 
-;; An archive that outranks the search below. The self-contained jolt has no Chez
-;; install to look in, so it carries the archive its own kernel was linked
-;; against and spills it for the one link it still performs (bld-relink-stub).
-(define bld-lz4-override (make-parameter #f))
+;; Archives the caller has already put on disk, as (("lz4" . path) ("z" . path)).
+;; They outrank the search below: the self-contained jolt has no Chez install to
+;; look in, so it carries the archives its own kernel was linked against and
+;; spills them for the one link it still performs (bld-relink-stub).
+(define bld-bundled-archives (make-parameter '()))
 
-(define (bld-lz4-archive)
-  (let loop ((thunks
-               (cons*
-                 (lambda () (bld-lz4-override))
-                 ;; The csv dir the kernel itself comes from. (bld-csv-dir), not
-                 ;; bld-host-csv-dir, for the reason the Linux branch gives below.
-                 ;; A cross build's link never asks (the pack's link-libs carries
-                 ;; its own -llz4, resolved against the static archive under
-                 ;; lib/), but build-jolt does, to embed it — hence the pack path.
-                 (lambda () (string-append (bld-csv-dir) "/liblz4.a"))
-                 (lambda () (and (bld-cross?)
-                                 (string-append (bld-target-pack) "/lib/liblz4.a")))
-                 ;; macOS only. A distro's static liblz4.a is deliberately NOT
-                 ;; searched on Linux: it may well be non-PIC, which would turn
-                 ;; today's working `jolt build --library` into a link error
-                 ;; ("recompile with -fPIC"). Chez's own archive is built
-                 ;; alongside libkernel.a, which that link already folds into a
-                 ;; shared object, so it carries the same guarantee. Darwin
-                 ;; compiles PIC throughout, so neither fallback has the problem.
-                 (if bld-osx?
-                     (list
-                       (lambda ()
-                         (let ((prefix (bld-sh-capture "brew --prefix lz4 2>/dev/null")))
-                           (and (> (string-length prefix) 0)
-                                (string-append prefix "/lib/liblz4.a"))))
-                       (lambda ()
-                         (let ((libdir (bld-sh-capture "pkg-config --variable=libdir liblz4 2>/dev/null")))
-                           (and (> (string-length libdir) 0)
-                                (string-append libdir "/liblz4.a")))))
-                     '()))))
-    (if (null? thunks)
-        #f
-        (let ((path ((car thunks))))
-          (if (and path (file-exists? path)) path (loop (cdr thunks)))))))
+;; lib name -> (Homebrew keg, pkg-config module), for the macOS fallbacks.
+(define bld-archive-sources '(("lz4" "lz4" "liblz4") ("z" "zlib" "zlib")))
+
+(define (bld-static-archive lib)
+  (let ((file (string-append "lib" lib ".a"))
+        (src (assoc lib bld-archive-sources)))
+    (let loop ((thunks
+                 (cons*
+                   (lambda () (cond ((assoc lib (bld-bundled-archives)) => cdr) (else #f)))
+                   ;; The csv dir the kernel itself comes from. (bld-csv-dir), not
+                   ;; bld-host-csv-dir, for the reason the Linux branch gives
+                   ;; below. A cross build's link never asks (the pack's link-libs
+                   ;; carries its own -llz4 -lz, resolved against the archives
+                   ;; under lib/), but build-jolt does, to embed them — hence the
+                   ;; pack path.
+                   (lambda () (string-append (bld-csv-dir) "/" file))
+                   (lambda () (and (bld-cross?)
+                                   (string-append (bld-target-pack) "/lib/" file)))
+                   ;; macOS only. A distro's static archive is deliberately NOT
+                   ;; searched on Linux: it may well be non-PIC, which would turn
+                   ;; today's working `jolt build --library` into a link error
+                   ;; ("recompile with -fPIC"). Chez's own archives are built
+                   ;; alongside libkernel.a, which that link already folds into a
+                   ;; shared object, so they carry the same guarantee. Darwin
+                   ;; compiles PIC throughout, so neither fallback has the problem.
+                   (if (and bld-osx? src)
+                       (list
+                         (lambda ()
+                           (let ((prefix (bld-sh-capture
+                                           (string-append "brew --prefix " (cadr src) " 2>/dev/null"))))
+                             (and (> (string-length prefix) 0)
+                                  (string-append prefix "/lib/" file))))
+                         (lambda ()
+                           (let ((libdir (bld-sh-capture
+                                           (string-append "pkg-config --variable=libdir "
+                                             (caddr src) " 2>/dev/null"))))
+                             (and (> (string-length libdir) 0)
+                                  (string-append libdir "/" file)))))
+                       '()))))
+      (if (null? thunks)
+          #f
+          (let ((path ((car thunks))))
+            (if (and path (file-exists? path)) path (loop (cdr thunks))))))))
 
 ;; No archive anywhere: the link still has to find SOMETHING, and a binary that
-;; needs a dylib beats one that does not link at all. Say so — the result runs
-;; here and nowhere else, which is not what a `jolt build` output is for.
-(define (bld-warn-dynamic-lz4!)
-  (display "jolt build: warning: no static liblz4.a found next to the Chez kernel\n")
-  (display "  — linking lz4 dynamically; the binary will need it on every machine that runs it\n"))
+;; needs a shared library beats one that does not link at all. Say so — the
+;; result runs here and nowhere else, which is not what a `jolt build` output is
+;; for.
+(define (bld-warn-dynamic-lib! lib)
+  (display (string-append
+    "jolt build: warning: no static lib" lib ".a found next to the Chez kernel\n"
+    "  — linking " lib " dynamically; the binary will need it on every machine that runs it\n")))
 
 ;; The macOS -llz4 fallback: the keg (or pkg-config) at least tells the linker
 ;; where the dylib is, which a bare -llz4 on a Mac with no lz4 in /usr/lib cannot.
 (define (bld-osx-lz4-dynamic)
-  (bld-warn-dynamic-lz4!)
+  (bld-warn-dynamic-lib! "lz4")
   (let ((prefix (bld-sh-capture "brew --prefix lz4 2>/dev/null")))
     (if (> (string-length prefix) 0)
         (string-append "-L" (bld-sh-quote (string-append prefix "/lib")) " -llz4")
@@ -324,6 +336,20 @@
           (if (> (string-length pc) 0)
               (string-append pc " -llz4")
               "-llz4")))))
+
+;; The link fragment for one of the kernel's compression libraries: the archive's
+;; path when one is reachable, else -l<lib>. WARN? says whether the fallback is
+;; worth a word. It always is for lz4, which no OS ships, and on Linux for zlib;
+;; on macOS libz is /usr/lib/libz.1.dylib, as much a part of the OS as libiconv,
+;; so falling back to it there is unremarkable.
+(define (bld-compression-lib lib warn?)
+  (let ((archive (bld-static-archive lib)))
+    (cond
+      (archive (string-append (bld-sh-quote archive) " "))
+      ;; a bare -llz4 finds nothing on a Mac: the keg is not on the default path.
+      ((and bld-osx? (string=? lib "lz4")) (string-append (bld-osx-lz4-dynamic) " "))
+      (else (when warn? (bld-warn-dynamic-lib! lib))
+            (string-append "-l" lib " ")))))
 
 ;; Link flags. The kernel's lz4/zlib/ncurses deps, lz4 statically (see above).
 ;; The host branches double as the target flags for a non-cross build
@@ -338,12 +364,16 @@
      (or (getenv "JOLT_TARGET_LINK_LIBS")
          (string-append "-L" (bld-sh-quote (string-append (bld-target-pack) "/lib")) " "
            (bld-sh-capture (string-append "cat " (bld-sh-quote (string-append (bld-target-pack) "/link-libs")))))))
-    ;; macOS: libz, libncurses, libiconv and Foundation ship with the OS, so they
-    ;; stay dynamic; lz4 does not, so it is named as an archive and baked in.
+    ;; macOS: libncurses, libiconv and Foundation ship with the OS and stay
+    ;; dynamic — they cannot be baked in. lz4 and zlib can, and are: lz4 because
+    ;; the OS has none at all, zlib because the archive Chez built is right there
+    ;; next to the kernel, which leaves the dependency list to things that are
+    ;; genuinely part of macOS.
     (bld-osx?
-     (let ((lz4 (bld-lz4-archive)))
-       (string-append (if lz4 (bld-sh-quote lz4) (bld-osx-lz4-dynamic))
-         " -lz -lncurses -framework Foundation -liconv -lm")))
+     (string-append
+       (bld-compression-lib "lz4" #t)
+       (bld-compression-lib "z" #f)
+       "-lncurses -framework Foundation -liconv -lm"))
     ;; Windows (ta6nt, MinGW-w64 under MSYS2): the Chez kernel pulls in
     ;; compression, winsock, COM/UUID, and the registry.
     (bld-nt?
@@ -372,18 +402,22 @@
        ;; caller of bld-link-libs takes -I and libkernel.a from the same
        ;; place, which for a cross build is the TARGET pack, not this host.
        "-L" (bld-sh-quote (bld-csv-dir)) " "
-       "-Wl,--exclude-libs,libncurses.a:libncursesw.a:libtinfo.a "
-       ;; lz4 by archive path rather than -llz4: the -L above already preferred
-       ;; the csv archive over any system liblz4.so, but only as a side effect of
-       ;; search order, so a Chez installed without it silently produced a binary
-       ;; with a runtime lz4 dependency. Naming it says so, and its absence is
-       ;; now a warning rather than silence. Falls back to -llz4 (the -L above,
-       ;; then LIBRARY_PATH, then the system dirs) when there is no archive.
-       (let ((lz4 (bld-lz4-archive)))
-         (if lz4
-             (string-append (bld-sh-quote lz4) " ")
-             (begin (bld-warn-dynamic-lz4!) "-llz4 ")))
-       "-lz -lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt"))))
+       ;; liblz4.a/libz.a join the list for a milder version of the same reason:
+       ;; the executable is searched before any dlopen'd library, so exporting a
+       ;; baked-in deflate/LZ4_decompress means an FFI-loaded libpng, libssl or
+       ;; libsqlite3 calls THIS copy instead of the one it was built against.
+       ;; ld matches these by basename, so naming the archives by absolute path
+       ;; above changes nothing here.
+       "-Wl,--exclude-libs,libncurses.a:libncursesw.a:libtinfo.a:liblz4.a:libz.a "
+       ;; lz4 and zlib by archive path rather than -llz4 -lz: the -L above
+       ;; already preferred the csv archives over any system .so, but only as a
+       ;; side effect of search order, so a Chez installed without them silently
+       ;; produced a binary with runtime compression dependencies. Naming them
+       ;; says so, and their absence is now a warning rather than silence. Falls
+       ;; back to -l (the -L above, then LIBRARY_PATH, then the system dirs).
+       (bld-compression-lib "lz4" #t)
+       (bld-compression-lib "z" #t)
+       "-lncurses -ltinfo -ldl -lm -lpthread -luuid -lrt"))))
 
 ;; --- optional built-binary startup profile ----------------------------------
 ;; JOLT_STARTUP_PROFILE=1 reports wall time, process CPU, collections,
@@ -2025,6 +2059,21 @@
                  "jolt build: note — on macOS this binary is unsigned; to share it,\n"
                  "  `xattr -d com.apple.quarantine " out-path "` on the target, or sign it.\n")))))
 
+;; Spill whichever bundled compression archives this binary carries into
+;; BUILDDIR, and answer them as bld-bundled-archives expects. Empty for a jolt
+;; built against a Chez that had none — bld-compression-lib then falls back and
+;; warns, exactly as it would on the dev machine.
+(define (bld-spill-bundled-archives builddir)
+  (fold-left
+    (lambda (acc lib)
+      (let ((name (string-append "lib" lib ".a")))
+        (if (jolt-embedded-bytes (string-append "csv/" name))
+            (let ((path (string-append builddir "/" name)))
+              (jolt-spill-embedded! (string-append "csv/" name) path)
+              (cons (cons lib path) acc))
+            acc)))
+    '() '("lz4" "z")))
+
 ;; Re-link the launcher stub with the app's static native archives baked in, to
 ;; OUT-PATH. The self-contained jolt bundles the Chez kernel (libkernel.a),
 ;; header, and launcher source; spill them and drive the system cc — the same link
@@ -2035,21 +2084,20 @@
   (let* ((h  (string-append builddir "/scheme.h"))
          (lk (string-append builddir "/libkernel.a"))
          (lc (string-append builddir "/launcher.c"))
-         ;; The bundled lz4 archive, spilled like the kernel: this link runs on a
-         ;; machine with no Chez install, so bld-lz4-archive has nowhere to look
-         ;; and the app would otherwise take whatever lz4 the machine happens to
-         ;; have — a runtime dependency the appended-stub path (the other 99% of
-         ;; builds) does not have, on a binary the user is about to ship. Absent
-         ;; only when the jolt running this was itself built against a Chez that
-         ;; had no archive; then the link falls back to -llz4 as it always did.
-         (lz4 (and (jolt-embedded-bytes "csv/liblz4.a")
-                   (string-append builddir "/liblz4.a"))))
+         ;; The bundled lz4/zlib archives, spilled like the kernel: this link runs
+         ;; on a machine with no Chez install, so bld-static-archive has nowhere
+         ;; to look and the app would otherwise take whatever lz4 and zlib the
+         ;; machine happens to have — runtime dependencies the appended-stub path
+         ;; (the other 99% of builds) does not have, on a binary the user is
+         ;; about to ship. An archive is absent only when the jolt running this
+         ;; was itself built against a Chez that had none; then the link falls
+         ;; back to -l as it always did.
+         (archives (bld-spill-bundled-archives builddir)))
     (jolt-spill-embedded! "csv/scheme.h" h)
     (jolt-spill-embedded! "csv/libkernel.a" lk)
     (jolt-spill-embedded! "stub/launcher.c" lc)
-    (when lz4 (jolt-spill-embedded! "csv/liblz4.a" lz4))
     (display "jolt build: relinking launcher stub with static native libraries\n")
-    (parameterize ((bld-lz4-override lz4))
+    (parameterize ((bld-bundled-archives archives))
       (bld-system (string-append
         "cc -O2 " (bld-export-symbols-flag)
         "-I'" builddir "' '" lc "' '" lk "' -o '" out-path "' "

--- a/host/chez/jolt-selfbuild-smoke.sh
+++ b/host/chez/jolt-selfbuild-smoke.sh
@@ -81,7 +81,8 @@ args: [alpha bb ccc]
 sum: 10
 greet-default: greet:default
 greet-loud: greet:loud
-greet-soft: greet:soft'
+greet-soft: greet:soft
+boot-threads: :ran :ran'
 rm -rf "$(dirname "$app")"
 if [ "$got" != "$want" ]; then
   echo "  FAIL: produced app output mismatch"
@@ -91,10 +92,12 @@ if [ "$got" != "$want" ]; then
 fi
 
 # 5. Static native linking through the distributed jolt: it bundles the Chez
-# kernel, so with the system cc (but still no external Chez) it re-links a stub
-# that bakes a :jolt/native :static archive into the app. The app then calls the
-# C function with the archive removed from disk. Uses the normal PATH so cc — and
-# the kernel's link deps (lz4/…) — are found, but Chez stays out of the build.
+# kernel AND the static liblz4.a that kernel was built against, so with the
+# system cc (but still no external Chez) it re-links a stub that bakes a
+# :jolt/native :static archive into the app. The app then calls the C function
+# with the archive removed from disk. Uses the normal PATH so cc and the kernel's
+# remaining link deps are found, but Chez stays out of the build — and lz4 comes
+# from the bundle, not from this machine, which the dependency check below pins.
 napp="$(mktemp -d)/native-app"
 mkdir -p "$napp/src/app"
 printf 'int jolt_static_answer(void){return 42;}\n' > "$napp/greet.c"
@@ -110,9 +113,30 @@ cat > "$napp/deps.edn" <<EOF
 EOF
 nout="$napp/app"
 echo "jolt self-build smoke: static-linking a native lib via the binary (no external Chez)"
-if ! JOLT_PWD="$napp" "$jolt" build -m app.core -o "$nout" >/dev/null 2>&1; then
+if ! JOLT_PWD="$napp" "$jolt" build -m app.core -o "$nout" > "$napp/build.log" 2>&1; then
   echo "  FAIL: static native build via distributed jolt exited non-zero"
+  cat "$napp/build.log"
   rm -rf "$(dirname "$napp")"; exit 1
+fi
+
+# The relink is the one link the distributed jolt performs, and it must take lz4
+# from the archive the binary carries rather than from this machine: an app built
+# on a box with liblz4 installed has to run on one without it. Skipped when this
+# jolt bundles no archive — it says so at link time — because then there is
+# nothing to take, and the fallback is the pre-existing behaviour.
+if grep -q "no static liblz4.a" "$napp/build.log"; then
+  echo "  (lz4 dependency check skipped: this jolt bundles no lz4 archive)"
+else
+  ndeps=""
+  if command -v otool >/dev/null 2>&1; then ndeps="$(otool -L "$nout" 2>/dev/null)"
+  elif command -v readelf >/dev/null 2>&1; then ndeps="$(readelf -d "$nout" 2>/dev/null)"
+  elif command -v ldd >/dev/null 2>&1; then ndeps="$(ldd "$nout" 2>/dev/null)"
+  fi
+  if printf '%s' "$ndeps" | grep -qi lz4; then
+    echo "  FAIL: the static-native app needs lz4 at runtime:"
+    printf '%s\n' "$ndeps" | grep -i lz4
+    rm -rf "$(dirname "$napp")"; exit 1
+  fi
 fi
 rm -f "$napp/libgreet.a" "$napp/greet.o"     # nothing to load at runtime
 got_n="$(cd / && "$nout" 2>&1)"

--- a/host/chez/jolt-selfbuild-smoke.sh
+++ b/host/chez/jolt-selfbuild-smoke.sh
@@ -92,12 +92,13 @@ if [ "$got" != "$want" ]; then
 fi
 
 # 5. Static native linking through the distributed jolt: it bundles the Chez
-# kernel AND the static liblz4.a that kernel was built against, so with the
-# system cc (but still no external Chez) it re-links a stub that bakes a
+# kernel AND the static liblz4.a / libz.a that kernel was built against, so with
+# the system cc (but still no external Chez) it re-links a stub that bakes a
 # :jolt/native :static archive into the app. The app then calls the C function
 # with the archive removed from disk. Uses the normal PATH so cc and the kernel's
-# remaining link deps are found, but Chez stays out of the build — and lz4 comes
-# from the bundle, not from this machine, which the dependency check below pins.
+# remaining link deps are found, but Chez stays out of the build — and the
+# compression libraries come from the bundle, not from this machine, which the
+# dependency check below pins.
 napp="$(mktemp -d)/native-app"
 mkdir -p "$napp/src/app"
 printf 'int jolt_static_answer(void){return 42;}\n' > "$napp/greet.c"
@@ -120,21 +121,21 @@ if ! JOLT_PWD="$napp" "$jolt" build -m app.core -o "$nout" > "$napp/build.log" 2
 fi
 
 # The relink is the one link the distributed jolt performs, and it must take lz4
-# from the archive the binary carries rather than from this machine: an app built
-# on a box with liblz4 installed has to run on one without it. Skipped when this
-# jolt bundles no archive — it says so at link time — because then there is
+# and zlib from the archives the binary carries rather than from this machine: an
+# app built on a box with them installed has to run on one without them. Skipped
+# when this jolt is missing one — it says so at link time — because then there is
 # nothing to take, and the fallback is the pre-existing behaviour.
-if grep -q "no static liblz4.a" "$napp/build.log"; then
-  echo "  (lz4 dependency check skipped: this jolt bundles no lz4 archive)"
+if grep -q "no static lib" "$napp/build.log"; then
+  echo "  (compression dependency check skipped: this jolt bundles no archive)"
 else
   ndeps=""
   if command -v otool >/dev/null 2>&1; then ndeps="$(otool -L "$nout" 2>/dev/null)"
   elif command -v readelf >/dev/null 2>&1; then ndeps="$(readelf -d "$nout" 2>/dev/null)"
   elif command -v ldd >/dev/null 2>&1; then ndeps="$(ldd "$nout" 2>/dev/null)"
   fi
-  if printf '%s' "$ndeps" | grep -qi lz4; then
-    echo "  FAIL: the static-native app needs lz4 at runtime:"
-    printf '%s\n' "$ndeps" | grep -i lz4
+  if printf '%s' "$ndeps" | grep -qEi 'lz4|libz\.'; then
+    echo "  FAIL: the static-native app needs a compression library at runtime:"
+    printf '%s\n' "$ndeps" | grep -Ei 'lz4|libz\.'
     rm -rf "$(dirname "$napp")"; exit 1
   fi
 fi

--- a/install
+++ b/install
@@ -187,6 +187,16 @@ chmod +x "$install_dir/jolt"
 if ! run_err="$("$install_dir/jolt" --version 2>&1 >/dev/null)"; then
     >&2 echo "The installed binary does not run on this system:"
     >&2 echo "  ${run_err}"
+    # A macOS build that was linked against a library the machine does not have
+    # (releases before jolt started baking lz4 in named Homebrew's
+    # liblz4.1.dylib, which only a Mac with `brew install lz4` carries).
+    if [[ "$run_err" == *"Library not loaded"* ]]; then
+        missing="$(printf '%s' "$run_err" | sed -nE 's/.*[Ll]ibrary not loaded: ([^ ]+).*/\1/p' | head -1)"
+        >&2 echo ""
+        >&2 echo "This build needs ${missing:-a library that is not installed here}."
+        >&2 echo "Install that library, or install a jolt that bakes it in:"
+        >&2 echo "  brew install lz4        # if the missing library is liblz4"
+    fi
     if [[ "$run_err" == *GLIBC_* ]]; then
         need="$(printf '%s' "$run_err" | sed -nE "s/.*GLIBC_([0-9.]+).*/\1/p" | head -1)"
         have="$(ldd --version 2>/dev/null | sed -nE '1s/.* ([0-9.]+)$/\1/p')"


### PR DESCRIPTION
Reported from a direct install on an M2 Pro Mac: `curl -sL .../install | bash` fails because the binary wants `/opt/homebrew/opt/lz4/lib/liblz4.1.dylib`. Fixing it properly means the goal in the title: a binary that runs on a stock machine, the way a Go binary does.

## What was wrong

lz4 and zlib are the Chez kernel's fasl compressors — they decompress the boot images and compiled code every jolt binary embeds — so jolt itself and everything `jolt build` produces links them. Three places got them from the machine instead of baking them in:

- **The macOS link line** took lz4 from `$(brew --prefix lz4)/lib`, and a directory holding both a `.dylib` and a `.a` gives `-llz4` the dylib. The released `aarch64-macos` binary therefore carried a hard load path into a Homebrew keg that a Mac only has if its owner ran `brew install lz4`. Everyone else's install died in the install script's own `jolt --version` check with a dyld error — at the very last step, after the download and the checksum.
- **The Linux link line** got the right answer by luck of search order: `-L<csv> -llz4 -lz` happened to find Chez's own archives first. A Chez installed without them silently produced a binary with runtime compression dependencies.
- **The relink inside the distributed jolt** — `bld-relink-stub`, which bakes a `:jolt/native` `:static` archive into an app, the one link jolt performs itself — had no Chez install to find archives in, so it resolved both off the user's machine. An app with a static native came out needing `libz.so.1`.

## The fix

**Name the archives.** Every link now names the static `liblz4.a` and `libz.a` that Chez installs next to `libkernel.a`. Naming an archive by path is what forces the static choice — Apple's `ld` has no `-Bstatic`. Homebrew's `chezscheme` vendors both rather than depending on the formulas, so the archives are already in the keg's csv dir; the brew keg and pkg-config remain macOS fallbacks. Where an archive is missing the link still falls back to `-l` — a binary that runs here beats one that doesn't link — but it says so instead of silently shipping a dependency. (Quietly, for zlib on macOS: `libz.1.dylib` is as much a part of the OS as libiconv.)

**Bundle them.** The self-contained jolt now carries both archives alongside the Chez kernel it already bundles: `build-jolt` xxd's them in like every other bundle, `jolt-materialize-bundles!` registers them, and `bld-relink-stub` spills them and points the link at them through a parameter that outranks the csv search. Cross builds take them from the target pack's `lib/`, where `make-pack.sh` already puts them. ~300K on a 27M binary. Unlike every other bundle these are optional: a Chez without them leaves zero-length arrays, materialize registers nothing, and the relink degrades to `-l` exactly as before.

**Stop exporting them.** `-rdynamic` puts the executable's symbols in the dynamic table, and the executable is searched before any `dlopen`'d library — so a baked-in `deflate` was answering for an FFI-loaded libpng or libssl instead of the zlib it was built against. That's the interposition the ncurses `--exclude-libs` entry has guarded against all along, and lz4 has been quietly exposed to ever since it started linking statically. `liblz4.a` and `libz.a` join that list; `ld` matches by basename, so the absolute paths change nothing. A `:jolt/native`'s own symbols stay exported, so `(load-shared-object #f)` resolution is untouched.

A distro's static archive is deliberately **not** searched on Linux: it may be non-PIC, which would turn a working `jolt build --library` into "recompile with -fPIC". Chez's own archives are built alongside the `libkernel.a` that link already folds into a shared object, so they carry that guarantee; Darwin compiles PIC throughout.

**Nothing would have caught this.** The release workflow now asserts the binary it built needs no library a stock machine lacks — every macOS load command must resolve under `/usr/lib` or `/System/Library`, no `NEEDED` entry on Linux may name lz4 or libz — and `jolt-selfbuild-smoke` asserts the same of the app the relink produces. The install script also names the missing library when a binary fails to load, which is what anyone installing an already-published macOS release will hit until the next one goes out.

## Verified (Linux, x86_64)

- `make jolt-release` — links, runs, needs `libncurses`/`libtinfo`/`libm`/`libuuid`/`libc` and no compression library.
- A plain `jolt build` app: `libm`, `libc`, nothing else.
- The `:jolt/native :static` app relinked by the distributed binary: runs, needs `libm`/`libc` (it needed `libz.so.1` before this), carries 110 `LZ4_*` symbols statically.
- Exported `LZ4_*`/`deflate` symbols went 103 → 0, and `jolt_static_answer` is still exported — so `--exclude-libs` matched the absolute archive paths and hit only what it was aimed at.
- Link line reads `… '<csv>/liblz4.a' '<csv>/libz.a' -lncurses …` (confirmed by pointing `JOLT_CHEZ_CSV` at a csv dir with a deliberately corrupt archive — ld names the exact path). Remove the archives and it warns, falls back, builds and runs.
- `make joltsmoke buildsmoke staticnativesmoke stdlibfasl` pass; `buildlibsmoke` skips on this box (its Chez kernel isn't PIC).

macOS and the `ta6osx` cross row are unverified locally — the cross link path is untouched (its pack already supplies both archives under `lib/`), and the new release assertion is what proves the macOS claim.

## One thing for a maintainer's eye

**`joltsmoke`'s expected output was stale.** The shared test app grew a `boot-threads` line in e0af8d7a and only `build-smoke.sh` was updated. Fixed here, because it's the gate that covers the relink path. It rotted unnoticed because `joltsmoke` is in no workflow and no gate list — adding it to `CI-GATES` costs a debug-jolt build per run, so I left that call to you.