### PR TITLE
Gate the no-arg method call on nil

### DIFF
--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -74,6 +74,19 @@
   {:suite "interop / Float statics" :label "Float carries the float bounds and specials, not double's" :expected "[true true true true true true true]" :actual "[(Float/isNaN Float/NaN) (Float/isInfinite Float/POSITIVE_INFINITY) (Float/isInfinite Float/NEGATIVE_INFINITY) (pos? Float/POSITIVE_INFINITY) (neg? Float/NEGATIVE_INFINITY) (> Float/MAX_VALUE 3.0E38) (< Float/MAX_VALUE Double/MAX_VALUE)]" :portability :jvm}
   {:suite "interop / Double statics" :label "isNaN / isInfinite / the specials / parseDouble" :expected "[true true false true true 1.5]" :actual "[(Double/isNaN (/ 0.0 0.0)) (Double/isInfinite (/ 1.0 0.0)) (Double/isNaN 1.0) (Double/isNaN Double/NaN) (Double/isInfinite Double/POSITIVE_INFINITY) (Double/parseDouble \"1.5\")]" :portability :jvm}
   {:suite "interop / exception constructors" :label "the common java.lang / java.io exception ctors carry their message" :expected "[\"a\" \"b\" \"c\" \"d\"]" :actual "[(.getMessage (NullPointerException. \"a\")) (.getMessage (IllegalStateException. \"b\")) (.getMessage (IndexOutOfBoundsException. \"c\")) (.getMessage (java.io.IOException. \"d\"))]" :portability :jvm}
+  ;; An instance method call on nil is a NullPointerException whatever the
+  ;; member: the JVM's reflector reads the target's class before it looks for
+  ;; anything, so no member name changes the answer. The row under "errors /
+  ;; host operations carry a JVM class" covers a call WITH arguments; these
+  ;; cover the no-arg member reads, which reach a different arm and where jolt
+  ;; used to answer for the nil rather than refuse it — (.iterator nil) handed
+  ;; back an empty iterator through v0.8.1 and (.toString nil) the empty string.
+  ;; That is what let a zero-input (m/latest f) run at all in jlt-commons/ebb
+  ;; (issue #4): its (.iterator (seq fs)) is a null target whenever fs is empty,
+  ;; which the JVM refuses too. Every member named here is real on SOME class,
+  ;; so nothing passes by being an unknown name.
+  {:suite "interop / method call on nil" :label "an instance method call on nil is a NullPointerException, whatever the member" :expected "[\"NullPointerException\" \"NullPointerException\" \"NullPointerException\" \"NullPointerException\" \"NullPointerException\"]" :actual "[(try (.iterator nil) (catch Throwable e (.getSimpleName (class e)))) (try (.toString nil) (catch Throwable e (.getSimpleName (class e)))) (try (.hasNext nil) (catch Throwable e (.getSimpleName (class e)))) (try (.length nil) (catch Throwable e (.getSimpleName (class e)))) (try (.getName nil) (catch Throwable e (.getSimpleName (class e))))]" :portability :jvm}
+  {:suite "interop / method call on nil" :label "the empty seq is a null target, so iterating one raises" :expected "[\"NullPointerException\" \"NullPointerException\"]" :actual "[(try (.iterator (seq [])) (catch Throwable e (.getSimpleName (class e)))) (try ((fn [& xs] (.iterator (seq xs)))) (catch Throwable e (.getSimpleName (class e))))]" :portability :jvm}
   {:suite "interop / exception constructors" :label "each is catchable as itself and as Throwable" :expected "[:npe :thr]" :actual "[(try (throw (NullPointerException. \"x\")) (catch NullPointerException _ :npe)) (try (throw (java.io.IOException. \"x\")) (catch Throwable _ :thr))]" :portability :jvm}
   {:suite "interop / File" :label "a File wraps its path and getName is the last segment" :expected "[\"/tmp/a/b.txt\" \"b.txt\"]" :actual "(let [f (java.io.File. \"/tmp/a/b.txt\")] [(.getPath f) (.getName f)])" :portability :jvm}
   {:suite "interop / Integer statics" :label "the int bounds" :expected "[2147483647 -2147483648]" :actual "[Integer/MAX_VALUE Integer/MIN_VALUE]" :portability :jvm}


### PR DESCRIPTION
jlt-commons/ebb#4 reports `(m/latest f)` with zero inputs failing under 0.8.2 and passing under 0.8.1, and guesses at the type-hint codegen bridges. It is not those. ebb's `latest/run` opens with

```clojure
(let [it (.iterator (seq fs))] ...)
```

and `fs` is the rest arg, so a zero-input `latest` calls `.iterator` on `nil`. The JVM refuses that — its reflector reads the target's class before it looks for a member, so every instance call on `nil` is a `NullPointerException`. jolt used to answer for some of them instead:

| | v0.8.1 | v0.8.2 | JVM |
|---|---|---|---|
| `(.iterator nil)` | an empty iterator | NPE | NPE |
| `(.toString nil)` | `""` | NPE | NPE |
| `(.hasNext nil)` | `false` | NPE | NPE |
| `(.someUnknownMethod nil)` | NPE | NPE | NPE |

So 0.8.2 is right and ebb has a latent bug 0.8.1 was covering. Confirmed end to end: with `(when-let [s (seq fs)] (.iterator s))` in `ebb/impl/latest.clj`, ebb's suite is 282 tests / 1198 assertions / 0 failures / 0 errors under the released 0.8.2 binary, against 2 errors unpatched.

No jolt fix, then — but nothing gated the corrected behavior. The one existing row (`errors / host operations carry a JVM class`) calls `.write` **with an argument**, which reaches a different arm of `no-method-throw` than a no-arg member read, and it was the no-arg reads that had the nil arms. That gap is why this could regress in the first place and go unnoticed until a downstream port tripped on it.

Two rows, both `:portability :jvm` so `certify` runs them on a real JVM:

- an instance method call on nil is a NullPointerException, whatever the member — `.iterator` / `.toString` / `.hasNext` / `.length` / `.getName`, each a real member on some class so none can pass by being an unknown name
- the empty seq is a null target, so iterating one raises — `(.iterator (seq []))` and the rest-arg shape ebb actually hit

`make corpus` 5160/5170, 0 NEW divergence. `make certify` against Clojure 1.12.5 on JDK 26.0.2.1: 0 NEW divergences, certifiable rows 5286 -> 5288.

https://claude.ai/code/session_019tGgRzPx3vtr5siPkKjjLE