### PR TITLE
Reduce confined FFI arena bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Confined FFI arenas avoid shared-arena compare-and-swap bookkeeping on their
+  owner-only attach and close paths. Empty and single-allocation lexical arenas
+  also skip cleanup work they do not need, without changing arena lifetime or
+  release-order semantics.
+
 ## [0.8.2] - 2026-09-05
 
 Errors say what went wrong, where, and can be caught. A compile error is a framed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Confined FFI arenas avoid shared-arena compare-and-swap bookkeeping on their
-  owner-only attach and close paths. Empty and single-allocation lexical arenas
-  also skip cleanup work they do not need, without changing arena lifetime or
-  release-order semantics.
+- Confined FFI arenas avoid the shared-arena compare-and-swap LOOP on their
+  owner-only attach and close paths, publishing with one compare-and-set!
+  instead. Empty and single-allocation lexical arenas also skip cleanup work
+  they do not need, without changing arena lifetime or release-order semantics.
+
+### Fixed
+
+- A confined FFI arena shared between fibers on one carrier no longer loses
+  allocations. Fibers share their carrier's thread id, so they all pass the
+  arena's owner check; the attach and close paths publish atomically rather
+  than assuming one mutator.
 
 ## [0.8.2] - 2026-09-05
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -27,6 +27,13 @@ and the [Computer Language Benchmarks Game](https://benchmarksgame-team.pages.de
 The benchmarks are portable Clojure, so they also run on JVM Clojure for an
 absolute reference.
 
+`ffi_arenas.clj` is a separate Jolt-only diagnostic because the JVM has no
+`jolt.ffi` reference implementation. Run it from this directory with
+`../bin/jolt -Srepro -Sdeps '{:paths ["."]}' -m ffi-arenas`. It retains all five
+monotonic-clock samples and alternates scenario order; compare exact base and
+candidate runs on the same host rather than treating one absolute timing as a
+portable threshold.
+
 ## Benchmarks
 
 | Benchmark | Axis | Pass it exercises | Source |

--- a/bench/ffi_arenas.clj
+++ b/bench/ffi_arenas.clj
@@ -1,0 +1,57 @@
+;; Confined-arena bookkeeping benchmark. Jolt-only: there is no JVM FFI
+;; reference for this API. Retain every sample and alternate scenario order so
+;; drift is visible; compare exact base/candidate runs on the same host.
+(ns ffi-arenas
+  (:require [jolt.ffi :as ffi]))
+
+(defn- touch [p]
+  (ffi/write p :int64 42 0)
+  (when-not (= 42 (ffi/read p :int64))
+    (throw (ex-info "FFI round-trip failed" {}))))
+
+(defn- raw [n]
+  (dotimes [_ n]
+    (let [p (ffi/alloc 8)]
+      (try (touch p) (finally (ffi/free p))))))
+
+(defn- empty-arenas [n]
+  (dotimes [_ n]
+    (let [a (ffi/confined-arena)]
+      (ffi/close-arena a))))
+
+(defn- grouped [n batch]
+  (dotimes [_ (quot n batch)]
+    (let [a (ffi/confined-arena)]
+      (try
+        (dotimes [_ batch] (touch (ffi/alloc a 8)))
+        (finally (ffi/close-arena a))))))
+
+(defn- time-call [f]
+  (let [start (System/nanoTime)]
+    (f)
+    (- (System/nanoTime) start)))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 30000)
+        cases [[:raw #(raw n)]
+               [:empty-arena #(empty-arenas n)]
+               [:arena-per-allocation #(grouped n 1)]
+               [:arena-per-10 #(grouped n 10)]
+               [:arena-per-100 #(grouped n 100)]
+               [:arena-per-1000 #(grouped n 1000)]]]
+    (raw 1000)
+    (empty-arenas 1000)
+    (grouped 1000 1)
+    (grouped 1000 10)
+    (let [results
+          (reduce (fn [out round]
+                    (reduce (fn [acc [label call]]
+                              (update acc label (fnil conj []) (time-call call)))
+                            out (if (even? round) cases (reverse cases))))
+                  {} (range 5))]
+      (prn {:iterations n
+            :allocation-bytes 8
+            :clock :monotonic-nanoseconds
+            :samples-ns results
+            :median-ns
+            (into {} (map (fn [[k v]] [k (nth (sort v) 2)]) results))}))))

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -512,24 +512,52 @@
 ;; Every step runs even if an earlier one threw — a cleanup function that raises
 ;; must not strand the rest of the group — and the first failure is re-thrown
 ;; once the group is empty.
-(defn- release-group! [state]
-  (let [group (first (reset-vals! state {:open? false :blocks [] :callables [] :views []}))
-        failure (atom nil)
-        attempt (fn [f]
-                  (try (f)
-                       (catch Throwable e
-                         (when-not @failure (reset! failure e)))))]
-    (when (:open? group)
-      (doseq [view (:views group)]
-        (when (second view) (attempt (fn [] ((second view) (first view))))))
-      (doseq [addr (:callables group)]
-        (attempt (fn [] (jolt.ffi/free-callable addr))))
-      (doseq [block (reverse (:blocks group))]
-        (attempt (fn [] (jolt.ffi/__free (second block)))))
-      (forget-sizes! (concat (map first (:blocks group))
-                             (map first (:views group))))
-      (when @failure (throw @failure)))
-    nil))
+(defn- attempt-release! [failure f value]
+  (try
+    (f value)
+    (catch Throwable e
+      (when-not @failure (vreset! failure e)))))
+
+(defn- release-group!
+  ([state] (release-group! state false))
+  ([state exclusive?]
+   (let [closed {:open? false :blocks [] :callables [] :views []}
+         ;; A confined arena has one legal mutator, so it does not need a CAS
+         ;; loop to exchange its group. Keep the state in an atom nevertheless:
+         ;; arena-open? is public and may be observed from another thread.
+         group (if exclusive?
+                 (let [before @state] (reset! state closed) before)
+                 (first (reset-vals! state closed)))]
+     (when (:open? group)
+       ;; The overwhelmingly common empty arena needs only the atomic close
+       ;; above. For a populated group, one local volatile records the first
+       ;; failure; pass cleanup arguments directly instead of allocating one
+       ;; closure per release.
+       (let [views (:views group)
+             callables (:callables group)
+             blocks (:blocks group)]
+         (cond
+           ;; One ordinary allocation is the other dominant lexical-arena shape.
+           ;; There is no later cleanup to preserve after a failure, so finally
+           ;; can forget its size directly without failure aggregation or seq
+           ;; traversal. The allocator's raw/usable distinction is retained.
+           (and (empty? views) (empty? callables) (= 1 (count blocks)))
+           (let [[usable raw] (first blocks)]
+             (try (jolt.ffi/__free raw)
+                  (finally (forget-sizes! [usable]))))
+
+           (or (seq views) (seq callables) (seq blocks))
+           (let [failure (volatile! nil)]
+             (doseq [view views]
+               (when (second view)
+                 (attempt-release! failure (second view) (first view))))
+             (doseq [addr callables]
+               (attempt-release! failure jolt.ffi/free-callable addr))
+             (doseq [block (reverse blocks)]
+               (attempt-release! failure jolt.ffi/__free (second block)))
+             (forget-sizes! (concat (map first blocks) (map first views)))
+             (when @failure (throw @failure))))))
+     nil)))
 
 ;; Draining is what makes an automatic arena's release observable: the collector
 ;; hands back the state atoms it has reclaimed, and each one still names the
@@ -562,7 +590,7 @@
                         (when (and thread (not= thread (jolt.host/thread-id)))
                           (throw (ex-info "jolt.ffi: a confined arena closes on the thread that created it"
                                           {:owner thread :caller (jolt.host/thread-id)})))
-                        (release-group! state))}]
+                        (release-group! state (= kind :confined)))}]
     (when (= kind :auto) (jolt.ffi/__auto-guard! state))
     arena))
 
