### PR TITLE
Measure the LZ4 fasl ceiling instead of asserting 2^28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   thing — the environment variable being the spelling a CI job can set without
   editing the build command. `--no-vfasl`, `:no-vfasl true` and `JOLT_NO_VFASL=1`
   are the spelling #886 asked for and are kept as aliases for `--boot plain`.
-  Precedence is resolved in one place: flag, then `deps.edn`, then environment.
-  It covers the self-contained, cc-linked and `--library` paths; jolt's own boot
-  is not a `jolt build` and is unaffected.
+  Precedence is resolved in one place: CLI, then `deps.edn`, then environment,
+  and within each of those the explicit `--boot` spelling beats the alias — a
+  script that adds `--boot small` without dropping the `--no-vfasl` it already
+  had is exactly the migration #886 is on, and the other order would silently
+  keep the boot it was trying to leave. A blank environment variable reads as
+  unset, the way `bin/jolt` already treats `JOLT_NO_DEVCACHE`, because CI exports
+  an empty value for a matrix leg nothing filled in. It covers the
+  self-contained, cc-linked and `--library` paths; jolt's own boot is not a
+  `jolt build` and is unaffected.
 
   **Reach for `small` before `plain`.** The size cost turns out to be mostly the
   *codec's* rather than vfasl's, so for a jolt app `small` beats `plain` on both
@@ -115,29 +121,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **A large binary's boot image loads again.** A program big enough for its boot
-  image to reach 256MiB built fine and then died on every run, inside
-  `Sbuild_heap`, before a line of its own code had executed:
+  image to cross Chez's LZ4 fasl ceiling built fine and then died on every run,
+  inside `Sbuild_heap`, before a line of its own code had executed:
 
   ```
   fasl-read: uncompressed size -222298112 for #vu8(…) is smaller than
              expected size 314572800
   ```
 
-  The negative number is the tell. Chez's kernel decompresses a fasl entry and
+  The nonsense number is the tell. Chez's kernel decompresses a fasl entry and
   compares the result against the size the entry declares; on the LZ4 arm
   (`c/new-io.c`, `S_bytevector_uncompress`) it returns that result as
   `Sfixnum(r)` with `int r`, and `Sfixnum` is `((ptr)(uptr)((x)*8))` — the
-  multiply happens in the argument's own type. At 2^28 bytes it overflows `int`,
-  the length comes back negative, and the comparison can never succeed. The gzip
-  arm of the same function hands zlib a `uLong` and has no ceiling: measured
-  against Chez 10.4.1, LZ4 round-trips at 2^28-1 and fails at 2^28, and gzip
-  round-trips at both.
+  multiply happens in the argument's own type, so the product leaves 32 bits and
+  the comparison can never succeed. The gzip arm of the same function hands zlib
+  a `uLong` and has no ceiling.
+
+  Where the line falls is undefined behaviour, and it is not the same on every
+  platform, because what the widening cast does with the top bit of an overflowed
+  `int` is the C compiler's business. Both of these are Chez 10.4.1: the product
+  keeps its sign on `ta6le`, so the length comes back negative at 2^28 and the
+  ceiling is 2^28 (the `-222298112` above is exactly `314572800 * 8` wrapped to
+  signed 32-bit and divided back by 8); it does not on `tarm64osx`, where the
+  length comes back `0` at 2^29 and the ceiling is 2^29.
 
   Nothing before 0.8.5 could reach it. A plain boot is one compressed entry per
   top-level form and its entries are kilobytes; the vfasl boot 0.8.5 introduced
   combines each input boot file into ONE entry, so a program's whole compiled
   half became a single image — 83MB for the build smoke's hello-world-plus, 43MB
-  for jolt itself, and past 256MiB an executable that cannot start. The failure
+  for jolt itself, and past the ceiling an executable that cannot start. The failure
   scaled with the program, which is the worst shape for it: every app that had
   been built with 0.8.5 worked, right up to the one that didn't.
 
@@ -145,21 +157,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it keeps the image off the ceiling instead. `jolt build` now reads back the
   entry headers of the boot it just converted, and when an LZ4 entry declares an
   uncompressed size at or over 2^28 it re-encodes the image with gzip and says
-  so. Only a build that was previously broken changes — every image under the
-  ceiling is byte-for-byte what it was — and it keeps the vfasl format, so what
-  it gives up is decompression speed, not the load. Measured on the build
+  so. 2^28 is jolt's floor rather than a measurement of the machine: at or below
+  every ceiling seen, so nothing it leaves on LZ4 can fail to load, and on a
+  platform whose real ceiling is 2^29 an image in between is re-encoded when it
+  did not have to be, which costs decompression speed and nothing else. Only a
+  build that was previously broken changes — every image under the ceiling is
+  byte-for-byte what it was — and it keeps the vfasl format, so what it gives up
+  is decompression speed, not the load. Measured on the build
   smoke's app, whose image is 83MB, with both codecs forced: **0.26s and a
   27.6MB binary on LZ4, 0.44s and a 16.8MB binary on gzip.** Slower to start and
-  a third smaller, which is the shape of the trade at any size; at 256MiB and up
+  a third smaller, which is the shape of the trade at any size; over the ceiling
   the alternative is a binary that does not start. The same check covers
   `--library` and jolt's own boot.
 
