### PR TITLE
Bump grenadine to 0.1.13, and print the dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`jolt -Sgraph` prints the dependency tree as a graph, and `-Soutdated`
+  marks the updates available for it.** `-Stree` renders the tools.deps trace —
+  a top dep unprefixed, the candidates that lost marked `X` with the reason —
+  which answers how the resolution got where it did. That is the wrong shape
+  for the other question, "what does this program depend on", and it is the one
+  people actually ask a dependency tree. `-Sgraph` answers that one instead:
+  the SELECTED edges, indented under the dependency that pulled each in, with a
+  library reached twice expanded once and marked `(already shown)` rather than
+  repeating its subtree, and a coordinate that reaches itself marked `(cycle)`.
+
+  ```
+  ├── org.clojure/data.json 2.4.0
+  ├── org.clojure/tools.reader 1.3.6
+  └── rewrite-clj/rewrite-clj 1.1.47
+      └── org.clojure/tools.reader 1.3.6 (already shown)
+  ```
+
+  `-Soutdated` renders the same graph and appends `-> VERSION` to every Maven
+  library with a newer release, which is the one thing here that costs a
+  network round-trip per library — so it is its own option rather than a mode
+  of `-Sgraph`, which stays as cheap as `-Stree`. A lookup that fails warns on
+  stderr and leaves that library unmarked instead of failing the command, so
+  one unreachable repository does not cost the whole report. Git and
+  `:local/root` coordinates are printed but have no "newer" to report.
+
+  Both take the aliases around them like every other report option, and
+  `-Stree` is unchanged — the two answer different questions and the
+  tools.deps rendering is what `clojure -Stree` prints.
+
 - **A `deps.edn` can vouch for a runtime var lookup, so `--tree-shake` proceeds
   past it.** The shake bails, and must, when reachable code resolves a var by
   name: the static graph cannot follow a runtime name. But some of those sites

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -201,6 +201,56 @@ case "$out" in
   *) check "-Stree indents a transitive dep" "child under parent" "$out" ;;
 esac
 
+# -Sgraph — the same resolution as -Stree, rendered as the indented graph
+# grenadine's --expand prints. It answers "what does this depend on", where
+# -Stree answers "how did the resolution get here", so the losing candidates
+# -Stree marks `X` are absent and a shared library is expanded once.
+out="$(runall -Sgraph)"
+case "$out" in
+  *"── local/liba "*) check "-Sgraph prints the top dep" ok ok ;;
+  *) check "-Sgraph prints the top dep" "a branch naming local/liba" "$out" ;;
+esac
+out="$(runall -A:dev -Sgraph)"
+case "$out" in
+  *"── local/libc "*) check "-Sgraph sees the alias's deps" ok ok ;;
+  *) check "-Sgraph sees the alias's deps" "local/libc in the graph" "$out" ;;
+esac
+# a transitive dep hangs under the dep that pulled it in, indented by the
+# connector rather than by -Stree's two spaces
+out="$(JOLT_PWD="$tmp/treeproj" JOLT_QUIET=1 "$JOLT" -Sgraph 2>/dev/null)"
+case "$out" in
+  *"── local/treeparent "*"
+    └── local/treechild "*) check "-Sgraph indents a transitive dep" ok ok ;;
+  *) check "-Sgraph indents a transitive dep" "child under parent" "$out" ;;
+esac
+# A library reached twice is expanded ONCE: the second parent shows it marked
+# rather than repeating the subtree, which is what keeps a wide graph readable.
+mkdir -p "$tmp/gshare/src"
+printf '{:paths ["src"] :deps {local/treeparent {:local/root "../treeparent"}\n
+                               local/treechild {:local/root "../treechild"}}}\n' \
+  > "$tmp/gshare/deps.edn"
+out="$(JOLT_PWD="$tmp/gshare" JOLT_QUIET=1 "$JOLT" -Sgraph 2>/dev/null)"
+case "$out" in
+  *"local/treechild "*"(already shown)"*) check "-Sgraph expands a shared dep once" ok ok ;;
+  *) check "-Sgraph expands a shared dep once" "treechild marked (already shown)" "$out" ;;
+esac
+# -Stree is NOT the same rendering — the two answer different questions and the
+# tools.deps one is what `clojure -Stree` prints, so it stays byte-for-byte.
+case "$(runall -Stree)" in
+  *"──"*) check "-Stree keeps the tools.deps format" "no box-drawing connectors" "$(runall -Stree)" ;;
+  *) check "-Stree keeps the tools.deps format" ok ok ;;
+esac
+# Both take the aliases around them, like every other report option. Compared
+# against the EXPECTED text rather than against each other: two empty outputs
+# are equal, so an -Sgraph that printed nothing would pass a side-by-side.
+before="$(runall -A:dev -Sgraph | tr '\n' ' ' | sed 's/ $//')"
+after="$(runall -Sgraph -A:dev | tr '\n' ' ' | sed 's/ $//')"
+case "$before" in
+  *"── local/libc "*) check "-Sgraph takes the aliases after it" ok ok ;;
+  *) check "-Sgraph takes the aliases after it" "local/libc in the graph" "$before" ;;
+esac
+check "-Sgraph takes the aliases before it" "$before" "$after"
+
 # accepted-and-ignored options don't change the answer or fail
 check "-Sforce is accepted" "$(runout path)" "$(runout -Sforce -Spath)"
 check "-Sthreads N is accepted" "$(runout path)" "$(runout -Sthreads 4 -Spath)"

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -51,6 +51,7 @@ grenadine.lock
 grenadine.repo
 grenadine.runtime
 grenadine.source
