### PR TITLE
Add byte-array and GC-pause benchmarks to the suite

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -45,6 +45,8 @@ portable threshold.
 | `vecops` | vector-of-vectors: pairwise `into` concatenation, `subvec` windows + reduce, split-at/rejoin loop | vector concat + slice (the RRB axis; `into`/`subvec` are wired through the RRB ops, so concat is O(log n) here and linear in core Clojure) | RRB workload |
 | `mandelbrot` | pure float compute (tight arith loops, no alloc/dispatch) | native arith, loop codegen | CLBG |
 | `arrays` | primitive `double-array` throughput (unboxed `aget`/`aset`, no boxing/collections) | unboxed primitive-array codegen (flvector read/write) | CLBG-style |
+| `byte-arrays` | RAW BYTES in bulk: block copies between byte arrays, a stream drained into a reusable buffer, the `String`↔`byte[]` round trip, and hinted `^bytes` element access | the byte array's BACKING — a bytevector, so every crossing is a block move — and, on the access side, `aget`'s direct backing read against `aset`'s narrowing store | — |
+| `gc-arrays` | major-collection PAUSE with a large primitive array live: a `long-array`, a `byte-array`, and a boxed `object-array` of the same length as the control | the heap SHAPE those backings give a typed array (an fxvector and a bytevector are leaves, so the collector has nothing to trace through them) | — |
 | `mathfns` | transcendental math (`java.lang.Math` sqrt/sin/cos/log/pow/atan2 over doubles) | native `Math` op lowering (`flsqrt`/`flsin`/… vs generic host-static dispatch) | CLBG-style |
 | `fib` | recursion: function-call + integer-arith overhead | native arith, small-fn inlining | CLBG |
 | `tak` | deep three-way self-recursion + integer arith | direct-linked self-calls, proven fixnum arith | CLBG/AWFY |
@@ -63,13 +65,26 @@ portable threshold.
 | `nth-access` | `nth` on a vector, small and large, and with a default — the constant cost of an indexed read | `Indexed`-first ordering in `jolt-nth` ahead of the extension-type probes | — |
 | `executors` | `java.util.concurrent` dispatch: fire-and-forget at a cached pool faster than it can drain, submit/get round trips, growth to 64 blocking tasks, and four producers on one pool | the RUNTIME rather than a pass — the executor's queue, its wake rule and its growth rule (`host/chez/java/concurrency.ss`) | — |
 
-`executors` is the one row that is not about a compiler pass. It is here because
-nothing else in the suite measures concurrency throughput, and the cost it watches
-is real: an enqueue that woke every idle worker instead of one took a no-op task
+`executors` and `gc-arrays` are the two rows that are not about a compiler pass.
+`executors` is here because nothing else in the suite measures concurrency
+throughput, and the cost it watches is real: an enqueue that woke every idle worker instead of one took a no-op task
 from 8.9µs to 152µs and the pool from 7 threads to 134, with every correctness
 gate still green. Concurrency numbers are noisier than the rest — the four-producer
 phase is a fight over one mutex on however many cores the machine has — so read a
 move here with more suspicion than usual, and re-run it alone on both sides.
+
+`gc-arrays` measures the collector rather than any code jolt emits: its timed
+region contains nothing but full collections with one array rooted across them.
+It is here because the backing a typed array holds is a heap-shape decision that
+every other row is blind to — they allocate arrays and drop them, so they see a
+small part of a change that makes a live 8-million-element array traced work
+again. Read its `mean:` against jolt only. Its vs-JVM column is an
+order-of-magnitude reading and no more: `System/gc` is a hint on the JVM and a
+full collection here, and a JVM full GC's own floor (11.5ms on the machine below)
+is 750× a Chez major collection's (15µs), which is most of what that ratio
+reports. The row's own `boxed` control is the comparison that
+means something, because it is measured in the same process as the two phases it
+is a control for.
 
 ## Scorecard
 
@@ -106,7 +121,8 @@ than a jolt-side change.
 > codegen round changed the SOURCE of `mathfns`, `arrays`, `string-ops` and
 > `char-scan` (each grew a phase for an axis it did not previously cover), so
 > their absolute ms and their vs-JVM ratios no longer describe what the benchmark
