### PR TITLE
Measure the unhinted path too, not only the hinted one

### DIFF
--- a/bench/arrays_unhinted.clj
+++ b/bench/arrays_unhinted.clj
@@ -1,0 +1,98 @@
+;; arrays-unhinted — the twin of `arrays` with every array and numeric hint
+;; removed. Same arrays, same loops, same sizes; no `^doubles`/`^objects`/
+;; `^longs` on the parameters, no `^long`/`^double` returns.
+;;
+;; This is the generic `nth` path: an unhinted (aget a i) nil-checks the index,
+;; coerces it, and walks vector/string/seq/record before it reaches the array arm,
+;; and the surrounding arithmetic stays boxed. Most code that touches an array in
+;; the wild looks like this file, not like its twin.
+;;
+;; The pair exists so a codegen round cannot make the hinted path faster while the
+;; generic path pays for it unnoticed: `arrays` went 229.7 -> 1272.6ms once with
+;; every ci target and every library green, and only the suite saw it. Kept as its
+;; own suite entry because ci/bench-gate.sh compares a ratio PER BENCHMARK.
+;;
+;; A transcription of arrays.clj — edit the two together; what differs is exactly
+;; the tags.
+;;
+;; Portable Clojure (jolt + JVM Clojure). On the JVM these are still primitive
+;; arrays, but every element read boxes and every call is reflective, which is the
+;; reference this is measured against.
+;; Sized 1000 rather than the hinted twin's 40000: without ^doubles the JVM's
+;; aget is reflective, and at 40000 the reference side alone runs about seven
+;; minutes a pass. The two rows' millisecond columns are therefore NOT directly
+;; comparable — the hinted-versus-unhinted figure is measured separately at
+;; matched sizes and quoted in bench/README.md.
+;;   bench/run.sh arrays-unhinted 1000
+(ns arrays-unhinted)
+
+(defn fill! [a n]
+  (loop [i 0]
+    (when (< i n)
+      (aset a i (double (+ (* i 0.5) 1.0)))
+      (recur (inc i))))
+  a)
+
+(defn dot [a b n]
+  (loop [i 0 acc 0.0]
+    (if (< i n)
+      (recur (inc i) (+ acc (* (aget a i) (aget b i))))
+      acc)))
+
+;; --- reference arrays --------------------------------------------------------
+(defn ofill! [a n]
+  (loop [i 0]
+    (when (< i n)
+      (aset a i (inc i))
+      (recur (inc i))))
+  a)
+
+(defn osum [a n]
+  (loop [i 0 acc 0]
+    (if (< i n)
+      (recur (inc i) (unchecked-add acc (aget a i)))
+      acc)))
+
+(defn lfill! [a n]
+  (loop [i 0]
+    (when (< i n)
+      (aset a i (* i 3))
+      (recur (inc i))))
+  a)
+
+(defn lsum [a n]
+  (loop [i 0 acc 0]
+    (if (< i n)
+      (recur (inc i) (unchecked-add acc (aget a i)))
+      acc)))
+
+;; Same shape as the hinted twin: the arrays are filled once (the aset path) then
+;; read every pass (the aget path), and the reference arrays are walked the same
+;; number of times.
+(defn run [passes]
+  (let [n 1000
+        a (fill! (double-array n) n)
+        b (fill! (double-array n) n)
+        o (ofill! (object-array n) n)
+        l (lfill! (long-array n) n)]
+    (loop [p 0 acc 0.0]
+      (if (< p passes)
+        (recur (inc p) (+ acc (dot a b n)
+                          (* 1.0e-9 (unchecked-add (osum o n) (lsum l n)))))
+        acc))))
+
+(defn -main [& args]
+  (let [passes (if (seq args) (Integer/parseInt (first args)) 40000)]
+    (dotimes [_ 2] (run (quot passes 2)))                ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run passes)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "arrays-unhinted passes" passes "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/char_scan_unhinted.clj
+++ b/bench/char_scan_unhinted.clj
@@ -1,0 +1,117 @@
+;; char-scan-unhinted — the twin of `char-scan` with the declared tags removed.
+;; Same four shapes, same string, same sizes; no `^String` on a target and no
+;; `^long` on a parameter or return.
+;;
+;; The casts written INSIDE the loops stay, because they are the code under
+;; measurement: honeysql's `alphanumeric?` is written that way, and what the
+;; original benchmark exists to price is what those casts cost. What goes is every
+;; tag that let the compiler prove the receiver or the index ahead of them, so
+;; `.charAt` and `.length` reach the generic dispatcher.
+;;
+;; Kept as its own suite entry because ci/bench-gate.sh compares a ratio PER
+;; BENCHMARK: with one row, a round that speeds the proven path while slowing the
+;; generic one nets out to roughly nothing and is invisible.
+;;
+;; A transcription of char_scan.clj — edit the two together; what differs is
+;; exactly the tags. The phase names are kept verbatim so a row here is obviously
+;; comparable to the row there, which is why `count-digits-hinted` still carries
+;; that name with nothing declared on it.
+;;
+;; Portable Clojure (jolt + JVM Clojure).
+;;   bench/run.sh char-scan-unhinted 40000
+(ns char-scan-unhinted)
+
+(def entities ["table" "some_column" "a" "x1" "SELECT" "order_by_2" "_leading" "42"])
+(def sentence "the quick brown fox jumps over the lazy dog 0123456789")
+
+;; --- honeysql's alphanumeric?, verbatim in shape ------------------------------
+;; `^(?:[0-9_]+|[A-Za-z_][A-Za-z0-9_]*)$` as a state machine. The three casts per
+;; character — the index, the char, and the widening — are the point.
+(defn alphanumeric? [s]
+  (let [leading-underscore 1
+        numeric 2
+        identifier 3
+        dead 4
+        n (long (.length s))]
+    (loop [i (unchecked-long 0)
+           state (unchecked-long 0)]
+      (if (or (= state dead) (>= i n))
+        (or (= state leading-underscore) (= state numeric) (= state identifier))
+        (let [c  (.charAt s (unchecked-int i))
+              c  (unchecked-long (unchecked-int c))
+              ni (unchecked-inc i)]
+          (case state
+            0 (cond (or (and (>= c 65) (<= c 90)) (and (>= c 97) (<= c 122)))
+                    (recur ni identifier)
+                    (and (>= c 48) (<= c 57)) (recur ni numeric)
+                    (= c 95) (recur ni leading-underscore)
+                    :else (recur ni dead))
+            1 (cond (or (and (>= c 65) (<= c 90)) (and (>= c 97) (<= c 122)))
+                    (recur ni identifier)
+                    (and (>= c 48) (<= c 57)) (recur ni identifier)
+                    (= c 95) (recur ni leading-underscore)
+                    :else (recur ni dead))
+            2 (if (or (and (>= c 48) (<= c 57)) (= c 95))
+                (recur ni numeric)
+                (recur ni dead))
+            3 (if (or (and (>= c 65) (<= c 90)) (and (>= c 97) (<= c 122))
+                      (and (>= c 48) (<= c 57)) (= c 95))
+                (recur ni identifier)
+                (recur ni dead))
+            (recur ni dead)))))))
+
+;; --- the same walk with no state machine: casts and .charAt only --------------
+(defn sum-code-points [s]
+  (let [n (long (.length s))]
+    (loop [i 0 acc 0]
+      (if (>= i n)
+        acc
+        (recur (unchecked-inc i)
+               (unchecked-add acc (unchecked-long (unchecked-int (.charAt s (unchecked-int i))))))))))
+
+;; --- the checked casts, which are the ones ordinary code writes ---------------
+(defn count-digits [s]
+  (let [n (int (.length s))]
+    (loop [i 0 acc 0]
+      (if (>= i n)
+        acc
+        (let [c (long (int (.charAt s (int i))))]
+          (recur (inc i) (if (and (>= c 48) (<= c 57)) (inc acc) acc)))))))
+
+;; --- the same walk with the index passed, not cast per use -------------------
+;; Nothing is declared, so the parameter carries no promise and the body is
+;; generic arithmetic over it — the contrast the hinted twin's row measures.
+(defn count-digits-hinted [s from]
+  (let [n (.length s)]
+    (loop [i from acc 0]
+      (if (>= i n)
+        acc
+        (let [c (long (int (.charAt s i)))]
+          (recur (inc i) (if (and (>= c 48) (<= c 57)) (inc acc) acc)))))))
+
+(defn run [iters]
+  (loop [i 0 acc 0]
+    (if (< i iters)
+      (recur (inc i)
+             (unchecked-add
+              acc
+              (unchecked-add
+               (unchecked-add (reduce (fn [a e] (if (alphanumeric? e) (inc a) a)) 0 entities)
+                              (sum-code-points sentence))
+               (unchecked-add (count-digits sentence)
+                              (count-digits-hinted sentence 0)))))
+      acc)))
+
+(defn -main [& args]
+  (let [iters (if (seq args) (Integer/parseInt (first args)) 40000)]
+    (dotimes [_ 2] (run (quot iters 4)))                 ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/currentTimeMillis)
+                           r (run iters)
+                           el (- (System/currentTimeMillis) t0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       el))
+                   (range runs))]
+      (println "runs:" ts)
+      (println "mean:" (quot (reduce + ts) runs) "ms"))))

