### PR TITLE
Prune prelude defs that carry a source registration, and gate that the shake ran

### DIFF
--- a/host/chez/dce.ss
+++ b/host/chez/dce.ss
@@ -166,6 +166,32 @@
 (define (dce-app-refs ir str)
   (append (dce-collect-refs '() ir) (dce-sexp-refs-str str)))
 
+;; The (def-var! "ns" "name" …) / (def-var-with-meta! …) form a prelude record
+;; defines, or #f for a non-def form. A def whose value holds an anonymous fn
+;; literal is minted as (begin (let* <quote pool> (image-register-fn-form! …)…)
+;; (def-var…)) — the source registration first, then the def — so look through
+;; exactly that shape. Read as a non-def form, every such def (138 of the 685
+;; prelude defs) was an unprunable root, and two of them, clojure.repl/find-doc
+;; and apropos, reference all-ns, ns-interns and ns-publics: every --tree-shake
+;; build bailed from the commit that made core's literals register (7d11cfed,
+;; 0.7.29), whatever the app did.
+;; Any other begin (a defrecord's several defs, a def-var-plain! group) stays a
+;; keep form as before: a record carries one fqn, and pruning several defs
+;; under one of their names is unsound.
+(define (dce-def-var-form b)
+  (define (def-var-form? x)
+    (and (pair? x) (memq (car x) '(def-var! def-var-with-meta!))
+         (pair? (cdr x)) (string? (cadr x))
+         (pair? (cddr x)) (string? (caddr x))))
+  (cond
+    ((def-var-form? b) b)
+    ((and (pair? b) (eq? (car b) 'begin)
+          (pair? (cdr b)) (pair? (cadr b)) (eq? (car (cadr b)) 'let*)
+          (pair? (cddr b)) (null? (cdddr b))
+          (def-var-form? (caddr b)))
+     (caddr b))
+    (else #f)))
+
 ;; str re-serializes the read form (compiled identically; comments/whitespace are
 ;; irrelevant).
 (define (dce-blob-records path)
@@ -190,12 +216,10 @@
                          "tree-shake: a prelude form does not round-trip through write/read"
                          (if (pair? form) (car form) form)))
                 (loop (cons
-                         (if (or (and (pair? b) (eq? (car b) 'def-var!) (pair? (cdr b)) (string? (cadr b))
-                                      (pair? (cddr b)) (string? (caddr b)))
-                                 (and (pair? b) (eq? (car b) 'def-var-with-meta!) (pair? (cdr b)) (string? (cadr b))
-                                      (pair? (cddr b)) (string? (caddr b))))
-                            (dce-rec #f (string-append (cadr b) "/" (caddr b)) refs str)
-                            (dce-rec #t #f refs str))
+                         (let ((d (dce-def-var-form b)))
+                           (if d
+                               (dce-rec #f (string-append (cadr d) "/" (caddr d)) refs str)
+                               (dce-rec #t #f refs str)))
                         acc)))))))))
 
 ;; A reader fn reached ONLY via runtime (read-string "#my/tag ..") resolves through

--- a/host/chez/run-dce-refs.ss
+++ b/host/chez/run-dce-refs.ss
@@ -175,6 +175,32 @@
           tw tc ratio)
   (gate-check "reachable: cost independent of work-list depth" (<= ratio 5.0) #t))
 
+;; --- dce-def-var-form: which prelude records are prunable ---------------------
+;; A def whose value holds an anonymous fn literal is minted with its source
+;; registration first, (begin (let* …) (def-var-with-meta! …)); it is a prunable
+;; def under that name like a bare def-var! is. Anything else stays a keep form:
+;; a defrecord's several defs under one begin (one record, several fqns), a
+;; def-var-plain! group, and a side-effecting top-level form.
+(let ((bare '(def-var! "app.core" "f" 1))
+      (meta '(def-var-with-meta! "clojure.repl" "find-doc" (lambda (x) x) (jolt-hash-map)))
+      (registered '(begin (let* ((_q$0 (jolt-symbol #f "fn*")))
+                            (image-register-fn-form! "jfn$clojure.repl$find-doc$0" _q$0 "clojure.repl" (jolt-vector)))
+                          (def-var-with-meta! "clojure.repl" "find-doc" (lambda (x) x) (jolt-hash-map))))
+      (record-group '(begin (begin (def-var-plain! "clojure.pprint" "nl-t" 1)
+                                   (def-var-plain! "clojure.pprint" "->nl-t" 2))
+                            (def-var-with-meta! "clojure.pprint" "make-nl-t" 3 (jolt-hash-map))
+                            (def-var-with-meta! "clojure.pprint" "nl-t?" 4 (jolt-hash-map))))
+      (side-effect '(jolt-invoke4 (var-deref "clojure.core" "attach-core-doc-meta!") "clojure.repl" "special-doc" jolt-nil jolt-nil)))
+  (gate-check "def-var-form: bare def-var! is its own def" (dce-def-var-form bare) bare)
+  (gate-check "def-var-form: bare def-var-with-meta! is its own def" (dce-def-var-form meta) meta)
+  (gate-check "def-var-form: registration then def is the def"
+              (dce-def-var-form registered) (caddr registered))
+  (gate-check "def-var-form: a defrecord group is not one def" (dce-def-var-form record-group) #f)
+  (gate-check "def-var-form: a side-effecting form is not a def" (dce-def-var-form side-effect) #f)
+  (gate-check "def-var-form: guard-unwrapped registration form"
+              (dce-def-var-form (dce-unwrap (list 'guard '(e (#t #f)) registered)))
+              (caddr registered)))
+
 ;; --- dce-bail-refs / dce-compile-refs existence gate -------------------------
 ;; Every name in the hand-maintained bail/compile lists must resolve to a runtime
 ;; binding. A stale entry (one that no longer exists in the runtime) fails here

--- a/host/chez/tree-shake-smoke.sh
+++ b/host/chez/tree-shake-smoke.sh
@@ -65,21 +65,46 @@ run_case() {
   echo "  - $1: ok (output identical; $((s0/1024))K -> $((s1/1024))K)"
 }
 
-# Same as run_case but looked up under the local test/chez/ directory, with
-# an optional flat.ss def-pruning assertion: if ASSERT_MISSING is set, grep
-# the --tree-shake .build dir for a "ns/def" string and fail if found.
+# Same as run_case but looked up under the local test/chez/ directory, with two
+# further checks. ASSERT_MISSING ($4): grep the --tree-shake .build dir for a
+# string and fail if found — a def the shake must have pruned. EXPECT ($5):
+# "shake" (the default) requires the shaken build to report `tree-shake kept`
+# and fails on `tree-shake skipped`, printing the offenders jolt named; "bail"
+# is for a fixture that resolves vars at runtime on purpose (ns-publics-app),
+# whose point is that the keep-everything fallback still answers identically.
+# Without the EXPECT check a bail passes this gate silently: it keeps every def,
+# so the outputs match by construction — which is how a prelude change that
+# bailed every --tree-shake build (0.7.29 to 0.8.4) went unnoticed here.
 # (The .build dir is the binary's build artifacts, kept alongside the binary.)
 run_local_case() {
-  app="$root/test/chez/$1"; ns="$2"; args="$3"; assert_missing="$4"
+  app="$root/test/chez/$1"; ns="$2"; args="$3"; assert_missing="$4"; expect="${5:-shake}"
   [ -d "$app" ] || { echo "  - $1: skipped (not present)"; return; }
   b0="$tmp/$1-plain"; b1="$tmp/$1-shake"
   bdir="$tmp/$1-shake.build"
   if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b0" >/dev/null 2>&1; then
     echo "  - $1: FAIL (default build)"; fail=1; return; fi
-  if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b1" --tree-shake 2>"$tmp/$1-shake-err"; then
+  if ! JOLT_PWD="$app" "$jolt" build -m "$ns" -o "$b1" --tree-shake >"$tmp/$1-shake-out" 2>"$tmp/$1-shake-err"; then
     echo "  - $1: FAIL (--tree-shake build)"
     cat "$tmp/$1-shake-err" | head -5
     fail=1; return; fi
+  case "$expect" in
+    shake)
+      if grep -q '^jolt build: tree-shake skipped' "$tmp/$1-shake-out"; then
+        echo "  - $1: FAIL (tree-shake skipped; the fixture must shake)"
+        sed -n '/^jolt build: tree-shake skipped/,/^jolt build: compiling/p' "$tmp/$1-shake-out" | grep -v '^jolt build: compiling' | head -8
+        fail=1; return
+      fi
+      if ! grep -q '^jolt build: tree-shake kept ' "$tmp/$1-shake-out"; then
+        echo "  - $1: FAIL (no 'tree-shake kept' report in the --tree-shake build output)"
+        fail=1; return
+      fi ;;
+    bail)
+      if ! grep -q '^jolt build: tree-shake skipped' "$tmp/$1-shake-out"; then
+        echo "  - $1: FAIL (expected the keep-everything bail; the shake ran)"
+        fail=1; return
+      fi ;;
+    *) echo "  - $1: FAIL (unknown EXPECT '$expect')"; fail=1; return ;;
+  esac
   o0="$(cd "$app" && "$b0" $args 2>&1)"
   o1="$(cd "$app" && "$b1" $args 2>&1)"
   if [ "$o0" != "$o1" ]; then
@@ -113,10 +138,15 @@ fi
 
 # Tree-shake correctness fixtures: apps whose output IDENTICAL default vs --tree-shake
 # verifies the fixes in jolt-2f87. The defonce-app additionally asserts a never-referenced
-# def ("app.core/dead") is absent from the shaken output.
+# def ("app.core/dead") is absent from the shaken output. The pattern names the var
+# without its def form: app defs are emitted as def-var-with-meta!, and a pattern
+# pinned to def-var! matched nothing, so the assertion passed against an unshaken
+# flat.ss for as long as the emitter has carried metadata.
+# ns-publics-app is the one fixture that must BAIL: it enumerates its namespace at
+# runtime, which the static graph cannot follow.
 echo "shake smoke: correctness fixtures (ns-publics, defonce, data-readers)"
-run_local_case ns-publics-app   app.core  ""   ""
-run_local_case defonce-app      app.core  ""   "def-var! \"app.core\" \"dead\""
+run_local_case ns-publics-app   app.core  ""   ""   bail
+run_local_case defonce-app      app.core  ""   "\"app.core\" \"dead\""
 run_local_case datareader-app   app.core  ""   ""
 # data-reader literal rewriting: a #tag whose reader returns a FORM must splice
 # identically under a plain and a --tree-shake build (the tree-shake path once


### PR DESCRIPTION
Every `jolt build --tree-shake` has bailed since 0.7.29, whatever the app:

```
jolt build: tree-shake skipped (reachable code resolves vars at runtime):
  clojure.repl/special-doc -> clojure.core/resolve
  <form> -> clojure.core/all-ns
  <form> -> clojure.core/ns-interns
  <form> -> clojure.core/all-ns
  <form> -> clojure.core/ns-publics
```

A bare `(ns hello.core)` with a println -main prints exactly that. The
`<form>` records are clojure.repl/find-doc and apropos. Both hold an anonymous
fn literal, so the mint emits each as

```
(begin (let* <quote pool> (image-register-fn-form! "jfn$clojure.repl$find-doc$0" …))
       (def-var-with-meta! "clojure.repl" "find-doc" …))
```

— the source registration first, then the def — and dce-blob-records only
recognises a record whose unwrapped body IS a def-var! form. Everything else
is a keep form, and a keep form's references are roots. 138 of the 685
prelude defs have this shape; find-doc and apropos are the two whose bodies
reference all-ns, ns-interns and ns-publics (and special-doc, which calls
resolve). They were ported in 0.7.21 (bf2934f9) as plain, prunable defs; the
registration siblings arrived when core's literals began to register
(7d11cfed, 0.7.29), and from that commit the roots have reached the bail set
before the app's own graph was consulted.

dce-def-var-form looks through exactly that (begin (let* …) (def-var…))
shape and nothing else: a defrecord's several defs under one begin, or a
def-var-plain! group, stay keep forms, because a record carries one fqn and
pruning several defs under one of their names is unsound.

The shake smoke did not catch this, for two reasons, both fixed here:

- it compares the plain and the shaken binary's output, and a bail keeps
  every def, so the outputs match by construction. run_local_case now reads
  the shaken build's report and requires `tree-shake kept` for a fixture
  that must shake, printing the offenders when it was skipped instead;
  ns-publics-app, whose point is the bail, is declared as such.
- defonce-app's pruned-def assertion grepped `def-var! "app.core" "dead"`,
  and app defs are emitted as def-var-with-meta!, so the assertion matched
  nothing against an unshaken flat.ss and passed. It names the var without
  its def form now, and with the fix above it holds for real.

run-dce-refs.ss pins the record shapes dce-def-var-form accepts and rejects.

dce-refs gate: 52/52. shakelocal (bin/jolt): every fixture but ns-publics-app
now shakes, 24.9M -> 18.5M each; ns-publics-app bails as it must. A hello
world builds `tree-shake kept 238 of 681 defs` and drops the compiler image.

---
One of four independent jolt changes that together let a real app tree-shake again on 0.8.4 — a `jolt.fs` + `jolt-lang/time` + core.async-via-ring-chez app whose `--tree-shake` build now reports `kept 2629 of 3316 defs` and drops the compiler image. Each stands alone and they merge cleanly in any order:

- #881 — prune prelude defs that carry a source registration, and gate that the shake ran
- #882 — keep spliced callees out of the tree-shake bail scan
- #883 — fill `babashka.fs/list-dir` through its var, not `intern`
- #884 — install the java.time Instant ctor through a static host reference
- jolt-lang/time#14 — reference `jolt.host/register-extension!` statically