-  `make vfaslceiling` pins all three legs — that the ceiling is real and is
-  exactly 2^28, that gzip has none, and that the scanner and the fallback do what
-  they claim, by lowering the ceiling under a boot small enough to build in a
-  second. The check for LZ4 *failing* at 2^28 is deliberately a check on the
-  kernel: when a future Chez fixes the overflow it turns red, and that is the
-  signal to delete the workaround rather than a regression.
+  The paths that convert in a spawned Chez — `build-with-cc`, `build-shared`, and
+  so every cross build, which is the configuration #886 reports from — now
+  degrade the way the in-process path already did. Their conversion is guarded,
+  and a boot that could not be imaged at all leaves the plain boot in place with
+  a note, instead of taking the build down through the spawned script's exit
+  status.
+
+  `make vfaslceiling` measures the ceiling of the kernel in front of it, by
+  writing and reading real compressed fasl entries, and then pins the properties
+  the fix rests on: that a ceiling still exists, that jolt's constant sits at or
+  below it while staying high enough that everything under it loads, that gzip
+  clears the size which defeated LZ4, and that the scanner and both fallbacks do
+  what they claim — the last by lowering the ceiling under a boot small enough to
+  build in a second. Finding no ceiling at all is the signal that a future Chez
+  fixed the overflow and the workaround can go, rather than a regression. It
+  measures rather than asserting one number because an equality on 2^28 is red on
+  `tarm64osx`, where it would read as "Chez fixed this" when Chez has done
+  nothing of the kind.
 
 - **A namespace-level `(defn double …)` owns the name, as it already did for
   `(defn first …)`.** jolt has two layers that rewrite a `clojure.core` call into

--- a/Makefile
+++ b/Makefile
@@ -927,14 +927,15 @@ adaptercheck:
 hostprops:
 	@$(CHEZ) --script test/chez/host-derived-props-test.ss
 
-# The boot image's LZ4 ceiling (jolt-23z). Chez cannot read back an LZ4 fasl
-# entry of 2^28 uncompressed bytes or more, and 0.8.5's vfasl boot is one entry
-# per input boot file rather than one per top-level form — so a large enough app
-# built a binary that died in Sbuild_heap. build.ss re-encodes such an image with
-# gzip; this pins the kernel fact behind that, the entry scanner that detects it,
-# and the fallback itself. JOLT_MAX_HEAP=off because two of the checks have to
-# allocate 256MiB to ask the question at all, and the runtime's own heap bound
-# would otherwise answer first.
+# The boot image's LZ4 ceiling (jolt-lang/jolt#886). Chez cannot read back a big
+# enough LZ4 fasl entry, and 0.8.5's vfasl boot is one entry per input boot file
+# rather than one per top-level form — so a large enough app built a binary that
+# died in Sbuild_heap. build.ss re-encodes such an image with gzip; this measures
+# the ceiling of the kernel in front of it (undefined behaviour, so 2^28 on some
+# platforms and 2^29 on others), then pins that jolt's constant sits safely under
+# it, plus the entry scanner and both fallbacks. JOLT_MAX_HEAP=off because some
+# of the checks have to allocate at the ceiling to ask the question at all, and
+# the runtime's own heap bound would otherwise answer first.
 vfaslceiling:
 	@JOLT_MAX_HEAP=off $(CHEZ) --script test/chez/vfasl-ceiling-test.ss
 

--- a/host/chez/build-smoke.sh
+++ b/host/chez/build-smoke.sh
@@ -1149,6 +1149,29 @@ fi
 if JOLT_PWD="$app" "$joltabs" build -m app.core --boot nope -o "$plainout.bad" >/dev/null 2>&1; then
   echo "  FAIL: --boot nope was accepted"; exit 1
 fi