--- a/bench/mathfns_unhinted.clj
+++ b/bench/mathfns_unhinted.clj
@@ -1,0 +1,69 @@
+;; mathfns-unhinted — the twin of `mathfns` with the numeric hints removed. Same
+;; two kernels, same calls, same sizes; no `^double`/`^long` on parameters or
+;; returns.
+;;
+;; Without a proven operand nothing here can lower to a native Chez op: every
+;; java.lang.Math call goes through the generic string-keyed host-static dispatch,
+;; which finds the class's method table and then the method by name, per
+;; invocation, and boxes across it. That is the path most code takes, and it is
+;; what this row watches.
+;;
+;; Kept as its own suite entry, not a phase inside `mathfns`, because
+;; ci/bench-gate.sh compares a ratio PER BENCHMARK: two rows are what let it see a
+;; round that speeds the proven path while slowing the generic one.
+;;
+;; A transcription of mathfns.clj — edit the two together; what differs is exactly
+;; the tags.
+;;
+;; Portable Clojure (jolt + JVM Clojure). The JVM still intrinsifies these; what
+;; it loses without the hints is the primitive signature, so the reference is an
+;; honest one for the same question.
+;;   bench/run.sh mathfns-unhinted 1000000
+(ns mathfns-unhinted)
+
+(defn kernel [n]
+  (loop [i 1 acc 0.0]
+    (if (<= i n)
+      (let [x (* i 1.0e-6)]
+        (recur (inc i)
+               (+ acc
+                  (Math/sqrt x)
+                  (Math/sin x)
+                  (Math/cos x)
+                  (Math/log (+ x 1.0))
+                  (Math/pow x 2.0)
+                  (Math/atan2 x 1.0))))
+      acc)))
+
+;; the integer half, equally unproven: nothing tells the compiler these are longs
+(defn int-kernel [n]
+  (loop [i 1 acc 0]
+    (if (<= i n)
+      (recur (inc i)
+             (unchecked-add
+              acc
+              (unchecked-add
+               (unchecked-add (Math/abs (- i 7)) (Math/min i 1000))
+               (unchecked-add (Math/max i 3)
+                              (unchecked-add (Math/floorDiv i 3)
+                                             (Math/floorMod i 7))))))
+      acc)))
+
+(defn run [n]
+  (+ (kernel n) (* 1.0e-9 (int-kernel n))))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 1000000)]
+    (dotimes [_ 2] (run (quot n 2)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "mathfns-unhinted n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -61,7 +61,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 mathfns:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 char-scan:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14 typed-records:100000 executors:60000"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 arrays-unhinted:1000 mathfns:1000000 mathfns-unhinted:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 string-ops-unhinted:100000 char-scan:40000 char-scan-unhinted:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14 typed-records:100000 typed-records-unhinted:100000 executors:60000"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/bench/string_ops_unhinted.clj
+++ b/bench/string_ops_unhinted.clj
@@ -1,0 +1,120 @@
+;; string-ops-unhinted — the twin of `string-ops` with the declared type tags
+;; removed. Same phases, same calls, same sizes; no `^String` on a target and no
+;; `^clojure.lang.Keyword` on a keyword.
+;;
+;; Inference still proves what it can — `scan-proven` builds its own string, and a
+;; method whose return type is known keeps proving down a chain — which is the
+;; point: this row is what a user gets when they write no hints at all, not a
+;; hypothetical worst case. What it loses is every proof that came from a DECLARED
+;; tag, so `scan-hinted`, `direct-methods`, `core-over-strings` and `kw-parts`
+;; drop to the generic dispatcher.
+;;
+;; Kept as its own suite entry because ci/bench-gate.sh compares a ratio PER
+;; BENCHMARK, so the declared-tag path and the no-tag path need two rows for a
+;; regression in one to be visible when the other improves.
+;;
+;; A transcription of string_ops.clj — edit the two together; what differs is
+;; exactly the tags. The phase names are kept verbatim for that reason, so
+;; `scan-hinted` here is the same function with nothing declared on it: the names
+;; identify which phase a row is comparable to, not what this file proves.
+;;
+;; Portable Clojure (jolt + JVM Clojure). Without the tags the JVM reflects on
+;; every interop call here, which is the reference this is measured against.
+;;   bench/run.sh string-ops-unhinted 100000
+(ns string-ops-unhinted
+  (:require [clojure.string :as str]))
+
+(def entity "some.qualified/entity-name")
+(def words (mapv (fn [i] (str "word" i)) (range 16)))
+(def kws (mapv (fn [i] (keyword "bench" (str "key" i))) (range 16)))
+
+;; --- hinted String target -----------------------------------------------------
+(defn scan-hinted [s]
+  (unchecked-add
+   (unchecked-add (.indexOf s ".") (.length s))
+   (unchecked-add (if (.startsWith s "some") 1 0)
+                  (count (.substring s 1 5)))))
+
+;; --- unhinted: the target must be PROVEN a string by inference ---------------
+(defn scan-proven [s]
+  (let [t (str s "!")]
+    (unchecked-add
+     (unchecked-add (.indexOf t "/") (if (.endsWith t "!") 1 0))
+     (count (.toLowerCase t)))))
+
+;; --- chained interop: every target but the first is an interop RESULT ---------
+;; Only provable once a method's return type is known; before that each outer call
+;; carried a string? test and a dispatch arm.
+(defn chain-proven [s]
+  (unchecked-add
+   (.length (.toUpperCase (.trim s)))
+   (let [t (.substring s 0 8)]                  ; let-bound interop result
+     (unchecked-add (.length (.toLowerCase t))
+                    (if (.startsWith (.trim t) "some") 1 0)))))
+
+;; --- methods that had no direct form: they fell to the generic dispatcher -----
+(defn direct-methods [a b]
+  (unchecked-add
+   (unchecked-add (if (.equals a b) 1 0) (if (.equalsIgnoreCase a b) 1 0))
+   (unchecked-add (.lastIndexOf a "e")
+                  (unchecked-add (if (.isBlank a) 1 0) (.compareTo a b)))))
+
+;; --- clojure.core over PROVEN strings ----------------------------------------
+(defn core-over-strings [s t]
+  (unchecked-add
+   (unchecked-add (count s) (count t))
+   (unchecked-add (count (str s t)) (count (str s "-" t)))))
+
+;; --- the clojure.string layer over arguments that are already strings --------
+(defn strfns [s]
+  (unchecked-add
+   (unchecked-add (count (str/upper-case s)) (count (str/lower-case s)))
+   (unchecked-add (if (str/starts-with? s "some") 1 0)
+                  (if (str/includes? s "entity") 1 0))))
+
+(defn join-words [ws] (count (str/join "," ws)))
+
+;; --- hinted Keyword target ----------------------------------------------------
+(defn kw-parts [k]
+  (unchecked-add (count (.getName k))
+                 (count (.getNamespace k))))
+
+(defn kw-core [k]
+  (unchecked-add (count (name k)) (count (namespace k))))
+
+(defn walk-kws [ks]
+  (reduce (fn [acc k] (unchecked-add acc (unchecked-add (kw-parts k) (kw-core k))))
+          0 ks))
+
+(defn run [iters]
+  (let [s entity
+        other "some.qualified/other-name"]
+    (loop [i 0 acc 0]
+      (if (< i iters)
+        (recur (inc i)
+               (unchecked-add
+                acc
+                (unchecked-add
+                 (unchecked-add
+                  (unchecked-add (scan-hinted s) (scan-proven s))
+                  (unchecked-add (chain-proven s)
+                                 (unchecked-add (direct-methods s other)
+                                                (core-over-strings s other))))
+                 (unchecked-add
+                  (unchecked-add (strfns s) (join-words words))
+                  (walk-kws kws)))))
+        acc))))
+
+(defn -main [& args]
+  (let [iters (if (seq args) (Integer/parseInt (first args)) 100000)]
+    (dotimes [_ 2] (run (quot iters 4)))                 ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/currentTimeMillis)
+                           r (run iters)
+                           el (- (System/currentTimeMillis) t0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       el))
+                   (range runs))]
+      (println "runs:" ts)
+      (println "mean:" (quot (reduce + ts) runs) "ms"))))