+grenadine.tree
 jolt.completions
 jolt.continuations
 jolt.fibers

--- a/jolt-core/jolt/completions.clj
+++ b/jolt-core/jolt/completions.clj
@@ -51,6 +51,8 @@
    ["-P"         "fetch every dependency, then stop"]
    ["-Spath"     "print the resolved source roots"]
    ["-Stree"     "print the dependency tree"]
+   ["-Sgraph"    "print the dependency tree as an indented graph"]
+   ["-Soutdated" "print the dependency graph, marking available updates"]
    ["-Strace"    "write the dep expansion to trace.edn"]
    ["-Sdescribe" "print the environment as an edn map"]
    ["-Sdeps"     "merge an extra deps.edn map"]

--- a/jolt-core/jolt/deps.clj
+++ b/jolt-core/jolt/deps.clj
@@ -516,6 +516,28 @@
             target
             (recur (rest repos))))))))
 
+(defn- mvn-http-host
+  "The host map grenadine.repo asks for: an in-memory GET. jolt's downloader
+  writes an artifact to a path — that is the right shape for a jar and the
+  wrong one for maven-metadata.xml, which is a few KB nobody wants on disk, so
+  this fetches to a temp file and reads it back.
+
+  :bytes->utf8 is `identity` because the read already decoded: slurp returns the
+  text, and the contract only requires that (:bytes->utf8 host) turn whatever
+  (:http-get host) put in :body into a string."
+  []
+  {:http-get
+   (fn [url]
+     (let [target (str (tmp-dir) "/jolt-mvn-meta-"
+                       (System/currentTimeMillis) "-" (rand-int 100000) ".xml")
+           result (http/fetch* url target)]
+       (try
+         (if (= :ok (:outcome result))
+           {:status 200 :body (slurp target)}
+           {:status (or (:status result) 404)})
+         (finally (rm-f target)))))
+   :bytes->utf8 identity})
+
 (defn- pom-text
   "Return a POM as text, sharing the standard Maven repository with tools.deps."
   [coords]
@@ -1028,7 +1050,7 @@
   :trace — {:log [node …] :vmap version-map}, the tools.deps trace shape, which
   dep-tree-lines renders and trace-edn-string writes out."
   ([deps base-dir] (resolve-deps deps base-dir nil))
-  ([deps base-dir {:keys [override-deps default-deps trace?]}]
+  ([deps base-dir {:keys [override-deps default-deps trace? graph?]}]
    ;; A nested resolve-deps inherits the outer atom, so the summary is printed
    ;; ONCE by whichever frame created it rather than once per level.
    (let [outermost? (nil? *unresolvable*)]
@@ -1051,6 +1073,14 @@
              :trace? trace?
              :on-warning expansion-warning})
            libmap (:libs expansion)
+           ;; The SELECTED-edge graph -Sgraph renders: parent -> child over the
+           ;; coordinates that won, which is a different question from :trace,
+           ;; whose log carries every decision including the losing ones.
+           ;; coord-deps is the same procurement the expansion just did and
+           ;; shares its *procure-memo*, so walking it again re-fetches nothing.
+           graph (when graph?
+                   ((requiring-resolve 'grenadine.tree/dependency-graph)
+                    top libmap ext/coord-deps))
            infos (keep (fn [lib]
                          (when-let [coord (get libmap lib)]
                            (let [info (ext/coord-info lib coord)]
@@ -1097,7 +1127,11 @@
         ;; caller warns with the lib names.
         :prep (vec (keep (fn [{:keys [lib edn]}] (when (:deps/prep-lib edn) lib)) infos))
         :libs libmap
-        :trace (:trace expansion)})))))
+        :trace (:trace expansion)
+        ;; The edges -Sgraph renders. Their labels come from :libs above, which
+        ;; is the mediated map — a library reached through two parents is
+        ;; labelled with the version that won.
+        :graph graph})))))
 
 ;; --- resolved-roots cache (.jolt/cpcache) -----------------------------------
 ;; tools.deps calls this .cpcache: the resolved classpath keyed on a content
