### PR TITLE
Re-measure an ambiguous io-scaling ratio before failing

### DIFF
--- a/test/io_scaling_test.clj
+++ b/test/io_scaling_test.clj
@@ -34,50 +34,98 @@
     (loop [c 0]
       (if (= :eof (read {:eof :eof} *in*)) c (recur (inc c))))))
 
+;; nanoTime, not currentTimeMillis: the ratio is judged to two decimals and a
+;; millisecond clock quantizes the small arm, which is the one a coarse tick
+;; moves furthest.
 (defn- timed [f]
-  (let [t (System/currentTimeMillis)
+  (let [t (System/nanoTime)
         v (f)]
-    [(- (System/currentTimeMillis) t) v]))
+    [(/ (- (System/nanoTime) t) 1e6) v]))
 
 (defn- best-of [k f]
   (reduce min (map first (repeatedly k #(timed f)))))
 
-;; 8000, not 2000: the small arm measured 2-3ms on a millisecond clock, so
-;; quantization plus one scheduler blip on a shared runner read 8.33 against
-;; the 8.0 ceiling (locally the drain sits ~4.5; the quadratic bug this gates
-;; sat ~16). At 8000 the small arm is ~10ms and the ratio stops moving with
-;; the clock's granularity. A regressed quadratic drain at 32000 items still
-;; finishes in seconds, so the gate keeps failing fast when it should.
+;; 8000, not 2000: at 2000 the drain is a couple of milliseconds and a single
+;; scheduler blip on a shared runner is most of the measurement (locally the
+;; drain sits ~4.5 against a linear 4.0; the quadratic bug this gates sat ~16).
+;; A regressed quadratic drain at 32000 items still finishes in seconds, so the
+;; gate keeps failing fast when it should.
 (def ^:private n1 8000)
 (def ^:private factor 4)
+(def ^:private samples 3)
 (def ^:private max-ratio 8.0)
 
-(defn- judge [label t1 t4]
-  (let [t1 (max 1 t1)
-        ratio (double (/ t4 t1))]
-    (println (format "io-scaling %s: %d items %dms, %d items %dms, ratio %.2f (linear ~%.1f, quadratic ~%.1f, ceiling %.1f)"
-                     label n1 t1 (* factor n1) t4 ratio
-                     (double factor) (double (* factor factor)) max-ratio))
-    (when (> ratio max-ratio)
-      (println (str "FAIL io-scaling: " label " drain scaled worse than linearly in the input. "
-                    "The IReader in jolt-core/clojure/core/50-io.clj is re-copying or re-parsing "
-                    "the remaining buffer per item instead of advancing a cursor."))
-      (System/exit 1))))
+;; A ratio at or above this is not ambiguous — it is most of the way to
+;; quadratic — so it fails on the spot with no re-measuring.
+(def ^:private clear-regression 12.0)
+
+;; ...and between the ceiling and that, re-measure before failing, exactly as
+;; read_scaling_test.clj does. This costs no POWER: a quadratic drain measures
+;; ~16 and is over the ceiling on every attempt, so it still fails
+;; deterministically. What it absorbs is interference, which this gate is
+;; especially exposed to: CI runs the suite as `make -j$(nproc) test`, the two
+;; arms are measured one after the other rather than side by side, and the 4x
+;; arm — being four times as long — is the more likely of the two to overlap a
+;; busy stretch. That is a bias toward a HIGH ratio, not just noise around it.
+;; It read 8.22 on a run whose sibling workflow measured 2.74 on the same
+;; commit (8000 items 55ms, 32000 items 452ms, against 95ms and 260ms).
+(def ^:private tries 3)
+
+(defn- report [label t1 t4 ratio]
+  (println (format "io-scaling %s: %d items %.2fms, %d items %.2fms, ratio %.2f (linear ~%.1f, quadratic ~%.1f, ceiling %.1f)"
+                   label n1 t1 (* factor n1) t4 ratio
+                   (double factor) (double (* factor factor)) max-ratio)))
+
+(defn- fail! [label]
+  (println (str "FAIL io-scaling: " label " drain scaled worse than linearly in the input. "
+                "The IReader in jolt-core/clojure/core/50-io.clj is re-copying or re-parsing "
+                "the remaining buffer per item instead of advancing a cursor."))
+  (System/exit 1))
+
+;; w1/w4 are the verification runs' own times — already paid, so screening with
+;; them fails an unambiguous regression after one run per arm.
+(defn- judge [label w1 w4 f1 f4]
+  (let [screen (/ w4 (max 0.001 w1))]
+    (when (>= screen clear-regression)
+      (report label w1 w4 screen)
+      (fail! label)))
+  (loop [attempt 1 seen []]
+    (let [t1 (max 0.001 (best-of samples f1))
+          t4 (best-of samples f4)
+          ratio (/ t4 t1)
+          seen (conj seen ratio)]
+      (report label t1 t4 ratio)
+      (cond
+        (<= ratio max-ratio) nil
+        (>= ratio clear-regression) (fail! label)
+        (< attempt tries)
+        (do (println (format "io-scaling %s: ratio %.2f over ceiling %.1f — re-measuring (attempt %d of %d)"
+                             label ratio max-ratio (inc attempt) tries))
+            (recur (inc attempt) seen))
+        :else
+        (do (println (str "  ratios over " tries " attempts: "
+                          (clojure.string/join ", " (map #(format "%.2f" %) seen))))
+            (fail! label))))))
 
 (defn -main [& _]
   (let [ls1 (lines-src n1) ls4 (lines-src (* factor n1))
-        fs1 (forms-src n1) fs4 (forms-src (* factor n1))]
-    ;; the drains must have read what they claim before their cost is judged;
-    ;; also pin the read/read-line interleave (read consumes exactly its form)
-    (when-not (and (= (drain-lines ls1) n1) (= (drain-lines ls4) (* factor n1))
-                   (= (drain-forms fs1) n1) (= (drain-forms fs4) (* factor n1))
+        fs1 (forms-src n1) fs4 (forms-src (* factor n1))
+        ;; the drains must have read what they claim before their cost is judged;
+        ;; also pin the read/read-line interleave (read consumes exactly its form).
+        ;; Timed, so these double as the warm-up and the screen below.
+        [lw1 lc1] (timed #(drain-lines ls1))
+        [lw4 lc4] (timed #(drain-lines ls4))
+        [fw1 fc1] (timed #(drain-forms fs1))
+        [fw4 fc4] (timed #(drain-forms fs4))]
+    (when-not (and (= lc1 n1) (= lc4 (* factor n1))
+                   (= fc1 n1) (= fc4 (* factor n1))
                    (= (with-in-str "(+ 1 2) tail-text\nnext"
                         [(read) (read-line) (read-line)])
                       ['(+ 1 2) " tail-text" "next"]))
       (println "FAIL io-scaling: wrong lines/forms through the reader")
       (System/exit 1))
-    (judge "read-line" (best-of 3 #(drain-lines ls1)) (best-of 3 #(drain-lines ls4)))
-    (judge "read" (best-of 3 #(drain-forms fs1)) (best-of 3 #(drain-forms fs4)))
+    (judge "read-line" lw1 lw4 #(drain-lines ls1) #(drain-lines ls4))
+    (judge "read" fw1 fw4 #(drain-forms fs1) #(drain-forms fs4))
     (println "io-scaling: passed")))
 
 (-main)


### PR DESCRIPTION
`test/io_scaling_test.clj` took one 1x-vs-4x ratio and judged it. Under `make -j$(nproc) test` the two arms are measured one after the other, and the 4x arm — four times as long — is the likelier of the two to overlap a busy stretch, so runner interference biases the ratio **up** rather than scattering it around the truth.

That is not hypothetical. #865 failed it at 8.22 against the 8.0 ceiling on a run whose sibling workflow measured 2.74 on the same commit:

| run | 8000 items | 32000 items | ratio |
|---|---:|---:|---:|
| [failing](https://github.com/jolt-lang/jolt/actions/runs/34007237429/job/101416594573) | 55ms | 452ms | 8.22 |
| [passing](https://github.com/jolt-lang/jolt/actions/runs/34007239495/job/101416600212) | 95ms | 260ms | 2.74 |

The gate had already been retuned once for a flake (2000 -> 8000 items, for millisecond-clock quantization). Its sibling `read_scaling_test.clj` — same shape, same judgment — grew the real fix and this one never got it.

So: screen with the verification runs that were already paid for, re-measure a ratio in the ambiguous band, and fail on the spot at or above 12.0. Clock moved to `nanoTime` so the small arm is not quantized either.

This costs no power. A quadratic drain measures far outside the band and fails after one run per arm.

## Verified

- `make ioscaling` — read-line 3.99, read 4.05.
- ceiling forced to 1.0: retries twice, prints all three ratios, exits 1.
- `clear-regression` forced to 2.0: fails on the screen, one run per arm.
- `drain-lines` made genuinely quadratic (re-copy the unread tail per line): ratio 28.17, fails on the screen with no retries.

https://claude.ai/code/session_019tGgRzPx3vtr5siPkKjjLE