### PR TITLE
edn refuses @ ` ~ instead of dropping the rest of the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   strictness and the same `:readers`/`:default`/`:eof` handling as the string
   arity (the 2-arity already did).
 
+- **`clojure.edn`'s dispatch table is closed.** `#(…)` read as a fn form, `#"…"`
+  as a regex, `#?(…)` as a reader conditional and `#'x` as a var form — none of
+  which edn can express, and all of which the reference refuses with `No
+  dispatch macro for: X`. EDN has `#{`, `#_`, `#^`, `#<`, `#:`, `##` and a
+  tagged literal, and nothing else; that is one gate now rather than a guard per
+  arm, so a dispatch character added later is refused there by default. A
+  leading `'` is part of the symbol for the same reason — edn has no quote, so
+  `'foo` reads as a symbol named `'foo` rather than `(quote foo)`. `#<…>` is
+  `Unreadable form` in both readers, where it used to report a tagged literal
+  running to end of input.
+
+- **A project file's task bodies are code, and are read like code.** `deps.edn`
+  and `bb.edn` went through `clojure.edn`, which worked only while jolt's edn
+  mode still honored the source reader's macros: a `:tasks` body is a form jolt
+  evaluates, and the ones people write are full of them — `(run 'clean)`,
+  `(require '[app.core])`, `@(future …)`, a `` ` ``/`~` template. Making the edn
+  seam strict (above) stopped every one of those reading. Both files go through
+  the source reader with `*read-eval*` false now, which is the reader babashka
+  reads a bb.edn with; a project file still evaluates nothing at read time.
+
 ### Internal
 
 - **Two new gates over the host tree.** `make mirrordrift` covers the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JVM; an atomic restored from an image written before the split keeps working
   through the tag it travelled with.
 
+- **`clojure.edn` refuses `@`, `` ` `` and `~` instead of dropping the rest of
+  the input.** `(edn/read-string "garbage!@")` answered `garbage!`, `"1@"`
+  answered `1` and `"a@b"` answered `a` — the reader ended the token at the `@`
+  and discarded everything after it, so junk that the reference rejects read as
+  a value. Those three are reader macro characters in SOURCE, which is why they
+  terminate a token there, but edn has no macros at all and its reader treats
+  them as non-constituent: inside or after a token that is `Invalid constituent
+  character: @`, where a form should start it is `Invalid leading character: @`,
+  and in a token that began like a number the character joins the token and
+  fails as `Invalid number: 1@` (a `NumberFormatException`, as on the JVM). A
+  character literal's name is checked the same way (`\a@`), an `@` after a
+  DELIMITED form is still ordinary trailing junk (`{:a 1}@` reads `{:a 1}`), and
+  source reading is untouched — `@foo` there is a deref form (#905).
+
+- **`(clojure.edn/read reader)` reads EDN, not source.** The 1-arity drained the
+  reader and handed the string to `clojure.core/read-string`, so everything the
+  edn seam exists to refuse got in through it: `::kw` resolved, `#(…)` and `#=`
+  were read, an `@` ended the token, and end of input answered `nil` where the
+  reference throws. It goes through `clojure.edn/read-string` now, with the same
+  strictness and the same `:readers`/`:default`/`:eof` handling as the string
+  arity (the 2-arity already did).
+
 ### Internal
 
 - **Two new gates over the host tree.** `make mirrordrift` covers the two

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1069,9 +1069,16 @@
               (begin (reader-refill! r (jolt-nth pr 1)) (values (jolt-nth pr 0) #t)))))))
 
 ;; clojure.edn/read over a reader: drain the jhost reader to a string and read the
-;; first EDN form (read-string). Re-asserted over the prelude in post-prelude.ss.
+;; first EDN form. Re-asserted over the prelude in post-prelude.ss.
+;;
+;; Through clojure.edn/read-string, NOT the core one: this is the edn seam, and
+;; the core reader is the SOURCE reader — it resolves ::kw, takes #(…) and #=,
+;; and ends a token at an @ where edn refuses it (#905). An empty opts map is
+;; what makes end of input an error here, as it is on the JVM; the core
+;; read-string answered nil.
 (define (chez-edn-read reader)
-  (jolt-invoke (var-deref "clojure.core" "read-string")
+  (jolt-invoke (var-deref "clojure.edn" "read-string")
+               empty-pmap
                (if (reader-jhost? reader) (drain-reader reader) (jolt-str-render-one reader))))
 
 ;; line-seq: an io/reader is a jhost StringReader. Drain it (or take a string)

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -1347,9 +1347,21 @@
 
 (rdr-set-dispatch-macro! #\$ rdr-interpolate #f)
 
+;; EDN's dispatch table is CLOSED, and much smaller than the source reader's:
+;; #{ #_ #^ #< #: ## and a tagged literal (#name, a LETTER) are all of it. Every
+;; character the clojure reader adds on top — #( #" #' #? #! #= and any macro a
+;; library registered — is "No dispatch macro for: X" there. One gate rather than
+;; a guard per arm, so a dispatch character added later is refused in edn by
+;; default instead of leaking in unnoticed (#905 was this, one arm at a time).
+(define (rdr-edn-dispatch-char? c)
+  (or (memv c '(#\{ #\_ #\^ #\< #\: #\#))
+      (char-alphabetic? c)))
+
 (define (rdr-read-dispatch s i end)      ; i points just past the '#'
   (when (>= i end) (rdr-error s i "EOF after #"))
   (let ((c (string-ref s i)))
+    (when (and (rdr-edn-mode) (not (rdr-edn-dispatch-char? c)))
+      (rdr-error s i (string-append "No dispatch macro for: " (string c))))
     (cond
       ((char=? c #\{)                    ; #{...} set
        (let-values (((elems j) (rdr-read-seq s (+ i 1) end #\})))
@@ -1374,13 +1386,16 @@
             (when cb (jolt-invoke cb d)))
           (rdr-read-form s j end)))
        ((char=? c #\!)                    ; #! shebang line comment — skip to EOL
-        ;; a clojure-reader extension only: EDN rejects #! (No dispatch macro)
-        (when (rdr-edn-mode) (rdr-error s i "No dispatch macro for: !"))
+        ;; a clojure-reader extension only; the edn gate above rejects it there
         (let eol ((j (+ i 1)))
           (if (or (>= j end) (char=? (string-ref s j) #\newline)
                   (char=? (string-ref s j) #\return))
               (rdr-read-form s j end)
               (eol (+ j 1)))))
+      ((char=? c #\<)                    ; #<…> is unreadable by construction: it is
+       ;; what a Java toString prints, and neither reader will take it back.
+       ;; Reported as the tagged literal "#<" running to EOF before.
+       (rdr-error s i "Unreadable form"))
       ((char=? c #\')                    ; #'x var-quote -> (var x)
        (let-values (((form j) (rdr-read-form s (+ i 1) end)))
          (values (jolt-list (jolt-symbol #f "var") form) j)))
@@ -1403,7 +1418,7 @@
        ;; computes its bit masks with #=). EDN has no = dispatch. The var cell
        ;; and the eval entry point live in later-loaded files; both resolve at
        ;; call time, and by the time user source is read the runtime is up.
-       (when (rdr-edn-mode) (rdr-error s i "No dispatch macro for: ="))
+       ;; EDN has no = dispatch; the gate above rejects it there.
        (let-values (((form j) (rdr-read-form s (+ i 1) end)))
          (when (rdr-eof? form) (rdr-error s i "EOF after #="))
          (unless (rdr-read-eval?)
@@ -1508,7 +1523,12 @@
             ((char=? c #\\) (rdr-read-char s (+ i 1) end i))
             ((char=? c #\:) (rdr-read-keyword s (+ i 1) end i))
             ((char=? c #\#) (rdr-read-dispatch s (+ i 1) end))
-            ((char=? c #\') (rdr-wrap s (+ i 1) end (jolt-symbol #f "quote")))
+            ;; ' is a reader macro in SOURCE only. EdnReader has no quote at all
+            ;; and does not terminate a token on it either, so "'foo" there is
+            ;; the symbol named 'foo — reading (quote foo) invented a form edn
+            ;; cannot express, exactly like the @ ` ~ arm below.
+            ((and (char=? c #\') (not (rdr-edn-mode)))
+             (rdr-wrap s (+ i 1) end (jolt-symbol #f "quote")))
             ;; EDN, before the three arms below claim these as reader macros:
             ;; ` @ ~ are non-constituent there, and one where a form should start
             ;; is the reference's "Invalid leading character" (see

--- a/host/chez/reader.ss
+++ b/host/chez/reader.ss
@@ -46,6 +46,16 @@
   (or (rdr-ws? c)
       (memv c '(#\( #\) #\[ #\] #\{ #\} #\" #\; #\@ #\^ #\` #\~ #\\))))
 
+;; @ ` ~ end a token above because they are reader MACRO characters in source.
+;; EDN has no macros for them at all, and Clojure's EdnReader goes further: they
+;; are NON-CONSTITUENT, refused wherever a token could hold one rather than
+;; quietly ending it. That difference is load-bearing — a token terminator makes
+;; "garbage!@" read as `garbage!` with the rest of the input dropped on the
+;; floor, where the reference throws (#905). Only the edn seam consults this;
+;; source reading keeps the terminator behavior.
+(define (rdr-nonconstituent? c)
+  (or (char=? c #\@) (char=? c #\`) (char=? c #\~)))
+
 (define (rdr-digit? c) (and (char>=? c #\0) (char<=? c #\9)))
 (define (rdr-octal? c) (and (char>=? c #\0) (char<=? c #\7)))
 (define (rdr-all-digits? s from to)
@@ -411,6 +421,16 @@
                      (or (char-alphabetic? c) (char-numeric? c))))
               (loop (+ j 1))
               (let ((name (substring s i j)))
+                ;; The character name is a token too, so in edn it may not run
+                ;; into an @ ` or ~ — \a@ is a constituent error there, not the
+                ;; character \a with the rest of the input dropped. (A literal
+                ;; \@ is still fine: the reference checks the name's FIRST
+                ;; character only when a form starts there, never after \.)
+                (when (and (< j end) (rdr-nonconstituent? (string-ref s j)) (rdr-edn-mode))
+                  (rdr-error-class s j "java.lang.RuntimeException"
+                                   (keyword "read" "invalid-constituent")
+                                   (string-append "Invalid constituent character: "
+                                                  (string (string-ref s j)))))
                 (if (= (string-length name) 1)
                     (values c0 j)
                     (values (rdr-named-char name s start) j)))))
@@ -456,11 +476,54 @@
                           (string-append "Unsupported character: \\" name)))))
 
 ;; --- token (symbol / keyword / number / nil|true|false) ---------------------
-(define (rdr-read-token s i end)
+;; Two entry points, differing only in EDN mode. rdr-read-token-lead is the main
+;; form dispatch's, the one call site where the JVM would have chosen readNumber
+;; — on a digit, or a sign directly in front of one. readNumber has no
+;; non-constituent check (it stops at whitespace or a macro char and nothing
+;; else), so an `@` there lands INSIDE the token and the failure is worded
+;; "Invalid number: 1@". Every other caller — keyword, #tag, ##, #:ns — reads a
+;; plain token, where the same `@` is a constituent error.
+(define (rdr-read-token s i end) (rdr-read-token* s i end #f))
+(define (rdr-read-token-lead s i end) (rdr-read-token* s i end #t))
+
+(define (rdr-read-token* s i end numeric?)
   (let loop ((j i))
     (if (and (< j end) (not (rdr-terminator? (string-ref s j))))
         (loop (+ j 1))
-        (values (substring s i j) j))))
+        ;; The character class is checked before the parameter: source reading
+        ;; pays three char compares on the token's last character and nothing
+        ;; else, and a token ends at whitespace or a close delimiter almost
+        ;; always.
+        (if (and (< j end) (rdr-nonconstituent? (string-ref s j)) (rdr-edn-mode))
+            (rdr-token-nonconstituent s i j end numeric?)
+            (values (substring s i j) j)))))
+
+;; The edn arm: the scan stopped on @ ` or ~. J is that character's index, I the
+;; token's start.
+(define (rdr-token-nonconstituent s i j end numeric?)
+  (if (and numeric? (rdr-number-lead? s i end))
+      ;; readNumber's loop, which the non-constituent never interrupts: take it
+      ;; into the token and let rdr-token->value report the whole run as an
+      ;; invalid number.
+      (let loop ((k j))
+        (if (and (< k end)
+                 (let ((c (string-ref s k)))
+                   (or (rdr-nonconstituent? c) (not (rdr-terminator? c)))))
+            (loop (+ k 1))
+            (values (substring s i k) k)))
+      (rdr-error-class s j "java.lang.RuntimeException"
+                       (keyword "read" "invalid-constituent")
+                       (string-append "Invalid constituent character: "
+                                      (string (string-ref s j))))))
+
+;; The JVM's number dispatch: a digit, or a sign with a digit behind it.
+(define (rdr-number-lead? s i end)
+  (and (< i end)
+       (let ((c (string-ref s i)))
+         (or (rdr-digit? c)
+             (and (or (char=? c #\+) (char=? c #\-))
+                  (< (+ i 1) end)
+                  (rdr-digit? (string-ref s (+ i 1))))))))
 
 ;; split a "ns/name" token on the FIRST slash (a lone "/" is name "/")
 (define (rdr-sym-parts tok)
@@ -1446,6 +1509,15 @@
             ((char=? c #\:) (rdr-read-keyword s (+ i 1) end i))
             ((char=? c #\#) (rdr-read-dispatch s (+ i 1) end))
             ((char=? c #\') (rdr-wrap s (+ i 1) end (jolt-symbol #f "quote")))
+            ;; EDN, before the three arms below claim these as reader macros:
+            ;; ` @ ~ are non-constituent there, and one where a form should start
+            ;; is the reference's "Invalid leading character" (see
+            ;; rdr-nonconstituent?). Reading it as a deref/quote form instead
+            ;; invented a value edn cannot express.
+            ((and (rdr-nonconstituent? c) (rdr-edn-mode))
+             (rdr-error-class s i "java.lang.RuntimeException"
+                              (keyword "read" "invalid-constituent")
+                              (string-append "Invalid leading character: " (string c))))
             ;; syntax-quote of a self-evaluating literal collapses to the literal at
             ;; READ time (Clojure's reader), so nested backticks over a literal are
             ;; inert: ``42 reads as 42, ```"meow" as "meow".
@@ -1478,7 +1550,7 @@
                    (rdr-error s i "EOF after ^meta"))
                  (values (rdr-attach-meta target (rdr-meta-map mform)) k))))
             (else
-             (let-values (((tok j) (rdr-read-token s i end)))
+             (let-values (((tok j) (rdr-read-token-lead s i end)))
                (values (rdr-token->value tok s i) j))))))))
 
 ;; wrap the next form in a 2-element list (READER-MACRO form)

--- a/host/chez/tasks-smoke.sh
+++ b/host/chez/tasks-smoke.sh
@@ -126,6 +126,13 @@ from-shell
 leave echo" "$(inbb "$BB" echo)"
 
 # babashka.tasks/run invokes another task in-process
+# A project file is edn that carries CODE, so a task body's reader macros —
+# quote, deref, syntax-quote/unquote, #() — have to read. EDN refuses ' @ ` ~
+# outright, so reading these files with the edn reader breaks every one of them.
+check "reader macros in a bb.edn task body" "enter macros
+macros: 41 sym [1 7] [2 4]
+leave macros" "$(inbb "$BB" macros)"
+
 check "run" "enter nested
 before
 enter clean
@@ -211,6 +218,7 @@ esac
 # --- jolt's own deps.edn :tasks forms ----------------------------------------
 
 check "deps.edn string task"    "deps-only-hello"           "$(inbb "$DEPS" hello)"
+check "reader macros in a deps.edn task body" "macros: 41 sym [2 4]" "$(inbb "$DEPS" macros)"
 check "deps.edn :main-opts task" 'depsonly main ("z")'      "$(inbb "$DEPS" main z)"
 check "a :main-opts task consumes one --" 'depsonly main ("z" "--" "w")' "$(inbb "$DEPS" main -- z -- w)"
 

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -167,9 +167,21 @@
                                      missed)))
             {:unresolved (mapv #(select-keys % [:coord :version :detail]) missed)}))))
 
+;; A project file is edn that also carries CODE: a :tasks body is a form jolt
+;; evaluates, and the ones people write are full of reader macros —
+;; (run 'clean), (require '[app.core]), @(future …), a `~ template. So the
+;; reader here is the source one with *read-eval* off, which is what babashka
+;; reads a bb.edn with and the only reader that takes those.
+;;
+;; clojure.edn cannot: EDN has no quote and no deref, and refuses ' @ ` ~
+;; outright. It only appeared to work while jolt's edn mode still honored the
+;; source reader macros, and the moment that seam was made strict (#905) a task
+;; body holding an @ stopped reading at all. *read-eval* false is the piece
+;; worth keeping from the edn reading — a project file must not evaluate
+;; anything at READ time.
 (defn- read-edn [path]
   (when (file-exists? path)
-    (try (edn/read-string (slurp path))
+    (try (binding [*read-eval* false] (read-string (slurp path)))
          (catch :default e
            (throw (ex-info (str path ": " (ex-message e)) {:path path :error e}))))))
 

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -6336,6 +6336,21 @@
   {:suite "clojure.edn / non-constituent @ ` ~" :label "an @ after a DELIMITED form is ordinary trailing junk, and still ignored" :expected "{:a 1}" :actual "(do (require (quote [clojure.edn :as en9])) (en9/read-string \"{:a 1}@\"))" :portability :common}
   {:suite "clojure.edn / non-constituent @ ` ~" :label "the source reader is untouched — there @ ends the token and derefs" :expected "[\"garbage!\" \"(clojure.core/deref foo)\"]" :actual "[(str (read-string \"garbage!@\")) (str (read-string \"@foo\"))]" :portability :common}
 
+  ;; EDN's dispatch table is CLOSED — #{ #_ #^ #< #: ## and a tagged literal are
+  ;; all of it — so every dispatch character the clojure reader adds is refused
+  ;; there. #( #" and #? used to read as a fn form, a regex and a conditional,
+  ;; inventing values edn cannot express; #! and #= were already refused, one arm
+  ;; at a time, which is why this is now one gate.
+  {:suite "clojure.edn / closed dispatch table" :label "the dispatch characters edn does not have" :expected "[\"No dispatch macro for: (\" \"No dispatch macro for: \\\"\" \"No dispatch macro for: '\" \"No dispatch macro for: ?\"]" :actual "(do (require (quote [clojure.edn :as ed1])) (mapv (fn [s] (try (ed1/read-string s) (catch RuntimeException e (.getMessage e)))) [\"#(inc 1)\" \"#\\\"re\\\"\" \"#'foo\" \"#?(:clj 1)\"]))" :portability :common}
+  {:suite "clojure.edn / closed dispatch table" :label "the ones it does have still read" :expected "(quote [#{1} 2 x {:a/b 1} ##Inf])" :actual "(do (require (quote [clojure.edn :as ed2])) [(ed2/read-string \"#{1}\") (ed2/read-string \"#_1 2\") (ed2/read-string \"#^{:m 1} x\") (ed2/read-string \"#:a{:b 1}\") (ed2/read-string \"##Inf\")])" :portability :common}
+  ;; ' is a reader macro in SOURCE only: EdnReader has no quote and does not end
+  ;; a token on it, so 'foo there is a symbol whose name starts with a quote.
+  {:suite "clojure.edn / closed dispatch table" :label "a leading quote is part of the symbol, not a quote form" :expected "[true \"'foo\"]" :actual "(do (require (quote [clojure.edn :as ed3])) (let [v (ed3/read-string \"'foo\")] [(symbol? v) (name v)]))" :portability :common}
+  {:suite "clojure.edn / closed dispatch table" :label "the source reader still quotes" :expected "(quote (quote foo))" :actual "(read-string \"'foo\")" :portability :common}
+  ;; #<…> is what a Java toString prints; neither reader takes it back. jolt read
+  ;; it as a tagged literal whose tag ran to end of input.
+  {:suite "clojure.edn / closed dispatch table" :label "#< is unreadable in both readers" :expected "[\"Unreadable form\" \"Unreadable form\"]" :actual "(do (require (quote [clojure.edn :as ed4])) (mapv (fn [f] (try (f) (catch RuntimeException e (.getMessage e)))) [(fn [] (ed4/read-string \"#<foo>\")) (fn [] (read-string \"#<foo>\"))]))" :portability :common}
+
   ;; The 1-arity (edn/read reader) drained the reader and handed the string to
   ;; the CORE read-string — the source reader, which resolves ::kw, takes #(…)
   ;; and #=, and ends a token at an @. It reads through clojure.edn/read-string

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -6318,4 +6318,29 @@
   ;; (host/chez/script-smoke.sh runs the executable-script end of it).
   {:suite "reader / shebang line" :label "a #! line reads as nothing, so a script's first line is a comment" :expected "42" :actual "(read-string \"#!/usr/bin/env jolt\\n42\")" :portability :common}
   {:suite "reader / shebang line" :label "and it comments to end of line anywhere, not only at the start of input" :expected "[1 3]" :actual "(read-string \"[1 #! two\\n 3]\")" :portability :common}
+
+  ;; EDN has no reader macros, and @ ` ~ are refused there rather than ending the
+  ;; token they sit in: "garbage!@" used to read as `garbage!` with the rest of the
+  ;; input silently dropped (#905). Where the reference dispatches readNumber — a
+  ;; digit, or a sign in front of one — the character joins the token instead and
+  ;; the failure is an invalid NUMBER naming the whole run, so both wordings and
+  ;; both throwable classes are pinned here.
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "a trailing @ after a token throws instead of truncating the read" :expected "\"Invalid constituent character: @\"" :actual "(do (require (quote [clojure.edn :as en1])) (try (en1/read-string \"garbage!@\") (catch RuntimeException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "an @ mid-token throws, rather than dropping everything from it on" :expected "\"Invalid constituent character: @\"" :actual "(do (require (quote [clojure.edn :as en2])) (try (en2/read-string \"a@b\") (catch RuntimeException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "a token that starts like a number takes the @ in and fails as a number" :expected "\"Invalid number: 1@\"" :actual "(do (require (quote [clojure.edn :as en3])) (try (en3/read-string \"1@\") (catch NumberFormatException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "@ where a form should start is a leading-character error, not a deref form" :expected "\"Invalid leading character: @\"" :actual "(do (require (quote [clojure.edn :as en4])) (try (en4/read-string \"@foo\") (catch RuntimeException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "` and ~ are non-constituent on the same terms" :expected "[\"Invalid constituent character: ~\" \"Invalid leading character: `\"]" :actual "(do (require (quote [clojure.edn :as en5])) (mapv (fn [s] (try (en5/read-string s) (catch RuntimeException e (.getMessage e)))) [\"a~b\" \"`foo\"]))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "a keyword's token is judged the same way" :expected "\"Invalid constituent character: @\"" :actual "(do (require (quote [clojure.edn :as en6])) (try (en6/read-string \":kw@\") (catch RuntimeException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "and so is a token inside a collection" :expected "\"Invalid constituent character: @\"" :actual "(do (require (quote [clojure.edn :as en7])) (try (en7/read-string \"[a@]\") (catch RuntimeException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "a character literal's name is a token too" :expected "\"Invalid constituent character: @\"" :actual "(do (require (quote [clojure.edn :as en8])) (try (en8/read-string \"\\\\a@\") (catch RuntimeException e (.getMessage e))))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "an @ after a DELIMITED form is ordinary trailing junk, and still ignored" :expected "{:a 1}" :actual "(do (require (quote [clojure.edn :as en9])) (en9/read-string \"{:a 1}@\"))" :portability :common}
+  {:suite "clojure.edn / non-constituent @ ` ~" :label "the source reader is untouched — there @ ends the token and derefs" :expected "[\"garbage!\" \"(clojure.core/deref foo)\"]" :actual "[(str (read-string \"garbage!@\")) (str (read-string \"@foo\"))]" :portability :common}
+
+  ;; The 1-arity (edn/read reader) drained the reader and handed the string to
+  ;; the CORE read-string — the source reader, which resolves ::kw, takes #(…)
+  ;; and #=, and ends a token at an @. It reads through clojure.edn/read-string
+  ;; now, so the seam is the same one read-string uses, end of input included.
+  {:suite "clojure.edn / read over a reader" :label "the same non-constituent rejection as read-string" :expected "\"Invalid constituent character: @\"" :actual "(do (require (quote [clojure.edn :as er1])) (try (er1/read (java.io.PushbackReader. (java.io.StringReader. \"garbage!@\"))) (catch RuntimeException e (.getMessage e))))" :portability :jvm}
+  {:suite "clojure.edn / read over a reader" :label "an auto-resolved keyword is not edn" :expected "\"Invalid token: ::kw\"" :actual "(do (require (quote [clojure.edn :as er2])) (try (er2/read (java.io.PushbackReader. (java.io.StringReader. \"::kw\"))) (catch RuntimeException e (.getMessage e))))" :portability :jvm}
+  {:suite "clojure.edn / read over a reader" :label "end of input is an error without an :eof option, and the option's value with one" :expected "[\"EOF while reading\" :end]" :actual "(do (require (quote [clojure.edn :as er3])) [(try (er3/read (java.io.PushbackReader. (java.io.StringReader. \"\"))) (catch RuntimeException e (.getMessage e))) (er3/read {:eof :end} (java.io.PushbackReader. (java.io.StringReader. \"\")))])" :portability :jvm}
 ]

--- a/test/chez/tasks/bbproj/bb.edn
+++ b/test/chez/tasks/bbproj/bb.edn
@@ -14,6 +14,13 @@
   args   {:task (println "args:" (pr-str *command-line-args*))}
   boom   {:doc "fail with 7" :task (shell "sh" "-c" "exit 7")}
   nested {:task (do (println "before") (run 'clean) (println "after"))}
+  ;; A task body is CODE, and the reader macros code uses have to read here:
+  ;; quote (as `nested` above already needs), deref, syntax-quote/unquote and
+  ;; #(). EDN has none of them and refuses ' @ ` ~ outright, which is why a
+  ;; project file is not read with the edn reader.
+  macros {:doc "the reader macros a code body needs"
+          :task (let [f (future 41) n 7]
+                  (println "macros:" @f (quote sym) (pr-str `[1 ~n]) (mapv #(* 2 %) [1 2])))}
   secret {:private true :task (println "secret")}
   ;; babashka's other spelling of "helper, not an entry point": a leading dash.
   ;; Hidden from the listing like :private, and runnable like it too.

--- a/test/chez/tasks/depsonly/deps.edn
+++ b/test/chez/tasks/depsonly/deps.edn
@@ -1,5 +1,8 @@
 ;; No bb.edn: jolt's own deps.edn :tasks forms keep working unchanged.
 {:paths ["src"]
+ ;; deps.edn :tasks carry code too, so the same reader macros have to read out
+ ;; of THIS file — it is not read as edn either.
  :tasks {hello "echo deps-only-hello"
+         macros {:task (println "macros:" @(future 41) (quote sym) (mapv #(* 2 %) [1 2]))}
          fail  "exit 3"
          main  {:doc "app entry" :main-opts ["-m" "depsonly.core"]}}}

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -706,8 +706,10 @@
   ;; whatever file the literal sits in. An ordinary read still positions its lists.
   {:suite "reader-macros" :expr "[(meta (nth (read-string \"#$\\\"a ~(inc x)\\\"\") 2)) (some? (:line (meta (read-string \"(inc x)\"))))]" :expected "[nil true]"}
   ;; edn is a closed grammar with no user extension point, so the table is not
-  ;; consulted there and #$ stays the unreadable tag it always was.
-  {:suite "reader-macros" :expr "(try (clojure.edn/read-string \"#$\\\"a\\\"\") :no-throw (catch Exception e (ex-message e)))" :expected "\"No reader function for tag $\""}
+  ;; consulted there. Nor does #$ fall through to the tagged-literal arm: the
+  ;; reference dispatches a tag on a LETTER only, and answers "No dispatch macro"
+  ;; for anything else — verified against Clojure 1.12.5.
+  {:suite "reader-macros" :expr "(try (clojure.edn/read-string \"#$\\\"a\\\"\") :no-throw (catch Exception e (ex-message e)))" :expected "\"No dispatch macro for: $\""}
   ;; the two registration tiers: the default reads the next form and hands it to
   ;; the fn, :raw hands the fn the source and an index and takes back [form end].
   {:suite "reader-macros" :expr "(do (require (quote [jolt.reader :as r])) (r/set-dispatch-macro! \\% (fn [f] (list (quote clojure.core/vector) f f))) (load-string \"#%(+ 1 2)\"))" :expected "[3 3]"}

--- a/test/conformance/error-kinds.edn
+++ b/test/conformance/error-kinds.edn
@@ -30,6 +30,14 @@
  "A token that is not a valid symbol or keyword: a leading or trailing slash, a
   bare `:` or `::`, or a keyword name beginning with a colon (`:::c`)."
 
+ :read/invalid-constituent
+ "An `@`, `` ` `` or `~` read as EDN (`clojure.edn`). EDN has no reader macros,
+  and those three are refused outright rather than ending the token they sit in:
+  inside or after a token it is an `Invalid constituent character`, where a form
+  should start an `Invalid leading character`. A `RuntimeException` on both
+  runtimes. Source reading is unaffected — there they are ordinary macro
+  characters."
+
  :read/invalid-character
  "A character literal that names nothing — an unknown `\\name`, or an octal escape
   outside `[0, 377]`."


### PR DESCRIPTION
Fixes #905.

## The divergence

`clojure.edn` ended a token at `@`, `` ` `` and `~` and dropped everything after
it, so input the reference rejects came back as a value:

```clojure
(edn/read-string "garbage!@")   ;; JVM: Invalid constituent character: @   jolt: garbage!
(edn/read-string "1@")          ;; JVM: Invalid number: 1@                 jolt: 1
(edn/read-string "a@b")         ;; JVM: Invalid constituent character: @   jolt: a
```

Those three are reader **macro** characters in source, which is why jolt's
reader terminates a token on them — correct there, and `@foo` in source is a
deref form. EDN has no reader macros at all, and Clojure's `EdnReader` goes
further: it treats them as **non-constituent** and refuses them outright.

## What the reference does, and what jolt does now

| input | result |
| --- | --- |
| `garbage!@`, `a@b`, `:kw@`, `[a@]`, `nil@`, `\a@`, `#foo@ 1` | `RuntimeException: Invalid constituent character: @` |
| `@foo`, `` `foo ``, `~foo`, `[1 @]` | `RuntimeException: Invalid leading character: @` |
| `1@`, `-1@`, `1.5@`, `1/2@`, `0x1@`, `[1@]` | `NumberFormatException: Invalid number: 1@` |
| `{:a 1}@`, `#{1}@`, `1 2` | first form, trailing junk ignored (unchanged) |
| `\@`, `"s@"`, `;c@` | legal (unchanged) |

The number split is the reference's own: `readNumber` has no constituent check
(it stops only at whitespace or a macro char), so where the JVM would have
dispatched a number — a digit, or a sign directly in front of one — the
character joins the token and the failure names the whole run. Every row above
was diffed against JVM Clojure 1.12.5 before and after.

## Also fixed

`(clojure.edn/read reader)` — the 1-arity — drained the reader and handed the
string to **`clojure.core/read-string`**, the source reader. So the seam whose
whole job is strictness resolved `::kw`, read `#(…)` and `#=`, ended a token at
an `@`, and answered `nil` at end of input where the reference throws. It goes
through `clojure.edn/read-string` now, like the 2-arity already did.

## Changes

- `host/chez/reader.ss` — `rdr-nonconstituent?`, the edn arm of the token scan
  (with the numeric-lead case), the leading-character arm in the form dispatch,
  and the character-literal name check. All four are gated on edn mode; source
  reading is unchanged, and the hot token loop pays three character compares on
  the character a token ends at.
- `host/chez/java/io.ss` — `chez-edn-read` reads through `clojure.edn/read-string`.
- `test/chez/corpus.edn` — 13 rows, all certified against reference Clojure.
- `test/conformance/error-kinds.edn` — `:read/invalid-constituent`.

## Gates

Green: `corpus`, `certify` (against JVM Clojure 1.12.5 — 0 new, 0 stale
divergences), `unit`, `documented`, `errorkinds`, `smoke`, `cts` (matches
baseline), `sci`, `grenadine`, `depsunit`, `depssmoke`, `depscpcache`,
`scriptsmoke`, `taskssmoke`, `stdlibfasl`, `seeddefs`, `manifestcheck`,
`devbootsmoke`, `readscaling`, `ioscaling`.

A whole-`make ci` run was killed twice by the dev box's memory watchdog (7.6 GB
box; cf. jolt-09i), and `buildsmoke` did not finish inside the time budget — so
those two are unrun rather than failing.