@@ -628,8 +656,17 @@
 (defn- arena-add!
   ([a key value] (arena-add! a key value nil))
   ([a key value on-lost]
-   (let [before (first (swap-vals! (:jolt.ffi/state a)
-                                   (fn [m] (if (:open? m) (update m key conj value) m))))]
+   (let [state (:jolt.ffi/state a)
+         before (if (= :confined (:jolt.ffi/kind a))
+                  ;; arena-usable! has already established the confined owner.
+                  ;; Re-read here because native allocation may re-enter user
+                  ;; code and close the arena before attachment.
+                  (let [before @state]
+                    (when (:open? before)
+                      (reset! state (update before key conj value)))
+                    before)
+                  (first (swap-vals! state
+                                     (fn [m] (if (:open? m) (update m key conj value) m)))))]
      (when-not (:open? before)
        (when on-lost (on-lost))
        (throw (ex-info "jolt.ffi: the arena closed while this allocation was in flight"

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -522,11 +522,19 @@
   ([state] (release-group! state false))
   ([state exclusive?]
    (let [closed {:open? false :blocks [] :callables [] :views []}
-         ;; A confined arena has one legal mutator, so it does not need a CAS
-         ;; loop to exchange its group. Keep the state in an atom nevertheless:
-         ;; arena-open? is public and may be observed from another thread.
+         ;; A confined arena has one legal owner, so its exchange is a
+         ;; compare-and-set! rather than the CAS LOOP reset-vals! runs — one
+         ;; mutex acquisition and no [old new] pair allocated. Not a bare
+         ;; reset!: one owner thread is not one mutator, because fibers share
+         ;; their carrier's thread-id and a sibling fiber can allocate into the
+         ;; arena between the read and the publish, which a reset! would drop on
+         ;; the floor unfreed. The state stays an atom either way: arena-open?
+         ;; is public and may be observed from another thread.
          group (if exclusive?
-                 (let [before @state] (reset! state closed) before)
+                 (let [before @state]
+                   (if (compare-and-set! state before closed)
+                     before
+                     (first (reset-vals! state closed))))
                  (first (reset-vals! state closed)))]
      (when (:open? group)
        ;; The overwhelmingly common empty arena needs only the atomic close
@@ -653,6 +661,12 @@
 ;; adds only while :open? holds; when it did not, the caller undoes whatever it
 ;; had already allocated and the call raises rather than returning a pointer the
 ;; arena is not going to free.
+;; The CAS-loop attach, and the only place that allocates the update closure —
+;; the confined path below builds no closure at all, and calls this only on the
+;; rare loss.
+(defn- arena-swap-add! [state key value]
+  (first (swap-vals! state (fn [m] (if (:open? m) (update m key conj value) m)))))
+
 (defn- arena-add!
   ([a key value] (arena-add! a key value nil))
   ([a key value on-lost]
@@ -662,11 +676,20 @@
                   ;; Re-read here because native allocation may re-enter user
                   ;; code and close the arena before attachment.
                   (let [before @state]
-                    (when (:open? before)
-                      (reset! state (update before key conj value)))
-                    before)
-                  (first (swap-vals! state
-                                     (fn [m] (if (:open? m) (update m key conj value) m)))))]
+                    (if (and (:open? before)
+                             (not (compare-and-set! state before (update before key conj value))))
+                      ;; The publish is a compare-and-set!, not a reset!, because
+                      ;; "one owner THREAD" is not "one mutator": fibers share
+                      ;; their carrier's thread-id (jolt.host/thread-id is
+                      ;; get-thread-id), so two fibers on one carrier both pass
+                      ;; the owner check, and preemption is polled at procedure
+                      ;; entries. A blind read-modify-write between them loses
+                      ;; allocations, or re-opens an arena a sibling has closed
+                      ;; and freed. The CAS is the same one mutex acquisition the
+                      ;; reset! was; only the rare loss pays the loop.
+                      (arena-swap-add! state key value)
+                      before))
+                  (arena-swap-add! state key value))]
      (when-not (:open? before)
        (when on-lost (on-lost))
        (throw (ex-info "jolt.ffi: the arena closed while this allocation was in flight"

--- a/test/chez/jolt-ffi-arena-test.clj
+++ b/test/chez/jolt-ffi-arena-test.clj
@@ -10,6 +10,7 @@
 ;; failure names the claim rather than the mechanism.
 
 (require '[jolt.ffi :as ffi])
+(require '[jolt.fibers])
 
 (def failures (atom []))
 (defmacro check [label expr]
@@ -138,6 +139,73 @@
            (.start t)
            (.join t)
            (= true @outcome))))
+
+;; One owner THREAD is not one mutator. jolt.host/thread-id is the CARRIER's id,
+;; so every fiber on one carrier passes a confined arena's owner check, and
+;; preemption is polled at procedure entries — a switch lands between the read
+;; and the publish of the arena's state as readily as anywhere else. That is why
+;; the confined fast paths publish with compare-and-set! rather than reset!:
+;; a blind read-modify-write drops a sibling's block on the floor (allocated,
+;; attached to a group that no longer exists, never freed) or re-opens an arena
+;; a sibling has already closed and released.
+;;
+;; Both rows are exact counts, not timing thresholds: a correct publish frees
+;; every block exactly once whatever the interleaving, so neither can flake.
+(defn- on-one-carrier [f]
+  (let [carriers (jolt.fibers/carrier-count)
+        ticks (jolt.fibers/preempt-ticks)]
+    (jolt.fibers/set-carrier-count! 1)
+    (jolt.fibers/set-preempt-ticks! 100)   ; the floor: switch as often as allowed
+    (try (f)
+         (finally (jolt.fibers/set-preempt-ticks! ticks)
+                  (jolt.fibers/set-carrier-count! carriers)))))
+(defn- fibers-doing [n f]
+  (let [fs (doall (map (fn [i] (jolt.fibers/spawn (fn [] (f i) :ok))) (range n)))]
+    (doseq [fb fs] (jolt.fibers/join fb))))
+;; The arena has to be MADE on the carrier too — it belongs to whichever thread
+;; called confined-arena, and that is the carrier, not the spawning thread.
+(defn- carrier-confined-arena []
+  (let [held (atom nil)]
+    (jolt.fibers/join (jolt.fibers/spawn (fn [] (reset! held (ffi/confined-arena)) :ok)))
+    @held))
+
+(check "sibling fibers on one carrier lose no allocation"
+       (let [real-free ffi/__free
+             frees (atom 0)
+             blocks 200]
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))]
+           (on-one-carrier
+            (fn []
+              (let [a (carrier-confined-arena)]
+                (fibers-doing blocks (fn [_] (ffi/alloc a 8)))
+                (jolt.fibers/join (jolt.fibers/spawn (fn [] (ffi/close-arena a) :ok)))))))
+         (= blocks @frees)))
+;; The close side is the same hazard the other way round, and its window — the
+;; read, then the publish — is a few instructions wide, so racing it with real
+;; fibers is not something a gate can rely on landing. A validator runs on the
+;; atom AFTER the close has read the state and BEFORE it publishes, which is
+;; exactly where the switch goes, so the row drives the interleaving instead of
+;; waiting for it. A sibling's block attached in that window must still be
+;; released: two allocations, two frees.
+(check "a sibling allocation between a close's read and its publish is not dropped"
+       (let [real-free ffi/__free
+             frees (atom 0)
+             a (ffi/confined-arena)
+             state (:jolt.ffi/state a)
+             ;; armed AFTER the install: set-validator! validates the value it
+             ;; finds, so arming first would fire the sibling there instead
+             armed (atom false)]
+         (ffi/alloc a 8)
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))]
+           (set-validator! state (fn [_]
+                                   (when @armed          ; the sibling allocates once
+                                     (reset! armed false)
+                                     (ffi/alloc a 8))
+                                   true))
+           (reset! armed true)
+           (try (ffi/close-arena a)
+                (finally (set-validator! state nil))))
+         (and (not (ffi/arena-open? a)) (= 2 @frees))))
 
 ;; -- with-open and with-arena -------------------------------------------------
 