@@ -1419,9 +1453,10 @@
   deps) and the result is written. The cache is OFF when JOLT_AOT_CACHE is off
   (the dev bin/jolt posture) or when trace? is set — a trace is a one-off query
   (-Stree/-Strace), not the resolution a run reuses, so it never caches and a
-  cached run never serves one. Emits the JOLT_DEBUG-gated hit/miss lines."
+  cached run never serves one. graph? is off for the same reason: a cached
+  basis carries no :graph, and -Sgraph would silently print nothing. Emits the JOLT_DEBUG-gated hit/miss lines."
   [project-dir deps alias-kws repro? opts]
-  (if (and (cpcache-enabled?) (not (:trace? opts)))
+  (if (and (cpcache-enabled?) (not (:trace? opts)) (not (:graph? opts)))
     (let [proj-bytes (or (slurp-quiet (str project-dir "/deps.edn")) "")
           skip-user? (or repro? (getenv "JOLT_NO_USER_DEPS"))
           user-path (user-deps-path)
@@ -1494,6 +1529,80 @@
                               (walk (conj path lib) (+ depth 2))))
                       (get by-parent path)))]
       (vec (walk [] 0)))))
+
+(defn- graph-label
+  "How -Sgraph names a node: the same one-line coordinate summary -Stree
+  prints, so the two renderings never disagree about what a version is."
+  [libs lib]
+  (if-let [coord (get libs lib)]
+    (ext/coord-summary lib coord)
+    (str lib)))
+
+(defn dep-graph-lines
+  "Render the SELECTED dependency graph as an indented tree, the shape
+  grenadine's --expand prints:
+
+    ├── babashka/process 0.6.25
+    │   └── babashka/fs 0.5.34 (already shown)
+    └── rewrite-clj/rewrite-clj 1.1.49
+
+  A library is expanded once — a later parent shows it `(already shown)` rather
+  than repeating the subtree — and a coordinate that reaches itself is marked
+  `(cycle)` instead of recurring forever. This answers \"what does the program
+  depend on\", where -Stree answers \"how did the resolution get here\", so the
+  losing candidates -Stree marks `X` are simply absent.
+
+  `updates` is an optional lib -> newer-version map; each entry appends
+  ` -> VERSION` to its line (-Soutdated supplies it, -Sgraph does not)."
+  ([resolved] (dep-graph-lines resolved nil))
+  ([{:keys [graph libs]} updates]
+   (if (nil? graph)
+     []
+     ((requiring-resolve 'grenadine.tree/lines)
+      graph
+      (fn [lib]
+        (str (graph-label libs lib)
+             (when-let [v (get updates lib)] (str " -> " v))))))))
+
+;; The remote half of -Soutdated. Only a :mvn coordinate has a version to
+;; compare — a git dep is pinned to a sha and a :local/root to a directory, so
+;; neither has a \"newer\" to report and both are simply printed as they are.
+;;
+;; A lookup that fails leaves the library unannotated rather than failing the
+;; command: -Soutdated over a dependency set that includes one unreachable
+;; repository should still report the rest, the way `grenadine --current` does.
+;; The warning goes to stderr so the tree itself still pipes.
+(defn dep-updates
+  "For each selected Maven library, the newest release available from the
+  configured repositories when it is newer than the selected version. Returns a
+  lib -> version string map; libraries with no update are absent."
+  [{:keys [graph libs mvn-repos]}]
+  (let [visible? (requiring-resolve 'grenadine.tree/visible?)
+        latest-version (requiring-resolve 'grenadine.repo/latest-version)
+        visible (when graph
+                  (filter visible?
+                          (distinct (concat (:roots graph)
+                                            (mapcat val (:children graph))))))]
+    (reduce
+     (fn [acc lib]
+       (let [coord (get libs lib)
+             current (:mvn/version coord)]
+         (if-not current
+           acc
+           ;; latest-version answers the version STRING, and THROWS when no
+           ;; release is found — it is not a nil-returning lookup.
+           (let [latest (try (latest-version {:group (mvn-group lib)
+                                              :artifact (name lib)}
+                                             {:host (mvn-http-host)
+                                              :repos mvn-repos})
+                             (catch :default e
+                               (warn "cannot determine the latest version of " lib
+                                     ": " (ex-message e))
+                               nil))]
+             (if (and latest (grenadine.version/newer? latest current))
+               (assoc acc lib latest)
+               acc)))))
+     {} visible)))
 
 (defn trace-edn-string
   "The trace as the edn text of `jolt -Strace`'s trace.edn: {:log [node …]
@@ -1583,7 +1692,7 @@
   ([project-dir] (resolve-project project-dir []))
   ([project-dir alias-kws] (resolve-project project-dir alias-kws nil))
   ([project-dir alias-kws extra-edn] (resolve-project project-dir alias-kws extra-edn nil))
-  ([project-dir alias-kws extra-edn {:keys [tool? repro? trace? cp tasks?]}]
+  ([project-dir alias-kws extra-edn {:keys [tool? repro? trace? graph? cp tasks?]}]
    (let [deps-edn (read-deps-file (str project-dir "/deps.edn"))
          bb-edn (read-bb-file (str project-dir "/bb.edn"))
          ;; with no deps.edn, bb.edn stands in as the project config
@@ -1636,7 +1745,7 @@
           ;; from there. tools.deps' --skip-cp draws the line in the same place:
           ;; the merged edn and argmap, without calc-basis.
           {dep-roots :roots dep-natives :natives dep-provides :provides
-           prep-libs :prep dep-trace :trace
+           prep-libs :prep dep-trace :trace dep-graph :graph dep-libs :libs
            dep-min-versions :min-versions dep-allow-dynamic :allow-dynamic}
           (when-not cp
             (binding [*mvn-local-repo* (when-let [r (:mvn/local-repo edn)]
@@ -1645,7 +1754,8 @@
               (resolve-deps-cached project-dir all-deps alias-kws repro?
                                    {:override-deps (:override-deps argmap)
                                     :default-deps (:default-deps argmap)
-                                    :trace? trace?})))
+                                    :trace? trace?
+                                    :graph? graph?})))
          ;; The floor is checked AFTER resolution, so a dep's own declaration is
          ;; in hand — a library is the natural declarer, since it knows which
          ;; jolt its bindings need and the app pulling it in does not. The
@@ -1709,6 +1819,12 @@
       :features (mapv #(if (keyword? %) (name %) (str %)) (:jolt/features edn))
       ;; the expansion trace, when it was asked for (-Stree renders it)
       :trace dep-trace
+      ;; the selected-edge graph and its coordinates (-Sgraph renders these),
+      ;; with the repositories the resolution used — -Soutdated asks those for
+      ;; a newer version, and *mvn-repos* is bound only around the expansion.
+      :graph dep-graph
+      :libs dep-libs
+      :mvn-repos (mvn-repo-urls edn)
       ;; nREPL middleware a library contributes (jolt.nrepl composes them over its
       ;; built-in handler) — symbols resolving to a middleware fn or a vector of them.
       :nrepl-middleware (:nrepl/middleware edn)})))

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -177,7 +177,8 @@
                          (merge {:tool? *cli-tool?*
                                  :repro? *cli-repro?*
                                  :cp *cli-cp*
-                                 :trace? (contains? #{:tree :trace-file} *cli-report*)}
+                                 :trace? (contains? #{:tree :trace-file} *cli-report*)
+                                 :graph? (contains? #{:graph :outdated} *cli-report*)}
                                 opts))))
 
 ;; The resolution a task runs against: :tasks? lets a project's bb.edn
@@ -233,6 +234,10 @@
   (case *cli-report*
     :path     (print-roots resolved)
     :tree     (run! println (deps/dep-tree-lines (:trace resolved)))
+    ;; -Sgraph and -Soutdated render the same tree; only -Soutdated pays for the
+    ;; remote lookups that fill in the `-> VERSION` arrows.
+    :graph    (run! println (deps/dep-graph-lines resolved))
+    :outdated (run! println (deps/dep-graph-lines resolved (deps/dep-updates resolved)))
     :describe (print-describe (into *cli-aliases* aliases))
     ;; -Strace: the same trace -Stree renders, written beside the deps.edn it
     ;; describes (`clojure -Strace` drops it in the current directory; jolt's is
@@ -967,7 +972,9 @@
   (println "Each takes the aliases around it, so -A:test -Spath and -Spath -M:test")
   (println "both report on the resolution that run would use:")
   (println "  -Spath                 print the resolved source roots")
-  (println "  -Stree                 print the dependency tree")
+  (println "  -Stree                 print the dependency tree, tools.deps format")
+  (println "  -Sgraph                print the dependency tree as an indented graph")
+  (println "  -Soutdated             the same graph, marking available updates")
   (println "  -Strace                write the dep expansion to trace.edn")
   (println "  -Sdescribe             print the environment as an edn map")
   (println "  -P                     fetch every dependency, then stop")
@@ -987,16 +994,18 @@
 
 ;; Argv forms that only add resolution context — which files to read, which
 ;; aliases to select, what to merge in — rather than doing something. A report
-;; option (-Spath / -Stree / -Sdescribe / -P) still lets these dispatch, since
+;; option (-Spath / -Stree / -Sgraph / -Soutdated / -Sdescribe / -P) still lets
+;; these dispatch, since
 ;; they change the answer, and skips everything else: a report runs no program.
 (defn- context-arg? [cmd]
   (boolean (and cmd (or (#{"-Sdeps" "-Scp" "-Srepro" "-Sforce" "-Sthreads" "-Sverbose"
-                           "-Spath" "-Stree" "-Strace" "-Sdescribe"} cmd)
+                           "-Spath" "-Stree" "-Sgraph" "-Soutdated" "-Strace"
+                           "-Sdescribe"} cmd)
                         (some #(str/starts-with? cmd %) ["-A" "-M" "-X" "-T" "-J"])))))
 
 (def ^:private report-opts
-  {"-Spath" :path, "-Stree" :tree, "-Strace" :trace-file,
-   "-Sdescribe" :describe, "-P" :prepare})
+  {"-Spath" :path, "-Stree" :tree, "-Sgraph" :graph, "-Soutdated" :outdated,
+   "-Strace" :trace-file, "-Sdescribe" :describe, "-P" :prepare})
 
 (defn -main [& args]
   (let [[cmd & more] args]

--- a/vendor/grenadine-generated/README.md
+++ b/vendor/grenadine-generated/README.md
@@ -21,7 +21,7 @@ The `grenadine-<version>-src.tar.gz` asset of the matching Grenadine release,
 which ships the generated sources alongside the committed ones. Verified
 against the release's `grenadine-checksums.txt`:
 
-    302e26b50f765abb9fee4a76148ed81ed8de74a6938acad3eeaa4d6c0106dd3b  grenadine-0.1.7-src.tar.gz
+    49c5f701e19d9a2a517581d0a4b222f2069209a9c2971d9f516b3dd15970c3e1  grenadine-0.1.13-src.tar.gz
 
 The tarball's copies of the files Grenadine *does* commit are byte-identical to
 the git tag, checked file by file — which is what makes taking half the tree
@@ -47,8 +47,11 @@ wrong way round for a gate.
     tar xzf grenadine-X.Y.Z-src.tar.gz
     cp grenadine-X.Y.Z-src/src/grenadine/{basis,coordinate,expander,gitlibs}.cljc \
        vendor/grenadine-generated/grenadine/
-    printf 'vX.Y.Z %s\n' "$(git -C vendor/grenadine rev-parse HEAD)" \
-      >> vendor/grenadine-generated/VERSION   # keep the comment header
+    # REPLACE the version line, keeping the comment header — appending a
+    # second one makes grenadinecheck read both shas as one string and fail.
+    { grep '^#' vendor/grenadine-generated/VERSION
+      printf 'vX.Y.Z %s\n' "$(git -C vendor/grenadine rev-parse HEAD)"
+    } > /tmp/VERSION && mv /tmp/VERSION vendor/grenadine-generated/VERSION
 
 If a future Grenadine generates a different set, `make grenadinecheck` will not
 catch that on its own — the load will fail with an unresolved namespace, which

--- a/vendor/grenadine-generated/VERSION
+++ b/vendor/grenadine-generated/VERSION
@@ -3,4 +3,4 @@
 # grenadinecheck compares the SHA, not the tag — a submodule checkout does not
 # necessarily carry tags (CI's does not), so `git describe` is not available
 # everywhere and a tag comparison fails wherever it is missing.
-v0.1.7 77992327c0b220c186ece61d74f7eb570978a6f5
+v0.1.13 9d0361c623d665aac5ced4e036bf716a4076f1ba

--- a/vendor/grenadine-generated/grenadine/basis.cljc
+++ b/vendor/grenadine-generated/grenadine/basis.cljc
@@ -20,7 +20,8 @@
             [grenadine.graph :as graph]
             [grenadine.lock :as lock]
             [grenadine.pom :as pom]
-            [grenadine.repo :as repo]))
+            [grenadine.repo :as repo]
+            [grenadine.tree :as tree]))
 
 (defn- join-path [base path]
   (if (or (nil? path) (= "" path))
@@ -368,7 +369,10 @@
                      [(coordinate/lib-symbol group artifact classifier) entry]))
               (:artifacts final-lock))
         parent-data (parents-data (:trace expansion) libs)
-        expansion-libs (filter #(contains? libs %) (:order expansion))
+        ;; Alternate mediators can select libraries tools-deps never expanded.
+        expansion-libs (distinct (concat (filter #(contains? libs %)
+                                                 (:order expansion))
+                                         (sort-by str (keys libs))))
         lib-map
         (into {}
               (map
@@ -510,4 +514,8 @@
             :grenadine/resolution expansion
             :grenadine/source-roots
             (vec (concat (:roots source-extraction)
-                         non-maven-source-roots))})))
+                         non-maven-source-roots))}
+           (when (:dependency-tree? opts)
+             {:grenadine/tree
+              (tree/dependency-graph
+               top libs (fn [lib coord] (:children (info lib coord))))}))))