-> now runs, and `typed-records` is new and has no row at all. They are marked
+> now runs, and `typed-records`, `byte-arrays` and `gc-arrays` are new and have no
+> row at all (the last two are measured in their own section below). They are marked
 > rather than patched on purpose: this table is one same-sitting run on one
 > machine, and dropping four freshly-measured numbers from a different machine
 > into it is precisely how the stale-scorecard incident below happened. The
@@ -191,6 +207,98 @@ showed the standalone `osum` with `jolt-vaget` and all three spliced copies — 
 call on the hot path — with `jolt-nth`. The A/B read 1.02×, i.e. the entire win
 cancelled. Restoring the refusal took the same benchmark to 0.32×. A ratio near
 1.00 on a change you expected to matter is worth reading the emitted code over.
+
+### The unboxed array backings (v0.8.3) — and the two rows that were missing
+
+0.8.3 moved `^longs`/`^ints`/`^bytes` arrays onto backings that know what they
+hold (an fxvector and a bytevector; see that release's CHANGELOG entry), and the
+suite could not see any of it. `arrays` is hinted element access on `^doubles`,
+`^objects` and `^longs`; nothing here touched a byte array at all, and nothing
+measured a collection pause. Every figure the release claimed — a 1MB
+`System/arraycopy`, an 8KB `InputStream/read` loop, the `String`↔`byte[]` round
+trip, the pause with a live numeric array — was measured outside the suite and not
+kept, so nothing guarded any of them afterwards. `byte-arrays` and `gc-arrays` are
+those two rows, added after the fact and wired into the release gate, so the next
+release is measured against 0.8.3 on them like every other row.
+
+Both were measured with `ci/bench-gate.sh <v0.8.2 binary> <this tree's jolt>` —
+the last release WITHOUT the backings against the tree that has them, building
+this checkout's bench sources with both compilers and alternating timed runs, min
+of 3 per side. Apple Silicon host (MacBook Pro, M1 Pro, macOS 26.3, Chez 10.4.1,
+OpenJDK 20.0.1), one sitting. Everything else that landed between the two tags is
+in these ratios too; they are quoted as what the gate prints, not as an attribution
+to the backings alone.
+
+| Benchmark | v0.8.2 (ms) | this tree (ms) | ratio |
+|---|---:|---:|---:|
+| `byte-arrays` | 13150.9 | 270.6 | **0.02×** |
+| `gc-arrays` | 1900.0 | 26.8 | **0.01×** |
+
+Two further runs of the same pair read 13020.9 / 267.9 and 1908.7 / 27.1, then
+13100.5 / 270.3 and 1907.7 / 27.9 — the same ratios each time, which is the only
+reason to quote any of them. The gate's verdict in this direction is `passed — 2
+benchmark(s) within 1.40x`: the threshold is one-sided, so a row that got 49x
+faster passes, as it should.
+
+The direction that matters for a NEW row is the other one. With the arguments
+swapped — this tree as the baseline, v0.8.2 as the candidate, which is what a
+change undoing the backings would look like — the same two rows read:
+
+```
+byte-arrays           270.3    13100.5   48.47x  <-- REGRESSED
+gc-arrays              27.9     1907.7   68.38x  <-- REGRESSED
+
+bench gate: FAILED — 2 of 2 benchmark(s) over 1.40x
+```
+
+and the script exits 1, which is what holds `publish` in the release workflow. A
+benchmark that cannot be shown to fail the gate is not a gate, so that run is
+worth doing once per row added.
+
+Per phase, same machine and sitting, 400 passes each — jolt is an `--opt` binary
+off this tree, the JVM column is the same source on OpenJDK 20.0.1. These are the
+figures the release claimed, restated at the size the suite runs:
+
+| phase | one pass | jolt (ms) | JVM (ms) | vs JVM |
+|---|---|---:|---:|---:|
+| `copy-full` | a 1MB `System/arraycopy`, whole array | 7.8 | 12.3 | **0.63×** |
+| `copy-region` | the same bytes at unequal offsets | 7.7 | 12.2 | **0.63×** |
+| `drain` | 1MB through an 8KB `InputStream/read` loop (128 reads) | 80.3 | 11.6 | 6.9× |
+| `round-trip` | 4 × `(String. (.getBytes s))` over a 5KB string | 21.0 | 9.9 | 2.1× |
+| `bfill` | 8192 `(aset ^bytes a i v)` | 95.2 | 0.6 | 159× |
+| `bsum` | 8192 `(aget ^bytes a i)` | 19.4 | 2.1 | 9.2× |
+
+The block copies **beat the JVM** — 19.5µs per megabyte against its 30.8µs — which
+is the backing change arriving: both sides of that seam are bytevectors, so the
+copy is one `bytevector-copy!` rather than an element loop with a sign fold per
+byte. Two gaps came out of writing the row, and it now watches both:
+
+- **`(aset ^bytes a i v)` costs 29ns an element**, where the matching
+  `(aget ^bytes a i)` costs 5.9ns. The read takes the direct backing read; the
+  hinted STORE is deliberately left on the generic path
+  (`jolt-core/jolt/passes/numeric.clj`) because a byte array narrows its value to
+  signed 8 bits at the store and that narrowing lives there, so `^bytes` is absent
+  from the `:v-aset` fast path `^longs`/`^ints`/`^objects` take. It is the largest
+  single ratio in the row.
+- **an 8KB `InputStream/read` costs 1.57µs**, against the JVM's 0.23µs. The
+  transfer itself is a block move now; what is left is per-call overhead on the way
+  to it.
+
+`gc-arrays`, per collection, 8-million-element arrays, same sitting:
+
+| live set | jolt (µs/collect) | JVM (µs/collect) |
+|---|---:|---:|
+| nothing large (floor) | 15.4 | 11551 |
+| `long-array` (fxvector) | 71.1 | 11507 |
+| `byte-array` (bytevector) | 299.4 | 11653 |
+| `object-array`, one shared value (control) | 25230 | 47225 |
+
+On jolt a boxed backing costs **355×** what the fxvector does for the same element
+count, which is the property the row exists to hold. The JVM's own full-GC floor
+is 750× jolt's, so its control only reads 4.1× — the reason to read this row
+against jolt and not across the columns. Scaled to the 20-million-element arrays
+the CHANGELOG quoted, the row reads 0.18ms and 0.75ms against the 0.19ms and
+0.67ms quoted there — the same measurement on a different machine.
 
 ### A stale scorecard hid a 1.7× regression for three weeks (now fixed)
 

--- a/bench/byte_arrays.clj
+++ b/bench/byte_arrays.clj
@@ -1,0 +1,121 @@
+;; byte-arrays — RAW BYTES crossing the host boundary in bulk: block copies
+;; between byte arrays, draining a stream into a reusable buffer, and the
+;; String<->byte[] round trip. Per-pass work is dominated by moves of whole
+;; regions, not by per-element arithmetic, which is what separates this from
+;; `arrays` (indexed reads/writes on a ^doubles array).
+;;
+;; The axis is the BACKING a byte array holds. A jolt array is a Chez vector plus
+;; an element-kind tag, and a ^bytes array's backing is a bytevector — the same
+;; shape of thing the host's own I/O, string and ffi primitives take — so every
+;; crossing here is a block move (bytevector-copy!, get-bytevector-n!,
+;; utf8->string) instead of an element loop with a sign fold per byte. Nothing
+;; else in the suite touches a byte array at all, and the paths below are exactly
+;; where that shows: against v0.8.2, the last release in which a byte array was a
+;; boxed vector of small integers, this whole bench runs 49x faster (13150.9ms ->
+;; 270.6ms through ci/bench-gate.sh; the per-phase split is in README.md).
+;;
+;; The element-access phase is here for the two halves of a hinted ^bytes access,
+;; which pull in opposite directions: (aget ^bytes a i) lowers to the direct
+;; backing read (jolt-vaget, skipping the generic nth dispatch walk), while
+;; (aset ^bytes a i v) deliberately stays on the generic path, because the store
+;; has to narrow its value to signed 8 bits. A codegen round that moves either one
+;; lands here.
+;;
+;; No unhinted twin: the generic (aget a i) / (aset a i v) dispatch walk is already
+;; covered by `arrays-unhinted`, and it is the same walk for every element kind.
+;; What this bench adds over that pair is the BULK path, which no hint reaches.
+;;
+;; Portable Clojure (jolt + JVM Clojure) — System/arraycopy, ByteArrayInputStream
+;; and String/getBytes are the same operations on both, and the JVM's arraycopy is
+;; an intrinsic, so that column is close to the machine's memcpy.
+;;   bench/run.sh byte-arrays 400
+(ns byte-arrays)
+
+(def block (* 1024 1024))   ; the copied/drained region
+(def chunk-size 8192)       ; the stream read buffer, as an I/O loop sizes it
+(def cells 8192)            ; the element-access loop, sized to weigh about
+                            ; the same as the three bulk phases together
+
+;; --- block copies -------------------------------------------------------------
+;; Two shapes: the whole array, and a middle-to-middle region at unequal offsets
+;; (which cannot be answered by handing the destination the source's backing).
+(defn copy-full! [^bytes src ^bytes dst ^long n]
+  (System/arraycopy src 0 dst 0 n)
+  dst)
+
+(defn copy-region! [^bytes src ^bytes dst ^long n]
+  (System/arraycopy src 8 dst 24 (- n 32))
+  dst)
+
+;; --- stream -> reusable buffer ------------------------------------------------
+;; The read-into-a-buffer loop every stream consumer is written as; `buf` is
+;; reused across reads, so the only per-read cost is the transfer itself.
+(defn drain ^long [^bytes src ^bytes buf]
+  (let [in (java.io.ByteArrayInputStream. src)
+        cap (alength buf)]
+    (loop [total 0]
+      (let [k (.read in buf 0 cap)]
+        (if (neg? k)
+          total
+          (recur (unchecked-add total k)))))))
+
+;; --- String <-> byte[] round trip ---------------------------------------------
+;; Encode and decode, the shape anything speaking a byte protocol does per message.
+(defn round-trip ^long [^String s ^long reps]
+  (loop [i 0 acc 0]
+    (if (< i reps)
+      (recur (inc i) (unchecked-add acc (.length (String. (.getBytes s)))))
+      acc)))
+
+;; --- element access -----------------------------------------------------------
+(defn bfill! [^bytes a ^long n]
+  (loop [i 0]
+    (when (< i n)
+      (aset a i (byte (bit-and i 127)))
+      (recur (inc i))))
+  a)
+
+(defn bsum ^long [^bytes a ^long n]
+  (loop [i 0 acc 0]
+    (if (< i n)
+      (recur (inc i) (unchecked-add acc (aget a i)))
+      acc)))
+
+;; One pass: two block copies of `block` bytes, one full drain of `block` bytes
+;; through a `chunk-size` buffer, four String<->byte[] round trips over a 5KB
+;; string, and a fill+sum over `cells` elements. The arrays are allocated once and
+;; reused, so allocation is not part of the measurement. At the default size the
+;; three bulk phases and the element loop each take about half the time.
+(defn run ^long [^long passes]
+  (let [src (bfill! (byte-array block) block)
+        dst (byte-array block)
+        buf (byte-array chunk-size)
+        cel (byte-array cells)
+        s   (apply str (repeat 1000 "abcde"))]
+    (loop [p 0 acc 0]
+      (if (< p passes)
+        (recur (inc p)
+               (unchecked-add
+                acc
+                (unchecked-add
+                 (unchecked-add (aget ^bytes (copy-full! src dst block) 1023)
+                                (aget ^bytes (copy-region! src dst block) 1023))
+                 (unchecked-add (unchecked-add (drain src buf) (round-trip s 4))
+                                (bsum (bfill! cel cells) cells)))))
+        acc))))
+
+(defn -main [& args]
+  (let [passes (if (seq args) (Integer/parseInt (first args)) 400)]
+    (dotimes [_ 2] (run (quot passes 4)))                ; warmup
+    (let [runs 3
+          ts (mapv (fn [_]
+                     (let [t0 (System/nanoTime)
+                           r (run passes)
+                           ms (/ (- (System/nanoTime) t0) 1000000.0)]
+                       (when (zero? r) (println "unexpected zero"))
+                       ms))
+                   (range runs))
+          mean (/ (reduce + ts) runs)]
+      (println "byte-arrays passes" passes)
+      (println "runs:" (mapv (fn [t] (/ (Math/round (* t 10.0)) 10.0)) ts))
+      (println "mean:" (/ (Math/round (* mean 10.0)) 10.0) "ms"))))

--- a/bench/gc_arrays.clj
+++ b/bench/gc_arrays.clj
@@ -1,0 +1,127 @@
+;; gc-arrays — what a MAJOR COLLECTION costs while a large primitive array is
+;; live. Not throughput: the timed region contains nothing but full collections,
+;; with one array rooted across them, so what is measured is the collector's own
+;; work over that live set.
+;;
+;; The axis is again the BACKING (see byte-arrays for the access side). A jolt
+;; ^longs/^ints array is an fxvector and a ^bytes array is a bytevector — leaf
+;; objects with no pointers in them — so the collector has nothing to trace
+;; through, where a boxed vector of the same length is a slot per element that it
+;; must walk on every full collection. That is a property of the heap shape rather
+;; than of any compiler pass, and nothing else in the suite measures it: a change
+;; that puts a typed array back on a boxed backing keeps every answer correct, and
+;; every other benchmark here (which allocates arrays and drops them) sees only a
+;; small part of the difference.
+;;
+;; Four phases, in this order and reported separately:
+;;   floor    no large array live — the fixed cost of a full collection over the
+;;            runtime's own image, which every row below includes
+;;   longs    a live long-array (fxvector: not traced)
+;;   bytes    a live byte-array (bytevector: not traced)
+;;   boxed    a live object-array of the same length, holding one shared value —
+;;            the CONTROL, and what a typed array's pause looks like when its
+;;            backing is a boxed vector. It is a scan of `cells` slots, not a
+;;            traversal of `cells` objects, so its cost is the walk itself
+;;
+;; `mean:` covers the two phases the backings changed (longs + bytes), measured
+;; three times over; floor and boxed are reported per collection on their own line
+;; and stay out of the mean, because neither is expected to move and a large
+;; constant on both sides would only dilute the ratio the release gate reads. The
+;; control runs a tenth of the collections for the same reason — one of its
+;; collections costs two orders of magnitude more than one of the gated ones.
+;;
+;; Each phase allocates its array inside its own frame and hands back only a
+;; nanosecond count, so the next phase does not inherit the previous live set; the
+;; array is READ after the timed region, which is what keeps it rooted across the
+;; collections rather than dead on arrival (a GC measurement whose live value is
+;; not actually reachable measures the floor and nothing else).
+;;
+;; Portable Clojure (jolt + JVM Clojure). System/gc is a hint on the JVM and a full
+;; collection here, and the two collectors are not the same machine, so the vs-JVM
+;; column on this row is an order-of-magnitude reading only — the useful comparison
+;; is jolt against jolt, which is what ci/bench-gate.sh does.
+;;   bench/run.sh gc-arrays 150
+(ns gc-arrays)
+
+(def cells (* 8 1024 1024))   ; elements in the live array
+
+(defn pause-ns ^long [^long collects]
+  (let [t0 (System/nanoTime)]
+    (loop [i 0]
+      (when (< i collects)
+        (System/gc)
+        (recur (inc i))))
+    (- (System/nanoTime) t0)))
+
+(defn floor-phase ^long [^long collects]
+  (pause-ns collects))
+
+(defn longs-phase ^long [^long n ^long collects]
+  (let [a (long-array n 7)
+        el (pause-ns collects)]
+    (when (zero? (aget ^longs a (dec n))) (println "unexpected zero"))
+    el))
+
+(defn bytes-phase ^long [^long n ^long collects]
+  (let [a (byte-array n (byte 7))
+        el (pause-ns collects)]
+    (when (zero? (aget ^bytes a (dec n))) (println "unexpected zero"))
+    el))
+
+(defn boxed-phase ^long [^long n ^long collects]
+  (let [shared (Object.)
+        a (object-array n)]
+    (loop [i 0]
+      (when (< i n)
+        (aset a i shared)
+        (recur (inc i))))
+    (let [el (pause-ns collects)]
+      (when (nil? (aget ^objects a (dec n))) (println "unexpected nil"))
+      el)))
+
+(defn us-each [^long nanos ^long collects] (/ (Math/round (/ nanos collects 100.0)) 10.0))
+
+(defn -main [& args]
+  (let [collects (if (seq args) (Integer/parseInt (first args)) 150)
+        ;; the control is a per-collect figure and each of its collections costs
+        ;; two orders of magnitude more than the phases being gated, so it runs a
+        ;; tenth as many rather than dominating the bench's wall time.
+        ctl (max 1 (quot collects 10))
+        warm (max 1 (quot collects 10))
+        reps 3]
+    (floor-phase warm)                                   ; warmup
+    (longs-phase 1024 warm)
+    (let [flr (floor-phase collects)
+          pairs (mapv (fn [_] [(longs-phase cells collects)
+                               (bytes-phase cells collects)])
+                      (range reps))
+          box (boxed-phase cells ctl)
+          lng (long (/ (reduce + (mapv (fn [p] (nth p 0)) pairs)) reps))
+          byt (long (/ (reduce + (mapv (fn [p] (nth p 1)) pairs)) reps))
+          means (mapv (fn [p] (/ (+ (nth p 0) (nth p 1)) 2.0)) pairs)
+          mean (/ (reduce + means) reps)]
+      (println "gc-arrays collects" collects "cells" cells "control collects" ctl)
+      ;; Sanity check on the measurement itself, as a ratio inside this one run: the
+      ;; control's collection walks `cells` slots, so it MUST cost measurably more
+      ;; than the floor's. When it does not, no collection is being timed — Chez refuses
+      ;; to collect while more than one thread is active and jolt's System/gc is then
+      ;; a guarded no-op (all the JVM's hint contract promises either) — and a mean
+      ;; over no-op calls would read as an extremely fast collector. So none is
+      ;; printed, which ci/bench-gate.sh treats as a failure. It is the right
+      ;; failure: the number would otherwise be meaningless on both sides.
+      ;; The 1.25x bar is deliberately loose: the two differ by the WALK, which is
+      ;; a fixed cost, so the ratio shrinks as the floor grows — under `jolt run` the
+      ;; dev image's own live heap puts the floor at 29ms and this reads 1.9x, where
+      ;; a built binary reads about 1600x. A no-op run reads 1.0x, since both phases
+      ;; then time the same empty loop.
+      (if (<= (/ box ctl) (* 1.25 (/ flr collects)))
+        (println "no collection was timed: the boxed control cost no more per"
+                 "collect than the floor (System/gc a no-op, or a collector that"
+                 "no longer walks a boxed vector)")
+        (do
+          (println "per-collect us: floor" (us-each flr collects)
+                   " longs" (us-each lng collects)
+                   " bytes" (us-each byt collects)
+                   " boxed" (us-each box ctl))
+          (println "runs:" (mapv (fn [m] (/ (Math/round (/ m 100000.0)) 10.0)) means))
+          (println "mean:" (/ (Math/round (/ mean 100000.0)) 10.0) "ms"))))))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -61,7 +61,7 @@ bindir="$(mktemp -d)"
 trap 'rm -rf "$bindir"' EXIT
 
 # name:default-arg, each sized to run in a few seconds. Axes: see README.md.
-BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 arrays-unhinted:1000 mathfns:1000000 mathfns-unhinted:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 string-ops-unhinted:100000 char-scan:40000 char-scan-unhinted:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14 typed-records:100000 typed-records-unhinted:100000 executors:60000"
+BENCHES="fib:30 tak:24 loop-recur:20000 mandelbrot:200 arrays:40000 arrays-unhinted:1000 byte-arrays:400 gc-arrays:150 mathfns:1000000 mathfns-unhinted:1000000 collections:30000 vecops:60000 seqs:20000 sorted-access:40000 nth-access:1000000 transducers:20000 transients:50000 keyed-lookup:3000 hash-eq:2000 literals:100000 string-build:60000 string-ops:100000 string-ops-unhinted:100000 char-scan:40000 char-scan-unhinted:40000 mono-dispatch:2000 dispatch:2000 binary-trees:14 typed-records:100000 typed-records-unhinted:100000 executors:60000"
 
 run_one() {
   ns="${1%%:*}"; arg="${2:-${1##*:}}"

--- a/ci/bench-gate.sh
+++ b/ci/bench-gate.sh
@@ -4,7 +4,7 @@
 #   ci/bench-gate.sh <baseline-jolt> <candidate-jolt> [max-ratio] [bench...]
 #
 # Naming benches runs only those — how a flagged row gets re-checked on its own,
-# and how this script is exercised without paying for all 22.
+# and how this script is exercised without paying for the whole suite.
 #
 # Both compilers build the SAME bench sources (this checkout's), so what is being
 # compared is codegen, not the benchmarks. Every measurement is a RATIO between


### PR DESCRIPTION
The 0.8.3 unboxed-backing work (#864) claimed five figures — a 1MB `System/arraycopy`, 2000 8KB `InputStream/read`s into a buffer, 2000 `(String. (.getBytes s))` round trips, and the major-GC pause with a live 20M-element `long-array` / `byte-array` — and the suite had no row that could see any of them. `bench/arrays` is hinted element access on `^doubles`/`^objects`/`^longs`; nothing in `bench/` touched a byte array at all, and nothing measured a collection pause. Those measurements were made outside the suite and not kept, so nothing guarded them afterwards.

Two new rows:

- **`byte-arrays`** — the bulk paths (a full-array and a middle-to-middle `System/arraycopy`, 1MB drained through an 8KB `ByteArrayInputStream` read loop, `String`↔`byte[]` round trips) plus hinted `^bytes` element access, which is the one place the read and the write pull in opposite directions (`aget` takes the direct backing read, `aset` stays on the generic path for the 8-bit narrowing). Sized so the bulk phases and the element loop weigh about the same.
- **`gc-arrays`** — full collections with one large array rooted across them: a `long-array` (fxvector), a `byte-array` (bytevector), a floor with nothing large live, and a boxed `object-array` of the same length as an in-process control. `mean:` covers the two phases the backings changed; the control and floor are reported per collection and stay out of it.

Both are in `bench/run.sh`'s `BENCHES` list, which `ci/bench-gate.sh` reads rather than keeping a second copy, so the release gate measures them against the previous release like every other row. At their default sizes they cost ~1.1s and ~0.9s a run.

### Verification

Against a v0.8.2 binary, the last release without the backings, on one machine in one sitting:

| bench | v0.8.2 | this tree | ratio |
|---|---:|---:|---:|
| `byte-arrays` | 13150.9 ms | 270.6 ms | 0.02× |
| `gc-arrays` | 1900.0 ms | 26.8 ms | 0.01× |

Two more runs of the pair read 13020.9 / 267.9 and 1908.7 / 27.1, then 13100.5 / 270.3 and 1907.7 / 27.9. With the arguments swapped — this tree as baseline, v0.8.2 as candidate, i.e. what undoing the backings would look like — both rows print `<-- REGRESSED` (48.47× and 68.38×) and the gate exits 1, so the rows can actually block a release rather than only decorate the scorecard.

`bench/README.md` carries the axis rows, the per-phase jolt-vs-JVM split, the per-collection GC table and all three readings. `gc-arrays` also self-checks: if its boxed control costs no more per collection than the floor, no collection was timed (Chez refuses to collect with more than one thread active) and it prints no `mean:` at all, which the gate treats as a failure.

### Two gaps the byte-arrays row exposed

Filed, not fixed here: a hinted `(aset ^bytes a i v)` costs 29ns an element against 5.9ns for the matching hinted read (jolt-ep6g), and an 8KB `InputStream/read` costs 1.57µs against the JVM's 0.23µs (jolt-z3zp). The block copies now *beat* the JVM (19.5µs per megabyte against 30.8µs).

One drive-by: `ci/bench-gate.sh`'s header said "without paying for all 22" — there are 31 rows now, so the count is gone rather than re-stated.