+# An empty environment variable reads as UNSET. `bin/jolt` already treats
+# JOLT_NO_DEVCACHE that way, and a CI matrix leg that does not fill a value in
+# exports an empty one — which must not fail the build (JOLT_BOOT= used to, with
+# "must be fast, small or plain (got )") nor silently change it (JOLT_NO_VFASL=
+# used to force plain).
+emptybootout="$(dirname "$out")/emptyboot-bin"
+emptynvout="$(dirname "$out")/emptynv-bin"
+if ! JOLT_PWD="$app" JOLT_BOOT= "$joltabs" build -m app.core -o "$emptybootout" >/dev/null 2>&1; then
+  echo "  FAIL: an empty JOLT_BOOT failed the build"; exit 1
+fi
+[ -f "$emptybootout.build/jolt.boot.vfasl" ] || { echo "  FAIL: an empty JOLT_BOOT did not build the default"; exit 1; }
+if ! JOLT_PWD="$app" JOLT_NO_VFASL= "$joltabs" build -m app.core -o "$emptynvout" >/dev/null 2>&1; then
+  echo "  FAIL: an empty JOLT_NO_VFASL failed the build"; exit 1
+fi
+[ -f "$emptynvout.build/jolt.boot.vfasl" ] || { echo "  FAIL: an empty JOLT_NO_VFASL forced plain"; exit 1; }
+# Within one source the explicit --boot spelling beats the --no-vfasl alias, in
+# either order: a script that adds --boot small without dropping its old
+# --no-vfasl is the migration #886 is on, and it used to silently get `plain`.
+precout="$(dirname "$out")/prec-boot-bin"
+if ! JOLT_PWD="$app" "$joltabs" build -m app.core --no-vfasl --boot small -o "$precout" >/dev/null 2>&1; then
+  echo "  FAIL: --no-vfasl --boot small build exited non-zero"; exit 1
+fi
+[ -f "$precout.build/jolt.boot.vfasl" ] || { echo "  FAIL: --boot small lost to the --no-vfasl alias"; exit 1; }
 got_small="$(cd / && "$smallout" alpha bb ccc 2>&1)"
 got_plain="$(cd / && "$plainout" alpha bb ccc 2>&1)"
 got_envplain="$(cd / && "$envplainout" alpha bb ccc 2>&1)"

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -2054,17 +2054,30 @@
 (define (bld-vfasl-disabled?) (eq? (bld-boot-mode) 'plain))
 
 ;; --- the boot image's LZ4 ceiling -------------------------------------------
-;; A compressed fasl entry whose UNCOMPRESSED size reaches 2^28 bytes cannot be
-;; read back by the Chez kernel when the entry is LZ4. c/new-io.c's
-;; S_bytevector_uncompress returns the decompressed length as `Sfixnum(r)` with
-;; `int r`, and Sfixnum is `((ptr)(uptr)((x)*8))` — the multiply happens in the
-;; argument's own type, so 2^28 and up overflow `int` to a NEGATIVE fixnum. The
-;; length check in c/fasl.c then cannot match and the load dies inside
-;; Sbuild_heap with "uncompressed size -N ... is smaller than expected size M",
-;; before a line of the binary's own code has run. The gzip arm of the same
-;; function hands zlib a uLong and has no such ceiling. Measured against Chez
-;; 10.4.1 (test/chez/vfasl-ceiling-test.ss): 2^28-1 round-trips, 2^28 does not,
-;; and gzip round-trips at both.
+;; A big enough compressed fasl entry cannot be read back by the Chez kernel when
+;; the entry is LZ4. c/new-io.c's S_bytevector_uncompress returns the
+;; decompressed length as `Sfixnum(r)` with `int r`, and Sfixnum is
+;; `((ptr)(uptr)((x)*8))` — the multiply happens in the argument's own type, so
+;; the product leaves 32 bits and the length check in c/fasl.c can never match.
+;; The load then dies inside Sbuild_heap with "uncompressed size N ... is smaller
+;; than expected size M", before a line of the binary's own code has run. The
+;; gzip arm of the same function hands zlib a uLong and has no such ceiling.
+;;
+;; WHERE the line falls is undefined behaviour, and it is not the same on every
+;; platform, because what the widening cast does with the top bit of an overflowed
+;; `int` is the C compiler's business. Both of these are Chez 10.4.1
+;; (test/chez/vfasl-ceiling-test.ss measures whichever one is in front of it):
+;;
+;;   sign-extended   a NEGATIVE length at 2^28    ceiling 2^28   ta6le, and the
+;;                   platform in jolt-lang/jolt#886 — its -222298112 is exactly
+;;                   314572800*8 wrapped to signed 32-bit and divided back by 8
+;;   zero-extended   a length of 0 at 2^29        ceiling 2^29   tarm64osx
+;;
+;; 2^28 is therefore jolt's FLOOR, not a measurement of the machine: at or below
+;; every ceiling seen, so nothing it leaves on LZ4 can fail to load. On a
+;; zero-extending platform an image between 2^28 and 2^29 is re-encoded when it
+;; did not have to be, which costs decompression speed and nothing else. That is
+;; the direction to be wrong in, and it is why nothing user-facing quotes a size.
 ;;
 ;; It is 0.8.5's vfasl boot that can reach the ceiling at all. A plain boot is
 ;; one compressed entry per top-level form and its entries are kilobytes;
@@ -2144,16 +2157,41 @@
 
 ;; Does BOOT hold an LZ4 entry the kernel could not read back? #f for a boot that
 ;; does not parse: the status quo already works for every image under the
-;; ceiling, and re-encoding on a guess would be the riskier answer.
+;; ceiling, and re-encoding on a guess would be the riskier answer. It says so
+;; out loud, though — a silent "could not check" is how this bug would come back
+;; wearing the same unreadable Sbuild_heap death it wore the first time.
 (define (bld-boot-over-lz4-ceiling? boot)
   (let ((biggest (bld-boot-max-lz4-entry boot)))
-    (and biggest (>= biggest (bld-lz4-image-ceiling)))))
+    (cond ((not biggest) (bld-note-unscannable-boot! boot) #f)
+          (else (>= biggest (bld-lz4-image-ceiling))))))
 
+;; "at or over" rather than a size: where the kernel actually gives out is
+;; undefined behaviour and moves by platform (2^28 or 2^29 — see
+;; bld-lz4-image-ceiling), so the number jolt acts on is its own floor, not a
+;; property of the machine, and quoting it as one would be wrong.
 (define (bld-note-wide-boot!)
   (display (string-append
              "jolt build: note — the boot image is at or over Chez's "
-             "256MiB LZ4 fasl ceiling;\n"
+             "LZ4 fasl ceiling;\n"
              "  re-encoding it with gzip (slower to decompress, but it loads)\n")))
+
+(define (bld-note-retry-wide!)
+  (display (string-append
+             "jolt build: note — the boot image could not be written as an LZ4 "
+             "vfasl entry;\n  retrying with gzip\n")))
+
+(define (bld-note-no-vfasl!)
+  (display (string-append
+             "jolt build: note — the boot could not be converted to a vfasl "
+             "image;\n  keeping the plain boot (slower to start, same "
+             "behaviour)\n")))
+
+(define (bld-note-unscannable-boot! boot)
+  (display (string-append
+             "jolt build: note — could not read the fasl entry headers of "
+             boot ";\n  leaving its codec alone. If a large binary dies in "
+             "Sbuild_heap reporting an\n  \"uncompressed size\", this is the "
+             "check that stopped covering it.\n")))
 
 ;; Convert BOOT to vfasl at VBOOT in this process, answering whether VBOOT is
 ;; usable. LZ4 first — it is the fast default and what every normal image wants —
@@ -2174,31 +2212,75 @@
 ;; The conversion as a form for the fresh-Chez compile scripts, empty under
 ;; 'plain. 'small sets the codec in that process the way sa-vfasl-convert-file's
 ;; 'wide does in this one.
+;;
+;; GUARDED, and it removes a half-written VBOOT on the way out. Those scripts run
+;; under bld-system, which turns a non-zero exit into a dead build — so an
+;; unguarded conversion means a target that cannot vfasl, or an image too big to
+;; write as one entry, takes the whole build down instead of degrading to the
+;; plain boot the way the in-process path does. bld-vfasl-ensure! reads the
+;; presence of VBOOT as the verdict.
 (define (bld-vfasl-script-form boot vboot)
   (if (bld-vfasl-disabled?)
       ""
       (string-append
         (if (eq? (bld-boot-mode) 'small) "(compress-format 'gzip)\n" "")
-        "(vfasl-convert-file " (ei-str-lit boot) " " (ei-str-lit vboot) " '())\n")))
+        "(guard (e (#t (when (file-exists? " (ei-str-lit vboot) ")\n"
+        "                (delete-file " (ei-str-lit vboot) "))))\n"
+        "  (vfasl-convert-file " (ei-str-lit boot) " " (ei-str-lit vboot) " '()))\n")))
 