--- a/vendor/grenadine-generated/grenadine/expander.cljc
+++ b/vendor/grenadine-generated/grenadine/expander.cljc
@@ -295,7 +295,7 @@
                     original-coordinate
                     (get default-deps lib))]
             (if (contains? provided-libs (base-lib lib))
-              (recur pending queue index version-map exclusions cuts
+              (recur pending queue (long index) version-map exclusions cuts
                      order
                      (if trace?
                        (conj trace
@@ -313,7 +313,7 @@
                          {:warning :unsupported-coordinate
                           :lib lib
                           :coordinate coordinate})
-                  (recur pending queue index version-map exclusions cuts
+                  (recur pending queue (long index) version-map exclusions cuts
                          order trace))
                 (let [id (coord-id lib coordinate)
                       decision
@@ -356,7 +356,7 @@
                                :include (boolean include?)
                                :reason reason})
                         trace)]
-                  (recur pending queue index version-map
+                  (recur pending queue (long index) version-map
                          (:exclusions update) (:cuts update)
                          (if include? (conj order lib) order)
                          trace)))))


### PR DESCRIPTION
Two halves: the vendored resolver moves to 0.1.13, and jolt gains the tree
rendering that release makes reusable.

## The bump

Grenadine 0.1.13 adds `grenadine.tree`, a portable renderer, and the currency
reporting behind its `--current`. jolt resolves *with* grenadine, so it can
render the same thing over its own expansion rather than reimplementing one.

