### PR TITLE
Fill babashka.fs/list-dir through its var, not intern

### DIFF
--- a/stdlib/jolt/bb/fs.clj
+++ b/stdlib/jolt/bb/fs.clj
@@ -37,9 +37,11 @@
      (vec stream))))
 
 ;; babashka.fs already declares the var (its own list-dirs and path-seq refer to
-;; it), so this fills the root the :bb branch left empty.
-(intern 'babashka.fs
-        (with-meta 'list-dir
-          {:doc (:doc (meta #'list-dir))
-           :arglists '([dir] [dir glob-or-accept])})
-        list-dir)
+;; it), so this fills the root the :bb branch left empty. Through the var, not
+;; `intern`: a top-level intern is a runtime var lookup by name, which is the one
+;; thing `jolt build --tree-shake` cannot follow, so every app that requires
+;; jolt.fs kept every def and the compiler image because of this one form.
+(alter-var-root #'babashka.fs/list-dir (constantly list-dir))
+(alter-meta! #'babashka.fs/list-dir assoc
+             :doc (:doc (meta #'list-dir))
+             :arglists '([dir] [dir glob-or-accept]))


### PR DESCRIPTION
jolt.bb.fs supplies the list-dir that babashka.fs leaves to a :bb host, and
did so with a top-level `(intern 'babashka.fs …)`. An intern is a var lookup by
name at runtime, which is the one thing the tree-shake's static graph cannot
follow, and the supplement loads right after babashka.fs — so every app that
requires jolt.fs carried a bail on its load path:

```
jolt build: tree-shake skipped (reachable code resolves vars at runtime):
  <form> -> clojure.core/intern
```

babashka.fs already `(declare list-dir)`s (that is what lets its own list-dirs
and modified-since compile), so the var exists to be set: alter-var-root fills
the root and alter-meta! carries the :doc and :arglists the intern used to
attach. #'babashka.fs/list-dir is a static reference the graph sees and keeps.

fs-test (bin/jolt run test/chez/fs-test.clj): FS-TEST OK, covering both
spellings and both arities of list-dir plus list-dirs and modified-since; the
var's :arglists and :doc read back as before. With the two dce.ss fixes that
unblock the prelude, a `(:require [jolt.fs])` app builds `tree-shake kept 588
of 1013 defs`, drops the compiler image, and list-dir answers in the shaken
binary.

---
One of four independent jolt changes that together let a real app tree-shake again on 0.8.4 — a `jolt.fs` + `jolt-lang/time` + core.async-via-ring-chez app whose `--tree-shake` build now reports `kept 2629 of 3316 defs` and drops the compiler image. Each stands alone and they merge cleanly in any order:

- #881 — prune prelude defs that carry a source registration, and gate that the shake ran
- #882 — keep spliced callees out of the tree-shake bail scan
- #883 — fill `babashka.fs/list-dir` through its var, not `intern`
- #884 — install the java.time Instant ctor through a static host reference
- jolt-lang/time#14 — reference `jolt.host/register-extension!` statically
