### PR TITLE
Keep spliced callees out of the tree-shake bail scan

### DIFF
--- a/host/chez/dce.ss
+++ b/host/chez/dce.ss
@@ -236,7 +236,7 @@
 ;; --- the shake: graph -> reachable -> bail check -> partition ----------------
 ;; edges: fqn -> refs (prunable defs only). roots: -main + the runtime-core roots +
 ;; every non-def form's refs.
-;; A callee the inline pass spliced is a ROOT even when nothing calls it any more.
+;; A callee the inline pass spliced is KEPT even when nothing calls it any more.
 ;; Splicing removes the last reference to a fn whose every call site was inlined,
 ;; so the graph walk below would prune its def -- and the def's record carries the
 ;; (jolt-register-source! …) that maps an inlined frame back to ns/name
@@ -244,11 +244,20 @@
 ;; unshaken build printed three (jolt-o13s). The kept def is bounded by the inline
 ;; budget, so the size this costs is small and the alternative is a trace that
 ;; silently loses frames the same build shows without --tree-shake.
+;;
+;; Kept, but not a ROOT of the bail scan. A spliced callee that no remaining
+;; reference reaches is code that never runs: its call sites are all copies now.
+;; Rooting it treated its references as reachable code, so a helper the inline
+;; pass had spliced — core.async's go-macro walkers, which call `resolve` while
+;; expanding a go body — bailed the shake of a program that never expands a go
+;; form. dce-build-graph therefore returns the spliced set apart from the roots:
+;; dce-shake closes over roots alone for the bail scan, and over roots plus the
+;; spliced set for what the binary keeps, so a kept callee's load-time var
+;; lookups still find every def they name.
 ;; inline-spliced-fqns is host-contract.ss; loaded well before build.ss loads this.
 (define (dce-build-graph records entry-main)
   (let ((edges (make-hashtable string-hash string=?))
-        (roots (append (inline-spliced-fqns)
-                       (dce-data-reader-roots)
+        (roots (append (dce-data-reader-roots)
                        (cons entry-main dce-runtime-core-roots))))
     (for-each (lambda (r)
                 (if (dce-rec-keep? r)
@@ -257,7 +266,7 @@
                       (lambda (old) (append (dce-rec-refs r) old))
                       '())))
               records)
-    (values edges roots)))
+    (values edges roots (inline-spliced-fqns))))
 
 ;; Closure of roots over edges -> a reached set (hashtable fqn -> #t). The append
 ;; copies only the visited node's OWN edge list and shares (cdr work) — append
@@ -315,8 +324,14 @@
 ;; Returns (values core-strs app-strs drop-compiler?). core-strs is #f on a bail,
 ;; signalling "inline prelude.ss unshaken" + keep the compiler.
 (define (dce-shake core-records app-records entry-main)
-  (let-values (((edges roots) (dce-build-graph (append core-records app-records) entry-main)))
-    (let* ((reached (dce-reachable edges roots)))
+  (let-values (((edges roots spliced)
+                (dce-build-graph (append core-records app-records) entry-main)))
+    (let* ((reached (dce-reachable edges roots))
+           ;; what the binary keeps: the reachable code, plus the spliced
+           ;; callees kept for frame identity closed over what they reference
+           (kept (if (null? spliced)
+                     reached
+                     (dce-reachable edges (append spliced roots)))))
       (let-values (((bail why needs-compiler) (dce-bail-scan (append core-records app-records) reached)))
         (let ((drop-compiler? (and (not bail) (not needs-compiler))))
           (if bail
@@ -324,8 +339,8 @@
                 (display "jolt build: tree-shake skipped (reachable code resolves vars at runtime):\n")
                 (for-each (lambda (w) (display (string-append "  " (car w) " -> " (cdr w) "\n"))) why)
                 (values #f (map dce-rec-str app-records) drop-compiler?))
-              (let-values (((core-strs cn ck) (dce-partition core-records reached))
-                           ((app-strs an ak) (dce-partition app-records reached)))
+              (let-values (((core-strs cn ck) (dce-partition core-records kept))
+                           ((app-strs an ak) (dce-partition app-records kept)))
                 (display (string-append "jolt build: tree-shake kept " (number->string (+ ck ak))
                                         " of " (number->string (+ cn an)) " defs (core "
                                         (number->string ck) "/" (number->string cn) ")\n"))

--- a/host/chez/run-dce-refs.ss
+++ b/host/chez/run-dce-refs.ss
@@ -207,4 +207,34 @@
   (for-each (lambda (n) (gate-check (string-append "compile-ref exists: " n) #f #t))
             (missing dce-compile-refs "compile-refs")))
 
+;; --- spliced callees: kept for frame identity, not roots of the bail scan ----
+;; The inline pass records every callee it spliced (hc-mark-spliced!), and the
+;; shake keeps those defs so an inlined frame still maps back to ns/name. They are
+;; not reachable code — every call site is a copy — so a spliced helper that
+;; resolves a var by name must not bail the shake, while a def nothing reaches
+;; is still pruned and everything a kept callee names stays defined.
+(let* ((rec (lambda (fqn refs) (dce-rec #f fqn refs (string-append "(" fqn ")"))))
+       (app (list (rec "gate.app/-main" '("gate.app/live"))
+                  (rec "gate.app/live" '())
+                  ;; spliced everywhere it was called, so no record references it
+                  (rec "gate.app/walker" '("clojure.core/resolve" "gate.app/named-by-walker"))
+                  (rec "gate.app/named-by-walker" '())
+                  (rec "gate.app/dead" '()))))
+  (hc-mark-spliced! #f "gate.app" "walker")
+  (let-values (((core-strs app-strs drop-compiler?) (dce-shake '() app "gate.app/-main")))
+    (gate-check "spliced: a spliced resolve caller does not bail the shake" (and core-strs #t) #t)
+    (gate-check "spliced: the compiler image is dropped" drop-compiler? #t)
+    (gate-check "spliced: the entry and what it reaches are kept"
+                (and (member "(gate.app/-main)" app-strs) (member "(gate.app/live)" app-strs) #t) #t)
+    (gate-check "spliced: the spliced callee is kept for frame identity"
+                (and (member "(gate.app/walker)" app-strs) #t) #t)
+    (gate-check "spliced: what the kept callee names stays defined"
+                (and (member "(gate.app/named-by-walker)" app-strs) #t) #t)
+    (gate-check "spliced: an unreferenced def is still pruned"
+                (and (member "(gate.app/dead)" app-strs) #t) #f))
+  ;; the same graph with the walker genuinely reachable bails as before
+  (let-values (((core-strs app-strs drop-compiler?)
+                (dce-shake '() (cons (rec "gate.app/-main" '("gate.app/walker")) (cdr app)) "gate.app/-main")))
+    (gate-check "spliced: a reachable resolve caller still bails" core-strs #f)))
+
 (gate-summary "dce-refs")


### PR DESCRIPTION
Since 0.7.29 every callee the inline pass spliced is a root of the shake graph
(jolt-o13s): its def carries the jolt-register-source! that maps an inlined
frame back to ns/name, and a callee whose every call site was spliced has no
reference left to keep it. Rooting it also made its references reachable code
for the bail scan, and that is one step too far. A spliced callee that nothing
reaches never runs — its call sites are all copies — yet a `resolve` inside it
bailed the whole shake:

```
jolt build: tree-shake skipped (reachable code resolves vars at runtime):
  clojure.core.async/sm-park-kind -> clojure.core/resolve
  clojure.core.async/sm-parks? -> clojure.core/resolve
```

Those are the go-macro's state-machine walkers, which resolve symbols against
&env while expanding a go body. Any app that loads clojure.core.async — a
ring-chez.adapter server, say — had them spliced into one another by the
inline pass, and so kept the compiler image without ever expanding a go form.

dce-build-graph now returns the spliced set beside the roots instead of in
them, and dce-shake closes over the graph twice: roots alone decide what is
reachable, and that is what the bail scan and the compiler-drop decision read;
roots plus the spliced set decide what the binary keeps, so a kept callee's
load-time var lookups still find every def it names, and the frame identity
jolt-o13s wanted is untouched.

run-dce-refs.ss drives dce-shake over a small record graph: a spliced helper
that calls resolve no longer bails, is kept, keeps what it names, a def nothing
references is still pruned, and the same helper made reachable still bails.
Those checks fail against the previous dce.ss (3 of 53) and pass with this one.
dce-refs gate: 53/53.

---
One of four independent jolt changes that together let a real app tree-shake again on 0.8.4 — a `jolt.fs` + `jolt-lang/time` + core.async-via-ring-chez app whose `--tree-shake` build now reports `kept 2629 of 3316 defs` and drops the compiler image. Each stands alone and they merge cleanly in any order:

- #881 — prune prelude defs that carry a source registration, and gate that the shake ran
- #882 — keep spliced callees out of the tree-shake bail scan
- #883 — fill `babashka.fs/list-dir` through its var, not `intern`
- #884 — install the java.time Instant ctor through a static host reference
- jolt-lang/time#14 — reference `jolt.host/register-extension!` statically