Refreshed by the recipe in `vendor/grenadine-generated/README.md`: submodule to
`v0.1.13` (`9d0361c`), the four generated namespaces from the release tarball,
checksum verified, and every one of the 15 committed files confirmed
byte-identical between tarball and git tag — which is what makes taking half
the tree from the submodule and half from the tarball coherent.

The bump is inert for jolt's resolution. `expander.cljc` gained only `(long
index)` coercions (upstream's "Preserve primitive loop counter types"), and
`basis.cljc`'s change is the `:dependency-tree?` option plus a mediator
ordering fix — jolt calls `expand-deps` directly, not `basis`.

## -Sgraph and -Soutdated

`-Stree` stays exactly what it is: the tools.deps trace, where every candidate
appears and the ones that lost are marked `X` with the reason. That is what
`clojure -Stree` prints and it answers *how the resolution got here*.

`-Sgraph` answers the other question — *what does this program depend on* —
over the selected edges:

```
├── org.clojure/data.json 2.4.0
├── org.clojure/tools.reader 1.3.6
└── rewrite-clj/rewrite-clj 1.1.47
    └── org.clojure/tools.reader 1.3.6 (already shown)
```

A library reached twice is expanded once and marked `(already shown)`; a
coordinate that reaches itself is marked `(cycle)`. `-Soutdated` renders the
same graph with `-> VERSION` per Maven library that has a newer release.

The remote lookups are their own option rather than a mode of `-Sgraph`: they
cost a round-trip per library, and `-Sgraph` should stay as cheap as `-Stree`.
A failed lookup warns on stderr and leaves that library unmarked instead of
failing the report, so one unreachable repository does not cost the whole
thing. Git and `:local/root` coordinates print but have no newer to report.

Both take the aliases around them like every other report option.

## Notes

`grenadine.tree` / `grenadine.repo` load through `requiring-resolve`, the seam
`jolt.tasks` and `jolt.completions` already use. Requiring them at the top of
`jolt.deps` puts them plus `coordinate`/`gitlibs`/`lock` in the boot image,
which is where network and XML code has no business sitting for the runs that
never ask. Startup measured at parity either way (eager 1.002x, lazy 0.989x vs
main, interleaved), so this is about what the image carries, not the clock.

The stdlib-fasl manifest gate caught `grenadine.tree` on the first build, which
is the gate working.

Two bugs fixed along the way:

- `grenadine.repo/latest-version` answers the version **string** and *throws*
  when none is found. Grenadine's own `cli.clj` reads `(:version result)` only
  because it wraps the call in its own map; copying that idiom silently
  produced no arrows.
- The vendoring README's refresh recipe used `>>` where it meant to replace,
  appending a second `VERSION` line that reads as two concatenated shas and
  fails `grenadinecheck`. It replaces now, and records the 0.1.13 checksum.

## Gates

`make test` green (109 CI targets + selfhost). `make libconformance` green:
50 libraries, 47 ok, 0 better, 0 regressed, 3 skipped. deps-alias smoke 130/0.

4 of the 6 new smoke rows fail on the previous binary. The two that do not are
a regression guard (`-Stree` keeps its format — an absence assertion by design)
and the alias-placement check, which now asserts the expected text rather than
comparing two outputs that were both empty before it existed.

Docs: jolt-lang/jolt-lang.github.io#31.