### PR TITLE
Provide configurable tree shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adds one caller nothing vouches for and must still bail with a hint naming
   that caller alone. Verified by mutation: dropping either declaration bails
   the shaking fixture. `run-dce-refs.ss` pins the semantics on a synthetic
-  graph, including that an unreachable allowed def is still pruned.
+  graph, including that an unreachable allowed def is still pruned. (#890)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A `deps.edn` can vouch for a runtime var lookup, so `--tree-shake` proceeds
+  past it.** The shake bails, and must, when reachable code resolves a var by
+  name: the static graph cannot follow a runtime name. But some of those sites
+  are dead in a built binary and the author can prove it, and one `s/def` was
+  enough to lose the whole shake — spec.alpha's `res` only qualifies a symbol
+  so a spec's form can be printed, and spec.gen's `dynaload` sits behind a
+  `delay` nothing forces. `:jolt/tree-shake {:allow-dynamic [ns/name …]}` in
+  the app's `deps.edn` or any library's names the defs the author vouches for,
+  read where `:jolt/native` is read and unioned, so a library ships its list
+  once for every app that uses it. Nothing is kept on an allowed def's behalf.
+  With no declaration the shake bails exactly as before.
+
+  An allowed def is skipped by the compiler-needed scan as well as the bail
+  scan, on purpose: a site vouched never to run needs no compiler, and skipping
+  only the bail scan would let an allowed `eval` caller shake without dropping
+  the compiler image, which breaks the "a shake that does not bail drops it"
+  invariant `make shakelocal` asserts.
+
+  The bail message lists each site once — the IR-walk-plus-text-scan ref union
+  had it printing every line twice — and ends with the paste-ready key for
+  every def it named:
+
+  ```
+  jolt build: tree-shake skipped (reachable code resolves vars at runtime):
+    clojure.spec.alpha/res -> clojure.core/resolve
+  to proceed, if these never run in the built binary, add to deps.edn:
+    :jolt/tree-shake {:allow-dynamic [clojure.spec.alpha/res]}
+  ```
+
+  The def to name is the one the lookup ended up in: the inline pass splices a
+  small helper into its callers, and the bail then names the caller. The hint
+  prints that name, so paste what it prints rather than the fn that wrote the
+  call.
+
+  `test/chez/allow-dynamic-app` is the build-level gate — the app's own `res`
+  and a `:local/root` library's `dynaload`, each vouched for by its own
+  `deps.edn`, must shake and prune `dead` — and `allow-dynamic-partial-app`
+  adds one caller nothing vouches for and must still bail with a hint naming
+  that caller alone. Verified by mutation: dropping either declaration bails
+  the shaking fixture. `run-dce-refs.ss` pins the semantics on a synthetic
+  graph, including that an unreachable allowed def is still pruned.
+
 ### Internal
 
 - **The repository's tooling is jolt, not Python.** `bench/pagecache.clj`

--- a/README.md
+++ b/README.md
@@ -440,6 +440,24 @@ library responsible — when reachable code resolves vars by name at runtime
 (`eval`/`resolve`/`ns-resolve`/…). See
 [RFC 0007](https://jolt-lang.github.io/docs/rfc/0007-compilation-modes-and-binary-output.html).
 
+When the site it names is dead in a built binary and you can say why — spec's
+`res` only qualifies a symbol for a description, spec.gen's `dynaload` sits
+behind a `delay` nothing forces — a `deps.edn` can vouch for it and the shake
+proceeds past it, keeping nothing extra:
+
+```clojure
+:jolt/tree-shake {:allow-dynamic [clojure.spec.alpha/res
+                                  clojure.spec.gen.alpha/dynaload]}
+```
+
+The key is read from the app's `deps.edn` and from every library's, and
+unioned, so a library ships its list once for every app that uses it. The bail
+message ends with the exact line to paste for the sites that remain; paste
+what it prints, because the def to name is the one the lookup ended up in
+after inlining, which may be the caller of the fn that wrote it. An allowed
+def is skipped by the compiler-image check too: a lookup vouched never to run
+needs no compiler.
+
 `--boot` trades the other way. The boot image ships as a prebuilt heap image
 (*vfasl*), which starts faster and takes more room — `--boot small` keeps the
 image but compresses it with gzip, and `--boot plain` drops it altogether:

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1135,7 +1135,8 @@
 ;; roots resolved at runtime against JOLT_PWD (ship-alongside resources).
 ;; allow-dynamic: "ns/name" strings the project and its deps vouch never resolve
 ;; vars at runtime in the built binary (deps.edn :jolt/tree-shake {:allow-dynamic
-;; […]}); dce-shake skips them in its bail scan. '() when nothing declared one.
+;; […]}); dce-shake skips them in its bail and compiler-needed scans (see
+;; dce-bail-scan). '() when nothing declared one.
 ;; direct-link?: closed-world direct-linking (app->app calls bind directly; a plain
 ;; def is frozen, ^:redef/^:dynamic stay var-routed). The caller (jolt.main) turns
 ;; this ON for release and optimized and OFF for --dev / --no-direct-link.

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1133,6 +1133,9 @@
 ;; natives: encoded :jolt/native libs to load at startup. embed-dirs: dirs whose
 ;; files bake into the binary (single-file). ext-roots: project-relative io/resource
 ;; roots resolved at runtime against JOLT_PWD (ship-alongside resources).
