### PR TITLE
Re-record malli's tally

### DIFF
--- a/test/conformance/libs/manifest.edn
+++ b/test/conformance/libs/manifest.edn
@@ -462,11 +462,11 @@
    ;;     eduction validates and parses; that is the 104 identical? failures in
    ;;     parser-test and the 12 in core-test.
    ;;
-   ;; Where the residue sits, per target/libconformance/malli.log: 11 of the 28
+   ;; Where the residue sits, per target/libconformance/malli.log: 9 of the 26
    ;; failures are malli.transform-test, then core-test (4), error-test (3),
    ;; instrument-test (3), generator-test (2), provider-test (2), swagger-test
-   ;; (2) and registry-test (1). The 10 errors are generator-test (7),
-   ;; experimental-test (1), instrument-test (1) and parser-test (1). Several
+   ;; (2) and registry-test (1). The 9 errors are generator-test (7),
+   ;; instrument-test (1) and parser-test (1). Several
    ;; draw from (mg/sample s {:seed 0}), and a fixed seed drawing different
    ;; values here than on the JVM is the same family as test.check's :tolerance,
    ;; not a malli bug.
@@ -487,7 +487,7 @@
    ;;     allocation (4.6x the collections, each stopping the world); the row
    ;;     runs in ~4 minutes, and :timeout 2400 is headroom for a loaded CI
    ;;     runner, not the expected cost.
-   :expect {:tests 219 :pass 13261 :fail 28 :error 10 :load-fail 1}}
+   :expect {:tests 219 :pass 13269 :fail 26 :error 9 :load-fail 1}}
 
   ;; ---------------------------------------------------------- web
   {:name "ring-codec"


### PR DESCRIPTION
`malli` has been reporting BETTER against a plain `main` binary — not only under
a change — so the recorded tally has been stale:

```
malli  BETTER  tests=219 pass=13269 fail=26 error=9 load-fail=1
               expected tests=219 pass=13261 fail=28 error=10 load-fail=1
```

A BETTER row never fails the gate, so malli could have regressed by eight passes
before anything noticed. Four runs gave the same numbers each time (twice on
#924's branch, once on a plain main binary, once after this edit — the last
reports `ok`).

The delta is `transform-test` losing two failures and `experimental-test` its
last error; the experimental suites are fully green now, which is the tail of the
jolt-lang/time work the comment above the entry already credits for them.
Measured against time at `v0.0.9-3-g75c1288` — `~time` is a sibling checkout this
repo does not pin, so this row tracks it.

The residue breakdown in the comment is a present-tense claim about where the
failures sit, so it moves with the tally.

Found while running `make libconformance` for #924; unrelated to that PR, which
leaves malli's numbers untouched.