### PR TITLE
Complete jolt's commands and a project's tasks, in zsh, bash and fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`jolt completions SHELL` prints a shell completion function**, for zsh, bash
+  or fish. `jolt <TAB>` then offers jolt's own commands and the project's tasks,
+  and under zsh each task carries its `:doc` as the description. Install it with
+  `source <(jolt completions zsh)` in `~/.zshrc` after `compinit`, or save the
+  output as `_jolt` on `$fpath`; both work.
+
+  The split from babashka is deliberate and is about latency. babashka calls its
+  binary back on every TAB press to compute the candidates for the line so far,
+  which it can afford. Jolt cannot: its floor is the Chez runtime coming up,
+  about 0.22s whatever it is asked for, and `jolt version` costs the same as
+  `jolt tasks`. So the two halves are split by how often they change. jolt's own
+  commands and options change when the binary does, so they are baked into the
+  snippet when it is generated and cost a completing shell nothing afterwards. A
+  project's tasks change when its `deps.edn` or `bb.edn` changes, so the snippet
+  caches them against those two mtimes and calls back only when one moves. The
+  zsh path uses `zsh/stat` and `$(<file)` and so forks nothing at all: a warm
+  press measures 0.4ms, against 97ms for the `bb tasks` that babashka's own
+  documented completion runs every time.
+
+  `jolt completions tasks` is the callback, and is useful on its own: one line
+  per listable task, `name<TAB>doc`, which is the machine-readable form of the
+  listing that `jolt tasks` writes for a person. Both go through
+  `jolt.tasks/listable`, so what TAB offers and what `jolt tasks` shows cannot
+  drift apart on which tasks exist. They differ deliberately on one point: a
+  task sharing a built-in's name is offered only when it wins that name with
+  `:override-builtin`, since a description says what the word will do and for a
+  task that loses to a command the answer is the command.
+
+  `make completionssmoke` gates the lines, all three snippets (parsed by their
+  own shells), the bash function run against a project, and the zsh function's
+  candidates read back through a stubbed `_describe` — that last one because
+  bash has no description column, so a candidate carrying the WRONG description
+  is invisible to every other check here.
+
 ### Fixed
 
 - **`jolt tasks` hides a task whose name starts with `-`.** `list-tasks!` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`jolt tasks` hides a task whose name starts with `-`.** `list-tasks!` is
+  babashka's listing, and babashka treats a leading dash the way it treats
+  `:private`: a helper another task calls, not an entry point someone picks off
+  a list. Jolt read the `:private` key and not the name, so a `bb.edn` using the
+  dash convention had its helpers listed. That file is one jolt reads directly,
+  so the convention arrives whether or not a jolt project would have chosen it.
+  Hiding is display only, here as in babashka: `jolt -dash` still runs the task.
+
+- **`jolt tasks` prints only the first line of a `:doc`.** The listing puts one
+  task on one line and aligns the docs into a column, so a docstring that spans
+  lines broke the shape it was being formatted into: the second line started at
+  column zero, in the name column, and read as a task of its own. Anything
+  parsing the listing for names picked it up as one. Babashka truncates for the
+  same reason.
+
 ## [0.8.4] - 2026-09-06
 
 A jolt file with `#!/usr/bin/env jolt` on its first line is an executable script:

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ install: build
 # naming the covered tree is written ONLY on a complete pass. `make gate-status`
 # answers "is this working tree gated?" — which is not something to remember.
 
-CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke taskssmoke scriptsmoke depscpcache depsunit \
+CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke taskssmoke scriptsmoke completionssmoke depscpcache depsunit \
   smoke tracesmoke errorreport errorkinds buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi ffidupsym continuations stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq narrowhash \
@@ -540,6 +540,12 @@ taskssmoke: testbin
 # Offline, throwaway projects in a temp dir.
 scriptsmoke: testbin
 	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/script-smoke.sh
+
+# `jolt completions`: the name/doc lines a completing shell asks for, and the
+# zsh/bash/fish snippets it installs — parsed by their own shells, and the bash
+# one actually run against a project to see what it offers.
+completionssmoke: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/completions-smoke.sh
 
 # The resolved-roots cache (.jolt/cpcache): a warm run reuses a project's final
 # dependency resolution instead of re-expanding the graph. Offline throwaway

--- a/README.md
+++ b/README.md
@@ -273,6 +273,51 @@ every run, which measures ~0.17s against babashka's ~0.01s on the same machine. 
 script called in a loop is better compiled once: give it an `(ns …)` with a
 `-main` and `jolt build -m` it into a binary.
 