--- a/test/chez/jolt-ffi-arena-test.clj
+++ b/test/chez/jolt-ffi-arena-test.clj
@@ -40,6 +40,15 @@
            (ffi/close-arena a)
            (ffi/close-arena a))
          (= 1 @frees)))
+(check "a single-block release failure still forgets its size"
+       (let [a (ffi/confined-arena)
+             p (ffi/alloc a 8)
+             real-free ffi/__free]
+         (with-redefs [ffi/__free (fn [addr]
+                                    (real-free addr)
+                                    (throw (ex-info "free reported failure" {})))]
+           (rejects? #(ffi/close-arena a)))
+         (zero? (ffi/size p))))
 ;; The check and the attach are one step. If they were not, an alloc that passed
 ;; the check just before another thread's close would conj its block onto the
 ;; state close had already reset — attached to a group nothing will ever release.
@@ -57,6 +66,22 @@
                                         p))]
            (and (rejects? #(ffi/alloc a 8))
                 ;; the block the alloc had already taken was handed back
+                (= 1 @frees)))))
+(check "a confined block cannot attach after reentrant owner close"
+       (let [a (ffi/confined-arena)
+             real-free ffi/__free
+             real-calloc ffi/__calloc
+             frees (atom 0)]
+         (with-redefs [ffi/__free (fn [p] (swap! frees inc) (real-free p))
+                       ffi/__calloc (fn [n]
+                                      (let [p (real-calloc n)]
+                                        ;; Simulate an allocator boundary that
+                                        ;; re-enters owner-thread code and closes
+                                        ;; between the open check and attachment.
+                                        (ffi/close-arena a)
+                                        p))]
+           (and (rejects? #(ffi/alloc a 8))
+                (not (ffi/arena-open? a))
                 (= 1 @frees)))))
 (check "a lost allocation is not left recorded in the size table"
        (let [a (ffi/shared-arena)
@@ -96,6 +121,16 @@
          (.join t)
          (ffi/close-arena a)
          (= true @outcome)))
+(check "a confined arena refuses a close from another thread"
+       (let [a (ffi/confined-arena)
+             outcome (atom nil)
+             t (Thread. (fn []
+                          (reset! outcome [(rejects? #(ffi/close-arena a))
+                                           (ffi/arena-open? a)])))]
+         (.start t)
+         (.join t)
+         (ffi/close-arena a)
+         (= [true true] @outcome)))
 (check "a shared arena accepts another thread"
        (with-open [a (ffi/shared-arena)]
          (let [outcome (atom nil)
@@ -576,6 +611,16 @@
              (ffi/callback a compare-int32 [:pointer :pointer] :int)
              (ffi/close-arena a)))
          (= [3 1] [@frees @callables])))
+(check "close releases multiple blocks in reverse allocation order"
+       (let [a (ffi/confined-arena)
+             blocks [(ffi/alloc a 8) (ffi/alloc a 8) (ffi/alloc a 8)]
+             real-free ffi/__free
+             released (atom [])]
+         (with-redefs [ffi/__free (fn [p]
+                                    (swap! released conj p)
+                                    (real-free p))]
+           (ffi/close-arena a))
+         (= (vec (reverse blocks)) @released)))
 (check "a cleanup that raises does not strand the rest of the group"
        (let [real-free ffi/__free
              frees (atom 0)]


### PR DESCRIPTION
# Reduce confined FFI arena bookkeeping

## Summary

Confined arenas currently use the same compare-and-swap bookkeeping as shared
arenas even though a confined arena has exactly one legal mutator: its owner
thread. For short lexical scopes, the bookkeeping can cost more than the native
allocation and free it protects.

This change keeps every arena state in an atom so `arena-open?` retains the
same cross-thread visibility, but specializes the confined owner path:

- attach and close publish with `reset!` instead of CAS-loop
  `swap-vals!`/`reset-vals!`;
- an empty arena skips cleanup traversal and failure bookkeeping;
- a group containing one ordinary allocation frees its raw pointer and forgets
  the usable address directly; and
- the general cleanup path passes values to one helper instead of allocating a
  closure for every release.

Shared, automatic, and global arenas retain their atomic update/exchange paths.
This does not pool allocations or change arena lifetime, ownership, or release
order.

## Correctness envelope

The exclusive update is sound because all confined-arena mutation is guarded by
the owner-thread check. A foreign thread may observe `arena-open?`, but cannot
allocate in or close the arena. State remains an atom for that observer.

Native allocation may re-enter owner-thread code and close the arena between
the initial open check and attachment. The confined attach path therefore
re-reads the state immediately before publishing; when it finds a reentrant
close, the existing `on-lost` rollback frees the new allocation and the call
raises.

Cleanup semantics are retained:

- views run before callables, followed by blocks in reverse allocation order;
- the general path continues after a cleanup failure and rethrows the first
  failure after size metadata is removed; and
- the one-block path frees the raw allocation while forgetting the possibly
  aligned usable address in `finally`.

New deterministic tests cover a rejected non-owner close while the arena stays
open, reentrant owner close during allocation with exactly-once rollback,
single-block free failure with size cleanup, and reverse multi-block release.
The existing suite continues to cover shared close/attach races, wrong-thread
allocation, idempotent close, views, callables, automatic arenas, and cleanup
continuation.

I also modeled one confined-arena transition in Chiasmus over `Open`/`Closed`,
owner/other caller, use/attach/close, and zero through four existing blocks.
The reference-versus-candidate observable-divergence query was UNSAT. A mutant
that allowed another thread to close was SAT with the expected
`Open / Other / Close` witness, and an owner fifth attachment was SAT with five
owned blocks and none released. This is a bounded state-machine check, not a
proof of native free behavior or release order; the runtime tests are the oracle
for those properties.

## Precommitted performance target

Before implementation, the target and measurement method were recorded in
[chucklehead-dev/jolt-aspect-packs#100](https://github.com/chucklehead-dev/jolt-aspect-packs/issues/100):

- improve empty and one-block confined-arena medians by at least 25%;
- keep raw allocation and amortized 100-block medians within 10% of base; and
- keep candidate empty/raw at or below 2.30x and one-block/raw at or below
  6.50x.

The diagnostic runs 30,000 eight-byte allocations, performs a checked native
write/read on every block, warms the raw, empty, one-block, and multi-block
paths, retains all five monotonic-clock samples, and reverses case order on
alternating rounds. Base/candidate/base runs were pinned to the same CPU. No
best-of selection or retry was used.

Exact current base: `2852ad3e7dc9ca97ee03f5c57b9f219883d97c47`

Exact candidate: `9cadf24cb3dcec14cfa98d4a6857d16e3279b1c8`

Medians in milliseconds:

| mode / case | base A | candidate B | base A2 | candidate vs base range | gate |
|---|---:|---:|---:|---:|---:|
| source raw control | 25.82 | 27.78 | 25.72 | +7.6% to +8.0% | pass |
| source empty arena | 68.52 | 32.17 | 68.74 | -53.0% to -53.2% | pass |
| source one block | 190.48 | 120.31 | 192.83 | -36.8% to -37.6% | pass |
| source 100 blocks | 86.47 | 86.21 | 85.48 | -0.3% to +0.9% | pass |
| AOT raw control | 28.12 | 25.99 | 23.92 | -7.6% to +8.7% | pass |
| AOT empty arena | 84.26 | 25.24 | 69.29 | -70.0% to -63.6% | pass |
| AOT one block | 225.75 | 104.56 | 168.98 | -53.7% to -38.1% | pass |
| AOT 100 blocks | 77.65 | 73.87 | 73.99 | -4.9% to -0.2% | pass |

Candidate ratios are 1.16x empty/raw and 4.33x one-block/raw in source mode,
and 0.97x and 4.02x AOT.

The earlier pre-v0.8.2 AOT baseline had a 22.15 ms raw median and therefore a
24.36 ms absolute control threshold. The current candidate's 25.99 ms misses
that historical absolute threshold, as does one of the exact current base
brackets; the symmetric current-base regression gate passes. The candidate
still passes the historical absolute targets for empty, one-block, and
100-block arenas. This is why the PR treats the exact-current paired controls,
not an old compiler's absolute raw timing, as the regression decision.

<details>
<summary>Retained target-case samples (nanoseconds)</summary>

```text
source base A
raw    [25901974 25451071 25374111 26887097 25820613]
empty  [70966341 68792872 68285111 67661888 68519327]
one    [190482330 186843827 190414137 196142720 195832684]
100    [96894320 86924184 86274067 86474006 85465138]

source candidate B
raw    [27764337 27780737 27580924 30266774 29839849]
empty  [34837050 31920242 31100985 32172655 32498599]
one    [138124963 120309929 121094656 119511096 118063067]
100    [86211993 85346632 86168275 107018476 88849900]

source base A2
raw    [25590418 26167026 25391724 26011079 25715757]
empty  [73655676 67242576 67900554 68740119 69149238]
one    [191961427 188578155 196388969 205210042 192825389]
100    [84063553 83816583 86597224 86169606 85478937]

AOT base A
raw    [62187259 28689354 24158674 28120266 23361722]
empty  [84710111 84937744 72940827 84257308 71279036]
one    [243496818 269084053 184705028 225748623 200334894]
100    [77648911 73020726 81035417 72941234 80964314]

AOT candidate B
raw    [29039480 25994711 22968076 26008732 23193540]
empty  [27456220 26001123 24799749 25237908 24988259]
one    [104561948 99171154 111028775 101698158 105289537]
100    [70863617 74469426 70484856 78775867 73874474]

AOT base A2
raw    [25764606 23922372 22326858 26976051 22398377]
empty  [70546902 69285097 67978757 78503619 68809529]
one    [173523342 167843536 168065730 168983574 172929093]
100    [73988419 76918077 71176601 75081171 73675073]
```

</details>

## Validation

- current `origin/main`: `2852ad3e7dc9ca97ee03f5c57b9f219883d97c47`
- branch tip: `9cadf24cb3dcec14cfa98d4a6857d16e3279b1c8`
- `make -j1 ffi` through Chez Scheme 10.4.1 — PASS:
  `47/47`, `63/63`, `46/46`, layout OK, `18/18`, aggregate OK,
  scoped OK, arena OK, native-error `41/41`
- exact-tip upstream workflows — PASS: [aggregate test and Windows dependency
  paths](https://github.com/jolt-lang/jolt/actions/runs/34001751867),
  [Linux and macOS](https://github.com/jolt-lang/jolt/actions/runs/34001751898)
- independent Claude review — approve with edits; its requested distinct-path
  warmups and non-owner-close regression are incorporated in this tip

## Provenance

The motivating measurements, precommitted target, and full investigation log
are tracked in
[chucklehead-dev/jolt-aspect-packs#100](https://github.com/chucklehead-dev/jolt-aspect-packs/issues/100).
That issue is provenance only; this patch, benchmark, and tests run on stock
Jolt without the aspect/compiler tooling.

## Scope

The branch changes `stdlib/jolt/ffi.clj`, adds one standalone Jolt-only
diagnostic under `bench/`, extends the existing arena test and benchmark docs,
and adds an Unreleased changelog entry. It changes no public API, native
allocator, lifetime contract, or shared-arena synchronization.
