### PR TITLE
Install the java.time Instant ctor through a static host reference

### DIFF
--- a/stdlib/jolt/time/instant.clj
+++ b/stdlib/jolt/time/instant.clj
@@ -123,6 +123,10 @@
   {"from" (fn [i] (java.util.Date. (u/floor-div (inst-nanos i) 1000000)))})
 
 ;; make the #inst/Date layer's Date.toInstant etc. yield THIS instant, so a Date
-;; and a library instant compare and print as one representation.
-(when-let [set-ctor (resolve 'jolt.host/set-instant-ctor!)]
-  ((deref set-ctor) (fn [nanos] (instant nanos))))
+;; and a library instant compare and print as one representation. The hook is
+;; a static reference: jolt.host/set-instant-ctor! is defined by the host that
+;; autoloads this namespace (inst-time.ss), and looking it up with `resolve` at
+;; load time made every app that reaches java.time resolve a var by name — the
+;; one thing `jolt build --tree-shake` cannot follow, so each kept every def and
+;; the compiler image for this one form.
+(jolt.host/set-instant-ctor! (fn [nanos] (instant nanos)))


### PR DESCRIPTION
jolt.time.instant hands the #inst/Date layer its epoch-nanos constructor
through jolt.host/set-instant-ctor!, and looked that var up with `resolve` at
load time. The host that autoloads this namespace is the one that defines the
var (inst-time.ss, unconditionally), so the guard guarded nothing — and a
top-level `resolve` is a var lookup by name at runtime, the one thing the
tree-shake's static graph cannot follow. Every app that reaches java.time —
babashka.fs through FileTime, the jolt-lang/time library, a #inst literal —
carried this on its load path:

```
jolt build: tree-shake skipped (reachable code resolves vars at runtime):
  <form> -> clojure.core/resolve
```

The call is now a plain fully-qualified reference, the way rrb_vector.clj
calls jolt.host/catvec; the analyzer resolves it against the host namespace
and the graph keeps it. The Gambit host does not load the java.time base
(rt-core.ss leaves it to the Chez autoload), so nothing there is asked for a
var it lacks.

unit gate: 1678/1678, including insttime 39/39. `(.toInstant (java.util.Date.
1000))` still answers the library Instant and compares equal to
`(java.time.Instant/ofEpochMilli 1000)`; `Date/from` round-trips. With the two
dce.ss fixes that unblock the prelude, a `(:require [jolt.fs] [jolt.time.fmt])`
app builds `tree-shake kept 732 of 1153 defs` and drops the compiler image.

---
One of four independent jolt changes that together let a real app tree-shake again on 0.8.4 — a `jolt.fs` + `jolt-lang/time` + core.async-via-ring-chez app whose `--tree-shake` build now reports `kept 2629 of 3316 defs` and drops the compiler image. Each stands alone and they merge cleanly in any order:

- #881 — prune prelude defs that carry a source registration, and gate that the shake ran
- #882 — keep spliced callees out of the tree-shake bail scan
- #883 — fill `babashka.fs/list-dir` through its var, not `intern`
- #884 — install the java.time Instant ctor through a static host reference
- jolt-lang/time#14 — reference `jolt.host/register-extension!` statically