+;; allow-dynamic: "ns/name" strings the project and its deps vouch never resolve
+;; vars at runtime in the built binary (deps.edn :jolt/tree-shake {:allow-dynamic
+;; […]}); dce-shake skips them in its bail scan. '() when nothing declared one.
 ;; direct-link?: closed-world direct-linking (app->app calls bind directly; a plain
 ;; def is frozen, ^:redef/^:dynamic stay var-routed). The caller (jolt.main) turns
 ;; this ON for release and optimized and OFF for --dev / --no-direct-link.
@@ -1343,7 +1346,7 @@
           (for-each (lambda (p) (put-string out (string-append "\n    " (car p) " " (cdr p)))) pairs)
           (put-string out "))\n"))))))
 
-(define (build-binary entry-ns out-path mode natives embed-dirs ext-roots direct-link? tree-shake? library?)
+(define (build-binary entry-ns out-path mode natives embed-dirs ext-roots direct-link? tree-shake? allow-dynamic library?)
   (ei-profile-init!)
   ;; Windows executables carry .exe; normalize here so the append-payload and
   ;; cc paths agree and the shell can run the result. A library keeps its own
@@ -1560,7 +1563,7 @@
                               (loopfe (cdr rest))))
                           (apply append (reverse per-ns))))
                         (string-append entry-ns "/-main")
-                        '())
+                        allow-dynamic)
                       (values
                         #f
                         ;; EAGER per-ns accumulation, NOT (apply append (map …)):
@@ -2605,8 +2608,10 @@
       "-o '" out-path "' " native-link " " (bld-link-libs))))
   (display (string-append "jolt build: wrote " out-path "\n")))
 
