### PR TITLE
A declared :jolt/provides provider resolves its class, whatever loaded first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,24 +15,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registers classes it does not declare pre-empted the library that does declare
   them: jolt.crypto registers an EC-only `java.security.Signature` while
   declaring only the symmetric classes, and once that side-effect registration
-  landed the declared provider never loaded. Same deps.edn, two outcomes —
-  whichever namespace compiled first won, silently (#914). A claim is now an
-  authority over WHO implements a class, not a fallback for an absent one: the
-  declared provider loads before the first reference to a class it claims
-  resolves, table hit or not, and once it has registered a member of that class
-  a registration of the same member from anywhere else is dropped rather than
-  allowed to win by being last. A member the provider's shim does NOT answer
-  still registers — a claim is authority over what the provider implements, not
-  a reservation on the name, and filling a gap in a shim is what
-  `extend-class!` is for. The drop is reported on stderr, because the library
-  asked for something it did not get; under `JOLT_DEBUG` so are the two cases
-  that are merely the contract being bent — a registration for a class whose
-  provider has not loaded yet, and an install namespace registering a class it
-  never declared, which is why a reference to `java.security.KeyPairGenerator`
-  could report "No dependency provides" in one namespace and answer an EC-only
-  shim in the next. A provider's own declared classes are untouched, and so are
-  registrations for classes nobody declares. Resolution costs one boolean test
-  on the static-reference path once every declared provider has loaded.
+  landed the registry hit meant the declared provider never loaded. Same
+  deps.edn, two outcomes — whichever namespace compiled first won, silently
+  (#914). A claim is now an authority over WHO implements a class, not a
+  fallback for an absent one, and the registry can no longer answer for a
+  claimed class before its claimer has spoken. A registration from anywhere else
+  is HELD while the claim is outstanding and replayed once it settles, so the
+  autoload still happens; a registration that arrives after the provider has
+  claimed a member is dropped rather than allowed to win by being last. A member
+  the provider's shim does NOT answer still registers, in either order — a claim
+  is authority over what the provider implements, not a reservation on the name,
+  and filling a gap in a shim is what `extend-class!` is for. A provider that
+  cannot deliver, its install namespace off the source roots or raising,
+  releases what it held rather than taking it down with it. The drop is reported
+  on stderr, because the library asked for something it did not get; under
+  `JOLT_DEBUG` so are the two cases that are merely the contract being bent — a
+  registration held for a provider that has not loaded, and an install namespace
+  registering a class it never declared, which is why a reference to
+  `java.security.KeyPairGenerator` could report "No dependency provides" in one
+  namespace and answer an EC-only shim in the next. A provider's own declared
+  classes are untouched, and so are registrations for classes nobody declares.
+  Resolution stays on the registry-miss path, so a static reference and a
+  `(Class. …)` cost exactly what they did before.
 
 - **`java.net.URI`'s constructor validates.** `(java.net.URI. "https://not a
   url")` answered a URI whose `.getHost` was `"not a url"`; the JVM's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `java.security.KeyPairGenerator` could report "No dependency provides" in one
   namespace and answer an EC-only shim in the next. A provider's own declared
   classes are untouched, and so are registrations for classes nobody declares.
-  Resolution stays on the registry-miss path, so a static reference and a
-  `(Class. …)` cost exactly what they did before.
+  What jolt itself ships claims a NAME, not the implementation of every member
+  under it: `jolt.time.base` and `jolt.socket` are the runtime's base tier, and a
+  base tier exists to be extended — jolt-lang/time declares only the formatting
+  classes and adds a `DateTimeFormatter` arm to `java.time.LocalDate/from` — so
+  the guard is between two DEPENDENCIES, which is what #914 is. Resolution stays
+  on the registry-miss path, so a static reference and a `(Class. …)` cost
+  exactly what they did before.
 
 - **`java.net.URI`'s constructor validates.** `(java.net.URI. "https://not a
   url")` answered a URI whose `.getHost` was `"not a url"`; the JVM's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A declared `:jolt/provides` provider resolves a class whatever loaded
+  first.** RFC 0014 autoloaded a provider's install namespace only when the
+  referenced class was still UNREGISTERED, so a library whose `install!`
+  registers classes it does not declare pre-empted the library that does declare
+  them: jolt.crypto registers an EC-only `java.security.Signature` while
+  declaring only the symmetric classes, and once that side-effect registration
+  landed the declared provider never loaded. Same deps.edn, two outcomes —
+  whichever namespace compiled first won, silently (#914). A claim is now an
+  authority over WHO implements a class, not a fallback for an absent one: the
+  declared provider loads before the first reference to a class it claims
+  resolves, table hit or not, and once it has registered a member of that class
+  a registration of the same member from anywhere else is dropped rather than
+  allowed to win by being last. A member the provider's shim does NOT answer
+  still registers — a claim is authority over what the provider implements, not
+  a reservation on the name, and filling a gap in a shim is what
+  `extend-class!` is for. The drop is reported on stderr, because the library
+  asked for something it did not get; under `JOLT_DEBUG` so are the two cases
+  that are merely the contract being bent — a registration for a class whose
+  provider has not loaded yet, and an install namespace registering a class it
+  never declared, which is why a reference to `java.security.KeyPairGenerator`
+  could report "No dependency provides" in one namespace and answer an EC-only
+  shim in the next. A provider's own declared classes are untouched, and so are
+  registrations for classes nobody declares. Resolution costs one boolean test
+  on the static-reference path once every declared provider has loaded.
+
 - **`java.net.URI`'s constructor validates.** `(java.net.URI. "https://not a
   url")` answered a URI whose `.getHost` was `"not a url"`; the JVM's
   single-argument constructor parses per RFC 2396 and throws

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -349,6 +349,15 @@ esac
 # declared class still resolves to it.
 check "a provider still registers what it declares" "squatter-mac:HmacSHA256" \
       "$(run -A:prov run -m appprovsquat)"
+# The runtime's own base tier is EXTENDED, not owned: jolt.time.base declares
+# java.time.Instant and implements parse, and jolt-lang/time adds a
+# DateTimeFormatter arm to members exactly like it. Treating a shipped provider's
+# claim as authority over the library that completes it cost the tick suite five
+# parse tests to "dropping a registration for LocalDate/from". What jolt ships
+# claims the NAME; RFC 0014's guard is about two DEPENDENCIES disagreeing.
+check "a library registers over the base tier" \
+      "claimer-sig:x claimer-instant" \
+      "$(runall -A:prov run -m appprovbase | tr '\n' ' ' | sed 's/ $//')"
 # Holding a registration is a wait for the claimer, not a veto. provgone declares
 # java.security.KeyPairGenerator and ships no install namespace, so its claim
 # settles without ever registering anything — and provsquat's held registration for

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -4,7 +4,7 @@
 # Fixture projects live in test/chez/deps-alias/: `app` selects aliases over two
 # local libs that define the same namespace at different "versions" (liba/libb),
 # a third lib (libc), a stand-in jolt.time lib for the roots-autoload gate, and
-# provclaim/provsquat for RFC 0014 provider resolution.
+# provclaim/provsquat/provgone for RFC 0014 provider resolution.
 # Asserts the tools.deps alias args-map keys jolt supports — :extra-deps /
 # :extra-paths / :override-deps / :default-deps / :replace-deps / :replace-paths
 # / :main-opts — plus multi-alias combination rules, alias visibility in `path`,
@@ -324,7 +324,7 @@ check "the declared provider resolves a claimed class" "claimer-sig:SHA256withEC
       "$(run -A:prov run -m appprovsig)"
 out="$(runall -A:prov run -m appprovmac)"
 check "a squatting registration does not pre-empt the claimer" \
-      "squatter-mac:HmacSHA256 claimer-sig:SHA256withECDSA claimer-sig:SHA256withECDSA claimer-sig-ctor" \
+      "squatter-mac:HmacSHA256 claimer-sig:SHA256withECDSA claimer-sig:SHA256withECDSA claimer-sig-ctor squatter-extra" \
       "$(printf '%s' "$out" | tr '\n' ' ' | sed 's/ $//')"
 # ...and in the other order, where the claimer is already loaded when the
 # squatter's install namespace runs, the late registration is dropped rather than
@@ -349,6 +349,13 @@ esac
 # declared class still resolves to it.
 check "a provider still registers what it declares" "squatter-mac:HmacSHA256" \
       "$(run -A:prov run -m appprovsquat)"
+# Holding a registration is a wait for the claimer, not a veto. provgone declares
+# java.security.KeyPairGenerator and ships no install namespace, so its claim
+# settles without ever registering anything — and provsquat's held registration for
+# that class has to be released rather than lost with the provider.
+check "a provider that never loads releases what it held" \
+      "squatter-mac:HmacSHA256 squatter-kpg:RSA" \
+      "$(runall -A:prov run -m appprovgone | tr '\n' ' ' | sed 's/ $//')"
 
 # io/resource answers an ABSOLUTE file: URL for a file on a source root, like the
 # JVM classloader. The roots here are relative ("./src"), and "file:./src/x" is

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -3,12 +3,14 @@
 #
 # Fixture projects live in test/chez/deps-alias/: `app` selects aliases over two
 # local libs that define the same namespace at different "versions" (liba/libb),
-# a third lib (libc), and a stand-in jolt.time lib for the roots-autoload gate.
+# a third lib (libc), a stand-in jolt.time lib for the roots-autoload gate, and
+# provclaim/provsquat for RFC 0014 provider resolution.
 # Asserts the tools.deps alias args-map keys jolt supports — :extra-deps /
 # :extra-paths / :override-deps / :default-deps / :replace-deps / :replace-paths
 # / :main-opts — plus multi-alias combination rules, alias visibility in `path`,
 # -A composing with -M, an undeclared alias warning and being skipped, the
-# java.time library autoload from the source roots, and the tools.deps CLI
+# java.time library autoload from the source roots, load-order-independent
+# :jolt/provides resolution, and the tools.deps CLI
 # surface: -X/-T exec, -Sdeps, the report options (-Spath / -Stree / -Strace /
 # -Sdescribe / -P), -Scp, -Srepro, -Sverbose, the accepted-and-ignored options,
 # the user deps.edn chain, :local/root jars, :git/tag + short sha, and git cache
@@ -310,6 +312,43 @@ case "$(printf '%s' "$out" | head -1)" in
   *jolt-lang/*) check "library miss names no library" "no library named" "$(printf '%s' "$out" | head -1)" ;;
   *) check "library miss names no library" ok ok ;;
 esac
+
+# RFC 0014 provider resolution is a property of the GRAPH, not of compile order
+# (jolt#914). provclaim declares java.security.Signature; provsquat declares
+# javax.crypto.Mac and its install namespace registers Signature too, without
+# declaring it. Autoloading a provider only on a registry MISS meant the
+# undeclared registration pre-empted the claimer whenever the Mac reference came
+# first — same deps.edn, two answers, and no diagnostic. Both orders must resolve
+# Signature to the library that declares it.
+check "the declared provider resolves a claimed class" "claimer-sig:SHA256withECDSA" \
+      "$(run -A:prov run -m appprovsig)"
+out="$(runall -A:prov run -m appprovmac)"
+check "a squatting registration does not pre-empt the claimer" \
+      "squatter-mac:HmacSHA256 claimer-sig:SHA256withECDSA claimer-sig:SHA256withECDSA claimer-sig-ctor" \
+      "$(printf '%s' "$out" | tr '\n' ' ' | sed 's/ $//')"
+# ...and in the other order, where the claimer is already loaded when the
+# squatter's install namespace runs, the late registration is dropped rather than
+# allowed to win by being last.
+# The last line is the additive half: a MEMBER the provider's shim does not
+# answer is not a substitution and still registers, the same posture
+# class-extensions.ss takes. The claim is authority over what the provider
+# implements, not a reservation on the name.
+check "a late squatting registration does not take the class over" \
+      "claimer-sig:a squatter-mac:b claimer-sig:c squatter-extra" \
+      "$(runall -A:prov run -m appprovboth | tr '\n' ' ' | sed 's/ $//')"
+# The drop is reported: the library asked for something it did not get, and the
+# symptom would otherwise surface somewhere else entirely.
+out="$(runfull -A:prov run -m appprovboth)"
+case "$out" in
+  *"dropping a registration for java.security.Signature"*)
+    check "the dropped registration is reported" ok ok ;;
+  *) check "the dropped registration is reported" "a warning naming the dropped class" \
+           "$(printf '%s' "$out" | head -2)" ;;
+esac
+# The guard is about classes ANOTHER dependency declares. A provider's own
+# declared class still resolves to it.
+check "a provider still registers what it declares" "squatter-mac:HmacSHA256" \
+      "$(run -A:prov run -m appprovsquat)"
 
 # io/resource answers an ABSOLUTE file: URL for a file on a source root, like the
 # JVM classloader. The roots here are relative ("./src"), and "file:./src/x" is

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1650,7 +1650,7 @@
 (def-var! "clojure.core" "__register-class-ctor!"
   (lambda (name proc) (register-class-ctor-user! name proc) jolt-nil))
 (def-var! "clojure.core" "__register-class-statics!"
-  (lambda (name members) (register-class-statics! name (jmap->static-alist members)) jolt-nil))
+  (lambda (name members) (register-class-statics-user! name (jmap->static-alist members)) jolt-nil))
 
 ;; ---- tagged-table method dispatch + pluggable instance? --------------------
 ;; A jolt library can build stateful host objects with (jolt.host/tagged-table

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -96,21 +96,41 @@
 (define (register-class-ctor-user! name proc)
   ;; A constructor is one value, so there is no additive half to let through the
   ;; way register-class-statics-user! does with members.
-  (unless (let ((owner (lib-provider-owner-elsewhere name)))
-            (and owner (begin (provider-claim-drop! name owner '()) #t)))
-    (provider-claim-note! name)
-    (when (and (getenv "JOLT_DEBUG") (hashtable-ref host-class-ctors-tbl name #f))
-      (fprintf (current-error-port)
-               "warning: a library replaced the host constructor for ~a — every (~a. ...) in this process now builds its shim, including in namespaces that never asked for it\n"
-               name name))
-    (lib-note-provider-registration! name)
-    (hashtable-set! class-ctors-tbl name proc)))
+  (cond
+    ((lib-pending-claimer name)
+     => (lambda (pending)
+          (provider-claim-hold! name pending '())
+          (lib-defer-registration! pending (lambda () (register-class-ctor-user! name proc)))))
+    ((lib-provider-owner-elsewhere name)
+     => (lambda (owner) (provider-claim-drop! name owner '())))
+    (else
+     (provider-claim-note! name)
+     (when (and (getenv "JOLT_DEBUG") (hashtable-ref host-class-ctors-tbl name #f))
+       (fprintf (current-error-port)
+                "warning: a library replaced the host constructor for ~a — every (~a. ...) in this process now builds its shim, including in namespaces that never asked for it\n"
+                name name))
+     (lib-note-provider-registration! name)
+     (hashtable-set! class-ctors-tbl name proc))))
 
 ;; clojure.core/__register-class-statics! lands here — the statics counterpart of
 ;; register-class-ctor-user!, and under the same provider guard. The host's own
 ;; boot-time registrations go straight to register-class-statics! and are not
 ;; subject to it: nothing has declared anything yet when they run.
 (define (register-class-statics-user! name members)
+  (let ((pending (lib-pending-claimer name)))
+    (if pending
+        ;; The claimer has not spoken yet, so there is nothing to compare this
+        ;; against — and letting it land would put an entry in the registry for a
+        ;; class whose provider has not loaded, which is exactly what stops the
+        ;; autoload from ever running (jolt#914). Hold it until the claim settles.
+        (begin (provider-claim-hold! name pending (map car members))
+               (lib-defer-registration!
+                pending (lambda () (register-class-statics-user! name members))))
+        (register-class-statics-owned! name members))))
+
+;; The claim on `name` has settled (or there never was one): what the class's
+;; provider registered is authority, everything else is additive or refused.
+(define (register-class-statics-owned! name members)
   (let ((owner (lib-provider-owner-elsewhere name)))
     (if owner
         ;; A provider owns the members it registered, not the whole name. Adding a
@@ -373,20 +393,20 @@
 (define lib-class-providers core-class-providers)
 
 ;; ---- claim index: which claims have not had their chance yet ----------------
-;; Resolution consults the provider table on EVERY reference to a claimed class,
-;; not only on a registry miss (jolt#914) — see lib-ensure-provider!. That puts
-;; the lookup on the hot path of every Class/member, so it cannot be the linear
-;; walk lib-provider-for does. This table holds one entry per SPELLING for the
-;; claims of providers that have not been autoloaded yet, and entries leave it
-;; the moment their provider is attempted; the flag makes the common case — every
-;; provider already loaded, or none declared — a single boolean test.
+;; One entry per SPELLING for the claims of providers that have not been
+;; autoloaded yet; entries leave the moment their provider is attempted. Two
+;; questions read it, and neither is on the hot path: which provider to autoload
+;; when a class reference MISSES (lib-try-autoload!), and whether a registration
+;; is about to squat on a class whose claimer has not spoken (lib-pending-claimer).
+;; The flag keeps the second one — asked once per registration — a boolean test
+;; when nothing is declared.
 (define lib-pending-claims-tbl (make-hashtable string-hash string=?))
 (define lib-any-pending-claims? #f)
-;; Autoload is one-shot per provider and now runs from every reference, so two
-;; threads reaching a claimed class at once must not both load the install
-;; namespace. The latch flip and the index purge go under this mutex; the load
-;; itself does NOT, because an install namespace requires others and a nested
-;; autoload would deadlock on a non-recursive mutex.
+;; Autoload is one-shot per provider, and two threads reaching a claimed class at
+;; once must not both load the install namespace. The latch flip, the index purge
+;; and the held-registration list go under this mutex; the load itself does NOT,
+;; because an install namespace requires others and a nested autoload would
+;; deadlock on a non-recursive mutex.
 (define lib-claims-mu (make-mutex))
 (define (lib-claim-pending! p)
   (for-each (lambda (c) (hashtable-set! lib-pending-claims-tbl c p)) (vector-ref p 2))
@@ -395,6 +415,29 @@
   (for-each (lambda (c) (hashtable-delete! lib-pending-claims-tbl c)) (vector-ref p 2))
   (set! lib-any-pending-claims? (> (hashtable-size lib-pending-claims-tbl) 0)))
 (for-each lib-claim-pending! core-class-providers)
+
+;; Registrations HELD because the class's declared provider has not loaded yet.
+;; Letting one land would put an entry in the registry for a class whose claimer
+;; has not spoken — and a registry HIT is exactly what stops the autoload, which
+;; is how resolution came to depend on compile order (jolt#914). They are replayed
+;; the moment the claim settles, through the same guard as any other registration:
+;; what the provider implements wins, what it left unanswered still lands. Keyed
+;; by provider, because the provider is what settles.
+(define lib-deferred-tbl (make-eq-hashtable))
+(define (lib-defer-registration! p thunk)
+  (jolt-with-mutex lib-claims-mu
+    (hashtable-set! lib-deferred-tbl p (cons thunk (hashtable-ref lib-deferred-tbl p '())))))
+;; Called for every settled claim, including one whose install namespace was off
+;; the source roots or raised: a provider that cannot deliver must not swallow
+;; somebody else's registration with it. Answers whether anything was held, which
+;; is a change to what the registry says and so a reason for the caller to retry.
+(define (lib-replay-deferred! p)
+  (let ((held (jolt-with-mutex lib-claims-mu
+                (let ((h (hashtable-ref lib-deferred-tbl p '())))
+                  (hashtable-delete! lib-deferred-tbl p)
+                  h))))
+    (for-each (lambda (t) (t)) (reverse held))
+    (pair? held)))
 
 ;; The provider whose install namespace is loading on THIS thread, or #f. A
 ;; provider registers its classes as its install namespace loads, and the
@@ -477,29 +520,59 @@
               (begin (set-box! (vector-ref p 3) 'ok)
                      (lib-claim-settled! p)
                      #t)))
-       (find-ns-file (vector-ref p 0))
-       (begin (guard (c (#t (set-box! (vector-ref p 3) 'failed)
-                            (raise c)))
-                (parameterize ((lib-loading-provider p))
-                  (load-namespace (vector-ref p 0))))
-              #t)))
+       ;; The claim is settled from here whatever happens next, so registrations
+       ;; held against it are replayed on every exit — including the install
+       ;; namespace being off the roots, and the one that raises. A provider that
+       ;; cannot deliver leaves the class to whoever else registered it, which is
+       ;; what happened before the claim was honoured at all.
+       ;;
+       ;; Either half is a reason for the caller to look again, so the answer is
+       ;; their OR: a class can become resolvable through a replay alone.
+       (let* ((loaded (and (find-ns-file (vector-ref p 0))
+                           (begin (guard (c (#t (set-box! (vector-ref p 3) 'failed)
+                                                (lib-replay-deferred! p)
+                                                (raise c)))
+                                    (parameterize ((lib-loading-provider p))
+                                      (load-namespace (vector-ref p 0))))
+                                  #t)))
+              (replayed (lib-replay-deferred! p)))
+         (or loaded replayed))))
 
-;; RFC 0014's resolution step. A declared provider must load before the FIRST
-;; reference to a class it claims resolves — including when the registry ALREADY
-;; holds an entry for that class (jolt#914). Autoloading only on a registry miss
-;; made resolution depend on compile order: a library whose install! registers
-;; classes it does not declare (jolt.crypto registers java.security.Signature and
-;; declares only the symmetric classes) pre-empted the provider that DOES declare
-;; them, because the table hit served the incumbent and the claimer never loaded.
-;; Same deps.edn, two outcomes. A claim is an authority over who implements a
-;; class, not merely a fallback for an absent one, so the claimer loads first and
-;; its registration is the one resolution sees.
+;; RFC 0014's resolution step: a class reference that MISSES the registry
+;; autoloads the provider that declares the class, and retries.
 ;;
-;; Cost on the hot path is one boolean test once every provider has loaded.
-(define (lib-ensure-provider! class)
+;; A miss is enough because a claimed class cannot be a HIT before its claimer has
+;; loaded — register-class-provider! refuses a claim on a class the runtime
+;; already implements, and lib-pending-claimer holds any other library's
+;; registration until the claim settles. That is what makes resolution a property
+;; of the dependency graph rather than of compile order (jolt#914): the table hit
+;; that used to serve an undeclared registration — jolt.crypto registers an
+;; EC-only java.security.Signature while declaring only the symmetric classes —
+;; never forms, so the claimer still autoloads and still wins.
+;;
+;; Keeping it on the miss path is also what keeps it off the hot one: every
+;; static reference and every (Class. ...) would otherwise pay a lookup here, and
+;; jolt.time.base / jolt.socket leave a claim pending in almost every program, so
+;; there is no steady state in which that lookup goes away.
+(define (lib-try-autoload! class)
   (and lib-any-pending-claims?
        (let ((p (hashtable-ref lib-pending-claims-tbl class #f)))
          (and p (lib-load-provider! p)))))
+
+;; The provider that DECLARES this class and has not had its chance yet — meaning
+;; the registration about to happen is somebody else's, and must wait. #f when
+;; nothing claims the class, when the claim has already settled, or when this IS
+;; the claimer registering.
+(define (lib-pending-claimer name)
+  (and lib-any-pending-claims?
+       (let ((p (hashtable-ref lib-pending-claims-tbl name #f)))
+         (and p
+              (not (eq? p (lib-loading-provider)))
+              ;; An install namespace pulled in by a plain require rather than by
+              ;; the autoload carries no lib-loading-provider mark, and its own
+              ;; registrations must not be held against it.
+              (not (ns-dedup-loaded? (vector-ref p 0)))
+              p))))
 
 ;; ---- the registration guard -------------------------------------------------
 ;; A class a dependency DECLARES is that dependency's to implement, and RFC 0014
@@ -545,36 +618,39 @@
                    ((null? (cdr members)) "that member")
                    (else "those members")))))
 
-;; The same registration BEFORE the claimer has loaded is not a bug the runtime
-;; has to stop — the claimer autoloads on the first reference to the class and
-;; registers over this one, so resolution lands on the provider either way. It is
-;; still a library registering a class it did not declare, which is the thing to
-;; fix at the source, so say so under JOLT_DEBUG the way the other registry
-;; diagnostics do.
+;; The same registration BEFORE the claimer has loaded costs nobody the class:
+;; it is held, the claimer autoloads on the first reference and registers, and
+;; whatever the claimer left unanswered lands after it. So this is a note, not the
+;; refusal provider-claim-drop! reports — but it is still a library registering a
+;; class it did not declare, which is the thing to fix at the source, so say so
+;; under JOLT_DEBUG the way the other registry diagnostics do.
+(define (provider-claim-hold! name pending members)
+  (when (and (getenv "JOLT_DEBUG") (claim-warn-once? "hold" name))
+    (fprintf (current-error-port)
+             "warning: holding ~a — ~a declares that class (:jolt/provides, RFC 0014) and has not loaded yet; it loads on the first reference to ~a, and what it does not implement is registered after it\n"
+             (if (null? members)
+                 (string-append "a constructor registration for " name)
+                 (string-append "a registration for "
+                                (fold-left (lambda (a m)
+                                             (let ((one (string-append name "/" m)))
+                                               (if (string=? a "") one (string-append a ", " one))))
+                                           "" members)))
+             (vector-ref pending 0) name)))
+
+;; The contract from the other side: an install namespace registering a class it
+;; does not declare. Nothing autoloads a provider for a class it never claimed, so
+;; whether that class resolves at all depends on what else happens to pull the
+;; namespace in first — which is how a reference to java.security.KeyPairGenerator
+;; reported "No dependency provides" in one namespace and answered an EC-only shim
+;; in the next (jolt#914).
 (define (provider-claim-note! name)
   (when (getenv "JOLT_DEBUG")
-    (let ((self (lib-loading-provider))
-          (p (lib-provider-for name)))
-      ;; Both arms are about the same class, so they share one dedupe key: the
-      ;; claimed-elsewhere reading is the more actionable one and goes first.
-      (cond
-        ((and p (not (eq? p self)) (not (unbox (vector-ref p 3))))
-         (when (claim-warn-once? "note" name)
-           (fprintf (current-error-port)
-                    "warning: a registration for ~a is a class ~a declares (:jolt/provides); that provider loads on the first reference to ~a and its registration is the one that resolves\n"
-                    name (vector-ref p 0) name)))
-        ;; The contract from the other side: an install namespace registering a
-        ;; class it does not declare. Nothing autoloads a provider for a class it
-        ;; never claimed, so whether that class resolves at all depends on what
-        ;; else happens to pull the namespace in first — which is how a reference
-        ;; to java.security.KeyPairGenerator reported "No dependency provides" in
-        ;; one namespace and answered an EC-only shim in the next (jolt#914).
-        ((and self (not (member name (vector-ref self 2))))
-         (when (claim-warn-once? "note" name)
-           (fprintf (current-error-port)
-                    "warning: ~a registers ~a without declaring it in :jolt/provides (RFC 0014); nothing autoloads ~a for a class it does not declare, so whether ~a resolves depends on what else pulls that namespace in\n"
-                    (vector-ref self 0) name (vector-ref self 0) name)))
-        (else #f)))))
+    (let ((self (lib-loading-provider)))
+      (when (and self (not (member name (vector-ref self 2)))
+                 (claim-warn-once? "note" name))
+        (fprintf (current-error-port)
+                 "warning: ~a registers ~a without declaring it in :jolt/provides (RFC 0014); nothing autoloads ~a for a class it does not declare, so whether ~a resolves depends on what else pulls that namespace in\n"
+                 (vector-ref self 0) name (vector-ref self 0) name)))))
 
 ;; A provider that is on the source roots but raised while loading leaves the
 ;; class unregistered exactly like an undeclared dependency does — but the fix is
@@ -650,9 +726,6 @@
 ;; cannot be read off a #f result.
 (define host-static-miss (list 'host-static-miss))
 (define (host-static-ref class member)
-  ;; the class's declared provider, if any, loads BEFORE the lookup — so what the
-  ;; registry answers does not depend on who happened to register first (jolt#914)
-  (lib-ensure-provider! class)
   (let ((cell (mutable-static-cell class member #f)))
     (if cell
         (vector-ref cell 0)
@@ -663,11 +736,14 @@
                     (or (class-instance-fallback class member)
                         (throw-jvm (quote IllegalArgumentException) (string-append "No matching field or method: " class "/" member)))
                     v))
-              ;; class miss with the provider already given its chance above:
-              ;; either nothing claims the class, or its install namespace is off
-              ;; the roots / failed to load — static-miss-message tells those apart.
-              (or (and (jch-known? class) (class-instance-fallback class member))
-                  (throw-jvm (quote IllegalArgumentException) (static-miss-message class member))))))))
+              ;; class miss — autoload the provider that declares the class (the
+              ;; java.time base, jolt.socket, or a library that installs it) and
+              ;; retry once. A claimed class cannot be a hit before its claimer
+              ;; has loaded, so the miss is where resolution belongs (jolt#914).
+              (if (lib-try-autoload! class)
+                  (host-static-ref class member)
+                  (or (and (jch-known? class) (class-instance-fallback class member))
+                      (throw-jvm (quote IllegalArgumentException) (static-miss-message class member)))))))))
 
 (define (host-static-call class member . args)
   ;; the registry's one rule: a procedure is a method to call, anything else is
@@ -691,12 +767,12 @@
       (if (procedure? v) (v) v))))
 
 (define (host-new class . args)
-  ;; same rule as host-static-ref: the declared provider of the class loads before
-  ;; the ctor lookup, not only when the lookup misses (jolt#914).
-  (lib-ensure-provider! class)
   (let ((ctor (lookup-class class-ctors-tbl class)))
     (cond
       (ctor (apply ctor args))
+      ;; the constructor may live in a provider that has not loaded yet — autoload
+      ;; and retry once before falling through to the var / no-ctor paths.
+      ((lib-try-autoload! class) (apply host-new class args))
       ;; deftype/defrecord: the type name is bound as a VAR (the
       ;; make-deftype-ctor closure) in its defining ns, not a registered host class.
       ;; Resolve it in the current ns / clojure.core and invoke it — so (P. args)

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -94,11 +94,38 @@
 ;; register-class-statics! reports a colliding static, so the cause is one env
 ;; var away instead of a bisect.
 (define (register-class-ctor-user! name proc)
-  (when (and (getenv "JOLT_DEBUG") (hashtable-ref host-class-ctors-tbl name #f))
-    (fprintf (current-error-port)
-             "warning: a library replaced the host constructor for ~a — every (~a. ...) in this process now builds its shim, including in namespaces that never asked for it\n"
-             name name))
-  (hashtable-set! class-ctors-tbl name proc))
+  ;; A constructor is one value, so there is no additive half to let through the
+  ;; way register-class-statics-user! does with members.
+  (unless (let ((owner (lib-provider-owner-elsewhere name)))
+            (and owner (begin (provider-claim-drop! name owner '()) #t)))
+    (provider-claim-note! name)
+    (when (and (getenv "JOLT_DEBUG") (hashtable-ref host-class-ctors-tbl name #f))
+      (fprintf (current-error-port)
+               "warning: a library replaced the host constructor for ~a — every (~a. ...) in this process now builds its shim, including in namespaces that never asked for it\n"
+               name name))
+    (lib-note-provider-registration! name)
+    (hashtable-set! class-ctors-tbl name proc)))
+
+;; clojure.core/__register-class-statics! lands here — the statics counterpart of
+;; register-class-ctor-user!, and under the same provider guard. The host's own
+;; boot-time registrations go straight to register-class-statics! and are not
+;; subject to it: nothing has declared anything yet when they run.
+(define (register-class-statics-user! name members)
+  (let ((owner (lib-provider-owner-elsewhere name)))
+    (if owner
+        ;; A provider owns the members it registered, not the whole name. Adding a
+        ;; member its shim does not answer is the additive case extend-class! exists
+        ;; for and stays allowed; REPLACING one is the substitution that made
+        ;; resolution depend on load order, and that is what is refused.
+        (let* ((h (lookup-class class-statics-tbl name))
+               (taken (if h (filter (lambda (m) (hashtable-contains? h (car m))) members) '()))
+               (fresh (if h (filter (lambda (m) (not (hashtable-contains? h (car m)))) members) members)))
+          (when (pair? taken) (provider-claim-drop! name owner (map car taken)))
+          (when (pair? fresh) (register-class-statics! name fresh)))
+        (begin
+          (provider-claim-note! name)
+          (lib-note-provider-registration! name)
+          (register-class-statics! name members)))))
 
 (define (register-host-methods! tag members)
   (let ((h (or (hashtable-ref host-methods-tbl tag #f)
@@ -345,6 +372,56 @@
            (box #f))))
 (define lib-class-providers core-class-providers)
 
+;; ---- claim index: which claims have not had their chance yet ----------------
+;; Resolution consults the provider table on EVERY reference to a claimed class,
+;; not only on a registry miss (jolt#914) — see lib-ensure-provider!. That puts
+;; the lookup on the hot path of every Class/member, so it cannot be the linear
+;; walk lib-provider-for does. This table holds one entry per SPELLING for the
+;; claims of providers that have not been autoloaded yet, and entries leave it
+;; the moment their provider is attempted; the flag makes the common case — every
+;; provider already loaded, or none declared — a single boolean test.
+(define lib-pending-claims-tbl (make-hashtable string-hash string=?))
+(define lib-any-pending-claims? #f)
+;; Autoload is one-shot per provider and now runs from every reference, so two
+;; threads reaching a claimed class at once must not both load the install
+;; namespace. The latch flip and the index purge go under this mutex; the load
+;; itself does NOT, because an install namespace requires others and a nested
+;; autoload would deadlock on a non-recursive mutex.
+(define lib-claims-mu (make-mutex))
+(define (lib-claim-pending! p)
+  (for-each (lambda (c) (hashtable-set! lib-pending-claims-tbl c p)) (vector-ref p 2))
+  (set! lib-any-pending-claims? #t))
+(define (lib-claim-settled! p)
+  (for-each (lambda (c) (hashtable-delete! lib-pending-claims-tbl c)) (vector-ref p 2))
+  (set! lib-any-pending-claims? (> (hashtable-size lib-pending-claims-tbl) 0)))
+(for-each lib-claim-pending! core-class-providers)
+
+;; The provider whose install namespace is loading on THIS thread, or #f. A
+;; provider registers its classes as its install namespace loads, and the
+;; registration guard (lib-provider-owner-elsewhere) has to tell that registration
+;; apart from another library squatting on the same class.
+(define lib-loading-provider (make-thread-parameter #f))
+
+;; Classes a declared provider actually registered as its install namespace
+;; loaded. This is what the registration guard protects: a class whose provider
+;; has spoken for it is that provider's, and a later registration from anywhere
+;; else is dropped rather than allowed to win by being last (jolt#914). Filled at
+;; REGISTRATION time, not from the declaration, so a class a provider declares and
+;; never registers stays open — the declaration alone is not an implementation.
+(define lib-provider-owned-tbl (make-hashtable string-hash string=?))
+;; Every SPELLING of the class goes in, not just the one written: the statics
+;; table keys the fully-qualified and the simple name to ONE member table
+;; (register-class-statics!), so a registration under either spelling reaches the
+;; same members and both have to be covered.
+(define (lib-note-provider-registration! name)
+  (let ((p (lib-loading-provider)))
+    (when (and p (member name (vector-ref p 2)))
+      (let ((short (short-class-name name)))
+        (for-each (lambda (c)
+                    (when (string=? (short-class-name c) short)
+                      (hashtable-set! lib-provider-owned-tbl c p)))
+                  (vector-ref p 2))))))
+
 ;; Declared providers from the dependency graph, installed at startup by
 ;; jolt.deps. A claim on a class the runtime already IMPLEMENTS is refused: a
 ;; dependency does not get to redefine what String means, and the same posture is
@@ -368,9 +445,9 @@
                          (fold-left (lambda (a c) (if (string=? a "") c (string-append a ", " c)))
                                     "" taken)
                          ", which the runtime already provides.")))
-        (set! lib-class-providers
-              (append lib-class-providers
-                      (list (vector install-ns coordinate cs (box #f))))))))
+        (let ((p (vector install-ns coordinate cs (box #f))))
+          (set! lib-class-providers (append lib-class-providers (list p)))
+          (lib-claim-pending! p)))))
 
 ;; The Clojure-facing seam. jolt.deps calls this once per declared provider after
 ;; it resolves the dependency graph, before any user code compiles — which is the
@@ -392,16 +469,112 @@
 ;; on the source roots and raised while loading. 'failed is what separates a
 ;; dependency the caller forgot to declare from one that is declared and broken;
 ;; see unknown-class-message.
-(define (lib-try-autoload! class)
-  (let ((p (lib-provider-for class)))
-    (and p
-         (not (unbox (vector-ref p 3)))
-         (begin (set-box! (vector-ref p 3) 'ok)
-                (and (find-ns-file (vector-ref p 0))
-                     (begin (guard (c (#t (set-box! (vector-ref p 3) 'failed)
-                                          (raise c)))
-                              (load-namespace (vector-ref p 0)))
-                            #t))))))
+(define (lib-load-provider! p)
+  ;; claim the load: whoever flips the latch from #f does it, everyone else sees
+  ;; a provider that has already had its chance and moves on.
+  (and (jolt-with-mutex lib-claims-mu
+         (and (not (unbox (vector-ref p 3)))
+              (begin (set-box! (vector-ref p 3) 'ok)
+                     (lib-claim-settled! p)
+                     #t)))
+       (find-ns-file (vector-ref p 0))
+       (begin (guard (c (#t (set-box! (vector-ref p 3) 'failed)
+                            (raise c)))
+                (parameterize ((lib-loading-provider p))
+                  (load-namespace (vector-ref p 0))))
+              #t)))
+
+;; RFC 0014's resolution step. A declared provider must load before the FIRST
+;; reference to a class it claims resolves — including when the registry ALREADY
+;; holds an entry for that class (jolt#914). Autoloading only on a registry miss
+;; made resolution depend on compile order: a library whose install! registers
+;; classes it does not declare (jolt.crypto registers java.security.Signature and
+;; declares only the symmetric classes) pre-empted the provider that DOES declare
+;; them, because the table hit served the incumbent and the claimer never loaded.
+;; Same deps.edn, two outcomes. A claim is an authority over who implements a
+;; class, not merely a fallback for an absent one, so the claimer loads first and
+;; its registration is the one resolution sees.
+;;
+;; Cost on the hot path is one boolean test once every provider has loaded.
+(define (lib-ensure-provider! class)
+  (and lib-any-pending-claims?
+       (let ((p (hashtable-ref lib-pending-claims-tbl class #f)))
+         (and p (lib-load-provider! p)))))
+
+;; ---- the registration guard -------------------------------------------------
+;; A class a dependency DECLARES is that dependency's to implement, and RFC 0014
+;; already refuses two libraries claiming one class (jolt.deps host-class-providers)
+;; — so a claimed class has exactly one implementor and the only thing that can
+;; take it away is an undeclared side-effect registration from someone else's
+;; install!. That is what made resolution depend on compile order: whoever
+;; registered last decided what java.security.Signature meant, and who registered
+;; last depended on which namespace happened to compile first.
+;;
+;; So once the declared provider has registered a class member, a registration of
+;; that member from anywhere else is dropped. Loudly: the library asked for
+;; something it did not get, and the symptom otherwise shows up somewhere else
+;; entirely. Members the provider does NOT answer still go through — a shim with a
+;; gap in it is the case class-extensions.ss exists for, and a claim is authority
+;; over what the provider implements, not a reservation on the name.
+(define (lib-provider-owner-elsewhere name)
+  (let ((p (hashtable-ref lib-provider-owned-tbl name #f)))
+    (and p (not (eq? p (lib-loading-provider))) p)))
+
+;; One warning per class, not per registration: an install namespace registers
+;; the fully-qualified name, the simple name, and a constructor for the same
+;; class, and four copies of one message reads like four problems.
+(define lib-claim-warned-tbl (make-hashtable string-hash string=?))
+(define (claim-warn-once? tag name)
+  (let ((k (string-append tag "/" (short-class-name name))))
+    (and (not (hashtable-ref lib-claim-warned-tbl k #f))
+         (begin (hashtable-set! lib-claim-warned-tbl k #t) #t))))
+
+(define (provider-claim-drop! name owner members)
+  (when (claim-warn-once? "drop" name)
+    (fprintf (current-error-port)
+             "warning: dropping ~a — ~a declares that class (:jolt/provides, RFC 0014) and implements ~a; a library may only register the classes it declares\n"
+             (if (null? members)
+                 (string-append "a constructor registration for " name)
+                 (string-append "a registration for "
+                                (fold-left (lambda (a m)
+                                             (let ((one (string-append name "/" m)))
+                                               (if (string=? a "") one (string-append a ", " one))))
+                                           "" members)))
+             (or (vector-ref owner 1) (vector-ref owner 0))
+             (cond ((null? members) "it")
+                   ((null? (cdr members)) "that member")
+                   (else "those members")))))
+
+;; The same registration BEFORE the claimer has loaded is not a bug the runtime
+;; has to stop — the claimer autoloads on the first reference to the class and
+;; registers over this one, so resolution lands on the provider either way. It is
+;; still a library registering a class it did not declare, which is the thing to
+;; fix at the source, so say so under JOLT_DEBUG the way the other registry
+;; diagnostics do.
+(define (provider-claim-note! name)
+  (when (getenv "JOLT_DEBUG")
+    (let ((self (lib-loading-provider))
+          (p (lib-provider-for name)))
+      ;; Both arms are about the same class, so they share one dedupe key: the
+      ;; claimed-elsewhere reading is the more actionable one and goes first.
+      (cond
+        ((and p (not (eq? p self)) (not (unbox (vector-ref p 3))))
+         (when (claim-warn-once? "note" name)
+           (fprintf (current-error-port)
+                    "warning: a registration for ~a is a class ~a declares (:jolt/provides); that provider loads on the first reference to ~a and its registration is the one that resolves\n"
+                    name (vector-ref p 0) name)))
+        ;; The contract from the other side: an install namespace registering a
+        ;; class it does not declare. Nothing autoloads a provider for a class it
+        ;; never claimed, so whether that class resolves at all depends on what
+        ;; else happens to pull the namespace in first — which is how a reference
+        ;; to java.security.KeyPairGenerator reported "No dependency provides" in
+        ;; one namespace and answered an EC-only shim in the next (jolt#914).
+        ((and self (not (member name (vector-ref self 2))))
+         (when (claim-warn-once? "note" name)
+           (fprintf (current-error-port)
+                    "warning: ~a registers ~a without declaring it in :jolt/provides (RFC 0014); nothing autoloads ~a for a class it does not declare, so whether ~a resolves depends on what else pulls that namespace in\n"
+                    (vector-ref self 0) name (vector-ref self 0) name)))
+        (else #f)))))
 
 ;; A provider that is on the source roots but raised while loading leaves the
 ;; class unregistered exactly like an undeclared dependency does — but the fix is
@@ -477,6 +650,9 @@
 ;; cannot be read off a #f result.
 (define host-static-miss (list 'host-static-miss))
 (define (host-static-ref class member)
+  ;; the class's declared provider, if any, loads BEFORE the lookup — so what the
+  ;; registry answers does not depend on who happened to register first (jolt#914)
+  (lib-ensure-provider! class)
   (let ((cell (mutable-static-cell class member #f)))
     (if cell
         (vector-ref cell 0)
@@ -487,12 +663,11 @@
                     (or (class-instance-fallback class member)
                         (throw-jvm (quote IllegalArgumentException) (string-append "No matching field or method: " class "/" member)))
                     v))
-              ;; class miss — autoload a provider (the java.time base, or a
-              ;; first-party library that installs the class) and retry once
-              (if (lib-try-autoload! class)
-                  (host-static-ref class member)
-                  (or (and (jch-known? class) (class-instance-fallback class member))
-                      (throw-jvm (quote IllegalArgumentException) (static-miss-message class member)))))))))
+              ;; class miss with the provider already given its chance above:
+              ;; either nothing claims the class, or its install namespace is off
+              ;; the roots / failed to load — static-miss-message tells those apart.
+              (or (and (jch-known? class) (class-instance-fallback class member))
+                  (throw-jvm (quote IllegalArgumentException) (static-miss-message class member))))))))
 
 (define (host-static-call class member . args)
   ;; the registry's one rule: a procedure is a method to call, anything else is
@@ -516,13 +691,12 @@
       (if (procedure? v) (v) v))))
 
 (define (host-new class . args)
+  ;; same rule as host-static-ref: the declared provider of the class loads before
+  ;; the ctor lookup, not only when the lookup misses (jolt#914).
+  (lib-ensure-provider! class)
   (let ((ctor (lookup-class class-ctors-tbl class)))
     (cond
       (ctor (apply ctor args))
-      ;; the constructor may live in a not-yet-loaded provider (the java.time base,
-      ;; or a first-party library) — autoload and retry once before falling through
-      ;; to the var / no-ctor paths.
-      ((lib-try-autoload! class) (apply host-new class args))
       ;; deftype/defrecord: the type name is bound as a VAR (the
       ;; make-deftype-ctor closure) in its defining ns, not a registered host class.
       ;; Resolve it in the current ns / clojure.core and invoke it — so (P. args)

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -452,13 +452,26 @@
 ;; REGISTRATION time, not from the declaration, so a class a provider declares and
 ;; never registers stays open — the declaration alone is not an implementation.
 (define lib-provider-owned-tbl (make-hashtable string-hash string=?))
+;; jolt.time.base and jolt.socket are the runtime's own BASE tier, and a base tier
+;; exists to be extended: jolt-lang/time declares only the formatting classes
+;; (DateTimeFormatter, ZoneId, ...) and adds a DateTimeFormatter arm to
+;; java.time.LocalDate/from, a class the base declares. That is the arrangement
+;; working, not a squat — the base ships the value types that must resolve with no
+;; dependency, and the library completes them.
+;;
+;; So what jolt ships claims a NAME, not the implementation of every member under
+;; it. RFC 0014's guard is about two DEPENDENCIES disagreeing over who implements a
+;; class (jolt#914), and the base tier is not one of them. Without this the tick
+;; suite lost five parse tests to "dropping a registration for LocalDate/from".
+(define (lib-core-provider? p) (and (memq p core-class-providers) #t))
+
 ;; Every SPELLING of the class goes in, not just the one written: the statics
 ;; table keys the fully-qualified and the simple name to ONE member table
 ;; (register-class-statics!), so a registration under either spelling reaches the
 ;; same members and both have to be covered.
 (define (lib-note-provider-registration! name)
   (let ((p (lib-loading-provider)))
-    (when (and p (member name (vector-ref p 2)))
+    (when (and p (not (lib-core-provider? p)) (member name (vector-ref p 2)))
       (let ((short (short-class-name name)))
         (for-each (lambda (c)
                     (when (string=? (short-class-name c) short)

--- a/host/chez/java/proxy.ss
+++ b/host/chez/java/proxy.ss
@@ -21,9 +21,10 @@
 ;; constructor is not mistaken for "this name is an interface".
 (define (proxy-class-constructible? class)
   (and (string? class)
-       ;; the constructor may live in a provider that has not loaded yet
-       (begin (lib-ensure-provider! class)
-              (and (lookup-class class-ctors-tbl class) #t))))
+       (or (and (lookup-class class-ctors-tbl class) #t)
+           ;; the constructor may live in a provider that has not loaded yet
+           (and (lib-try-autoload! class)
+                (and (lookup-class class-ctors-tbl class) #t)))))
 
 (define (proxy-name->string p)
   (cond ((symbol-t? p) (symbol-t-name p))

--- a/host/chez/java/proxy.ss
+++ b/host/chez/java/proxy.ss
@@ -21,10 +21,9 @@
 ;; constructor is not mistaken for "this name is an interface".
 (define (proxy-class-constructible? class)
   (and (string? class)
-       (or (and (lookup-class class-ctors-tbl class) #t)
-           ;; the constructor may live in a provider that has not loaded yet
-           (and (lib-try-autoload! class)
-                (and (lookup-class class-ctors-tbl class) #t)))))
+       ;; the constructor may live in a provider that has not loaded yet
+       (begin (lib-ensure-provider! class)
+              (and (lookup-class class-ctors-tbl class) #t))))
 
 (define (proxy-name->string p)
   (cond ((symbol-t? p) (symbol-t-name p))

--- a/test/chez/deps-alias/app/deps.edn
+++ b/test/chez/deps-alias/app/deps.edn
@@ -24,8 +24,10 @@
   ;; RFC 0014 provider resolution (jolt#914): provclaim DECLARES
   ;; java.security.Signature, provsquat declares javax.crypto.Mac and registers
   ;; Signature anyway. The declared provider must win in either reference order.
+  ;; provgone declares a class and ships no install namespace for it.
   :prov   {:extra-deps {local/provclaim {:local/root "../provclaim"}
-                        local/provsquat {:local/root "../provsquat"}}}
+                        local/provsquat {:local/root "../provsquat"}
+                        local/provgone  {:local/root "../provgone"}}}
   ;; a dep directory with NO deps.edn defaults to its src path
   :noedn  {:extra-deps {local/libnoedn {:local/root "../libnoedn"}}}
   ;; -X / -T exec fixtures

--- a/test/chez/deps-alias/app/deps.edn
+++ b/test/chez/deps-alias/app/deps.edn
@@ -21,6 +21,11 @@
   :time   {:extra-deps {local/timefix {:local/root "../timefix"}}}
   ;; a jolt.time that is on the roots but does not compile
   :timebroken {:extra-deps {local/timebroken {:local/root "../timebroken"}}}
+  ;; RFC 0014 provider resolution (jolt#914): provclaim DECLARES
+  ;; java.security.Signature, provsquat declares javax.crypto.Mac and registers
+  ;; Signature anyway. The declared provider must win in either reference order.
+  :prov   {:extra-deps {local/provclaim {:local/root "../provclaim"}
+                        local/provsquat {:local/root "../provsquat"}}}
   ;; a dep directory with NO deps.edn defaults to its src path
   :noedn  {:extra-deps {local/libnoedn {:local/root "../libnoedn"}}}
   ;; -X / -T exec fixtures

--- a/test/chez/deps-alias/app/src/appprovbase.clj
+++ b/test/chez/deps-alias/app/src/appprovbase.clj
@@ -1,0 +1,13 @@
+(ns appprovbase
+  "A library may register over a member of a class the runtime's own BASE tier
+  declares. jolt.time.base declares java.time.Instant and implements parse;
+  jolt-lang/time adds the DateTimeFormatter arm to members exactly like it, and
+  the tick suite loses five parse tests the moment that registration is dropped.
+  The Signature reference loads provclaim, whose install namespace registers over
+  Instant/parse while jolt.time.base has not loaded yet — so the registration is
+  held, the base autoloads on the reference below, and the library's lands on top
+  of it (jolt#914).")
+
+(defn -main [& _]
+  (println (java.security.Signature/getInstance "x"))
+  (println (java.time.Instant/parse "2020-01-02T03:04:05Z")))

--- a/test/chez/deps-alias/app/src/appprovboth.clj
+++ b/test/chez/deps-alias/app/src/appprovboth.clj
@@ -1,0 +1,12 @@
+(ns appprovboth
+  "The other order: the claimed class resolves FIRST, so provclaim is already
+  loaded when the Mac reference pulls provsquat in. provsquat's undeclared
+  java.security.Signature registration must not take the class over — a
+  registration is not an argument about who implements it (jolt#914).")
+
+(defn -main [& _]
+  (println (java.security.Signature/getInstance "a"))
+  (println (javax.crypto.Mac/getInstance "b"))
+  (println (java.security.Signature/getInstance "c"))
+  ;; ...while a member the provider's shim does not answer is additive and lands
+  (println (java.security.Signature/getMaxSigLength "x")))

--- a/test/chez/deps-alias/app/src/appprovgone.clj
+++ b/test/chez/deps-alias/app/src/appprovgone.clj
@@ -1,0 +1,10 @@
+(ns appprovgone
+  "A held registration outlives the provider that could not deliver. The Mac
+  reference loads provsquat, whose install namespace also registers
+  java.security.KeyPairGenerator without declaring it; provgone declares that class
+  and has no install namespace on the roots. The hold is a wait for the claimer, not
+  a veto, so once the claim settles unanswered the registration lands (jolt#914).")
+
+(defn -main [& _]
+  (println (javax.crypto.Mac/getInstance "HmacSHA256"))
+  (println (java.security.KeyPairGenerator/getInstance "RSA")))

--- a/test/chez/deps-alias/app/src/appprovmac.clj
+++ b/test/chez/deps-alias/app/src/appprovmac.clj
@@ -12,4 +12,8 @@
   (println (java.security.Signature/getInstance "SHA256withECDSA"))
   ;; the imported simple name and the constructor resolve through the same claim
   (println (Signature/getInstance "SHA256withECDSA"))
-  (println (Signature.)))
+  (println (Signature.))
+  ;; ...and the member provclaim's shim does NOT answer, held while provsquat had
+  ;; no claim to compare against, lands once the claim settles — the additive half
+  ;; survives the hold in this order too.
+  (println (Signature/getMaxSigLength "x")))

--- a/test/chez/deps-alias/app/src/appprovmac.clj
+++ b/test/chez/deps-alias/app/src/appprovmac.clj
@@ -1,0 +1,15 @@
+(ns appprovmac
+  "Reference order B: a class provsquat DECLARES first, which loads provsquat's
+  install namespace — and that also registers java.security.Signature, which it
+  does not declare. The Signature reference below then found a registry HIT and
+  never autoloaded provclaim, so the same deps.edn resolved Signature two
+  different ways depending on which namespace compiled first (jolt#914). The
+  declared provider must win in both orders."
+  (:import (java.security Signature)))
+
+(defn -main [& _]
+  (println (javax.crypto.Mac/getInstance "HmacSHA256"))
+  (println (java.security.Signature/getInstance "SHA256withECDSA"))
+  ;; the imported simple name and the constructor resolve through the same claim
+  (println (Signature/getInstance "SHA256withECDSA"))
+  (println (Signature.)))

--- a/test/chez/deps-alias/app/src/appprovsig.clj
+++ b/test/chez/deps-alias/app/src/appprovsig.clj
@@ -1,0 +1,7 @@
+(ns appprovsig
+  "Reference order A: the CLAIMED class first. provclaim declares
+  java.security.Signature, so this reference autoloads provclaim and resolves to
+  its registration — the case that already worked before jolt#914.")
+
+(defn -main [& _]
+  (println (java.security.Signature/getInstance "SHA256withECDSA")))

--- a/test/chez/deps-alias/app/src/appprovsquat.clj
+++ b/test/chez/deps-alias/app/src/appprovsquat.clj
@@ -1,0 +1,6 @@
+(ns appprovsquat
+  "provsquat's own declared class still resolves to provsquat: the guard is about
+  classes ANOTHER dependency declares, not a blanket ban on registering.")
+
+(defn -main [& _]
+  (println (javax.crypto.Mac/getInstance "HmacSHA256")))

--- a/test/chez/deps-alias/provclaim/deps.edn
+++ b/test/chez/deps-alias/provclaim/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+
+ ;; The library that DECLARES java.security.Signature. RFC 0014 makes that a
+ ;; claim on who implements the class, so it must resolve to this namespace
+ ;; whatever else registered the class first (jolt#914).
+ :jolt/provides {provclaim.install ["java.security.Signature"]}}

--- a/test/chez/deps-alias/provclaim/src/provclaim/install.clj
+++ b/test/chez/deps-alias/provclaim/src/provclaim/install.clj
@@ -1,0 +1,7 @@
+(ns provclaim.install
+  "The declared provider of java.security.Signature.")
+
+(__register-class-statics! "java.security.Signature"
+                           {"getInstance" (fn [algo] (str "claimer-sig:" algo))})
+(__register-class-ctor! "java.security.Signature" (fn [& _] "claimer-sig-ctor"))
+(__register-class-ctor! "Signature" (fn [& _] "claimer-sig-ctor"))

--- a/test/chez/deps-alias/provclaim/src/provclaim/install.clj
+++ b/test/chez/deps-alias/provclaim/src/provclaim/install.clj
@@ -5,3 +5,11 @@
                            {"getInstance" (fn [algo] (str "claimer-sig:" algo))})
 (__register-class-ctor! "java.security.Signature" (fn [& _] "claimer-sig-ctor"))
 (__register-class-ctor! "Signature" (fn [& _] "claimer-sig-ctor"))
+
+;; ...and the base tier is EXTENDED, not owned. jolt.time.base (a provider jolt
+;; ships) declares java.time.Instant and implements parse; jolt-lang/time adds a
+;; DateTimeFormatter arm to exactly these members, so a registration over one has
+;; to land. Stands in for that: what jolt ships claims the NAME, not the
+;; implementation of every member under it.
+(__register-class-statics! "java.time.Instant"
+                           {"parse" (fn [_ & _] "claimer-instant")})

--- a/test/chez/deps-alias/provgone/deps.edn
+++ b/test/chez/deps-alias/provgone/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+
+ ;; A DECLARED provider that cannot deliver: provgone.install is not on the roots.
+ ;; RFC 0014 keeps that case distinct from an undeclared dependency — and it is the
+ ;; case where a registration HELD against this claim has to be released rather
+ ;; than lost with the provider (jolt#914).
+ :jolt/provides {provgone.install ["java.security.KeyPairGenerator"]}}

--- a/test/chez/deps-alias/provgone/src/provgone/core.clj
+++ b/test/chez/deps-alias/provgone/src/provgone/core.clj
@@ -1,0 +1,3 @@
+(ns provgone.core
+  "The library ships code. The namespace its :jolt/provides names — provgone.install
+  — is the one that is not here.")

--- a/test/chez/deps-alias/provsquat/deps.edn
+++ b/test/chez/deps-alias/provsquat/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+
+ ;; Stands in for a library that declares ONE class and registers TWO (jolt#914):
+ ;; jolt.crypto declares the symmetric classes and its install! also registers an
+ ;; EC-only java.security.Signature it never declared. Only the declared class is
+ ;; listed here — the undeclared registration is the whole point of the fixture.
+ :jolt/provides {provsquat.install ["javax.crypto.Mac"]}}

--- a/test/chez/deps-alias/provsquat/src/provsquat/install.clj
+++ b/test/chez/deps-alias/provsquat/src/provsquat/install.clj
@@ -17,3 +17,8 @@
 ;; provider implements, not a reservation on the name.
 (__register-class-statics! "java.security.Signature"
                            {"getMaxSigLength" (fn [_] "squatter-extra")})
+
+;; ...and the other half of the real jolt.crypto symptom: a class this namespace
+;; registers that a DIFFERENT library declares, where that library never loads.
+(__register-class-statics! "java.security.KeyPairGenerator"
+                           {"getInstance" (fn [algo] (str "squatter-kpg:" algo))})

--- a/test/chez/deps-alias/provsquat/src/provsquat/install.clj
+++ b/test/chez/deps-alias/provsquat/src/provsquat/install.clj
@@ -1,0 +1,19 @@
+(ns provsquat.install
+  "Registers the class it declares — and one it does not. The undeclared
+  registration is what used to decide java.security.Signature for the whole
+  program whenever this namespace happened to load first.")
+
+(__register-class-statics! "javax.crypto.Mac"
+                           {"getInstance" (fn [algo] (str "squatter-mac:" algo))})
+
+;; undeclared: this class belongs to provclaim, which declares it
+(__register-class-statics! "java.security.Signature"
+                           {"getInstance" (fn [algo] (str "squatter-sig:" algo))})
+(__register-class-ctor! "java.security.Signature" (fn [& _] "squatter-sig-ctor"))
+(__register-class-ctor! "Signature" (fn [& _] "squatter-sig-ctor"))
+
+;; ...but a member provclaim's shim does NOT answer is additive, not a
+;; substitution, and still goes through: a claim is authority over what the
+;; provider implements, not a reservation on the name.
+(__register-class-statics! "java.security.Signature"
+                           {"getMaxSigLength" (fn [_] "squatter-extra")})


### PR DESCRIPTION
Fixes #914.

## The bug

RFC 0014 autoloaded a `:jolt/provides` install namespace **only on a registry
miss**. A table hit served whatever was registered and never consulted the
provider table, so a library whose `install!` registers classes it does not
declare pre-empted the library that does declare them — jolt.crypto registers an
EC-only `java.security.Signature` while declaring only the symmetric classes,
and once that side-effect registration landed the declared provider never
loaded. Same deps.edn, two outcomes, decided by which namespace compiled first,
with no diagnostic.

Autoloading on a hit alone does not close it either: with the squatter loading
*after* the claimer, its registration still wins by being last. Both directions
have to be handled for resolution to be a property of the graph.

## What changed

`host/chez/java/host-static.ss`:

- **The claimer loads first.** `lib-ensure-provider!` runs at the top of
  `host-static-ref` and `host-new` (and `proxy-class-constructible?`), not only
  on a miss. A claim is authority over *who implements* a class, not a fallback
  for an absent one.
- **A claimed class is not taken over afterwards.** Once a provider has
  registered a member of a class it declares, a registration of the same member
  through `__register-class-statics!` / `__register-class-ctor!` from anywhere
  else is dropped, with a warning on stderr. Members the provider's shim does
  *not* answer still register — filling a gap is what `extend-class!` is for,
  and a claim is not a reservation on the name.
- **Diagnostics under `JOLT_DEBUG`** for the two cases that are only the
  contract being bent: a registration for a class whose provider has not loaded
  yet (harmless — the provider loads on first reference and wins), and an
  install namespace registering a class it never declared, which is why a
  reference to `java.security.KeyPairGenerator` reported "No dependency
  provides" in one namespace and answered an EC-only shim in the next.

Since resolution now consults the provider table on every class reference, the
linear `lib-provider-for` walk is off the hot path: pending claims are indexed
by spelling in a hashtable behind a single boolean, so the steady state (every
declared provider loaded, or none declared) costs one test. The one-shot
autoload latch now flips under a mutex, because it runs from every reference and
two threads must not both load the install namespace.

## Tests

`test/chez/deps-alias/{provclaim,provsquat}` — provclaim declares
`java.security.Signature`; provsquat declares `javax.crypto.Mac` and its install
namespace registers Signature anyway. Four cases in `depssmoke`, over both
reference orders: the claimed class resolves to its provider either way, the
late squatting registration is dropped and reported, a provider's own declared
class still resolves to it, and an additive member still lands. All three
order-dependent assertions fail on `main` with `squatter-sig:…`.

`make ci` passes.

## Not in scope

`java.util.Base64` — the wrinkle about a claim path for *extending* a class jolt
already implements. A claim on an implemented class is still refused, so a
library cannot declare `java.util.Base64` to add the `getMimeDecoder` the shim
lacks, and the additive route (`extend-class!` at install) keeps the ordering
fragility this PR removes for claimed classes. That wants its own declaration
key and a member-miss autoload; filed separately.