-;; The fresh-Chez counterpart. The paths that convert inside their compile script
-;; (build-with-cc, build-shared, build-jolt.ss) have to: $fasl-to-vfasl lays an
-;; image out for one machine, and a cross build needs the xpatch's constants. So
-;; the conversion has already happened by the time we get here, and this only
-;; re-runs it under gzip when what it produced is over the ceiling.
+;; One conversion in a fresh Chez, guarded the same way, leaving VBOOT present
+;; only if it worked. CODEC is 'wide for gzip, anything else for the default.
+(define (bld-vfasl-run-convert! builddir boot vboot codec)
+  (when (file-exists? vboot) (delete-file vboot))
+  (let ((cs (string-append builddir "/vfasl-convert.ss")))
+    (let ((p (open-output-file cs 'replace)))
+      (put-string p
+        (string-append
+          "(import (chezscheme))\n"
+          (if (bld-cross?) (string-append "(load " (ei-str-lit (bld-xpatch)) ")\n") "")
+          (if (eq? codec 'wide) "(compress-format 'gzip)\n" "")
+          "(guard (e (#t (when (file-exists? " (ei-str-lit vboot) ")\n"
+          "                (delete-file " (ei-str-lit vboot) "))))\n"
+          "  (vfasl-convert-file " (ei-str-lit boot) " " (ei-str-lit vboot) " '()))\n"))
+      (close-port p))
+    (bld-system (string-append bld-chez " --script '" cs "'"))))
+
+;; The fresh-Chez counterpart of bld-vfasl-convert!, and the same contract:
+;; answer whether VBOOT is usable, never raise for a boot that simply could not
+;; be imaged. The paths that convert inside their compile script (build-with-cc,
+;; build-shared, and so every cross build) have to convert there — $fasl-to-vfasl
+;; lays an image out for one machine, and a cross build needs the xpatch's
+;; constants — so by the time we get here the attempt has already been made and
+;; this only has to grade it:
+;;
+;;   nothing produced   the script's conversion raised. Retry under gzip, which
+;;                      is also the arm for an image whose COMPRESSED half
+;;                      clears the ceiling. Still nothing: keep the plain boot.
+;;   over the ceiling   re-encode with gzip, as bld-vfasl-convert! does.
+;;   otherwise          the LZ4 image stands.
+(define (bld-vfasl-ensure! builddir boot vboot)
+  (cond
+    ((not (file-exists? vboot))
+     (bld-note-retry-wide!)
+     (bld-vfasl-run-convert! builddir boot vboot 'wide)
+     (cond ((file-exists? vboot) #t)
+           (else (bld-note-no-vfasl!) #f)))
+    ((bld-boot-over-lz4-ceiling? vboot)
+     (bld-note-wide-boot!)
+     (bld-vfasl-run-convert! builddir boot vboot 'wide)
+     (cond ((file-exists? vboot) #t)
+           (else (bld-note-no-vfasl!) #f)))
+    (else #t)))
+
+;; jolt's OWN boot (build-jolt.ss), whose conversion is not guarded: a jolt build
+;; that cannot image its boot is a broken toolchain, not a user's app degrading,
+;; so this raises rather than quietly shipping a plain boot.
 (define (bld-vfasl-regzip! builddir boot vboot)
   (when (bld-boot-over-lz4-ceiling? vboot)
     (bld-note-wide-boot!)
-    (let ((cs (string-append builddir "/vfasl-gzip.ss")))
-      (let ((p (open-output-file cs 'replace)))
-        (put-string p
-          (string-append
-            "(import (chezscheme))\n"
-            (if (bld-cross?) (string-append "(load " (ei-str-lit (bld-xpatch)) ")\n") "")
-            "(compress-format 'gzip)\n"
-            "(vfasl-convert-file " (ei-str-lit boot) " " (ei-str-lit vboot) " '())\n"))
-        (close-port p))
-      (bld-system (string-append bld-chez " --script '" cs "'")))))
+    (bld-vfasl-run-convert! builddir boot vboot 'wide)
+    (unless (file-exists? vboot)
+      (error 'jolt-build "gzip re-encode of the boot image failed" vboot))))
 
 ;; units: a list of (src so kind) compiled in order and loaded into the boot in
 ;; that order, so the runtime half's defines precede the app half's reads.
@@ -2390,9 +2472,12 @@
       (close-port p))
     (bld-system (string-append bld-chez " --script '" cs "'")))
   ;; the converted boot is what gets embedded
+  ;; …and only switch to it if one actually exists: bld-vfasl-ensure! answers #f
+  ;; for a target that could not be imaged at all, and the plain boot is then
+  ;; what gets embedded.
   (unless (bld-vfasl-disabled?)
-    (bld-vfasl-regzip! builddir boot (string-append boot ".vfasl"))
-    (set! boot (string-append boot ".vfasl")))
+    (when (bld-vfasl-ensure! builddir boot (string-append boot ".vfasl"))
+      (set! boot (string-append boot ".vfasl"))))
   (bld-system (string-append "xxd -i '" boot "' > '" boot-h "'"))
   ;; The xxd symbol is derived from the path; normalize to jolt_boot.
   (bld-system (string-append
@@ -2490,9 +2575,12 @@
           (bld-vfasl-script-form boot (string-append boot ".vfasl"))))
       (close-port p))
     (bld-system (string-append bld-chez " --script '" cs "'")))
+  ;; …and only switch to it if one actually exists: bld-vfasl-ensure! answers #f
+  ;; for a target that could not be imaged at all, and the plain boot is then
+  ;; what gets embedded.
   (unless (bld-vfasl-disabled?)
-    (bld-vfasl-regzip! builddir boot (string-append boot ".vfasl"))
-    (set! boot (string-append boot ".vfasl")))
+    (when (bld-vfasl-ensure! builddir boot (string-append boot ".vfasl"))
+      (set! boot (string-append boot ".vfasl"))))
   (bld-system (string-append "xxd -i '" boot "' > '" boot-h "'"))
   (bld-system (string-append
     "sed -i.bak -E 's/unsigned char [A-Za-z0-9_]+\\[\\]/unsigned char jolt_boot[]/; "

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -791,19 +791,32 @@
             ;;   plain  no vfasl      the boot 0.8.4 produced
             ;; --no-vfasl is the spelling #886 asked for and stays as an alias for
             ;; `--boot plain`. Precedence, resolved here and nowhere else so there
-            ;; is one rule: CLI flag > deps.edn > environment > default.
-            boot-mode (let [tail (drop-while #(not= "--boot" %) flag-args)
+            ;; is one rule: CLI > deps.edn > environment > default, and WITHIN
+            ;; each of those the explicit --boot spelling beats the alias. The
+            ;; other order looks harmless and is not: a script that adds
+            ;; `--boot small` without dropping the `--no-vfasl` it already had is
+            ;; exactly the migration #886 is on, and it would silently keep the
+            ;; larger, slower `plain` boot it was trying to leave.
+            ;;
+            ;; A BLANK environment variable reads as unset, the way bin/jolt
+            ;; already treats JOLT_NO_DEVCACHE. CI exports an empty value for a
+            ;; matrix leg that did not fill one in, and that must neither fail the
+            ;; build (JOLT_BOOT= hit the validation below with an empty string)
+            ;; nor quietly change it (JOLT_NO_VFASL= forced plain).
+            boot-mode (let [env (fn [k] (let [v (System/getenv k)]
+                                          (when-not (str/blank? v) v)))
+                            tail (drop-while #(not= "--boot" %) flag-args)
                             cli (when (seq tail)
                                   (let [v (second tail)]
                                     (when (or (nil? v) (str/starts-with? v "-"))
                                       (throw (ex-info "--boot needs a value: fast, small or plain" {})))
                                     v))
-                            v (or (when (some #{"--no-vfasl"} flag-args) "plain")
-                                  cli
-                                  (when (:no-vfasl build) "plain")
+                            v (or cli
+                                  (when (some #{"--no-vfasl"} flag-args) "plain")
                                   (some-> (:boot build) name)
-                                  (when (System/getenv "JOLT_NO_VFASL") "plain")
-                                  (System/getenv "JOLT_BOOT")
+                                  (when (:no-vfasl build) "plain")
+                                  (env "JOLT_BOOT")
+                                  (when (env "JOLT_NO_VFASL") "plain")
                                   "fast")]
                         (when-not (#{"fast" "small" "plain"} v)
                           (throw (ex-info (str "--boot must be fast, small or plain (got " v ")")

--- a/test/chez/vfasl-ceiling-test.ss
+++ b/test/chez/vfasl-ceiling-test.ss
@@ -112,8 +112,23 @@
     (and lz4-ceiling (<= (bld-lz4-image-ceiling) lz4-ceiling)))
 ;; The other half of that invariant: jolt's constant must not be so HIGH that a
 ;; doomed image slips under it. Everything below it has to load.
-(ok "lz4 loads one byte under jolt's ceiling"
-    (fasl-round-trips? 'lz4 (- (bld-lz4-image-ceiling) 1)))
+;;
+;; A KILOBYTE under, not a byte. These probes are sized by PAYLOAD, while the
+;; ceiling is compared against the size the ENTRY declares, and an entry declares
+;; its payload plus a few bytes of fasl framing — so a payload one byte under the
+;; ceiling makes an entry a few bytes OVER it, and this check failed on ta6le
+;; (ceiling 2^28) while passing on tarm64osx (ceiling 2^29) for that reason
+;; alone. The margin cannot hide a real ceiling: the boundary comes from a 32-bit
+;; multiply overflowing, so it lands on a power of two, never a kilobyte below
+;; one.
+(ok "lz4 loads comfortably under jolt's ceiling"
+    (fasl-round-trips? 'lz4 (- (bld-lz4-image-ceiling) 1024)))
+;; The same probe against the MEASURED ceiling rather than jolt's constant. On a
+;; platform where the two are equal this is the same check twice; where they are
+;; not, it is the only one that exercises the tight boundary, which is what makes
+;; the framing mistake above visible on tarm64osx instead of only in CI.
+(ok "lz4 loads comfortably under the measured ceiling"
+    (and lz4-ceiling (fasl-round-trips? 'lz4 (- lz4-ceiling 1024))))
 ;; gzip is what the fallback re-encodes to, so it has to clear the size that
 ;; defeated LZ4.
 (ok "gzip loads at the measured ceiling"

--- a/test/chez/vfasl-ceiling-test.ss
+++ b/test/chez/vfasl-ceiling-test.ss
@@ -1,31 +1,41 @@
-;; vfasl-ceiling-test.ss — the boot image's LZ4 ceiling (jolt-23z).
+;; vfasl-ceiling-test.ss — the boot image's LZ4 ceiling (jolt-lang/jolt#886).
 ;;
-;; A compressed fasl entry whose UNCOMPRESSED size reaches 2^28 bytes cannot be
-;; read back when the entry is LZ4: c/new-io.c's S_bytevector_uncompress returns
-;; the length as `Sfixnum(r)` with `int r`, and Sfixnum multiplies by 8 in the
-;; argument's own type, so 2^28 and up wrap to a negative fixnum and c/fasl.c's
-;; length check can never match. A binary whose boot image is over the line dies
-;; inside Sbuild_heap before a line of its own code runs. gzip's arm of the same
-;; function hands zlib a uLong and has no ceiling.
+;; A compressed fasl entry big enough cannot be read back when the entry is LZ4:
+;; c/new-io.c's S_bytevector_uncompress returns the length as `Sfixnum(r)` with
+;; `int r`, and Sfixnum multiplies by 8 in the argument's own type, so the
+;; product leaves 32 bits and c/fasl.c's length check can never match. A binary
+;; whose boot image is over the line dies inside Sbuild_heap before a line of its
+;; own code runs. gzip's arm of the same function hands zlib a uLong and has no
+;; ceiling.
+;;
+;; WHERE the line falls is undefined behaviour and differs by platform: 2^28
+;; where the widened product keeps its sign (the reporter's ta6le), 2^29 where
+;; it does not (tarm64osx). jolt re-encodes at 2^28, at or below both, so this
+;; gate measures the kernel in front of it rather than asserting one number.
 ;;
 ;; That only became reachable in 0.8.5, which ships the boot as vfasl: a plain
 ;; boot is one compressed entry per top-level form and its entries are kilobytes,
 ;; while vfasl-convert-file combines each input boot file into ONE entry — so the
-;; app half of a large program is a single image, and past 256MiB it stops
-;; loading rather than merely loading slowly.
+;; app half of a large program is a single image that stops loading rather than
+;; merely loading slowly.
 ;;
 ;; jolt cannot patch the kernel it links against, so build.ss measures the
 ;; converted boot and re-encodes over-ceiling images with gzip. This gate pins
-;; the three things that fix rests on:
+;; what that fix rests on:
 ;;
-;;   a. the ceiling is real, and it is exactly 2^28 — case (b) failing means a
-;;      newer Chez fixed the overflow and the workaround can go
-;;   b. gzip has no ceiling, so it is a valid answer for an oversized image
+;;   a. a ceiling still exists, and jolt's constant sits at or below it while
+;;      staying high enough that everything under it loads — no ceiling found at
+;;      all means a newer Chez fixed the overflow and the workaround can go
+;;   b. gzip clears the size that defeated LZ4, so it is a valid answer
 ;;   c. the entry scanner reads real converted boots correctly, answers 0 for a
-;;      boot with no LZ4 entries at all, and trips at exactly the ceiling
+;;      boot with no LZ4 entries at all, and trips at exactly jolt's constant
+;;   d. both fallbacks run: bld-vfasl-convert! in process, and bld-vfasl-ensure!
+;;      for the paths that convert in a spawned Chez (build-with-cc,
+;;      build-shared, and every cross build)
 ;;
-;; (a) and (b) allocate 256MiB bytevectors; the Makefile target runs this with
-;; JOLT_MAX_HEAP=off so the runtime's own heap bound does not fire first.
+;; (a) and (b) allocate bytevectors of the measured ceiling; the Makefile target
+;; runs this with JOLT_MAX_HEAP=off so the runtime's own heap bound does not fire
+;; first.
 ;;
 ;;   chez --script test/chez/vfasl-ceiling-test.ss
 (import (chezscheme))
@@ -47,24 +57,67 @@
 (define (at name) (string-append tmp "/" name))
 
 ;; --- a/b: the kernel fact the workaround exists for -------------------------
-;; All-zero bytes so the compressor is fast and the compressed form is ~1MB:
-;; what is under test is the LENGTH the kernel reports back, not the codec.
-(define (round-trips? fmt n)
-  (parameterize ((compress-format fmt) (compress-level 'minimum))
+;; Drive the REAL site: a compressed fasl ENTRY, written and read back through
+;; c/fasl.c's fasl_entry, which is where the length comparison that gives out
+;; lives. All-zero bytes so the compressor is fast and the file stays ~1MB: what
+;; is under test is the LENGTH the kernel reports back, not the codec's ratio.
+(define (fasl-round-trips? fmt n)
+  (let ((path (at (format "probe-~a-~a.fasl" fmt n))))
     (guard (e (#t #f))
-      (let* ((bv (make-bytevector n 0))
-             (back (bytevector-uncompress (bytevector-compress bv))))
-        (= n (bytevector-length back))))))
+      (parameterize ((fasl-compressed #t) (compress-format fmt) (compress-level 'minimum))
+        (let ((p (open-file-output-port path (file-options no-fail))))
+          (fasl-write (make-bytevector n 0) p)
+          (close-port p)))
+      (let* ((p (open-file-input-port path))
+             (v (fasl-read p)))
+        (close-port p)
+        (= n (bytevector-length v))))))
 
-(ok "lz4 entry round-trips one byte under the ceiling"
-    (round-trips? 'lz4 (- (bld-lz4-image-ceiling) 1)))
-;; The one that must keep failing. If it starts passing, the Chez being built
-;; against has fixed S_bytevector_uncompress and bld-vfasl-convert! can drop the
-;; gzip arm — so this is a "delete the workaround" signal, not a regression.
-(ok "lz4 entry does NOT round-trip at the ceiling"
-    (not (round-trips? 'lz4 (bld-lz4-image-ceiling))))
-(ok "gzip entry round-trips at the ceiling"
-    (round-trips? 'gzip (bld-lz4-image-ceiling)))
+;; The ceiling is UNDEFINED BEHAVIOUR, and it does not land in the same place on
+;; every platform. Sfixnum(x) is ((ptr)(uptr)((x)*8)) over an `int`: the product
+;; leaves 32 bits at x = 2^28, and what the widening cast then does with the top
+;; bit is the C compiler's business. Both manifestations are real, on Chez 10.4.1:
+;;
+;;   sign-extended   length comes back NEGATIVE at 2^28     ceiling 2^28
+;;                   (ta6le, and the platform in jolt-lang/jolt#886 — its
+;;                    -222298112 is exactly 314572800*8 wrapped to signed
+;;                    32-bit and divided back by 8)
+;;   zero-extended   length comes back 0 at 2^29            ceiling 2^29
+;;                   (tarm64osx)
+;;
+;; So this MEASURES the ceiling of the kernel in front of it rather than
+;; asserting one platform's number — an equality on 2^28 is red on tarm64osx,
+;; where it reads as "Chez fixed the overflow" when Chez has done nothing of the
+;; kind. What gets asserted instead is the property that keeps binaries working.
+(define (measured-lz4-ceiling)
+  (let loop ((cands (list (expt 2 28) (expt 2 29))))
+    (cond ((null? cands) #f)
+          ((not (fasl-round-trips? 'lz4 (car cands))) (car cands))
+          (else (loop (cdr cands))))))
+(define lz4-ceiling (measured-lz4-ceiling))
+(printf "  measured LZ4 fasl ceiling on ~a: ~a (jolt re-encodes at ~a)\n"
+        (machine-type) (or lz4-ceiling "none at or below 2^29") (bld-lz4-image-ceiling))
+
+;; The check that must keep FINDING a ceiling. If no probe fails, the Chez being
+;; built against has fixed S_bytevector_uncompress, and the whole workaround —
+;; the gzip arms of bld-vfasl-convert! and bld-vfasl-ensure!, the entry scanner,
+;; this gate — can be deleted. That is a "drop the workaround" signal, not a
+;; regression.
+(ok "the LZ4 fasl ceiling is still there"
+    (and lz4-ceiling #t))
+;; The safety invariant the fix rests on: jolt re-encodes at or before the point
+;; where the kernel gives out, so no image it leaves on LZ4 is one that cannot
+;; be read back.
+(ok "jolt's ceiling is at or below the kernel's"
+    (and lz4-ceiling (<= (bld-lz4-image-ceiling) lz4-ceiling)))
+;; The other half of that invariant: jolt's constant must not be so HIGH that a
+;; doomed image slips under it. Everything below it has to load.
+(ok "lz4 loads one byte under jolt's ceiling"
+    (fasl-round-trips? 'lz4 (- (bld-lz4-image-ceiling) 1)))
+;; gzip is what the fallback re-encodes to, so it has to clear the size that
+;; defeated LZ4.
+(ok "gzip loads at the measured ceiling"
+    (and lz4-ceiling (fasl-round-trips? 'gzip lz4-ceiling)))
 
 ;; --- c: the scanner, over boots it actually produced -------------------------
 ;; A compiled object with a body big enough to clear the 100-byte floor under
@@ -101,7 +154,7 @@
     (and (not (bld-boot-over-lz4-ceiling? lz4-boot))
          (not (bld-boot-over-lz4-ceiling? gzip-boot))))
 
-;; --- c: the ceiling branch, without building a 256MiB app --------------------
+;; --- c: the ceiling branch, without building an over-ceiling app ------------
 ;; Boot framing, from ChezScheme s/strip.ss (read-entry): a header entry, then
 ;; one LZ4 object entry declaring DECLARED as its uncompressed size. Only the
 ;; declared size is read, so the payload can be anything.
@@ -165,6 +218,62 @@
     (parameterize ((bld-lz4-image-ceiling 1024))
       (and (bld-vfasl-convert! probe-so fallback-boot)
            (= (bld-boot-max-lz4-entry fallback-boot) 0))))
+
+;; --- d: the spawned-script path (build-with-cc, build-shared, every cross) ----
+;; Those paths convert inside a compile script run under bld-system, which turns
+;; a non-zero exit into a dead build. So what they hand the codec decision is a
+;; STRING, and the only thing between a conversion that raises and a failed build
+;; is that the form is guarded. Nothing else pins this: build-smoke drives the
+;; self-contained binary, which takes the in-process path instead.
+(define (substring? needle hay)
+  (let ((n (string-length needle)) (h (string-length hay)))
+    (let loop ((i 0))
+      (cond ((> (+ i n) h) #f)
+            ((string=? needle (substring hay i (+ i n))) #t)
+            (else (loop (+ i 1)))))))
+(define (script-form-for mode)
+  (parameterize ((bld-boot-mode mode))
+    (bld-vfasl-script-form "/tmp/in.boot" "/tmp/out.vfasl")))
+
+(ok "'plain emits no conversion at all"
+    (string=? (script-form-for 'plain) ""))
+(ok "'fast emits a conversion on the default codec"
+    (let ((s (script-form-for 'fast)))
+      (and (substring? "vfasl-convert-file" s)
+           (not (substring? "compress-format" s)))))
+(ok "'small emits the gzip codec"
+    (let ((s (script-form-for 'small)))
+      (and (substring? "vfasl-convert-file" s)
+           (substring? "(compress-format 'gzip)" s))))
+;; the guard is the whole point: without it a target that cannot vfasl takes the
+;; build down instead of falling back to the plain boot.
+(ok "a conversion that raises cannot kill the build"
+    (let ((s (script-form-for 'fast)))
+      (and (substring? "guard" s) (substring? "delete-file" s))))
+
+;; bld-vfasl-ensure! for real, in a spawned Chez, over all three of its arms.
+(define ensure-over (at "ensure-over.vfasl"))
+(ok "ensure! re-encodes an over-ceiling image the script produced"
+    (parameterize ((bld-lz4-image-ceiling 1024))
+      (and (sa-vfasl-convert-file probe-so ensure-over)     ; stand in for the script's LZ4 result
+           (bld-vfasl-ensure! tmp probe-so ensure-over)
+           (= (bld-boot-max-lz4-entry ensure-over) 0))))
+(define ensure-under (at "ensure-under.vfasl"))
+(ok "ensure! leaves an under-ceiling image alone"
+    (and (sa-vfasl-convert-file probe-so ensure-under)
+         (bld-vfasl-ensure! tmp probe-so ensure-under)
+         (> (bld-boot-max-lz4-entry ensure-under) 0)))
+;; The arm the cc path had no answer for: the script's conversion raised, so
+;; there is no image at all. It retries under gzip rather than dying.
+(define ensure-missing (at "ensure-missing.vfasl"))
+(when (file-exists? ensure-missing) (delete-file ensure-missing))
+(ok "ensure! retries a conversion that produced nothing"
+    (and (bld-vfasl-ensure! tmp probe-so ensure-missing)
+         (file-exists? ensure-missing)))
+;; …and when even that cannot produce one, it answers #f so the caller keeps the
+;; plain boot, instead of raising and taking the build with it.
+(ok "ensure! answers #f rather than raising when no image is possible"
+    (not (bld-vfasl-ensure! tmp (at "no-such-input.so") (at "no-such-output.vfasl"))))
 
 (printf "\nvfasl ceiling gate: ~a/~a passed~a\n"
         (- total fails) total (if (= fails 0) "" (format " (~a failed)" fails)))


### PR DESCRIPTION
Follow-up review of #889. The fix in that PR is sound and every binary it produces is correct, but the gate it added is red on macOS arm64, and four smaller things came out of the same read.

## `make ci` was red on macOS arm64

`vfaslceiling` asserted that an LZ4 fasl entry fails at *exactly* 2^28. That is one platform's number. Where the overflow lands is undefined behaviour: `Sfixnum` multiplies an `int` by 8, and whether the widened product keeps its sign decides whether the wrap is at 2^31 or 2^32.

Measured against the real fasl reader, Chez 10.4.1, by writing and reading compressed entries:

| platform | behaviour | ceiling |
|---|---|---|
| `ta6le`, and the reporter in #886 | negative length at 2^28 | 2^28 |
| `tarm64osx` | length of 0 at 2^29 | 2^29 |

The `ta6le` half is confirmed by the issue's own error text: `-222298112` is exactly `314572800 * 8` wrapped to signed 32-bit and divided back by 8.

So the gate failed on macOS at 14/15, and it failed on the one check whose stated purpose is to mean "a future Chez fixed the overflow, delete the workaround". Chez has not fixed anything there. CI never saw it because only the Linux x86_64 job runs `make test`; the macOS job in `flake.yml` builds and smoke-tests the Nix package.

The gate now measures the ceiling of the kernel in front of it and asserts the properties that actually keep binaries working: a ceiling still exists, jolt's constant sits at or below it, everything under jolt's constant loads, and gzip clears the size that defeated LZ4. Finding no ceiling at all is the drop-the-workaround signal.

jolt still re-encodes at 2^28, deliberately. It is a floor, not a measurement: at or below every ceiling seen, so nothing it leaves on LZ4 can fail to load. On a zero-extending platform an image between 2^28 and 2^29 is re-encoded when it did not have to be, which costs decompression speed and nothing else. That is the direction to be wrong in.

## Four smaller ones

- **The spawned-script paths had no fallback.** `build-with-cc`, `build-shared`, and so every cross build, which is the configuration #886 reports from, convert inside a script run under `bld-system` — a non-zero exit is a dead build. #889 added the gzip retry to the in-process path only. The generated conversion is guarded now, and `bld-vfasl-ensure!` grades the outcome: retry under gzip, then keep the plain boot and say so. This also removes a latent `xxd` on a file that was never written.
- **A blank `JOLT_BOOT` failed every build** with `--boot must be fast, small or plain (got )`, and a blank `JOLT_NO_VFASL` silently forced `plain`. CI exports an empty value for a matrix leg nothing filled in. Both read as unset now, the way `bin/jolt` already treats `JOLT_NO_DEVCACHE`.
- **`--no-vfasl` beat an explicit `--boot small`**, in either order. A script that adds the new flag without dropping the old alias is exactly the migration #886 is on, and it silently kept the boot it was trying to leave. Within each source the explicit spelling wins now.
- **A boot the entry scanner cannot parse** disabled the protection silently. It says so, since the failure it stops covering is an unreadable death inside `Sbuild_heap`.

## Gates

`vfaslceiling` goes 15 checks to 24. New coverage: the generated script form for all three `--boot` modes, and all three arms of `bld-vfasl-ensure!` driven against a real spawned Chez. Nothing covered the spawned-script path before, because `build-smoke` drives the self-contained binary.

`build-smoke` gains the two blank-environment cases and the precedence case. All three were red before this change and are green after.

Verified locally on `tarm64osx`: `vfaslceiling` 24/24, `buildsmoke` green including the new cases, plus `portcheck`, `adaptercheck`, `manifestcheck`, `readmecheck` and `completionssmoke`. `buildlibsmoke` skips here (this Chez is not `-fPIC`); CI runs it.

Docs for `--boot` are in jolt-lang/jolt-lang.github.io#28 alongside this.