### PR TITLE
Hide a -dash task from the listing, and print one line of a :doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`jolt tasks` hides a task whose name starts with `-`.** `list-tasks!` is
+  babashka's listing, and babashka treats a leading dash the way it treats
+  `:private`: a helper another task calls, not an entry point someone picks off
+  a list. Jolt read the `:private` key and not the name, so a `bb.edn` using the
+  dash convention had its helpers listed. That file is one jolt reads directly,
+  so the convention arrives whether or not a jolt project would have chosen it.
+  Hiding is display only, here as in babashka: `jolt -dash` still runs the task.
+
+- **`jolt tasks` prints only the first line of a `:doc`.** The listing puts one
+  task on one line and aligns the docs into a column, so a docstring that spans
+  lines broke the shape it was being formatted into: the second line started at
+  column zero, in the name column, and read as a task of its own. Anything
+  parsing the listing for names picked it up as one. Babashka truncates for the
+  same reason.
+
 ## [0.8.4] - 2026-09-06
 
 A jolt file with `#!/usr/bin/env jolt` on its first line is an executable script:

--- a/host/chez/tasks-smoke.sh
+++ b/host/chez/tasks-smoke.sh
@@ -165,6 +165,19 @@ echo "$out" | grep -q "secret" \
   && check "tasks hides :private" "hidden" "shown" || check "tasks hides :private" "hidden" "hidden"
 echo "$out" | grep -q "^bare$" \
   && check "tasks lists a doc-less task" "yes" "yes" || check "tasks lists a doc-less task" "yes" "no"
+# A leading dash is babashka's other spelling of :private, and a bb.edn we read
+# may well use it. Hidden from the listing, but still runnable.
+echo "$out" | grep -q -- "-dash" \
+  && check "tasks hides a -dash name" "hidden" "shown" || check "tasks hides a -dash name" "hidden" "hidden"
+check "a -dash task still runs" "enter -dash
+dash ran
+leave -dash" "$(inbb "$BB" -dash)"
+# One task per line is the listing's whole shape: the second line of a docstring
+# would land in the name column and read as a task of its own.
+echo "$out" | grep -q "^multi *first line$" \
+  && check "tasks prints a doc's first line" "yes" "yes" || check "tasks prints a doc's first line" "yes" "no"
+echo "$out" | grep -q "second line of the doc" \
+  && check "tasks drops a doc's later lines" "dropped" "printed" || check "tasks drops a doc's later lines" "dropped" "dropped"
 
 # --- run <task> --------------------------------------------------------------
 

--- a/jolt-core/jolt/tasks.clj
+++ b/jolt-core/jolt/tasks.clj
@@ -238,12 +238,25 @@
 
 ;; --- the listing -------------------------------------------------------------
 
+(defn- first-line
+  "Everything before the first newline. A listing is one task per line, so a
+  docstring that spans lines has to be cut to fit it — see list-tasks!."
+  [s]
+  (apply str (take-while #(not= \newline %) s)))
+
 (defn list-tasks!
   "`jolt tasks` — the project's task names and their :doc, babashka's listing.
-  :private tasks are helpers for other tasks and stay out of it."
+  Two kinds of task stay out of it, both of them helpers for other tasks:
+  a :private one, and one whose name starts with `-`, which is babashka's
+  spelling of the same intent and reaches us through the bb.edn files we read.
+  Only the first line of a :doc is printed, because the listing's whole shape is
+  one task per line: a docstring's second line would otherwise sit in the name
+  column and read as a task of its own."
   [tasks]
   (let [entries (->> (tasks-of tasks)
-                     (remove (fn [[_ v]] (and (map? v) (:private v))))
+                     (remove (fn [[k v]]
+                               (or (and (map? v) (:private v))
+                                   (= \- (first (str k))))))
                      (sort-by (comp str key)))]
     (if (empty? entries)
       (println "No tasks found. Add a :tasks map to bb.edn or deps.edn.")
@@ -253,5 +266,6 @@
         (doseq [[k v] entries]
           (let [doc (when (map? v) (:doc v))]
             (println (if doc
-                       (str (apply str k (repeat (- w (count (str k))) \space)) "  " doc)
+                       (str (apply str k (repeat (- w (count (str k))) \space))
+                            "  " (first-line doc))
                        (str k)))))))))

--- a/test/chez/tasks/bbproj/bb.edn
+++ b/test/chez/tasks/bbproj/bb.edn
@@ -15,6 +15,12 @@
   boom   {:doc "fail with 7" :task (shell "sh" "-c" "exit 7")}
   nested {:task (do (println "before") (run 'clean) (println "after"))}
   secret {:private true :task (println "secret")}
+  ;; babashka's other spelling of "helper, not an entry point": a leading dash.
+  ;; Hidden from the listing like :private, and runnable like it too.
+  -dash  {:doc "a dash-named helper" :task (println "dash ran")}
+  ;; a :doc that spans lines. The listing is one task per line, so only the
+  ;; first may reach it.
+  multi  {:doc "first line\nsecond line of the doc" :task (println "multi")}
   needs  {:requires ([bbproj.core :as c]) :task (println (c/hello))}
   helper {:requires ([helper]) :task (println (helper/help))}
   echo   {:task (shell "echo" "from-shell")}


### PR DESCRIPTION
Fixes #877.

`jolt.tasks/list-tasks!` describes itself as babashka's listing:

> `jolt tasks` — the project's task names and their :doc, babashka's listing.

On two points it wasn't, and both arrive through `bb.edn` files, which jolt
reads directly — so the conventions come from projects written for babashka
rather than from anything a jolt project would have chosen.

**A task whose name starts with `-` was listed.** babashka hides it, treating
the leading dash as the same statement `:private` makes. From
`src/babashka/impl/tasks.clj`:

```clojure
"For a task to be listed
 - its name has to be a symbol but should not start with `-`, and
 - should not be `:private`."
```

jolt read the key and not the name, so a project using the dash convention for
helper tasks had them listed.

**A multi-line `:doc` broke the listing's own format.** The listing puts one
task on one line and pads names into a column, so a docstring that spans lines
had its continuation printed at column zero, in the name column, where it is
indistinguishable from an entry. babashka truncates to the first line.

That second one isn't only cosmetic: anything reading the listing for names
picks the continuation up as one, which is exactly what a shell completion does.

### Reproduction

Same `bb.edn` through both tools:

```clojure
{:tasks
 {alpha   {:doc "one line" :task (println 1)}
  beta    {:doc "line one\nline two with spaces" :task (println 2)}
  helper  {:doc "hidden" :private true :task (println 3)}
  -dashed {:doc "dash-named" :task (println 4)}}}
```

`jolt tasks` before this change:

```
The following tasks are available:

-dashed  dash-named
alpha    one line
beta     line one
line two with spaces
```

`bb tasks` (1.12.196):

```
The following tasks are available:

alpha one line
beta  line one
```

### Notes

Hiding stays display-only, as in babashka: `jolt -dash` still runs the task, and
the gate pins that alongside the hiding, since a hidden task that could not be
run would be a different and worse behaviour.

`first-line` walks to the first newline rather than calling `clojure.string`,
which this namespace does not require and which didn't seem worth adding to a
seed-baked file for one truncation. Happy to switch if you'd rather have the
require.

Two fixture tasks (`-dash`, `multi`) carry the cases, and four checks pin them.

```
make taskssmoke     60 passed, 0 failed
make scriptsmoke    33 passed, 0 failed
```

Verified against `main` at 92fef2ce (v0.8.4) on 2026-09-07, macOS arm64.
babashka comparison measured with 1.12.196.