-;; optional trailing (target target-pack): a Chez machine string + a prepared
-;; target pack dir when cross-compiling (jolt build --target). Absent/nil = host.
+;; optional trailing (target target-pack boot-mode allow-dynamic): a Chez machine
+;; string + a prepared target pack dir when cross-compiling (jolt build --target)
+;; — absent/nil = host — then the boot mode (bld-opt-boot-mode) and the
+;; :allow-dynamic list (bld-opt-strs).
 (define (bld-opt-str opt i)
   (let loop ((o opt) (i i))
     (cond ((or (null? o) (< i 0)) #f)
@@ -2620,6 +2625,13 @@
     (cond ((equal? s "small") 'small)
           ((equal? s "plain") 'plain)
           (else 'fast))))
+;; optional trailing (allow-dynamic), index 3: a vector of "ns/name" strings
+;; (see build-binary). Absent/nil = '().
+(define (bld-opt-strs opt i)
+  (let loop ((o opt) (i i))
+    (cond ((or (null? o) (< i 0)) '())
+          ((= i 0) (if (jolt-nil? (car o)) '() (bld-strs (car o))))
+          (else (loop (cdr o) (- i 1))))))
 (def-var! "jolt.host" "build-binary"
   (lambda (entry out mode natives embed-dirs ext-roots direct-link? tree-shake? . opt)
     (parameterize ((bld-target (bld-opt-str opt 0)) (bld-target-pack (bld-opt-str opt 1))
@@ -2627,7 +2639,8 @@
       (build-binary (jolt-str-render-one entry)
                     (jolt-str-render-one out)
                     (jolt-str-render-one mode)
-                    natives embed-dirs ext-roots (jolt-truthy? direct-link?) (jolt-truthy? tree-shake?) #f))
+                    natives embed-dirs ext-roots (jolt-truthy? direct-link?) (jolt-truthy? tree-shake?)
+                    (bld-opt-strs opt 3) #f))
     jolt-nil))
 (def-var! "jolt.host" "build-library"
   (lambda (entry out mode natives embed-dirs ext-roots direct-link? tree-shake? . opt)
@@ -2636,5 +2649,6 @@
       (build-binary (jolt-str-render-one entry)
                     (jolt-str-render-one out)
                     (jolt-str-render-one mode)
-                    natives embed-dirs ext-roots (jolt-truthy? direct-link?) (jolt-truthy? tree-shake?) #t))
+                    natives embed-dirs ext-roots (jolt-truthy? direct-link?) (jolt-truthy? tree-shake?)
+                    (bld-opt-strs opt 3) #t))
     jolt-nil))

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1559,7 +1559,8 @@
                                           per-ns)))
                               (loopfe (cdr rest))))
                           (apply append (reverse per-ns))))
-                        (string-append entry-ns "/-main"))
+                        (string-append entry-ns "/-main")
+                        '())
                       (values
                         #f
                         ;; EAGER per-ns accumulation, NOT (apply append (map …)):

--- a/host/chez/dce.ss
+++ b/host/chez/dce.ss
@@ -3,7 +3,8 @@
 ;; Build one call graph over the re-emitted app + libraries AND the clojure.core
 ;; prelude, keep -main + every side-effecting top-level form + everything reachable
 ;; from those, drop the rest. Bails (keeps everything) if reachable code resolves a
-;; var by name at runtime (eval/resolve/...), which a static graph can't follow. Per
+;; var by name at runtime (eval/resolve/...), which a static graph can't follow —
+;; unless a deps.edn vouches for that def (:jolt/tree-shake {:allow-dynamic […]}). Per
 ;; Stalin's rule, ANY reference — a call OR a value/#'x — keeps its target live, so a
 ;; fn passed to map or referenced as #'x is never dropped.
 ;;
@@ -312,28 +313,50 @@
   (or (dce-rec-keep? r) (hashtable-ref reached (dce-rec-fqn r) #f)))
 
 ;; Scan the KEPT records: does any resolve a var at runtime (bail), and does any need
-;; the compiler? Returns (values bail? bail-why needs-compiler?). bail-why is up to 6
-;; (def . bail-ref) pairs for the diagnostic. Uses hash sets for O(1) membership
-;; instead of O(n*m) linear scans over the bail/compile lists.
-(define (dce-bail-scan records reached)
-  (let ((bail #f) (why '()) (needs-compiler #f)
+;; the compiler? Returns (values bail? bail-why bail-hint needs-compiler?). bail-why
+;; is up to 6 DISTINCT (def . bail-ref) pairs for the diagnostic — distinct because
+;; dce-app-refs unions an IR walk with a text scan, so one call is usually two refs,
+;; and each line printed twice. bail-hint is every distinct def that bailed
+;; (uncapped, first-seen order) for the paste-ready key. Uses hash sets for O(1)
+;; membership instead of O(n*m) linear scans over the lists.
+;;
+;; allow: "ns/name" strings from deps.edn :jolt/tree-shake {:allow-dynamic […]} —
+;; callers pass the union of the app's and every library's; a list, '() when
+;; nothing is declared, never #f. A def in the set is skipped by BOTH scans: the
+;; author is asserting its lookup never runs in the built binary (or names only
+;; vars the graph keeps anyway), and a site that never runs needs no compiler
+;; either. Nothing is kept on an allowed def's behalf — it enters the graph
+;; exactly as before, and the scan is the only place the set is consulted. A
+;; top-level non-def form has no fqn and cannot be allowed by name. The fqn to
+;; allow is the def the ref ended up IN — after the inline pass that is the
+;; caller of a spliced helper, not the helper — which is why the hint prints the
+;; name rather than leaving it to the reader to derive.
+(define (dce-bail-scan records reached allow)
+  (let ((bail #f) (why '()) (hint '()) (needs-compiler #f)
         (bail-ht (make-hashtable string-hash string=?))
-        (compile-ht (make-hashtable string-hash string=?)))
+        (compile-ht (make-hashtable string-hash string=?))
+        (allow-ht (make-hashtable string-hash string=?)))
     (for-each (lambda (b) (hashtable-set! bail-ht b #t)) dce-bail-refs)
     (for-each (lambda (c) (hashtable-set! compile-ht c #t)) dce-compile-refs)
+    (for-each (lambda (a) (hashtable-set! allow-ht a #t)) allow)
     (for-each
       (lambda (r)
-        (when (dce-rec-reached? r reached)
-          (for-each (lambda (ref)
-                      (when (hashtable-ref bail-ht ref #f)
-                        (set! bail #t)
-                        (when (< (length why) 6)
-                          (set! why (cons (cons (or (dce-rec-fqn r) "<form>") ref) why)))))
-                    (dce-rec-refs r))
-          (when (ormap (lambda (ref) (and (hashtable-ref compile-ht ref #f) #t)) (dce-rec-refs r))
-            (set! needs-compiler #t))))
+        (let ((fqn (dce-rec-fqn r)))
+          (when (and (dce-rec-reached? r reached)
+                     (not (and fqn (hashtable-ref allow-ht fqn #f))))
+            (for-each (lambda (ref)
+                        (when (hashtable-ref bail-ht ref #f)
+                          (set! bail #t)
+                          (let ((pair (cons (or fqn "<form>") ref)))
+                            (when (and (< (length why) 6) (not (member pair why)))
+                              (set! why (cons pair why))))
+                          (when (and fqn (not (member fqn hint)))
+                            (set! hint (cons fqn hint)))))
+                      (dce-rec-refs r))
+            (when (ormap (lambda (ref) (and (hashtable-ref compile-ht ref #f) #t)) (dce-rec-refs r))
+              (set! needs-compiler #t)))))
       records)
-    (values bail (reverse why) needs-compiler)))
+    (values bail (reverse why) (reverse hint) needs-compiler)))
 
 ;; Kept records -> (values kept-strings n-defs n-kept-defs).
 (define (dce-partition records reached)
@@ -346,8 +369,10 @@
               (loop (cdr rs) acc (if isdef (+ n 1) n) k))))))
 
 ;; Returns (values core-strs app-strs drop-compiler?). core-strs is #f on a bail,
-;; signalling "inline prelude.ss unshaken" + keep the compiler.
-(define (dce-shake core-records app-records entry-main)
+;; signalling "inline prelude.ss unshaken" + keep the compiler. allow: see
+;; dce-bail-scan. On a bail the diagnostic ends with the deps.edn key that would
+;; allow every def it named, so the path from "skipped" to "kept" is one paste.
+(define (dce-shake core-records app-records entry-main allow)
   (let-values (((edges roots spliced)
                 (dce-build-graph (append core-records app-records) entry-main)))
     (let* ((reached (dce-reachable edges roots))
@@ -356,12 +381,16 @@
            (kept (if (null? spliced)
                      reached
                      (dce-reachable edges (append spliced roots)))))
-      (let-values (((bail why needs-compiler) (dce-bail-scan (append core-records app-records) reached)))
+      (let-values (((bail why hint needs-compiler)
+                    (dce-bail-scan (append core-records app-records) reached allow)))
         (let ((drop-compiler? (and (not bail) (not needs-compiler))))
           (if bail
               (begin
                 (display "jolt build: tree-shake skipped (reachable code resolves vars at runtime):\n")
                 (for-each (lambda (w) (display (string-append "  " (car w) " -> " (cdr w) "\n"))) why)
+                (unless (null? hint)
+                  (display "to proceed, if these never run in the built binary, add to deps.edn:\n")
+                  (display (string-append "  :jolt/tree-shake {:allow-dynamic [" (jolt-str-join hint) "]}\n")))
                 (values #f (map dce-rec-str app-records) drop-compiler?))
               (let-values (((core-strs cn ck) (dce-partition core-records kept))
                            ((app-strs an ak) (dce-partition app-records kept)))

--- a/host/chez/run-dce-refs.ss
+++ b/host/chez/run-dce-refs.ss
@@ -247,7 +247,7 @@
                   (rec "gate.app/named-by-walker" '())
                   (rec "gate.app/dead" '()))))
   (hc-mark-spliced! #f "gate.app" "walker")
-  (let-values (((core-strs app-strs drop-compiler?) (dce-shake '() app "gate.app/-main")))
+  (let-values (((core-strs app-strs drop-compiler?) (dce-shake '() app "gate.app/-main" '())))
     (gate-check "spliced: a spliced resolve caller does not bail the shake" (and core-strs #t) #t)
     (gate-check "spliced: the compiler image is dropped" drop-compiler? #t)
     (gate-check "spliced: the entry and what it reaches are kept"
@@ -260,7 +260,86 @@
                 (and (member "(gate.app/dead)" app-strs) #t) #f))
   ;; the same graph with the walker genuinely reachable bails as before
   (let-values (((core-strs app-strs drop-compiler?)
-                (dce-shake '() (cons (rec "gate.app/-main" '("gate.app/walker")) (cdr app)) "gate.app/-main")))
+                (dce-shake '() (cons (rec "gate.app/-main" '("gate.app/walker")) (cdr app)) "gate.app/-main" '())))
     (gate-check "spliced: a reachable resolve caller still bails" core-strs #f)))
+
+;; --- :allow-dynamic: a vouched-for def is not a bail --------------------------
+;; deps.edn :jolt/tree-shake {:allow-dynamic [ns/name …]} names the defs whose
+;; runtime var lookups the author asserts never run in a built binary (or name
+;; only vars the graph keeps anyway). An allowed def is skipped by the bail scan
+;; and by the compiler-needed scan — a site vouched never to run needs no
+;; compiler — but nothing is kept on its behalf: it is pruned or kept exactly as
+;; reachability says, and what it names stays defined when it is kept.
+;; (The block above marked gate.app/walker spliced, and that mark is process-
+;; global; none of the records here is named walker, so it does not reach in.)
+(let* ((rec (lambda (fqn refs) (dce-rec #f fqn refs (string-append "(" fqn ")"))))
+       (app (list (rec "gate.app/-main" '("gate.app/res"))
+                  (rec "gate.app/res" '("clojure.core/resolve" "gate.app/named-by-res"))
+                  (rec "gate.app/named-by-res" '())
+                  (rec "gate.app/dead" '()))))
+  ;; the empty allow list is today's behaviour: a reachable resolve caller bails
+  (let-values (((core-strs app-strs drop-compiler?) (dce-shake '() app "gate.app/-main" '())))
+    (gate-check "allow: a reachable resolve caller bails with an empty allow list" core-strs #f)
+    (gate-check "allow: that bail keeps the compiler image" drop-compiler? #f))
+  (let-values (((core-strs app-strs drop-compiler?) (dce-shake '() app "gate.app/-main" '("gate.app/res"))))
+    (gate-check "allow: an allowed resolve caller does not bail" (and core-strs #t) #t)
+    (gate-check "allow: the compiler image is dropped" drop-compiler? #t)
+    (gate-check "allow: the allowed def is kept because it is reachable"
+                (and (member "(gate.app/res)" app-strs) #t) #t)
+    (gate-check "allow: what the allowed def names stays defined"
+                (and (member "(gate.app/named-by-res)" app-strs) #t) #t)
+    (gate-check "allow: an unreferenced def is still pruned"
+                (and (member "(gate.app/dead)" app-strs) #t) #f))
+  ;; an allowed def that is NOT reachable is pruned like any other def
+  (let-values (((core-strs app-strs drop-compiler?)
+                (dce-shake '() (cons (rec "gate.app/-main" '()) (cdr app)) "gate.app/-main" '("gate.app/res"))))
+    (gate-check "allow: an unreachable allowed def is pruned, not kept"
+                (and (member "(gate.app/res)" app-strs) #t) #f))
+  ;; a second, non-allowed reachable caller still bails, and the hint names it
+  ;; alone. Its resolve ref is listed twice, as dce-app-refs' IR+text union
+  ;; produces in a real build, and must print once.
+  (let* ((app2 (cons (rec "gate.app/-main" '("gate.app/res" "gate.app/lookup"))
+                     (cons (rec "gate.app/lookup" '("clojure.core/resolve" "clojure.core/resolve")) (cdr app))))
+         (got-core #t) (got-drop #t)
+         (out (with-output-to-string
+                (lambda ()
+                  (let-values (((core-strs app-strs drop-compiler?)
+                                (dce-shake '() app2 "gate.app/-main" '("gate.app/res"))))
+                    (set! got-core core-strs)
+                    (set! got-drop drop-compiler?))))))
+    (gate-check "allow: a non-allowed reachable caller still bails" got-core #f)
+    (gate-check "allow: a non-allowed bail keeps the compiler image" got-drop #f)
+    (gate-check "allow: the bail lists the non-allowed caller"
+                (gate-sub? out "  gate.app/lookup -> clojure.core/resolve\n") #t)
+    (gate-check "allow: a ref counted twice in one record is listed once"
+                (gate-sub? out "resolve\n  gate.app/lookup -> clojure.core/resolve\n") #f)
+    (gate-check "allow: the bail does not list the allowed def"
+                (gate-sub? out "gate.app/res ->") #f)
+    (gate-check "allow: the hint is the paste-ready deps.edn key"
+                (gate-sub? out "  :jolt/tree-shake {:allow-dynamic [gate.app/lookup]}\n") #t))
+  ;; two non-allowed bailing defs join the hint space-separated, in record order
+  (let ((out (with-output-to-string
+               (lambda ()
+                 (dce-shake '() (list (rec "gate.app/-main" '("gate.app/a" "gate.app/b"))
+                                      (rec "gate.app/a" '("clojure.core/resolve"))
+                                      (rec "gate.app/b" '("clojure.core/ns-resolve")))
+                            "gate.app/-main" '())))))
+    (gate-check "allow: the hint names every bailing def, space-joined in record order"
+                (gate-sub? out "  :jolt/tree-shake {:allow-dynamic [gate.app/a gate.app/b]}\n") #t))
+  ;; an allowed caller of a compile-ref (eval) is skipped by the compile scan too
+  (let-values (((core-strs app-strs drop-compiler?)
+                (dce-shake '() (list (rec "gate.app/-main" '("gate.app/ev"))
+                                     (rec "gate.app/ev" '("clojure.core/eval")))
+                           "gate.app/-main" '("gate.app/ev"))))
+    (gate-check "allow: an allowed eval caller does not bail" (and core-strs #t) #t)
+    (gate-check "allow: an allowed eval caller drops the compiler image" drop-compiler? #t))
+  ;; a top-level non-def form has no fqn and cannot be allowed by name: no hint
+  (let ((out (with-output-to-string
+               (lambda ()
+                 (dce-shake '() (list (dce-rec #t #f '("clojure.core/resolve") "(resolve-at-load)")
+                                      (rec "gate.app/-main" '()))
+                            "gate.app/-main" '())))))
+    (gate-check "allow: a <form> bail lists the form" (gate-sub? out "  <form> -> clojure.core/resolve\n") #t)
+    (gate-check "allow: a <form> bail prints no hint" (gate-sub? out ":jolt/tree-shake") #f)))
 
 (gate-summary "dce-refs")

--- a/host/chez/tree-shake-smoke.sh
+++ b/host/chez/tree-shake-smoke.sh
@@ -93,9 +93,14 @@ run_case() {
 #   - the compiler image: a shake that does NOT bail always drops it (every
 #     dce-compile-ref is also a dce-bail-ref, so reaching no bail ref means
 #     reaching no compile ref either — see dce.ss), and a bail always keeps it.
+#
+# EXPECT_OUT ($7): a fixed string the --tree-shake build's stdout must contain —
+# for a bailing fixture, the paste-ready :allow-dynamic hint naming exactly the
+# sites that remain, which is how the gate proves an allowed site next to a
+# non-allowed one is neither let through nor re-suggested.
 run_local_case() {
   app="$root/test/chez/$1"; ns="$2"; args="$3"; assert_missing="$4"; expect="${5:-shake}"
-  max_kept="${6:-$shake_max_kept}"
+  max_kept="${6:-$shake_max_kept}"; expect_out="$7"
   [ -d "$app" ] || { echo "  - $1: skipped (not present)"; return; }
   b0="$tmp/$1-plain"; b1="$tmp/$1-shake"
   bdir="$tmp/$1-shake.build"
@@ -142,6 +147,11 @@ run_local_case() {
       fi ;;
     *) echo "  - $1: FAIL (unknown EXPECT '$expect')"; fail=1; return ;;
   esac
+  if [ -n "$expect_out" ] && ! grep -qF -- "$expect_out" "$tmp/$1-shake-out"; then
+    echo "  - $1: FAIL (the --tree-shake build output lacks: $expect_out)"
+    sed -n '/^jolt build: tree-shake skipped/,/^jolt build: compiling/p' "$tmp/$1-shake-out" | grep -v '^jolt build: compiling' | head -8
+    fail=1; return
+  fi
   o0="$(cd "$app" && "$b0" $args 2>&1)"
   o1="$(cd "$app" && "$b1" $args 2>&1)"
   if [ "$o0" != "$o1" ]; then
@@ -208,6 +218,19 @@ run_local_case dupfqn-app      app.core  ""     ""
 # loaded core.async. Bails against the pre-#882 dce.ss. app.core/walk-body is the
 # unreachable caller the helpers were spliced into, so it must be pruned.
 run_local_case spliced-resolve-app app.core "" "\"app.core\" \"walk-body\""
+# deps.edn :jolt/tree-shake {:allow-dynamic […]}: two reachable `resolve` callers
+# on paths -main never takes — the app's own `res` (spec.alpha/res's shape) and
+# a :local/root library's `dynaload` behind a delay (spec.gen's shape). The app's
+# deps.edn vouches for the first, the LIBRARY's for the second, and the union
+# lets the shake run: `dead` is pruned and the compiler image dropped. Bails
+# against a jolt that does not read the key. Both callers are ^:redef so the
+# inline pass leaves them as the defs the bail names.
+run_local_case allow-dynamic-app app.core "" "\"app.core\" \"dead\""
+# …and the same app with one more reachable caller nothing vouches for must
+# still bail, with the hint naming that caller alone — proof the allowed sites
+# were honoured (neither is listed) and the non-allowed one was not let through.
+run_local_case allow-dynamic-partial-app app.core "" "" bail "" \
+  ':jolt/tree-shake {:allow-dynamic [app.core/lookup]}'
 
 [ "$fail" = 0 ] && echo "shake smoke: passed" || echo "shake smoke: FAILED"
 exit $fail

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -990,12 +990,24 @@
          (into [(str install-ns) (when lib (str lib))] (map str classes)))
        (:jolt/provides edn)))
 
+(defn- allow-dynamic-entries
+  "The defs a deps.edn vouches never resolve vars at runtime in a built binary
+  — :jolt/tree-shake {:allow-dynamic [ns/name …]} — as \"ns/name\" strings, the
+  shape the build driver's bail scan (dce.ss) keys on. Symbols are the
+  documented form; a string is taken as written. Nothing else is validated
+  here: an entry that names no def is inert, and the bail diagnostic prints the
+  exact key for the sites that remain, so a misspelling corrects itself on the
+  next build rather than needing a checker of its own."
+  [edn]
+  (mapv str (:allow-dynamic (:jolt/tree-shake edn))))
+
 (defn resolve-deps
   "Expand a deps map through the tools.deps expansion engine, then collect the
   selected libraries' source roots, :jolt/native and :jolt/provides declarations
   in stable first-inclusion order. Returns {:roots [...] :natives [...]
-  :min-versions [...] :provides [...] :prep [...] :libs {lib coord}} — :libs is
-  the tools.deps lib map (selected coordinate per library).
+  :allow-dynamic [...] :min-versions [...] :provides [...] :prep [...]
+  :libs {lib coord}} — :libs is the tools.deps lib map (selected coordinate per
+  library).
 
   `opts` carries the alias-combined coordinate maps applied at every node like
   tools.deps: :override-deps replaces a lib's coordinate wherever it appears
@@ -1049,6 +1061,13 @@
                                 (map #(assoc % :jolt.deps/root root)
                                      (:jolt/native edn)))
                               infos))
+        ;; The defs each dep vouches never resolve vars at runtime in a built
+        ;; binary (:jolt/tree-shake {:allow-dynamic […]}). A LIBRARY is the
+        ;; natural declarer — spec.alpha knows its `res` only qualifies a symbol
+        ;; for a description and its `dynaload` sits behind a delay — and it
+        ;; ships the list once for every app that uses it, the way :jolt/native
+        ;; ships a shared library.
+        :allow-dynamic (vec (mapcat (fn [{:keys [edn]}] (allow-dynamic-entries edn)) infos))
         ;; Each dep's declared jolt floor, as [lib version] — checked by
         ;; resolve-project against the running runtime. A LIBRARY is the common
         ;; declarer: it knows which jolt its FFI bindings or host shims need, and
@@ -1520,8 +1539,10 @@
 
 (defn resolve-project
   "Resolve `project-dir`'s deps.edn with the selected alias keywords. Returns
-  {:roots [...] :main-opts [...] :tasks {...} :natives [...]}; :natives are the
-  project's + deps' :jolt/native shared-library declarations.
+  {:roots [...] :main-opts [...] :tasks {...} :natives [...] :allow-dynamic [...]};
+  :natives are the project's + deps' :jolt/native shared-library declarations,
+  :allow-dynamic the project's + deps' :jolt/tree-shake {:allow-dynamic […]}
+  entries as \"ns/name\" strings.
 
   :jolt/min-version, declared by the project or by any dependency, is the oldest
   jolt that entry works on; a runtime below it raises here rather than running
@@ -1604,7 +1625,7 @@
           ;; the merged edn and argmap, without calc-basis.
           {dep-roots :roots dep-natives :natives dep-provides :provides
            prep-libs :prep dep-trace :trace
-           dep-min-versions :min-versions}
+           dep-min-versions :min-versions dep-allow-dynamic :allow-dynamic}
           (when-not cp
             (binding [*mvn-local-repo* (when-let [r (:mvn/local-repo edn)]
                                          (abspath project-dir r))
@@ -1652,6 +1673,12 @@
                          (concat (map #(assoc % :jolt.deps/root project-dir)
                                       (:jolt/native edn))
                                  dep-natives))
+      ;; the project's own vouched-for defs first, then every dep's, deduped —
+      ;; `jolt build --tree-shake` hands the union to the bail scan. The
+      ;; project's list is where an app allows a site in a library that has
+      ;; not shipped its own list yet.
+      :allow-dynamic (dedup-by identity
+                               (concat (allow-dynamic-entries edn) dep-allow-dynamic))
       ;; declared host-class providers (RFC 0014), the project's own first: a
       ;; project may supply a class itself rather than take a library's.
       :provides (host-class-providers (concat (provides-entries edn nil) dep-provides))

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -946,10 +946,10 @@
 ;; Dependencies are resolved as a TREE (resolve-deps' BFS, which visits each
 ;; coordinate once) and then reconciled into a definitive, de-duplicated set —
 ;; one place, not ad-hoc per call site. dedup-by keeps the first item per key,
-;; order preserved; it dedups both source roots (by path) and native libraries
-;; (by identity), so an app pulling two libs that declare the same shared object
-;; (e.g. libcrypto via both http-client and the ring adapter) includes and loads
-;; it ONCE.
+;; order preserved; it dedups source roots (by path), native libraries (by
+;; identity) and the :allow-dynamic list (by name), so an app pulling two libs
+;; that declare the same shared object (e.g. libcrypto via both http-client and
+;; the ring adapter) includes and loads it ONCE.
 (defn- dedup-by [key xs]
   (second (reduce (fn [[seen acc] x]
                     (let [k (key x)]

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -854,6 +854,12 @@
                           (throw (ex-info (str "--boot must be fast, small or plain (got " v ")")
                                           {:boot v})))
                         v)
+            ;; defs the project and its deps vouch never resolve vars at runtime
+            ;; in the built binary (deps.edn :jolt/tree-shake {:allow-dynamic […]},
+            ;; unioned by resolve-project): the shake skips them in its bail scan
+            ;; instead of keeping everything. Passed even without --tree-shake;
+            ;; the driver ignores it then.
+            allow-dynamic (vec (:allow-dynamic resolved))
             ;; a shared library (callable from C/C++/Rust via jolt_library_init +
             ;; jolt_lookup) instead of an executable: --library.
             library? (some #{"--library"} flag-args)
@@ -867,8 +873,8 @@
         ;; embed-dirs (absolute) are walked + baked into the binary by the driver;
         ;; project-paths (relative) become runtime io/resource roots (ship-alongside).
         (if library?
-          (jolt.host/build-library entry out mode natives embed-dirs project-paths direct-link? tree-shake? target target-pack boot-mode)
-          (jolt.host/build-binary entry out mode natives embed-dirs project-paths direct-link? tree-shake? target target-pack boot-mode))))))
+          (jolt.host/build-library entry out mode natives embed-dirs project-paths direct-link? tree-shake? target target-pack boot-mode allow-dynamic)
+          (jolt.host/build-binary entry out mode natives embed-dirs project-paths direct-link? tree-shake? target target-pack boot-mode allow-dynamic))))))
 
 (defn- nrepl [more]
   ;; resolve the project (deps on the roots, native libs loaded), then start the

--- a/test/chez/allow-dynamic-app/deps.edn
+++ b/test/chez/allow-dynamic-app/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {allowlib/allowlib {:local/root "lib"}}
+ ;; the app vouches for its own site; the library's comes from lib/deps.edn
+ :jolt/tree-shake {:allow-dynamic [app.core/res]}}

--- a/test/chez/allow-dynamic-app/lib/deps.edn
+++ b/test/chez/allow-dynamic-app/lib/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ ;; the library vouches for its own dynamic site, once, for every app that
+ ;; uses it — the way spec.gen would for dynaload
+ :jolt/tree-shake {:allow-dynamic [allowlib.core/dynaload]}}

--- a/test/chez/allow-dynamic-app/lib/src/allowlib/core.clj
+++ b/test/chez/allow-dynamic-app/lib/src/allowlib/core.clj
@@ -1,0 +1,18 @@
+(ns allowlib.core)
+
+;; spec.gen.alpha/dynaload's shape: a `resolve` reached only through a delay
+;; that nothing in this program forces. It is reachable code — `describe`
+;; references the delay — so without the library's :allow-dynamic it bails
+;; the shake of every app that uses the library.
+;;
+;; ^:redef keeps the inline pass from splicing this body into gen-delay: the
+;; bail scan names the def a `resolve` ref ends up IN, and the allow entry in
+;; lib/deps.edn names dynaload, so dynaload must still own its call.
+(defn ^:redef dynaload [s]
+  (or (resolve s)
+      (throw (ex-info (str "Var " s " is not on the classpath") {}))))
+
+(def gen-delay (delay (dynaload 'clojure.test.check.generators/int)))
+
+(defn describe [x]
+  (if (= x :gen) @gen-delay (str "allowlib:" x)))

--- a/test/chez/allow-dynamic-app/src/app/core.clj
+++ b/test/chez/allow-dynamic-app/src/app/core.clj
@@ -1,0 +1,26 @@
+(ns app.core
+  (:require [allowlib.core :as lib]))
+
+;; Tree-shake fixture for deps.edn :jolt/tree-shake {:allow-dynamic […]}.
+;;
+;; Two runtime var lookups sit on paths -main reaches and never takes: this
+;; ns's `res` (spec.alpha/res's shape — qualify a symbol for a description) and
+;; the library's `dynaload` (behind a delay, spec.gen's shape). Both are real
+;; `resolve` calls in reachable code, so without the key the shake bails. The
+;; app's deps.edn vouches for res, the library's own deps.edn for dynaload, and
+;; the union lets this app SHAKE: `dead` must be pruned and the compiler image
+;; dropped. Bails against a jolt that does not read the key.
+;;
+;; ^:redef on res: the inline pass would otherwise splice it into describe and
+;; the bail would name app.core/describe (or -main), not res — and the allow
+;; entry would be inert. The bail names the def a ref ends up in.
+(defn ^:redef res [s]
+  (if (resolve s) (symbol "app.core" (name s)) s))
+
+(defn describe [form]
+  (str (res form)))
+
+(defn dead [] :never)
+
+(defn -main [& args]
+  (println (lib/describe (if (seq args) (describe 'inc) "plain"))))

--- a/test/chez/allow-dynamic-partial-app/deps.edn
+++ b/test/chez/allow-dynamic-partial-app/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :deps {allowlib/allowlib {:local/root "lib"}}
+ :jolt/tree-shake {:allow-dynamic [app.core/res]}}

--- a/test/chez/allow-dynamic-partial-app/lib/deps.edn
+++ b/test/chez/allow-dynamic-partial-app/lib/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ ;; the library vouches for its own dynamic site, once, for every app that
+ ;; uses it — the way spec.gen would for dynaload
+ :jolt/tree-shake {:allow-dynamic [allowlib.core/dynaload]}}

--- a/test/chez/allow-dynamic-partial-app/lib/src/allowlib/core.clj
+++ b/test/chez/allow-dynamic-partial-app/lib/src/allowlib/core.clj
@@ -1,0 +1,18 @@
+(ns allowlib.core)
+
+;; spec.gen.alpha/dynaload's shape: a `resolve` reached only through a delay
+;; that nothing in this program forces. It is reachable code — `describe`
+;; references the delay — so without the library's :allow-dynamic it bails
+;; the shake of every app that uses the library.
+;;
+;; ^:redef keeps the inline pass from splicing this body into gen-delay: the
+;; bail scan names the def a `resolve` ref ends up IN, and the allow entry in
+;; lib/deps.edn names dynaload, so dynaload must still own its call.
+(defn ^:redef dynaload [s]
+  (or (resolve s)
+      (throw (ex-info (str "Var " s " is not on the classpath") {}))))
+
+(def gen-delay (delay (dynaload 'clojure.test.check.generators/int)))
+
+(defn describe [x]
+  (if (= x :gen) @gen-delay (str "allowlib:" x)))

--- a/test/chez/allow-dynamic-partial-app/src/app/core.clj
+++ b/test/chez/allow-dynamic-partial-app/src/app/core.clj
@@ -1,0 +1,23 @@
+(ns app.core
+  (:require [allowlib.core :as lib]))
+
+;; The allow-dynamic-app with one more reachable `resolve` caller, `lookup`,
+;; that nothing vouches for. An allowed site next to a non-allowed one must
+;; not let the non-allowed one through: this app BAILS, and the hint names
+;; app.core/lookup alone — not res (allowed by the app's deps.edn) and not
+;; allowlib.core/dynaload (allowed by the library's).
+;;
+;; ^:redef on both, so the bail names these defs and not the caller the
+;; inline pass would have spliced them into (see allow-dynamic-app).
+(defn ^:redef res [s]
+  (if (resolve s) (symbol "app.core" (name s)) s))
+
+(defn describe [form]
+  (str (res form)))
+
+(defn ^:redef lookup [s]
+  (resolve s))
+
+(defn -main [& args]
+  (println (lib/describe (if (seq args) (describe 'inc) "plain")))
+  (println (boolean (lookup 'app.core/-main))))

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -362,6 +362,15 @@
   (is= "the key without :allow-dynamic is the empty list" []
        (allow-dynamic-entries {:jolt/tree-shake {}})))
 
+;; The union itself, against the committed shake fixture: the app's own entry
+;; comes first, the :local/root library's after it, and both arrive — the
+;; build-level gate (make shakelocal) can only show that the shake ran, not
+;; which declaration got it there. Relative to the repo root, like the "."
+;; base-dir the resolve-deps cases above use.
+(is= "resolve-project unions the project's list with its :local/root dep's, project first"
+     ["app.core/res" "allowlib.core/dynaload"]
+     (:allow-dynamic (deps/resolve-project "test/chez/allow-dynamic-app")))
+
 (println (str "deps-expand: " (- @checks @failures) "/" @checks " passed"))
 (when (pos? @failures)
   (System/exit 1))

--- a/test/deps_expand_test.clj
+++ b/test/deps_expand_test.clj
@@ -346,6 +346,22 @@
                         [{:static {:archive "native/libfoo.a"} :jolt.deps/root "/a"}
                          {:static {:archive "native/libfoo.a"} :jolt.deps/root "/b"}]))))
 
+;;;; :jolt/tree-shake {:allow-dynamic […]} → "ns/name" strings
+
+(let [allow-dynamic-entries (var jolt.deps/allow-dynamic-entries)]
+  ;; The list travels to the Scheme build driver as strings — the shape
+  ;; dce-bail-scan keys its allow set on — so a symbol is rendered as written.
+  (is= "symbols render as ns/name strings"
+       ["clojure.spec.alpha/res" "clojure.spec.gen.alpha/dynaload"]
+       (allow-dynamic-entries {:jolt/tree-shake {:allow-dynamic '[clojure.spec.alpha/res
+                                                                  clojure.spec.gen.alpha/dynaload]}}))
+  (is= "a string entry is taken as written"
+       ["a.b/c"]
+       (allow-dynamic-entries {:jolt/tree-shake {:allow-dynamic ["a.b/c"]}}))
+  (is= "no key is the empty list, not nil" [] (allow-dynamic-entries {}))
+  (is= "the key without :allow-dynamic is the empty list" []
+       (allow-dynamic-entries {:jolt/tree-shake {}})))
+
 (println (str "deps-expand: " (- @checks @failures) "/" @checks " passed"))
 (when (pos? @failures)
   (System/exit 1))


### PR DESCRIPTION
`deps.edn` can now vouch for a runtime var lookup so `jolt build --tree-shake` proceeds past it:

```clojure
:jolt/tree-shake {:allow-dynamic [clojure.spec.alpha/res
                                  clojure.spec.gen.alpha/dynaload]}
```

The key is read from the app's `deps.edn` and every library's, where `:jolt/native` is read, and unioned. A `def` in the set is skipped by the bail scan. Nothing is kept on its behalf. With no key, the shake bails exactly as before.

When the shake still bails, the message lists each site once and ends with the paste-ready key:

```
jolt build: tree-shake skipped (reachable code resolves vars at runtime):
  clojure.spec.alpha/res -> clojure.core/resolve
to proceed, if these never run in the built binary, add to deps.edn:
  :jolt/tree-shake {:allow-dynamic [clojure.spec.alpha/res]}
```

Real-world check, the hello world from the issue with `spec.alpha 0.5.238`: bails with the two sites the issue names; with the pasted key it shakes, drops the compiler image, and `s/describe` still prints `int?`. Binary 30.7MB -> 17.4MB (13.3MB, 43%).

Fixes #890 