+`jolt completions zsh` gives a shell the project's task names, so a script or a
+task is a TAB away: see [Shell completion](#shell-completion).
+
+## Shell completion
+
+`jolt completions SHELL` prints a completion function for zsh, bash or fish.
+`jolt <TAB>` then offers jolt's commands and the project's tasks, and under zsh
+each task carries its `:doc`:
+
+```
+$ jolt build<TAB>
+build             -- compile a standalone binary or shared library
+build:linux       -- Compile native/libtsj.so for AWS Lambda (AL2023 arm64) via Docker
+build:linux:host  -- Compile native/libtsj.so natively for THIS Linux host (no Docker)
+```
+
+For zsh, in `~/.zshrc` after `compinit`:
+
+```bash
+source <(jolt completions zsh)
+```
+
+Or save it as `_jolt` somewhere on `$fpath`, which works too. For bash, source
+`jolt completions bash` from `~/.bashrc`. For fish, save `jolt completions fish`
+as `~/.config/fish/completions/jolt.fish`.
+
+A snippet holds jolt's own commands directly, since those change only when the
+binary does. The project's tasks it fetches with `jolt completions tasks` and
+caches against the mtimes of `deps.edn` and `bb.edn`, so a press costs nothing
+until one of those files moves. Under zsh that path forks no process at all and
+measures 0.4ms. Set `JOLT_COMPLETION_NO_CACHE=1` to bypass it.
+
+`jolt completions tasks` is worth knowing on its own: one line per listable
+task, `name<TAB>doc`, which is the machine-readable form of what `jolt tasks`
+prints for a person. Anything scripting over a project's tasks should read that
+rather than parse the listing.
+
+A `:private` task and one whose name starts with `-` are left out, the same two
+`jolt tasks` hides. One case differs on purpose: a task sharing a built-in
+command's name is offered only when it wins that name with `:override-builtin`,
+because a completion's description says what the word will do, and for a task
+that loses to a command the answer is the command. `jolt tasks` lists it either
+way, being a list of what the project defines rather than of what typing the
+word gets you.
+
 ## Runtime dependencies
 
 Jolt supplies `org.clojure/clojure` and `org.clojure/clojurescript` itself, so

--- a/host/chez/completions-smoke.sh
+++ b/host/chez/completions-smoke.sh
@@ -1,0 +1,165 @@
+#!/bin/sh
+# completions-smoke.sh — `jolt completions`: the name/doc lines a completing
+# shell asks for, and the three snippets it can install.
+#
+# The snippets are checked two ways, because they fail differently. `zsh -n` /
+# `bash -n` catch a snippet that will not parse, which is what a generator
+# emitting shell text gets wrong most often. Then the bash function is actually
+# RUN against a project and its COMPREPLY asserted, because a snippet can parse
+# perfectly and still offer nothing: the first zsh draft of this feature defined
+# its function and never called it under autoload, which no syntax check sees.
+#
+# JOLT_BIN overrides the binary under test. Offline, throwaway project in a
+# temp dir.
+set -u
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+JOLT="${JOLT_BIN:-bin/jolt}"
+case "$JOLT" in /*) JOLT_ABS="$JOLT" ;; *) JOLT_ABS="$root/$JOLT" ;; esac
+export JOLT_EXE="$JOLT_ABS"
+export JOLT_NO_USER_DEPS=1
+# Never read or write the developer's real completion cache from a gate.
+export JOLT_COMPLETION_NO_CACHE=1
+pass=0; fail=0
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+check() { # label expected actual
+  if [ "$2" = "$3" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    echo "  FAIL: $1" >&2
+    echo "    expected: $2" >&2
+    echo "    got:      $3" >&2
+  fi
+}
+
+proj="$tmp/proj"
+mkdir -p "$proj"
+cat > "$proj/bb.edn" <<'EOF'
+{:tasks
+ {alpha   {:doc "one line" :task (println 1)}
+  beta    {:doc "first line\nsecond line" :task (println 2)}
+  build:x {:doc "a colon in the name" :task (println 3)}
+  quiet   {:doc "hidden" :private true :task (println 4)}
+  -dash   {:doc "also hidden" :task (println 5)}
+  gamma   (println 6)
+  ;; Two tasks named after built-in commands. `build` does not ask to override,
+  ;; so `jolt build` is the compiler and the completion must describe THAT.
+  ;; `path` does ask, so the task is what runs and the task is what to describe.
+  build   {:doc "loses to the build command" :task (println 7)}
+  path    {:doc "wins the path name" :override-builtin true :task (println 8)}}}
+EOF
+
+run() { d="$1"; shift; JOLT_PWD="$d" JOLT_QUIET=1 "$JOLT_ABS" "$@" 2>&1; }
+
+# --- the name/doc lines ------------------------------------------------------
+
+out="$(run "$proj" completions tasks)"
+check "a task with a :doc is name<TAB>doc" "alpha	one line" \
+  "$(printf '%s\n' "$out" | grep '^alpha')"
+check "only the first line of a :doc" "beta	first line" \
+  "$(printf '%s\n' "$out" | grep '^beta')"
+check "a doc-less task is a bare name" "gamma" \
+  "$(printf '%s\n' "$out" | grep '^gamma')"
+check "a colon in a task name survives" "build:x	a colon in the name" \
+  "$(printf '%s\n' "$out" | grep '^build:x')"
+check ":private stays out" "" "$(printf '%s\n' "$out" | grep '^quiet')"
+check "a -dash name stays out" "" "$(printf '%s\n' "$out" | grep '^-dash')"
+# A description is a promise about what the word will do, so a task that LOSES
+# its name to a built-in must not carry one: `jolt build` is the compiler here.
+check "a task that loses to a builtin stays out" "" \
+  "$(printf '%s\n' "$out" | grep '^build	')"
+check "...and one that overrides a builtin is in" "path	wins the path name" \
+  "$(printf '%s\n' "$out" | grep '^path')"
+check "one line per offered task" "5" "$(printf '%s\n' "$out" | grep -c .)"
+
+check "a project with no tasks says nothing" "" "$(run "$tmp" completions tasks)"
+check "...and exits 0" "0" \
+  "$(JOLT_PWD="$tmp" "$JOLT_ABS" completions tasks >/dev/null 2>&1; echo $?)"
+
+# --- the snippets ------------------------------------------------------------
+
+for sh_name in zsh bash fish; do
+  snip="$tmp/snip.$sh_name"
+  run "$proj" completions "$sh_name" > "$snip"
+  check "completions $sh_name emits something" "yes" \
+    "$([ -s "$snip" ] && echo yes || echo no)"
+done
+
+# A generated snippet that does not parse is the failure mode of emitting shell
+# from a string, so parse each with its own shell where that shell exists.
+if command -v zsh >/dev/null 2>&1; then
+  zsh -n "$tmp/snip.zsh" 2>/dev/null
+  check "the zsh snippet parses" "0" "$?"
+  grep -q 'loadautofunc' "$tmp/snip.zsh"
+  check "the zsh snippet handles autoload as well as source" "0" "$?"
+fi
+if command -v bash >/dev/null 2>&1; then
+  bash -n "$tmp/snip.bash" 2>/dev/null
+  check "the bash snippet parses" "0" "$?"
+fi
+
+check "an unknown shell is an error" "1" \
+  "$(JOLT_PWD="$proj" "$JOLT_ABS" completions klingon >/dev/null 2>&1; echo $?)"
+check "completions with no argument is an error" "1" \
+  "$(JOLT_PWD="$proj" "$JOLT_ABS" completions >/dev/null 2>&1; echo $?)"
+
+# --- the bash function, actually run -----------------------------------------
+#
+# Parsing is not offering. This sources the snippet and asks it what `jolt b`
+# completes to, which is the only check here that would have caught a function
+# that loads and returns nothing.
+if command -v bash >/dev/null 2>&1; then
+  got="$(cd "$proj" && PATH="$(dirname "$JOLT_ABS"):$PATH" \
+    bash --noprofile --norc -c '
+      set -u
+      . "$1"
+      COMP_WORDS=(jolt b); COMP_CWORD=1
+      _jolt_completions
+      printf "%s\n" "${COMPREPLY[@]}" | sort | tr "\n" " "
+    ' _ "$tmp/snip.bash" 2>/dev/null)"
+  check "the bash function offers the build command and both b-tasks" \
+    "beta build build:x " "$got"
+fi
+
+# --- the zsh function's candidates, with descriptions ------------------------
+#
+# The bash check above cannot see this class of bug at all: bash has no
+# description column, so a candidate carrying the WRONG description looks
+# identical to a right one. Stubbing _describe and calling the real function is
+# enough to read the pairs back without a pty or the completion system, and it
+# is what caught `build` being described as the compiler in a project whose
+# `build` task overrides it.
+if command -v zsh >/dev/null 2>&1; then
+  desc="$(cd "$proj" && PATH="$(dirname "$JOLT_ABS"):$PATH" \
+    zsh -f -c '
+      _describe() { local n=${@[-1]}; print -l -- ${(P)n}; }
+      _files()   { : }
+      _message() { : }
+      _alternative() { : }
+      _arguments()   { : }
+      compdef()  { : }
+      source "$1"
+      words=(jolt ""); CURRENT=2
+      _jolt
+    ' _ "$tmp/snip.zsh" 2>/dev/null)"
+  check "a task that wins a builtin's name carries the TASK's description" \
+    "path:wins the path name" \
+    "$(printf '%s\n' "$desc" | grep '^path:')"
+  check "...and the builtin it displaced is not offered twice" "1" \
+    "$(printf '%s\n' "$desc" | grep -c '^path:')"
+  check "a builtin no task took keeps its own description" \
+    "tasks:list the project's bb.edn/deps.edn :tasks" \
+    "$(printf '%s\n' "$desc" | grep '^tasks:')"
+  # -Fx, because `^build:` also matches the unrelated `build:x` task, which is
+  # exactly the kind of near-miss a loose pattern turns into a false pass.
+  check "a task that lost its name is described as the builtin" "yes" \
+    "$(printf '%s\n' "$desc" \
+       | grep -Fxq 'build:compile a standalone binary or shared library' \
+       && echo yes || echo no)"
+fi
+
+echo "completions-smoke: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -52,6 +52,7 @@ grenadine.repo
 grenadine.runtime
 grenadine.source
 jolt.bb.fs
+jolt.completions
 jolt.continuations
 jolt.fibers
 jolt.fs

--- a/host/chez/tasks-smoke.sh
+++ b/host/chez/tasks-smoke.sh
@@ -165,6 +165,19 @@ echo "$out" | grep -q "secret" \
   && check "tasks hides :private" "hidden" "shown" || check "tasks hides :private" "hidden" "hidden"
 echo "$out" | grep -q "^bare$" \
   && check "tasks lists a doc-less task" "yes" "yes" || check "tasks lists a doc-less task" "yes" "no"
+# A leading dash is babashka's other spelling of :private, and a bb.edn we read
+# may well use it. Hidden from the listing, but still runnable.
+echo "$out" | grep -q -- "-dash" \
+  && check "tasks hides a -dash name" "hidden" "shown" || check "tasks hides a -dash name" "hidden" "hidden"
+check "a -dash task still runs" "enter -dash
+dash ran
+leave -dash" "$(inbb "$BB" -dash)"
+# One task per line is the listing's whole shape: the second line of a docstring
+# would land in the name column and read as a task of its own.
+echo "$out" | grep -q "^multi *first line$" \
+  && check "tasks prints a doc's first line" "yes" "yes" || check "tasks prints a doc's first line" "yes" "no"
+echo "$out" | grep -q "second line of the doc" \
+  && check "tasks drops a doc's later lines" "dropped" "printed" || check "tasks drops a doc's later lines" "dropped" "dropped"
 
 # --- run <task> --------------------------------------------------------------
 

--- a/jolt-core/jolt/completions.clj
+++ b/jolt-core/jolt/completions.clj
@@ -1,0 +1,322 @@
+(ns jolt.completions
+  "`jolt completions` — shell completion for jolt's own commands and a project's
+  tasks.
+
+    jolt completions zsh    # the function to source, for zsh / bash / fish
+    jolt completions tasks  # name<TAB>doc per listable task, for that function
+
+  The split between those two is the whole design, and it is a departure from
+  babashka, which calls its binary back on every TAB press to compute the
+  candidates for the line so far.
+
+  Jolt cannot afford that. Its floor is the Chez runtime coming up, about 0.22s
+  whatever it is asked for, and `jolt version` costs the same as `jolt tasks`.
+  A quarter of a second between pressing TAB and seeing anything is the
+  difference between completion that feels instant and completion that feels
+  broken, and no amount of care inside the process removes it.
+
+  So the two halves are split by how often they change. jolt's own commands and
+  options change when the binary does, so they are baked into the snippet at the
+  moment it is generated and cost nothing afterwards. A project's tasks change
+  when its deps.edn or bb.edn changes, so the snippet caches them against those
+  two mtimes and calls back only when one of them moves. A warm press reads a
+  small file, and jolt does not run at all."
+  (:require [jolt.tasks :as tasks]))
+
+;; --- what jolt itself answers to ---------------------------------------------
+
+;; Baked into a generated snippet, so this list is as current as the binary that
+;; generated it and costs a completing shell nothing. Kept beside main's usage
+;; text: a command that appears in one and not the other is a bug in whichever
+;; was edited alone.
+(def ^:private commands
+  [["repl"         "start a REPL"]
+   ["nrepl-server" "start an nREPL server (default 7888) for editors"]
+   ["run"          "load a file, or run -m NS"]
+   ["build"        "compile a standalone binary or shared library"]
+   ["path"         "print the resolved source roots"]
+   ["tasks"        "list the project's bb.edn/deps.edn :tasks"]
+   ["completions"  "print a shell completion snippet"]
+   ["help"         "print usage"]
+   ["version"      "print the jolt version"]])
+
+(def ^:private options
+  [["-e"         "evaluate EXPR and print the result"]
+   ["-m"         "resolve deps.edn, load NS, call its -main"]
+   ["-f"         "load FILE, whose name may be a command or a task"]
+   ["-M"         "run an alias's :main-opts"]
+   ["-A"         "add an alias's paths and deps"]
+   ["-X"         "invoke an alias's :exec-fn"]
+   ["-T"         "like -X, with the project's paths replaced"]
+   ["-P"         "fetch every dependency, then stop"]
+   ["-Spath"     "print the resolved source roots"]
+   ["-Stree"     "print the dependency tree"]
+   ["-Strace"    "write the dep expansion to trace.edn"]
+   ["-Sdescribe" "print the environment as an edn map"]
+   ["-Sdeps"     "merge an extra deps.edn map"]
+   ["-Scp"       "run against these roots, expanding no deps"]
+   ["-Srepro"    "ignore the user deps.edn"]
+   ["-Sverbose"  "print where deps are read from"]])
+
+;; --- the dynamic half --------------------------------------------------------
+
+;; The commands a task can take the name of. jolt.main dispatches a built-in
+;; ahead of a task of the same name unless the task sets :override-builtin, and
+;; this set has to be the one main checks — a name here that main does not guard
+;; would hide a task that actually runs.
+(def ^:private overridable
+  #{"run" "repl" "nrepl-server" "path" "build" "tasks" "completions"})
+
+(defn task-lines
+  "One line per listable task: `name<TAB>doc`, or the bare name when it has no
+  :doc. This is the only part a completing shell has to ask jolt for, and it
+  goes through jolt.tasks/listable so that TAB and `jolt tasks` agree on which
+  tasks exist.
+
+  A task that shares a built-in's name is dropped unless it wins that name,
+  because a completion's description is a promise about what the word will do.
+  `jolt tasks` is a list of what the project defines and lists such a task
+  either way; this is a list of what typing the word gets you, and for a task
+  that loses to a built-in the answer is the built-in. The snippet offers what
+  comes back here BEFORE its own baked-in commands, so an overriding task's
+  description is the one that survives the shell's de-duplication."
+  [tasks]
+  (for [[k v] (tasks/listable tasks)
+        :when (or (not (overridable (str k)))
+                  (and (map? v) (:override-builtin v)))]
+    (if-let [doc (tasks/doc-line v)]
+      (str k \tab doc)
+      (str k))))
+
+;; --- the snippets ------------------------------------------------------------
+
+;; clojure.string is not required here on purpose: jolt-core is baked into the
+;; seed and jolt.tasks avoids the dependency for the same reason, so two small
+;; escapers are cheaper than pulling the namespace in for them.
+
+(defn- esc-sq
+  "For inside a single-quoted shell word: a quote closes, escapes and reopens."
+  [s]
+  (apply str (mapcat #(if (= % \') [\' \\ \' \'] [%]) (str s))))
+
+(defn- esc-fish
+  "For inside a single-quoted fish word, where a backslash escapes."
+  [s]
+  (apply str (mapcat #(if (= % \') [\\ \'] [%]) (str s))))
+
+(defn- pairs->sh
+  "A shell array literal of `name<TAB>doc` rows, single-quoted. A description is
+  ours and holds no quote today, but a task's :doc is a project's text, so the
+  same escaping is applied to both rather than only where it currently matters."
+  [pairs]
+  (->> pairs
+       (map (fn [[n d]] (str "'" (esc-sq n) \tab (esc-sq d) "'")))
+       (interpose " ")
+       (apply str)))
+
+(defn- zsh [prog cmds opts]
+  (str "#compdef " prog "\n"
+       "# Generated by `" prog " completions zsh`. jolt's own commands are baked in\n"
+       "# below; a project's tasks are fetched once per change to its deps.edn or\n"
+       "# bb.edn and cached, because jolt costs ~0.22s to start and a completing\n"
+       "# shell must not pay that on every press.\n"
+       "\n"
+       "_jolt_cached_tasks() {\n"
+       "  local dir=$PWD stamp cache key\n"
+       "  [[ -f $dir/deps.edn || -f $dir/bb.edn ]] || return 0\n"
+       "  # zsh/stat reads an mtime without forking; the fallback is for a zsh\n"
+       "  # built without the module.\n"
+       "  if zmodload -F zsh/stat b:zstat 2>/dev/null; then\n"
+       "    local -a s\n"
+       "    zstat -A s +mtime $dir/deps.edn 2>/dev/null && stamp+=$s[1]\n"
+       "    zstat -A s +mtime $dir/bb.edn   2>/dev/null && stamp+=:$s[1]\n"
+       "  else\n"
+       "    stamp=$(stat -f %m $dir/deps.edn $dir/bb.edn 2>/dev/null ||\n"
+       "            stat -c %Y $dir/deps.edn $dir/bb.edn 2>/dev/null)\n"
+       "  fi\n"
+       "  cache=${XDG_CACHE_HOME:-$HOME/.cache}/jolt/completion\n"
+       "  key=$cache/${${dir//\\//%}//:/%%}\n"
+       "  if [[ -z $JOLT_COMPLETION_NO_CACHE && -r $key ]]; then\n"
+       "    local -a c=(\"${(@f)$(<$key)}\")\n"
+       "    if [[ $c[1] == $stamp ]]; then print -l -- \"${(@)c[2,-1]}\"; return 0; fi\n"
+       "  fi\n"
+       "  local out; out=$(" prog " completions tasks 2>/dev/null) || return 0\n"
+       "  print -r -- $out\n"
+       "  if [[ -z $JOLT_COMPLETION_NO_CACHE ]] && mkdir -p $cache 2>/dev/null; then\n"
+       "    print -r -- $stamp$'\\n'$out > $key 2>/dev/null\n"
+       "  fi\n"
+       "}\n"
+       "\n"
+       "_jolt() {\n"
+       "  local -a commands=(" (pairs->sh cmds) ")\n"
+       "  local -a options=(" (pairs->sh opts) ")\n"
+       "  local -a described bare\n"
+       "  local l v d\n"
+       "  # _describe eats a backslash and splits `value:description` at the first\n"
+       "  # colon, so both characters are escaped in both halves. Task names carry\n"
+       "  # colons routinely (build:linux, release:macos); unescaped, such a name is\n"
+       "  # truncated at the colon and vanishes behind the command it then collides\n"
+       "  # with.\n"
+       "  _jolt_add() {\n"
+       "    v=${1%%$'\\t'*}; d=; [[ $1 == *$'\\t'* ]] && d=${1#*$'\\t'}\n"
+       "    v=${v//\\\\/\\\\\\\\}; v=${v//:/\\\\:}\n"
+       "    d=${d//\\\\/\\\\\\\\}; d=${d//:/\\\\:}\n"
+       "    if [[ -n $d ]]; then described+=(\"$v:$d\"); else bare+=(\"$v\"); fi\n"
+       "  }\n"
+       "\n"
+       "  case ${words[CURRENT-1]} in\n"
+       "    -f|--file|-o) _files; return ;;\n"
+       "    -e|-m|-Sdeps|-Scp|--target) _message 'value'; return ;;\n"
+       "  esac\n"
+       "\n"
+       "  if (( CURRENT == 2 )); then\n"
+       "    if [[ ${words[CURRENT]} == -* ]]; then\n"
+       "      for l in $options; do _jolt_add $l; done\n"
+       "    else\n"
+       ;; Tasks first, then any command a task has NOT taken the name of.
+       ;; Dropping the command explicitly rather than letting the two candidates
+       ;; collide: _describe does not keep the first of a repeated value, so
+       ;; with both present the command's description is what shows, on the one
+       ;; name where the task is what actually runs. A task only reaches here
+       ;; with a command's name when it wins that name.
+       "      local -A taken\n"
+       "      for l in ${(f)\"$(_jolt_cached_tasks)\"}; do\n"
+       "        [[ -n $l ]] || continue\n"
+       "        taken[${l%%$'\\t'*}]=1\n"
+       "        _jolt_add $l\n"
+       "      done\n"
+       "      for l in $commands; do\n"
+       "        [[ -n ${taken[${l%%$'\\t'*}]} ]] && continue\n"
+       "        _jolt_add $l\n"
+       "      done\n"
+       "    fi\n"
+       "    (( $#described )) && _describe -t commands 'jolt' described\n"
+       "    (( $#bare )) && _describe -t commands 'jolt' bare\n"
+       "    _files\n"
+       "    return\n"
+       "  fi\n"
+       "\n"
+       "  case ${words[2]} in\n"
+       "    run)\n"
+       "      if (( CURRENT == 3 )); then\n"
+       "        for l in ${(f)\"$(_jolt_cached_tasks)\"}; do [[ -n $l ]] && _jolt_add $l; done\n"
+       "        (( $#described )) && _describe -t commands 'task' described\n"
+       "        (( $#bare )) && _describe -t commands 'task' bare\n"
+       "      fi\n"
+       "      _files ;;\n"
+       "    completions)\n"
+       "      (( CURRENT == 3 )) && _describe -t commands 'shell' \\\n"
+       "        '(zsh:a\\ zsh\\ completion\\ function bash:a\\ bash\\ completion\\ function"
+       " fish:a\\ fish\\ completion tasks:name/doc\\ lines\\ for\\ a\\ snippet)' ;;\n"
+       "    build)\n"
+       "      _arguments '-m[entry namespace]:namespace:' '-o[output path]:output:_files' \\\n"
+       "        '--opt[optimized build]' '--dev[development build]' \\\n"
+       "        '--no-direct-link[disable direct linking]' '--dynamic[link dynamically]' \\\n"
+       "        '--tree-shake[drop unreachable code]' '--library[build a shared object]' \\\n"
+       "        '--target[cross-compile for a Chez machine]:machine:' \\\n"
+       "        '--target-pack[support directory]:dir:_files -/' ;;\n"
+       "    tasks|path|version|help|repl) ;;\n"
+       "    nrepl-server) (( CURRENT == 3 )) && _message 'port' ;;\n"
+       "    *) _files ;;\n"
+       "  esac\n"
+       "}\n"
+       "\n"
+       ;; Both ways of installing this have to work, and they need opposite
+       ;; endings. Sourced from .zshrc, the file defines _jolt and then has to
+       ;; register it with compdef. Saved as _jolt on fpath, zsh autoloads it at
+       ;; the first press and runs the FILE ITSELF as the function body, so a
+       ;; file that only defines _jolt completes nothing: the definition lands
+       ;; and the press that caused it returns no candidates. zsh_eval_context
+       ;; names the case.
+       "\n# Sourced, this registers the function. Autoloaded off fpath, the file\n"
+       "# IS the function body and has to call it, or the press that triggered\n"
+       "# the load completes nothing.\n"
+       "if [[ ${zsh_eval_context[-1]} == loadautofunc ]]; then\n"
+       "  _jolt \"$@\"\n"
+       "else\n"
+       "  compdef _jolt " prog "\n"
+       "fi\n"))
+
+(defn- bash [prog cmds opts]
+  (str "# Generated by `" prog " completions bash`. Source it from ~/.bashrc.\n"
+       "# bash shows no description column, so only names are offered here.\n"
+       "_jolt_cached_tasks() {\n"
+       "  [ -f deps.edn ] || [ -f bb.edn ] || return 0\n"
+       "  local stamp cache key\n"
+       "  stamp=$(stat -f %m deps.edn bb.edn 2>/dev/null || stat -c %Y deps.edn bb.edn 2>/dev/null)\n"
+       "  cache=\"${XDG_CACHE_HOME:-$HOME/.cache}/jolt/completion\"\n"
+       "  key=\"$cache/$(printf '%s' \"$PWD\" | cksum | tr -d ' ')\"\n"
+       "  if [ -z \"${JOLT_COMPLETION_NO_CACHE:-}\" ] && [ -r \"$key\" ] &&\n"
+       "     [ \"$(head -n 1 \"$key\")\" = \"$stamp\" ]; then\n"
+       "    tail -n +2 \"$key\"; return 0\n"
+       "  fi\n"
+       "  local out; out=$(" prog " completions tasks 2>/dev/null) || return 0\n"
+       "  printf '%s\\n' \"$out\"\n"
+       "  if [ -z \"${JOLT_COMPLETION_NO_CACHE:-}\" ] && mkdir -p \"$cache\" 2>/dev/null; then\n"
+       "    { printf '%s\\n' \"$stamp\"; printf '%s\\n' \"$out\"; } > \"$key\" 2>/dev/null\n"
+       "  fi\n"
+       "}\n"
+       "\n"
+       "_jolt_completions() {\n"
+       "  local cur prev commands options tasks\n"
+       "  COMPREPLY=()\n"
+       "  cur=\"${COMP_WORDS[COMP_CWORD]}\"\n"
+       "  prev=\"${COMP_WORDS[COMP_CWORD-1]}\"\n"
+       "  commands=\"" (->> cmds (map first) (interpose " ") (apply str)) "\"\n"
+       "  options=\"" (->> opts (map first) (interpose " ") (apply str)) "\"\n"
+       "  case \"$prev\" in\n"
+       "    -f|--file|-o|--target-pack) COMPREPLY=( $(compgen -f -- \"$cur\") ); return 0 ;;\n"
+       "    -e|-m|-Sdeps|-Scp|--target) return 0 ;;\n"
+       "  esac\n"
+       "  if [ \"$COMP_CWORD\" -eq 1 ]; then\n"
+       "    if [ \"${cur#-}\" != \"$cur\" ]; then\n"
+       "      COMPREPLY=( $(compgen -W \"$options\" -- \"$cur\") )\n"
+       "    else\n"
+       "      tasks=$(_jolt_cached_tasks | cut -f1)\n"
+       ;; awk drops a repeat: a task that has taken a command's name is in both
+       ;; lists, and bash would offer the word twice.
+       "      COMPREPLY=( $(compgen -W \"$tasks $commands\" -- \"$cur\" | awk '!seen[$0]++') )\n"
+       "    fi\n"
+       "    return 0\n"
+       "  fi\n"
+       "  case \"${COMP_WORDS[1]}\" in\n"
+       "    run) tasks=$(_jolt_cached_tasks | cut -f1)\n"
+       "         COMPREPLY=( $(compgen -W \"-m -f --file --parallel $tasks\" -- \"$cur\") ) ;;\n"
+       "    completions) COMPREPLY=( $(compgen -W \"zsh bash fish tasks\" -- \"$cur\") ) ;;\n"
+       "    build) COMPREPLY=( $(compgen -W \"-m -o --opt --dev --no-direct-link --dynamic\n"
+       "                                     --tree-shake --library --target --target-pack\" -- \"$cur\") ) ;;\n"
+       "    tasks|path|version|help|repl) ;;\n"
+       "    *) COMPREPLY=( $(compgen -f -- \"$cur\") ) ;;\n"
+       "  esac\n"
+       "  return 0\n"
+       "}\n"
+       "complete -o default -F _jolt_completions " prog "\n"))
+
+(defn- fish [prog cmds _opts]
+  (str "# Generated by `" prog " completions fish`. Save under\n"
+       "# ~/.config/fish/completions/" prog ".fish\n"
+       "# fish caches per shell session, so a task added mid-session needs a new one.\n"
+       "function __jolt_tasks\n"
+       "  if not set -q __jolt_tasks_cache\n"
+       "    set -g __jolt_tasks_cache (" prog " completions tasks 2>/dev/null)\n"
+       "  end\n"
+       "  for l in $__jolt_tasks_cache\n"
+       "    echo $l\n"
+       "  end\n"
+       "end\n"
+       "complete -c " prog " -f -n '__fish_is_first_arg' -a '(__jolt_tasks)'\n"
+       (apply str
+              (for [[n d] cmds]
+                (str "complete -c " prog " -f -n '__fish_is_first_arg' -a '" n "' -d '"
+                     (esc-fish d) "'\n")))))
+
+(defn snippet
+  "The completion function for `shell`, as text."
+  [shell prog]
+  (case shell
+    "zsh"  (zsh prog commands options)
+    "bash" (bash prog commands options)
+    "fish" (fish prog commands options)
+    (throw (ex-info (str "unknown shell for completions: " shell
+                         " (want zsh, bash or fish)")
+                    {:shell shell}))))

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -617,6 +617,20 @@
 (defn- cmd-tasks []
   ((requiring-resolve 'jolt.tasks/list-tasks!) (deps/project-tasks (project-dir))))
 
+;; `jolt completions <shell>` prints the function to source; `completions tasks`
+;; prints the name/doc lines that function asks for when a project's config
+;; changes. Both read the config files only, like cmd-tasks and for the same
+;; reason: a completing shell must not be the thing that discovers your deps
+;; don't resolve.
+(defn- cmd-completions [more]
+  (let [what (first more)]
+    (case what
+      nil (throw (ex-info "completions needs a shell: zsh, bash, fish, or tasks" {}))
+      "tasks" (run! println
+                    ((requiring-resolve 'jolt.completions/task-lines)
+                     (deps/project-tasks (project-dir))))
+      (print ((requiring-resolve 'jolt.completions/snippet) what "jolt")))))
+
 ;; babashka's :override-builtin — a task only displaces the jolt command of the
 ;; same name when it says so. Checked from the :tasks maps directly, so it costs
 ;; a small file read rather than loading the task runner on every command.
@@ -847,6 +861,9 @@
   (println "                         (see tools/cross-compile)")
   (println "  path                   print the resolved source roots")
   (println "  tasks                  list the project's bb.edn/deps.edn :tasks")
+  (println "  completions SHELL      print a completion function to source, for")
+  (println "                         zsh, bash or fish; `completions tasks` prints")
+  (println "                         the name/doc lines that function asks for")
   (println "  <task> [args]          run a task (`run <task>` and `run --parallel")
   (println "                         <task>` do the same)")
   (println "  help, --help, -h       print this message")
@@ -955,7 +972,7 @@
       ;; (babashka's :override-builtin). Checked here, after the two commands
       ;; that read no project at all, so it costs nothing a command doesn't
       ;; already pay: everything below resolves the project anyway.
-      (and (#{"run" "repl" "nrepl-server" "path" "build" "tasks"} cmd)
+      (and (#{"run" "repl" "nrepl-server" "path" "build" "tasks" "completions"} cmd)
            (builtin-overridden? cmd))
       (run-task cmd more false)
 
@@ -964,6 +981,7 @@
       (= cmd "nrepl-server")             (nrepl more)
       (= cmd "path")                     (cmd-path)
       (= cmd "tasks")                    (cmd-tasks)
+      (= cmd "completions")              (cmd-completions more)
       ;; -Sdeps '<edn>' — an extra deps.edn map merged last into the chain,
       ;; bound around the re-dispatch of the remaining argv.
       (= cmd "-Sdeps")

--- a/jolt-core/jolt/tasks.clj
+++ b/jolt-core/jolt/tasks.clj
@@ -244,28 +244,44 @@
   [s]
   (apply str (take-while #(not= \newline %) s)))
 
-(defn list-tasks!
-  "`jolt tasks` — the project's task names and their :doc, babashka's listing.
-  Two kinds of task stay out of it, both of them helpers for other tasks:
+(defn listable
+  "The entries a listing offers, sorted by name. Two kinds of task stay out,
+  both of them helpers for other tasks rather than things to pick off a list:
   a :private one, and one whose name starts with `-`, which is babashka's
   spelling of the same intent and reaches us through the bb.edn files we read.
-  Only the first line of a :doc is printed, because the listing's whole shape is
-  one task per line: a docstring's second line would otherwise sit in the name
-  column and read as a task of its own."
+  Neither is unrunnable — `jolt -dash` works — they are only unlisted.
+
+  `jolt tasks` and shell completion both go through here, so that what a person
+  is shown and what TAB offers cannot drift apart."
   [tasks]
-  (let [entries (->> (tasks-of tasks)
-                     (remove (fn [[k v]]
-                               (or (and (map? v) (:private v))
-                                   (= \- (first (str k))))))
-                     (sort-by (comp str key)))]
+  (->> (tasks-of tasks)
+       (remove (fn [[k v]]
+                 (or (and (map? v) (:private v))
+                     (= \- (first (str k))))))
+       (sort-by (comp str key))))
+
+(defn doc-line
+  "The one line of :doc a listing shows for a task's value, or nil."
+  [v]
+  (when-let [d (and (map? v) (:doc v))]
+    (first-line d)))
+
+(defn list-tasks!
+  "`jolt tasks` — the project's task names and their :doc, babashka's listing.
+  What is listed and what is hidden is `listable`. Only the first line of a
+  :doc is printed, because the listing's whole shape is one task per line: a
+  docstring's second line would otherwise sit in the name column and read as a
+  task of its own."
+  [tasks]
+  (let [entries (listable tasks)]
     (if (empty? entries)
       (println "No tasks found. Add a :tasks map to bb.edn or deps.edn.")
       (let [w (apply max (map (comp count str key) entries))]
         (println "The following tasks are available:")
         (println)
         (doseq [[k v] entries]
-          (let [doc (when (map? v) (:doc v))]
+          (let [doc (doc-line v)]
             (println (if doc
                        (str (apply str k (repeat (- w (count (str k))) \space))
-                            "  " (first-line doc))
+                            "  " doc)
                        (str k)))))))))

--- a/jolt-core/jolt/tasks.clj
+++ b/jolt-core/jolt/tasks.clj
@@ -238,12 +238,25 @@
 
 ;; --- the listing -------------------------------------------------------------
 
+(defn- first-line
+  "Everything before the first newline. A listing is one task per line, so a
+  docstring that spans lines has to be cut to fit it — see list-tasks!."
+  [s]
+  (apply str (take-while #(not= \newline %) s)))
+
 (defn list-tasks!
   "`jolt tasks` — the project's task names and their :doc, babashka's listing.
-  :private tasks are helpers for other tasks and stay out of it."
+  Two kinds of task stay out of it, both of them helpers for other tasks:
+  a :private one, and one whose name starts with `-`, which is babashka's
+  spelling of the same intent and reaches us through the bb.edn files we read.
+  Only the first line of a :doc is printed, because the listing's whole shape is
+  one task per line: a docstring's second line would otherwise sit in the name
+  column and read as a task of its own."
   [tasks]
   (let [entries (->> (tasks-of tasks)
-                     (remove (fn [[_ v]] (and (map? v) (:private v))))
+                     (remove (fn [[k v]]
+                               (or (and (map? v) (:private v))
+                                   (= \- (first (str k))))))
                      (sort-by (comp str key)))]
     (if (empty? entries)
       (println "No tasks found. Add a :tasks map to bb.edn or deps.edn.")
@@ -253,5 +266,6 @@
         (doseq [[k v] entries]
           (let [doc (when (map? v) (:doc v))]
             (println (if doc
-                       (str (apply str k (repeat (- w (count (str k))) \space)) "  " doc)
+                       (str (apply str k (repeat (- w (count (str k))) \space))
+                            "  " (first-line doc))
                        (str k)))))))))

--- a/llms.txt
+++ b/llms.txt
@@ -67,6 +67,10 @@ and on a stale entry.
 - `jolt FILE [args]`: run a file; with a `#!/usr/bin/env jolt` first line and an
   exec bit it is a script (`./tool arg`). `-f FILE` when the name is also a
   command or a task. `make scriptsmoke` gates it.
+- `jolt completions zsh|bash|fish`: a shell completion function to source, so
+  `jolt <TAB>` offers jolt's commands and the project's tasks.
+  `jolt completions tasks` is the machine-readable listing it calls back for,
+  one `name<TAB>doc` per listable task. `make completionssmoke` gates it.
 - `make test`: the full gate. Individual gates: `corpus`, `unit`, `selfhost`,
   `smoke`, `sci`, `ffi`, `transient`, `certify`, `libconformance`.
 - `make remint`: re-mint the bootstrap seed to a byte-fixpoint. Required after

--- a/test/chez/tasks/bbproj/bb.edn
+++ b/test/chez/tasks/bbproj/bb.edn
@@ -15,6 +15,12 @@
   boom   {:doc "fail with 7" :task (shell "sh" "-c" "exit 7")}
   nested {:task (do (println "before") (run 'clean) (println "after"))}
   secret {:private true :task (println "secret")}
+  ;; babashka's other spelling of "helper, not an entry point": a leading dash.
+  ;; Hidden from the listing like :private, and runnable like it too.
+  -dash  {:doc "a dash-named helper" :task (println "dash ran")}
+  ;; a :doc that spans lines. The listing is one task per line, so only the
+  ;; first may reach it.
+  multi  {:doc "first line\nsecond line of the doc" :task (println "multi")}
   needs  {:requires ([bbproj.core :as c]) :task (println (c/hello))}
   helper {:requires ([helper]) :task (println (helper/help))}
   echo   {:task (shell "echo" "from-shell")}


### PR DESCRIPTION
Closes #878.

`jolt <TAB>` offers nothing today, in any shell — greps for `compgen`,
`COMP_WORDS`, `--completions` and `_jolt` across the tree come back empty. This
adds `jolt completions zsh` (or `bash`, or `fish`), which prints a function to
source. Under zsh each task carries its `:doc` as the description.

> **Stacked on #875.** This branch contains that commit, because the completion
> depends on its `:doc` truncation: without it a multi-line docstring puts a
> phantom name in the candidate list. Merge #875 first and this shrinks to its
> own commit. Happy to rebase if you'd rather it stood alone.

### The design is not babashka's, and that is the part worth your eye

The obvious move is to copy babashka, which since 1.13.219 emits a zsh function
that calls `bb` back on **every TAB press** to compute candidates for the line
so far.

That doesn't port, because of startup. Measured here, release binary, five runs:

| command | real |
|---|---|
| `jolt version` (resolves no project at all) | 0.21-0.22s |
| `jolt -e '(println 1)'` | 0.22-0.24s |
| `jolt tasks` | 0.21-0.27s |

The floor is the runtime coming up, not a project resolving — which is why
`version` costs what `tasks` costs. A per-press callback therefore puts about a
quarter second between TAB and the first candidate. For scale, `bb tasks`
measures 97ms on this machine, and babashka is the tool whose design this would
be copying.

So the two halves are split by how often they change:

- **jolt's own commands and options change when the binary does**, so they are
  baked into the snippet as it is generated, and cost a completing shell nothing.
- **A project's tasks change when its `deps.edn` or `bb.edn` changes**, so the
  snippet caches them against those two mtimes and calls back only when one moves.

Under zsh that path uses `zsh/stat` and `$(<file)` and forks no process at all.
A warm press measures **0.4ms**. `JOLT_COMPLETION_NO_CACHE=1` bypasses it.

I saw #874 while checking this was still current, so the 0.22s figure is a
number you are actively working on. The split doesn't depend on it: 0.4ms beats
any process spawn by orders of magnitude, and a faster cold start makes the
cache-miss path cheaper rather than making the design wrong. It does mean the
paragraph above should be read as "as of 92fef2ce".

The cost of the split is that per-task **argument** completion is out of reach,
since that genuinely needs the line. jolt has no per-task option metadata today
(babashka gets it from `:exec-fn`/`:cmd` through `babashka.cli`), so there is
nothing to offer yet, and nothing here forecloses a line-aware callback later.

**One design question I'd want your call on:** whether `completions` should be a
command at all, or whether the snippets belong in `share/` as files the
installer places. I went with the command because it needs no install-path
handling and works the same from a Homebrew install, the curl installer, or a
checkout — but it is your call and I'll rework it.

### `jolt completions tasks`

The callback, and useful alone: one `name<TAB>doc` per listable task, the
machine-readable form of what `jolt tasks` writes for a person. Both go through
the new `jolt.tasks/listable`, so the listing and TAB cannot disagree about
which tasks exist.

They differ on one point by intent. A task sharing a built-in's name is offered
only when it wins that name with `:override-builtin`, and the snippet drops the
command it displaced. A description is a promise about what the word will do,
and for a task that loses to a command the answer is the command.

### Three bugs found by running a real zsh, not by reading the output

None is visible to `zsh -n`:

- A file saved as `_jolt` on `$fpath` is **autoloaded**, and zsh runs the FILE
  as the function body. A snippet that only defines `_jolt` completes nothing on
  the press that loaded it. It checks `zsh_eval_context` now and either calls the
  function or registers it with `compdef`, so sourcing and fpath both work.
- `_describe` splits `value:description` at the first colon and eats
  backslashes, so both are escaped in both halves. Task names carry colons
  routinely (`build:linux`, `release:macos`); unescaped, such a name is cut at
  the colon and vanishes behind the command it then collides with.
- `_describe` does **not** keep the first of a repeated value, so offering both
  a task and the command it overrides showed the command's description on the
  one name where the task is what runs. Dropping the displaced command
  explicitly is the fix; ordering is not.

That third one survived a green gate, which is why the gate grew a group that
sources the generated zsh function with `_describe` stubbed and reads the
candidates back. bash has no description column, so a candidate carrying the
wrong description was invisible to every check that existed at the time.

### Gates

```
make completionssmoke   24 passed, 0 failed
make taskssmoke         60 passed, 0 failed
make scriptsmoke        33 passed, 0 failed
```

Run against `target/release/jolt`, not source mode.

Also confirmed by hand in two unrelated projects: one with 40-odd tasks,
several colon-named, one carrying `:override-builtin`; and one with a plain
seven-task `bb.edn`. Both offer jolt's commands and their own tasks correctly.

### One note for anyone adding a jolt-core namespace

`jolt.completions` had to go into `host/chez/stdlib-fasl-manifest.txt`. Source
mode runs happily without the entry and only `make build` rejects it, so three
green gate runs said nothing about it.

Verified against `main` at 92fef2ce (v0.8.4) on 2026-09-07, macOS arm64.
