### PR TITLE
Key a :jolt/native spec's dedup identity on :windows, not :win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **On Windows, two different `:jolt/native` libraries no longer reconcile to
+  one.** A resolved project dedups its native declarations so that an app pulling
+  two dependencies that name the same shared object loads it once. The identity a
+  spec dedups on is its `:name`, or — when it has none — the candidate paths it
+  declares for each platform, and it read those from `:darwin`, `:linux` and
+  `:win`. The key the loader selects with is `:windows`, the spelling everything
+  else documents and reads, so a Windows-only spec with no `:name` contributed no
+  candidates at all: every such spec keyed on the same empty vector and all but
+  the first were dropped before anything tried to load them. Specs that also
+  declared `:darwin`/`:linux` candidates keyed correctly by accident. The identity
+  reads `:windows` now, and a spec that carries neither a `:name` nor a candidate
+  under any platform key (one declaring only `:static`) keys on its own shape, so
+  that shape cannot collapse this way either.
+
 - **Shutdown hooks run on `^C`.** `Runtime.addShutdownHook` and
   `jolt.host/add-shutdown-hook` fired on a normal exit, on `System/exit`, and on
   `SIGTERM`/`SIGHUP`, but not on `SIGINT`: Chez owns that signal through

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -956,15 +956,28 @@
                       (if (contains? seen k) [seen acc] [(conj seen k) (conj acc x)])))
                   [#{} []] xs)))
 
+;; The platform keys a :jolt/native spec declares its candidates under: exactly
+;; the values main.clj's current-platform selects with, so the identity below
+;; reads the same keys the loader does. It listed :win, which current-platform
+;; never produces, so on Windows a spec that declared candidates only under
+;; :windows keyed on nothing at all (jolt-ajd).
+(def ^:private native-platform-keys [:darwin :linux :windows])
+
 (defn- native-key
   "Identity of a :jolt/native spec. A :process lib (the running process's own
   symbols, e.g. libc) keys on that flag; a file lib on its :name, else on its
-  platform candidate paths — two deps naming the same lib reconcile to one load."
+  platform candidate paths — two deps naming the same lib reconcile to one load.
+  A spec with neither a :name nor a candidate under any platform key (it declares
+  only :static, or only a key no platform selects) keys on its own shape, minus
+  the declaring root: distinct specs stay distinct instead of collapsing to one
+  under dedup-by, and two deps declaring the same lib still reconcile."
   [spec]
   (letfn [(cands [k] (let [v (get spec k)] (cond (string? v) [v] (sequential? v) (vec v) :else [])))]
     (if (:process spec)
       [:process (:name spec)]
-      [:native (or (:name spec) (vec (sort (concat (cands :darwin) (cands :linux) (cands :win)))))])))
+      [:native (or (:name spec)
+                   (let [paths (vec (sort (mapcat cands native-platform-keys)))]
+                     (if (seq paths) paths (dissoc spec :jolt.deps/root))))])))
 
 (defn- provides-entries
   "A deps.edn :jolt/provides map as provider-table rows: [install-ns lib class ...].

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -10,6 +10,9 @@
 
 (defn- version [] (jolt.host/jolt-version))
 
+;; The key a :jolt/native spec's candidates are read under. These three
+;; spellings are the whole set — jolt.deps/native-platform-keys, which builds a
+;; spec's dedup identity, must list the same ones.
 (defn- current-platform []
   (let [os (str/lower-case (or (System/getProperty "os.name") ""))]
     (cond (str/includes? os "mac") :darwin

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -302,6 +302,50 @@
          (and (str/includes? (str msg) "a/one 1.0")
               (str/includes? (str msg) "b/two 2.0")))))
 
+;;;; :jolt/native dedup identity
+
+(let [native-key (var jolt.deps/native-key)
+      dedup-by (var jolt.deps/dedup-by)]
+  ;; The keys a spec's candidates are declared under are the ones
+  ;; current-platform selects with. native-key read :win, which it never
+  ;; produces, so two Windows-only specs with no :name both keyed on an empty
+  ;; vector and dedup-by dropped the second (jolt-ajd).
+  (let [a {:windows ["sqlite3.dll"]}
+        b {:windows ["libcrypto-3-x64.dll"]}]
+    (is= "Windows-only specs key distinctly" true
+         (not= (native-key a) (native-key b)))
+    (is= "Windows-only specs both survive dedup" [a b] (dedup-by native-key [a b])))
+  (is= "a Windows candidate is part of the identity"
+       (native-key {:windows ["sqlite3.dll"]})
+       (native-key {:windows "sqlite3.dll"}))
+  (is= "the same Windows lib from two deps reconciles to one"
+       [{:windows ["sqlite3.dll"] :jolt.deps/root "/a"}]
+       (dedup-by native-key [{:windows ["sqlite3.dll"] :jolt.deps/root "/a"}
+                             {:windows ["sqlite3.dll"] :jolt.deps/root "/b"}]))
+
+  ;; Every platform key contributes, and :name still overrides all of them.
+  (is= "each platform key contributes to the identity" 3
+       (count (dedup-by native-key [{:darwin ["libz.dylib"]}
+                                    {:linux ["libz.so.1"]}
+                                    {:windows ["zlib1.dll"]}])))
+  (is= "a :name reconciles specs whose candidates differ" 1
+       (count (dedup-by native-key [{:name "z" :linux ["libz.so.1"]}
+                                    {:name "z" :windows ["zlib1.dll"]}])))
+  (is= "a :process lib keys on the flag, not on candidates" 1
+       (count (dedup-by native-key [{:process true :name "c"}
+                                    {:process true :name "c" :linux ["libc.so.6"]}])))
+
+  ;; A spec with no :name and no candidate under any platform key — a
+  ;; :static-only lib, or a key no platform selects — falls back to its own
+  ;; shape rather than to one shared empty identity.
+  (is= "static-only specs stay distinct" 2
+       (count (dedup-by native-key [{:static {:archive "native/libfoo.a"}}
+                                    {:static {:archive "native/libbar.a"}}])))
+  (is= "an identical static-only spec from two roots reconciles" 1
+       (count (dedup-by native-key
+                        [{:static {:archive "native/libfoo.a"} :jolt.deps/root "/a"}
+                         {:static {:archive "native/libfoo.a"} :jolt.deps/root "/b"}]))))
+
 (println (str "deps-expand: " (- @checks @failures) "/" @checks " passed"))
 (when (pos? @failures)
   (System/exit 1))


### PR DESCRIPTION
Fixes jolt-ajd.

A resolved project dedups its `:jolt/native` declarations by identity, so an app pulling two dependencies that name the same shared object includes and loads it once. A spec with no `:name` keys on the candidate paths it declares per platform — and `native-key` read those from `:darwin`, `:linux` and `:win`.

`:windows` is the key the loader actually selects with (`current-platform`, `jolt-core/jolt/main.clj:16`) and the spelling `jolt.ffi`'s per-OS spec documents and reads. `:win` is produced nowhere. So on Windows, a spec with no `:name` that declared candidates only under `:windows` contributed nothing to its own identity: every such spec keyed on the same empty vector and all but the first were dropped by `dedup-by` before anything tried to load them. Specs that also declared `:darwin`/`:linux` candidates keyed correctly by accident, since those arms still contributed.

Pre-existing, not a regression from #870.

## The change

- The platform keys are one list (`native-platform-keys`) beside `native-key`, holding exactly the three values `current-platform` can return. A comment on each side points at the other so they cannot drift apart again silently.
- A spec carrying neither a `:name` nor a candidate under any platform key — one declaring only `:static` — keys on its own shape rather than on a shared empty vector, so that shape cannot collapse the same way either. The declaring root is dropped from that fallback: two dependencies declaring the same library from different roots must still reconcile to one, which is why `native-key` never read the root.

## Validation

- `make depsunit` — the new `:jolt/native` dedup identity section in `test/deps_expand_test.clj`: two Windows-only no-`:name` specs key distinctly and both survive `dedup-by`, each platform key contributes, `:name` and `:process` still override candidates, and a static-only pair stays two. Reverting `native-key` alone fails 3 of these checks; with the fix, 74/74 pass.
- `make staticnativesmoke`, `make ffidupsym`, `make grenadine` — pass.