--- a/bench/typed_records_unhinted.clj
+++ b/bench/typed_records_unhinted.clj
@@ -1,0 +1,85 @@
+;; typed-records-unhinted — the twin of `typed-records` with every type hint
+;; removed. Same records, same work, same sizes; no `^double`/`^long`/`^String`
+;; on the fields, no `^Row` on the reader, no primitive return tags.
+;;
+;; Why the suite carries both. A type-hint codegen round can only make the HINTED
+;; path faster, and a scorecard that measures only that path cannot tell the
+;; difference between "hints now specialize" and "hints now specialize and the
+;; generic path got slower paying for it". Most code in the wild is this file, not
+;; its twin: hints are the exception. Kept as a separate suite entry rather than a
+;; phase inside `typed-records` because ci/bench-gate.sh compares a ratio PER
+;; BENCHMARK, so the two paths need two rows for the gate to watch them
+;; independently.
+;;
+;; The pair is only meaningful if the work is otherwise identical, so this file is
+;; a transcription of typed_records.clj and should be edited with it. What differs
+;; is exactly the tags.
+;;
+;; Portable Clojure (jolt + JVM Clojure). On the JVM the fields here are Object
+;; fields and the arithmetic is boxed, which is the reference this is measured
+;; against.
+;;   bench/run.sh typed-records-unhinted 100000
+(ns typed-records-unhinted)
+
+(defrecord Vec3 [x y z])
+(defrecord Row [id name score])
+
+;; --- construction ------------------------------------------------------------
+;; The `sink` write is what makes this measure a CONSTRUCTOR at all: a record that
+;; never leaves the loop is removed outright by scalar-replace. Storing into an
+;; array makes it escape, so the allocation is real. (Same reason as the hinted
+;; twin; the note is repeated because deleting it here would quietly turn this
+;; benchmark into one that times nothing.)
+(defn make-vecs [n]
+  (let [sink (object-array 1)]
+    (loop [i 0 acc 0.0]
+      (if (< i n)
+        (let [v (->Vec3 i (+ i 1) 2.5)
+              w (->Vec3 (:x v) (:y v) (:z v))]
+          (aset sink 0 w)
+          (recur (inc i) (+ acc (:z w))))
+        acc))))
+
+;; --- reads -------------------------------------------------------------------
+;; No receiver hint, so no field read can be typed: every `:id`/`:name`/`:score`
+;; answers "unknown" and the arithmetic and interop below take the dynamic path.
+;; That is the point of this file.
+(defn row-work [r]
+  (let [id (:id r)
+        nm (:name r)
+        sc (:score r)]
+    (+ (* sc 1.5)
+       (* 1.0e-6
+          (unchecked-add
+           (unchecked-add (unchecked-multiply id 3) (.length nm))
+           (unchecked-add (count nm)
+                          (unchecked-add (.indexOf nm "-")
+                                         (count (.toUpperCase nm)))))))))
+
+(defn walk-rows [rows passes]
+  (loop [p 0 acc 0.0]
+    (if (< p passes)
+      (recur (inc p)
+             (+ acc (reduce (fn [a r] (+ a (row-work r))) 0.0 rows)))
+      acc)))
+
+(def rows (mapv (fn [i] (->Row i (str "row-name-" i) (* i 0.25))) (range 32)))
+
+(defn run [n]
+  (+ (make-vecs n) (walk-rows rows (quot n 32))))
+
+(defn -main [& args]
+  (let [n (if (seq args) (Integer/parseInt (first args)) 100000)]
+    (dotimes [_ 2] (run (quot n 2)))                     ; warmup
+    (let [runs 3
+          times (mapv (fn [_]
+                        (let [t0 (System/nanoTime)
+                              r (run n)
+                              ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                          [ms r]))
+                      (range runs))
+          mss (mapv first times)
+          mean (/ (reduce + mss) runs)]
+      (println "typed-records-unhinted n" n "result" (second (first times)))
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) mss))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))


### PR DESCRIPTION
`arrays`, `mathfns`, `string-ops`, `char-scan` and `typed-records` each measure a type-hinted workload and nothing else. Most code in the wild is the other shape — hints are the exception.

That matters because a codegen round aimed at hints can only make the *hinted* path faster, and a suite measuring only that path cannot distinguish "hints now specialize" from "hints now specialize and the generic path pays for it".

Each benchmark gets a twin with the declared tags removed and nothing else changed. They are **separate suite entries** rather than extra phases inside the existing rows, because `ci/bench-gate.sh` compares a ratio *per benchmark*: with one row, a round that speeds one path and slows the other nets out to roughly nothing and is invisible. New names are safe — the gate SKIPs a bench the baseline cannot build.

`arrays-unhinted` is sized 1000 rather than its twin's 40000: without `^doubles` the JVM's `aget` is reflective, and 40000 costs about seven minutes per pass on the reference side. That pair's millisecond columns are therefore not directly comparable, and the file says so.

All five build and run on both jolt and JVM Clojure.

**No table changes.** The scorecard is one same-sitting run on one machine, and dropping freshly-measured numbers into it from a different sitting is what the README's own stale-scorecard note warns against. The four ⚠ rows keep their marker until a full refresh can be run on a quiet machine.