### PR TITLE
A provider reached from another provider's install namespace is its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `java.security.SecureRandom`. The note stays for what it is for: a class
   nothing implements and nothing declares (#926).
 
+- **A user `deftype` is not a host class.** Every `deftype` and `defrecord`
+  registers its constructor — and a record its static `create` — through the
+  same tables the host's own classes use, under its `ns.Name` tag *and* its bare
+  name. Those tables are what "does the runtime provide this class?" is answered
+  from, so a `(deftype Widget …)` anywhere in a process made an unrelated
+  `com.example.Widget` read as the runtime's: the note above went silent for it,
+  while `register-class-provider!` — which runs at deps time, before any user
+  type exists — would still have accepted a `:jolt/provides` claim on it. The
+  two answers have to agree, so a user type takes a plain table write and only
+  the host's boot-time registrations record a class as the runtime's.
+
 - **`JOLT_DEBUG` no longer reports the runtime's own boot as registry drift.**
   A class registered under both its qualified and its simple name shares ONE
   member table, so a fresh closure per spelling re-registers the member with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the registry-miss path, so a static reference and a `(Class. …)` cost
   exactly what they did before.
 
+- **A provider reached from another provider's install namespace is still its
+  own.** RFC 0014 marked the whole load with the provider being autoloaded, so a
+  second declared provider that its install namespace reaches with a plain
+  `require` — kmet's provider requires jolt.crypto — had every class it
+  registered attributed to the OUTER one. Those classes then belonged to nobody,
+  so a later registration for a member the inner provider answers was accepted
+  instead of dropped: #914's nondeterminism, one level down. Under `JOLT_DEBUG`
+  the undeclared-registration note named the outer namespace for a class the
+  inner one declares. The mark now comes from whoever LOADS an install namespace
+  rather than from the autoload alone, so a provider's registrations are its own
+  however it was reached; a helper namespace a provider requires still registers
+  on the provider's behalf (#926).
+
+- **The undeclared-registration note no longer advises a declaration jolt
+  refuses.** For a class the runtime itself implements, `register-class-provider!`
+  refuses the claim ("which the runtime already provides"), so `JOLT_DEBUG`'s
+  advice to declare it in `:jolt/provides` could not be taken — registering the
+  members at install is the route, and it is the additive case `extend-class!`
+  exists for. Nothing autoloads for a class that is already there, so there was
+  no order dependence left to warn about either. It fired for kmet's
+  `java.util.Base64`, jolt-lang/time's `java.util.Date` and jolt.crypto's
+  `java.security.SecureRandom`. The note stays for what it is for: a class
+  nothing implements and nothing declares (#926).
+
+- **`JOLT_DEBUG` no longer reports the runtime's own boot as registry drift.**
+  A class registered under both its qualified and its simple name shares ONE
+  member table, so a fresh closure per spelling re-registers the member with a
+  different value — "static member java.security.SecureRandom/getInstance
+  registered twice with different values", and the same for `clojure.lang.RT/iter`.
+  Both now register one procedure under both names. `java.nio.charset.Charset`
+  was a real duplicate: a short-name registration answering `forName` with the
+  canonical name string, dead since the qualified one started answering with the
+  charset object and overwriting it member for member.
+
 - **`java.net.URI`'s constructor validates.** `(java.net.URI. "https://not a
   url")` answered a URI whose `.getHost` was `"not a url"`; the JVM's
   single-argument constructor parses per RFC 2396 and throws

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -439,12 +439,25 @@ esac
 
 # The undeclared-registration note is advice: declare the class in :jolt/provides.
 # It fires for a class nothing implements and nothing declares...
+# ...even when a user type in the same process happens to share its simple name:
+# a deftype writes the host ctor table, a defrecord that table AND the statics
+# one (its `create`), and both are keyed under the bare name as well as the
+# qualified one, so recording either as the RUNTIME's would silence the note for
+# an unrelated class. KeyStore is preceded by a deftype and MessageDigest by a
+# defrecord, so the ctor half of that fails on its own.
 out="$(rundebug -A:prov run -m appprovsquat)"
 case "$out" in
   *"registers java.security.KeyStore without declaring it"*)
     check "an undeclared registration is reported" ok ok ;;
   *) check "an undeclared registration is reported" "a note naming java.security.KeyStore" \
            "$(printf '%s' "$out" | grep 'without declaring it' | head -1)" ;;
+esac
+case "$out" in
+  *"registers java.security.MessageDigest without declaring it"*)
+    check "a user type of the same simple name does not silence the note" ok ok ;;
+  *) check "a user type of the same simple name does not silence the note" \
+           "a note naming java.security.MessageDigest" \
+           "$(printf '%s' "$out" | grep 'MessageDigest' | head -1)" ;;
 esac
 # ...and not for one the RUNTIME implements, where register-class-provider! refuses
 # the claim the note asks for and extending the class member by member at install

--- a/host/chez/deps-alias-smoke.sh
+++ b/host/chez/deps-alias-smoke.sh
@@ -50,6 +50,10 @@ runfull() { JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" "$@" 2>&1; }
 # be able to displace. runall keeps every line (a tree, a describe map).
 runout() { JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" "$@" 2>/dev/null | tail -1; }
 runall() { JOLT_PWD="$APP" JOLT_QUIET=1 "$JOLT" "$@" 2>/dev/null; }
+# stdout+stderr with the registry diagnostics on — the RFC 0014 notes are
+# JOLT_DEBUG-only, and a note that fires where its advice cannot be taken is as
+# much a defect as a missing one.
+rundebug() { JOLT_PWD="$APP" JOLT_QUIET=1 JOLT_DEBUG=1 "$JOLT" "$@" 2>&1; }
 
 # baseline: project deps only
 check "project dep resolves (liba)" "liba A" "$(run run -m appver)"
@@ -415,6 +419,43 @@ check "a library registers over the base tier" \
 check "a provider that never loads releases what it held" \
       "squatter-mac:HmacSHA256 squatter-kpg:RSA" \
       "$(runall -A:prov run -m appprovgone | tr '\n' ' ' | sed 's/ $//')"
+
+# A provider reached from ANOTHER provider's install namespace is still its own
+# (jolt#926). provnest declares javax.crypto.Cipher and requires provinner.install,
+# which declares and registers java.security.KeyFactory. Marking the whole load
+# with the OUTER provider left KeyFactory owned by nobody, so the app's squatting
+# registration was accepted instead of dropped — jolt#914 one level down.
+check "a nested provider owns the class it declares" \
+      "outer-cipher:AES inner-kf:RSA" \
+      "$(runall -A:prov2 run -m appprovnest | tr '\n' ' ' | sed 's/ $//')"
+out="$(rundebug -A:prov2 run -m appprovnest)"
+case "$out" in
+  *"provnest.install registers java.security.KeyFactory"*)
+    check "the nested registration is not blamed on the outer provider" \
+          "no note naming provnest.install" \
+          "$(printf '%s' "$out" | grep 'without declaring it' | head -1)" ;;
+  *) check "the nested registration is not blamed on the outer provider" ok ok ;;
+esac
+
+# The undeclared-registration note is advice: declare the class in :jolt/provides.
+# It fires for a class nothing implements and nothing declares...
+out="$(rundebug -A:prov run -m appprovsquat)"
+case "$out" in
+  *"registers java.security.KeyStore without declaring it"*)
+    check "an undeclared registration is reported" ok ok ;;
+  *) check "an undeclared registration is reported" "a note naming java.security.KeyStore" \
+           "$(printf '%s' "$out" | grep 'without declaring it' | head -1)" ;;
+esac
+# ...and not for one the RUNTIME implements, where register-class-provider! refuses
+# the claim the note asks for and extending the class member by member at install
+# is the only route there is (jolt#926).
+case "$out" in
+  *"java.util.Base64 without declaring it"*)
+    check "no note where the declaration would be refused" \
+          "no note naming java.util.Base64" \
+          "$(printf '%s' "$out" | grep 'without declaring it' | head -1)" ;;
+  *) check "no note where the declaration would be refused" ok ok ;;
+esac
 
 # io/resource answers an ABSOLUTE file: URL for a file on a source root, like the
 # JVM classloader. The roots here are relative ("./src"), and "file:./src/x" is

--- a/host/chez/java/class-extensions.ss
+++ b/host/chez/java/class-extensions.ss
@@ -242,9 +242,11 @@
              (class-ext-table-put! class-ext-extend-tbl name ms)
              (class-ext-install-fallback!)))))
       (unless (jolt-nil? statics)
-        ;; register-class-statics! already merges into the class's existing member
-        ;; table and reports a differing re-registration under JOLT_DEBUG.
-        (register-class-statics! name (class-ext-members "statics" name statics #f)))
+        ;; class-statics-merge! already merges into the class's existing member
+        ;; table and reports a differing re-registration under JOLT_DEBUG. The
+        ;; merge and not register-class-statics!: extending a class is not the
+        ;; runtime coming to provide it (host-static.ss host-class-statics-tbl).
+        (class-statics-merge! name (class-ext-members "statics" name statics #f)))
       (unless (jolt-nil? ctor)
         (unless (procedure? ctor)
           (class-ext-bad! (string-append "extend-class!: :ctor for " name

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1495,13 +1495,12 @@
     (let loop ((l lst) (i 0)) (if (null? l) bv (begin (bytevector-u8-set! bv i (car l)) (loop (cdr l) (+ i 1)))))))
 (register-class-statics! "URLEncoder" (list (cons "encode" url-encode)))
 (register-class-statics! "URLDecoder" (list (cons "decode" url-decode)))
-;; Charset/forName yields the canonical name STRING (not an opaque object) so it
-;; threads straight into (.getBytes s cs) / (String. bytes cs), which take a name.
-;; defaultCharset is likewise the canonical name string ("UTF-8" — jolt's I/O is
-;; UTF-8 throughout), so it threads into the same name-taking APIs as forName.
-(register-class-statics! "Charset"
-  (list (cons "forName" (lambda (nm) (jolt-str-render-one nm)))
-        (cons "defaultCharset" (lambda () "UTF-8"))))
+;; Charset is registered further down, under the qualified name — which mirrors
+;; to the short one — and answers with a charset OBJECT (charset-for-name, which
+;; validates the name and carries the encoding). A second short-name registration
+;; stood here answering with the canonical name string, and was overwritten member
+;; for member by that one: dead, and JOLT_DEBUG reported the overwrite as drift
+;; between two host files.
 
 ;; ---- Base64 (RFC 4648) ------------------------------------------------------
 ;; One codec, two alphabets: basic (+/) and URL-safe (-_), section 5 of the RFC.
@@ -2520,16 +2519,20 @@
                (r (modulo u bound)))
           (if (<= (- u r) (- 2147483648 bound)) (->num r) (loop))))))
 
+;; (SecureRandom. seed) is accepted and the seed ignored: the JVM's seeded ctor
+;; SUPPLEMENTS entropy rather than replacing it, so ignoring it cannot make the
+;; output weaker than the caller asked for. There is no state either way, so one
+;; procedure serves the constructor and both getInstance forms — and both
+;; spellings, which share one member table: a fresh closure per spelling
+;; re-registers the member with a different value, and JOLT_DEBUG then reports the
+;; runtime's own boot as registry drift.
+(define (sr-new . args) (make-jhost "securerandom" #f))
 (for-each
   (lambda (nm)
-    (register-class-ctor! nm
-      ;; (SecureRandom. seed) is accepted and the seed ignored: the JVM's seeded
-      ;; ctor SUPPLEMENTS entropy rather than replacing it, so ignoring it cannot
-      ;; make the output weaker than the caller asked for.
-      (lambda args (make-jhost "securerandom" #f)))
+    (register-class-ctor! nm sr-new)
     (register-class-statics! nm
-      (list (cons "getInstance" (lambda args (make-jhost "securerandom" #f)))
-            (cons "getInstanceStrong" (lambda args (make-jhost "securerandom" #f))))))
+      (list (cons "getInstance" sr-new)
+            (cons "getInstanceStrong" sr-new))))
   '("SecureRandom" "java.security.SecureRandom"))
 
 (register-host-methods! "securerandom"

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -267,8 +267,13 @@
 ;; clojure.lang.RT/iter: an Iterator over any seqable — the same jiterator
 ;; (.iterator coll) dispatches to. orchard/inspect.analytics walks collections
 ;; through it.
-(register-class-statics! "RT" (list (cons "iter" (lambda (coll) (make-jiterator (jolt-seq coll))))))
-(register-class-statics! "clojure.lang.RT" (list (cons "iter" (lambda (coll) (make-jiterator (jolt-seq coll))))))
+;; One procedure for both spellings, like nextID below: the two names share ONE
+;; member table (register-class-statics! mirrors the FQN to the short name), so a
+;; fresh closure per spelling re-registers the member with a different value and
+;; JOLT_DEBUG reports the runtime's own boot as registry drift.
+(define (rt-iter coll) (make-jiterator (jolt-seq coll)))
+(register-class-statics! "RT" (list (cons "iter" rt-iter)))
+(register-class-statics! "clojure.lang.RT" (list (cons "iter" rt-iter)))
 
 ;; clojure.lang.RT/REQUIRE_LOCK — the JVM's `static final Object REQUIRE_LOCK`.
 ;; Nothing inside require takes it; it is the AGREED lock a caller holds around a

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -109,7 +109,15 @@
 
 (define (register-class-ctor! name proc)
   (hashtable-set! host-class-ctors-tbl name #t)
-  (hashtable-set! class-ctors-tbl name proc))
+  (class-ctor-set! name proc))
+
+;; The plain table write, for a ctor that is NOT the runtime coming to provide a
+;; host class: every deftype and defrecord binds (Name. …) through this table
+;; (protocols.ss), under its "ns.Name" tag AND its simple name. Recording those
+;; as the host's would make host-class-ctors-tbl — which is what
+;; runtime-provides-class? and the constructor-override warning read — answer
+;; yes for any class whose simple name a user type happens to share.
+(define (class-ctor-set! name proc) (hashtable-set! class-ctors-tbl name proc))
 
 ;; clojure.core/__register-class-ctor! lands here. Registering a class jolt does
 ;; not model is the intended use; REPLACING one it does is a process-wide

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -57,7 +57,34 @@
              "warning: ~a member ~a/~a registered twice with different values\n"
              kind class member)))
 
-(define (register-class-statics! name members)  ; members: list of (str . val/proc)
+;; The host's own boot-time registrations (io.ss, host-static-classes.ss, …), the
+;; statics counterpart of host-class-ctors-tbl. Together they are what "the
+;; runtime provides this class" means: register-class-provider! refuses a claim on
+;; a class already in the tables, and at declaration time — jolt.deps, before any
+;; library code runs — the only entries there are these. Both spellings, because a
+;; claim is tested under both (class-spellings).
+(define host-class-statics-tbl (make-hashtable string-hash string=?))
+
+(define (register-class-statics! name members)
+  (hashtable-set! host-class-statics-tbl name #t)
+  (hashtable-set! host-class-statics-tbl (short-class-name name) #t)
+  (class-statics-merge! name members))
+
+;; Would register-class-provider! refuse a :jolt/provides claim on this class?
+;; Answered from the HOST tables and not the live ones: a class ANOTHER library
+;; registered is still free to be declared — nothing has claimed it — and a
+;; registration that just landed must not make itself the reason.
+(define (runtime-provides-class? name)
+  (let ((short (short-class-name name)))
+    (and (or (hashtable-ref host-class-statics-tbl name #f)
+             (hashtable-ref host-class-statics-tbl short #f)
+             (hashtable-ref host-class-ctors-tbl name #f)
+             (hashtable-ref host-class-ctors-tbl short #f))
+         #t)))
+
+;; The merge itself: also the LIBRARY path (register-class-statics-owned!,
+;; extend-class!), which adds members without making the class the runtime's.
+(define (class-statics-merge! name members)  ; members: list of (str . val/proc)
   (let* ((short (short-class-name name))
          (h (or (hashtable-ref class-statics-tbl name #f)
                 (hashtable-ref class-statics-tbl short #f)
@@ -141,11 +168,11 @@
                (taken (if h (filter (lambda (m) (hashtable-contains? h (car m))) members) '()))
                (fresh (if h (filter (lambda (m) (not (hashtable-contains? h (car m)))) members) members)))
           (when (pair? taken) (provider-claim-drop! name owner (map car taken)))
-          (when (pair? fresh) (register-class-statics! name fresh)))
+          (when (pair? fresh) (class-statics-merge! name fresh)))
         (begin
           (provider-claim-note! name)
           (lib-note-provider-registration! name)
-          (register-class-statics! name members)))))
+          (class-statics-merge! name members)))))
 
 (define (register-host-methods! tag members)
   (let ((h (or (hashtable-ref host-methods-tbl tag #f)
@@ -443,7 +470,31 @@
 ;; provider registers its classes as its install namespace loads, and the
 ;; registration guard (lib-provider-owner-elsewhere) has to tell that registration
 ;; apart from another library squatting on the same class.
+;;
+;; Whoever LOADS an install namespace sets the mark (loader.ss load-namespace*,
+;; through lib-with-install-ns-mark) — not the autoload alone. A provider whose
+;; install namespace requires a SECOND provider's, which is how kmet reached
+;; jolt.crypto, registers that second provider's classes under a plain require;
+;; marking the whole load with the outer provider left the inner one's classes
+;; owned by nobody, so a later registration for a member it answers was accepted
+;; instead of dropped — jolt#914 one level down — and JOLT_DEBUG named the wrong
+;; namespace (jolt#926).
 (define lib-loading-provider (make-thread-parameter #f))
+
+(define (lib-provider-by-install-ns ns)
+  (let loop ((ps lib-class-providers))
+    (cond ((null? ps) #f)
+          ((string=? ns (vector-ref (car ps) 0)) (car ps))
+          (else (loop (cdr ps))))))
+
+;; Run `thunk` marked with the provider `ns` installs, if it installs one. A
+;; namespace that is NOT an install namespace leaves the mark alone rather than
+;; clearing it: a provider whose install! calls a helper namespace of its own is
+;; still that provider registering, and only another DECLARED provider is a
+;; different registrant.
+(define (lib-with-install-ns-mark ns thunk)
+  (let ((p (lib-provider-by-install-ns ns)))
+    (if p (parameterize ((lib-loading-provider p)) (thunk)) (thunk))))
 
 ;; Classes a declared provider actually registered as its install namespace
 ;; loaded. This is what the registration guard protects: a class whose provider
@@ -545,8 +596,11 @@
                            (begin (guard (c (#t (set-box! (vector-ref p 3) 'failed)
                                                 (lib-replay-deferred! p)
                                                 (raise c)))
-                                    (parameterize ((lib-loading-provider p))
-                                      (load-namespace (vector-ref p 0))))
+                                    ;; the mark comes from load-namespace* itself
+                                    ;; (lib-with-install-ns-mark), which is the
+                                    ;; only way it can also cover an install
+                                    ;; namespace reached by a plain require.
+                                    (load-namespace (vector-ref p 0)))
                                   #t)))
               (replayed (lib-replay-deferred! p)))
          (or loaded replayed))))
@@ -660,6 +714,14 @@
   (when (getenv "JOLT_DEBUG")
     (let ((self (lib-loading-provider)))
       (when (and self (not (member name (vector-ref self 2)))
+                 ;; ...but not for a class the RUNTIME implements. There the
+                 ;; declaration the note asks for is refused ("which the runtime
+                 ;; already provides"), so the advice cannot be taken: registering
+                 ;; the members at install IS the route, and it is the additive
+                 ;; case class-extensions.ss exists for. Nothing autoloads for a
+                 ;; class that is already there either, so there is no order
+                 ;; dependence left to warn about (jolt#926).
+                 (not (runtime-provides-class? name))
                  (claim-warn-once? "note" name))
         (fprintf (current-error-port)
                  "warning: ~a registers ~a without declaring it in :jolt/provides (RFC 0014); nothing autoloads ~a for a class it does not declare, so whether ~a resolves depends on what else pulls that namespace in\n"

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -1880,9 +1880,16 @@
       ;; (a continuation escaping the load for good) never reached ldr-load-body's
       ;; guard, so the mark is rolled back here instead. Idempotent against the
       ;; guard's own rollback on the throw path.
+      ;;
+      ;; RFC 0014: an install namespace's registrations belong to the provider
+      ;; that DECLARES it, whichever way the load was reached — the class-miss
+      ;; autoload, or a plain require from another provider's install namespace
+      ;; (host-static.ss lib-with-install-ns-mark, jolt#926).
       (dynamic-wind
         (lambda () (ldr-assert-claim! name))
-        (lambda () (ldr-load-body name force? was-loaded?) (set! finished? #t))
+        (lambda ()
+          (lib-with-install-ns-mark name (lambda () (ldr-load-body name force? was-loaded?)))
+          (set! finished? #t))
         (lambda ()
           (unless (jolt-park-unwinding?)
             (unless (or finished? was-loaded?) (ldr-unmark-loaded! name))

--- a/host/chez/protocols.ss
+++ b/host/chez/protocols.ss
@@ -566,14 +566,14 @@
     ;; (Name. …) in the DEFINING ns is qualified to this by the analyzer, so a
     ;; deftype whose simple name collides with a built-in host class (tools.reader's
     ;; PushbackReader vs java.io.PushbackReader) still resolves correctly there.
-    (register-class-ctor! tag ctor)
+    (class-ctor-set! tag ctor)
     ;; Also register the simple name so (Name. …) resolves ns-agnostically across
     ;; files — BUT never clobber a built-in host class of the same simple name (an
     ;; unrelated ns's bare (Name. …) must still reach the built-in). A prior deftype
     ;; (tracked in chez-simple-name-tag) is fine to overwrite (last def wins / redef).
     (when (or (not (hashtable-ref class-ctors-tbl (symbol-t-name name-sym) #f))
               (hashtable-ref chez-simple-name-tag (symbol-t-name name-sym) #f))
-      (register-class-ctor! (symbol-t-name name-sym) ctor))
+      (class-ctor-set! (symbol-t-name name-sym) ctor))
     ;; index the tag so a cross-ns extend-protocol resolves the bare type name.
     (jolt-with-mutex rec-tbl-mu
       (hashtable-set! chez-deftype-tag-set tag #t)

--- a/host/chez/records-dispatch.ss
+++ b/host/chez/records-dispatch.ss
@@ -730,11 +730,20 @@
                                      "clojure.lang.IHashEq" "java.io.Serializable"))))
     ;; every defrecord gets a static create(map) on the JVM — it is what the
     ;; #ns.Rec{…} literal is read through, positionally or by key.
+    ;;
+    ;; class-statics-merge! and not register-class-statics!: this runs when USER
+    ;; code defines a record, not at boot, and register-class-statics! also
+    ;; records the class in host-class-statics-tbl — "the runtime provides this
+    ;; class", the table runtime-provides-class? answers from. A record's tag is
+    ;; not the runtime's: register-class-provider! runs at deps time, before any
+    ;; defrecord exists, so it would happily accept a :jolt/provides claim on
+    ;; that name, and the predicate has to agree. Both spellings would be marked
+    ;; too, so a bare `Widget` record shadowed every com.acme.Widget.
     (let ((ctor (hashtable-ref class-ctors-tbl tag #f))
           (shape (hashtable-ref chez-record-shapes-tbl
                                 (string-append (chez-current-ns) "/->" (symbol-t-name name-sym)) #f)))
       (when (and ctor shape)
-        (register-class-statics! tag
+        (class-statics-merge! tag
           (list (cons "create"
                       (lambda (m)
                         ;; declared fields positionally, anything else assoc'd on —

--- a/host/chez/smoke.sh
+++ b/host/chez/smoke.sh
@@ -1879,5 +1879,23 @@ check '(do (load-string "(set! *unchecked-math* true) :x") *unchecked-math*)' 'f
 check '(do (load-string "(set! *warn-on-reflection* true) :x") *warn-on-reflection*)' 'false'
 check '(do (load-string "(set! *assert* false) :x") *assert*)' 'true'
 
+# The runtime's own boot must not read as registry drift. A class registered
+# under BOTH its qualified and its simple name shares one member table, so a
+# fresh closure per spelling re-registers the member with a different value and
+# JOLT_DEBUG reports two sources fighting over one static — the diagnostic that
+# is supposed to find a library squatting on a host class. java.security.
+# SecureRandom, clojure.lang.RT/iter and a dead short-name java.nio.charset.
+# Charset block all did, so five such lines were there to be scrolled past in
+# every debug session (jolt#926). Nothing but the runtime is loaded here, so any
+# such line is the host disagreeing with itself.
+dbg_err="$(JOLT_DEBUG=1 $jolt -e '(do (Charset/forName "UTF-8") (java.security.SecureRandom/getInstance) (clojure.lang.RT/iter [1]) :ok)' 2>&1 >/dev/null)"
+if printf '%s' "$dbg_err" | grep -q 'registered twice with different values'; then
+  echo "  FAIL (no): the runtime's own boot reports registry drift"
+  echo "    got \`$(printf '%s' "$dbg_err" | grep 'registered twice with different values')\`"
+  fails=$((fails + 1))
+else
+  pass=$((pass + 1))
+fi
+
 echo "cli smoke: $pass passed, $fails failed"
 [ "$fails" -eq 0 ]

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -766,6 +766,11 @@ eturn)) (loop (- n 1)))
     (unless (string=? name (short-class-name name))
       (hashtable-set! class-statics-tbl (short-class-name name) h))
     (for-each (lambda (p) (hashtable-set! h (car p) (cdr p))) members)))
+;; The two are one procedure here. On Chez they differ only in whether the class
+;; is also recorded as one the RUNTIME provides (host-static.ss), and the gambit
+;; boot has no provider registry to ask — records-dispatch.ss's defrecord
+;; `create` takes the merge, so the name has to exist.
+(define (class-statics-merge! name members) (register-class-statics! name members))
 
 ;; Chez gensym accepts a STRING prefix; Gambit only a symbol. Normalize.
 (define %gambit-gensym gensym)

--- a/host/gambit/records-gambit.ss
+++ b/host/gambit/records-gambit.ss
@@ -1703,7 +1703,7 @@
                           (number->string n)
                           ") passed to: "
                           ctor-name))))))))
-    (register-class-ctor! tag ctor)
+    (class-ctor-set! tag ctor)
     (when (or (not (hashtable-ref
                      class-ctors-tbl
                      (symbol-t-name name-sym)
@@ -1712,7 +1712,7 @@
                 chez-simple-name-tag
                 (symbol-t-name name-sym)
                 #f))
-      (register-class-ctor! (symbol-t-name name-sym) ctor))
+      (class-ctor-set! (symbol-t-name name-sym) ctor))
     (jolt-with-mutex
       rec-tbl-mu
       (hashtable-set! chez-deftype-tag-set tag #t)
@@ -2798,7 +2798,7 @@
                      (symbol-t-name name-sym))
                    #f)))
       (when (and ctor shape)
-        (register-class-statics!
+        (class-statics-merge!
           tag
           (list
             (cons

--- a/host/gambit/rt-core.ss
+++ b/host/gambit/rt-core.ss
@@ -1324,6 +1324,10 @@
 ;; this boot reads them back — no host interop), so definitions succeed.
 (define class-ctors-tbl (make-hashtable string-hash string=?))
 (define (register-class-ctor! tag ctor) (hashtable-set! class-ctors-tbl tag ctor))
+;; On Chez the two differ in whether the class is also recorded as one the host
+;; provides (java/host-static.ss); there is no such registry here, so a deftype's
+;; ctor takes the same write under the name protocols.ss calls.
+(define (class-ctor-set! tag ctor) (register-class-ctor! tag ctor))
 ;; register-class-methods! is what host-vars.ss binds clojure.core/__register-class-methods!
 ;; to. Without that binding the var is UNBOUND on this host, and jolt.socket and
 ;; the eight jolt.time namespaces call it at load — they could not load at all.

--- a/test/chez/deps-alias/app/deps.edn
+++ b/test/chez/deps-alias/app/deps.edn
@@ -28,6 +28,10 @@
   :prov   {:extra-deps {local/provclaim {:local/root "../provclaim"}
                         local/provsquat {:local/root "../provsquat"}
                         local/provgone  {:local/root "../provgone"}}}
+  ;; A provider whose install namespace requires ANOTHER provider's (jolt#926):
+  ;; provnest declares javax.crypto.Cipher and requires provinner.install, which
+  ;; declares java.security.KeyFactory.
+  :prov2  {:extra-deps {local/provnest {:local/root "../provnest"}}}
   ;; a dep directory with NO deps.edn defaults to its src path
   :noedn  {:extra-deps {local/libnoedn {:local/root "../libnoedn"}}}
   ;; -X / -T exec fixtures

--- a/test/chez/deps-alias/app/src/appprovnest.clj
+++ b/test/chez/deps-alias/app/src/appprovnest.clj
@@ -1,0 +1,12 @@
+(ns appprovnest
+  "The Cipher reference autoloads provnest, whose install namespace requires
+  provinner's — a second declared provider. provinner's java.security.KeyFactory
+  registration lands under provinner's own claim, so the squatting registration
+  below is dropped, exactly as it would be if provinner had autoloaded (jolt#926).
+  Attributing it to the outer provider left the class unowned and the squat won.")
+
+(defn -main [& _]
+  (println (javax.crypto.Cipher/getInstance "AES"))
+  (__register-class-statics! "java.security.KeyFactory"
+                             {"getInstance" (fn [algo] (str "squat-kf:" algo))})
+  (println (java.security.KeyFactory/getInstance "RSA")))

--- a/test/chez/deps-alias/provinner/deps.edn
+++ b/test/chez/deps-alias/provinner/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+
+ ;; A second declared provider, reached by a plain `require` from ANOTHER
+ ;; provider's install namespace rather than by the autoload (jolt#926). The
+ ;; class it declares is its own however it was loaded — the mark the registration
+ ;; guard reads has to name the namespace that is loading, not the one that
+ ;; started the load.
+ :jolt/provides {provinner.install ["java.security.KeyFactory"]}}

--- a/test/chez/deps-alias/provinner/src/provinner/install.clj
+++ b/test/chez/deps-alias/provinner/src/provinner/install.clj
@@ -1,0 +1,6 @@
+(ns provinner.install
+  "The declared provider of java.security.KeyFactory. Loaded through
+  provnest.install's require, never by an autoload of its own.")
+
+(__register-class-statics! "java.security.KeyFactory"
+                           {"getInstance" (fn [algo] (str "inner-kf:" algo))})

--- a/test/chez/deps-alias/provnest/deps.edn
+++ b/test/chez/deps-alias/provnest/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps {local/provinner {:local/root "../provinner"}}
+
+ ;; The OUTER provider: its install namespace requires provinner's. Stands in for
+ ;; kmet, whose provider required jolt.crypto — a second declared provider — and
+ ;; got jolt.crypto's classes attributed to itself (jolt#926).
+ :jolt/provides {provnest.install ["javax.crypto.Cipher"]}}

--- a/test/chez/deps-alias/provnest/src/provnest/install.clj
+++ b/test/chez/deps-alias/provnest/src/provnest/install.clj
@@ -1,0 +1,8 @@
+(ns provnest.install
+  "Declares one class and requires a second provider's install namespace, which
+  declares and registers its own. Attribution follows the namespace that is
+  LOADING: provinner's registration is provinner's."
+  (:require [provinner.install]))
+
+(__register-class-statics! "javax.crypto.Cipher"
+                           {"getInstance" (fn [algo] (str "outer-cipher:" algo))})

--- a/test/chez/deps-alias/provsquat/src/provsquat/install.clj
+++ b/test/chez/deps-alias/provsquat/src/provsquat/install.clj
@@ -23,11 +23,24 @@
 (__register-class-statics! "java.security.KeyPairGenerator"
                            {"getInstance" (fn [algo] (str "squatter-kpg:" algo))})
 
-;; ...and two undeclared registrations that read differently to the diagnostic
+;; ...and undeclared registrations that read differently to the diagnostic
 ;; (jolt#926). java.security.KeyStore is a class NOTHING implements and nothing
 ;; declares, so the note's advice — declare it in :jolt/provides — is the fix.
+;;
+;; Each is preceded by a USER TYPE whose simple name collides with it, because
+;; "does the runtime provide this class?" is answered from the host ctor and
+;; statics tables under BOTH spellings, and a deftype writes the ctor table
+;; while a defrecord writes both (its static `create`). Recording either as the
+;; host's would silence the note through the short name alone — and
+;; register-class-provider!, which runs at deps time before any user type
+;; exists, would still accept a :jolt/provides claim on the class. The two
+;; answers have to agree. deftype first, so the ctor half fails on its own.
+(deftype KeyStore [_])
 (__register-class-statics! "java.security.KeyStore"
                            {"getDefaultType" (fn [] "squatter-ks")})
+(defrecord MessageDigest [_])
+(__register-class-statics! "java.security.MessageDigest"
+                           {"getInstance" (fn [_] "squatter-md")})
 ;; java.util.Base64 is one the RUNTIME implements, so register-class-provider!
 ;; refuses a claim on it and the same advice cannot be taken: extending it member
 ;; by member at install is the only route, and it is the additive case. No note.

--- a/test/chez/deps-alias/provsquat/src/provsquat/install.clj
+++ b/test/chez/deps-alias/provsquat/src/provsquat/install.clj
@@ -22,3 +22,14 @@
 ;; registers that a DIFFERENT library declares, where that library never loads.
 (__register-class-statics! "java.security.KeyPairGenerator"
                            {"getInstance" (fn [algo] (str "squatter-kpg:" algo))})
+
+;; ...and two undeclared registrations that read differently to the diagnostic
+;; (jolt#926). java.security.KeyStore is a class NOTHING implements and nothing
+;; declares, so the note's advice — declare it in :jolt/provides — is the fix.
+(__register-class-statics! "java.security.KeyStore"
+                           {"getDefaultType" (fn [] "squatter-ks")})
+;; java.util.Base64 is one the RUNTIME implements, so register-class-provider!
+;; refuses a claim on it and the same advice cannot be taken: extending it member
+;; by member at install is the only route, and it is the additive case. No note.
+(__register-class-statics! "java.util.Base64"
+                           {"getMimeDecoder" (fn [] "squatter-b64")})


### PR DESCRIPTION
Fixes #926 — the two independent defects in the #924 code.

## 1. Nested provider attribution

`lib-load-provider!` parameterized `lib-loading-provider` around the whole load, so a second declared provider that the install namespace reaches with a plain `require` was attributed to the outer one: its declared classes never entered `lib-provider-owned-tbl`, a later registration for a member it answers was accepted instead of dropped (#914 one level down), and `JOLT_DEBUG` named the wrong namespace.

The mark now comes from `load-namespace*` (`lib-with-install-ns-mark`) — whoever loads an install namespace sets it — so a provider's registrations are its own however the load was reached. A namespace that is not itself a declared provider leaves the mark alone, so a helper namespace a provider requires still registers on the provider's behalf.

Issue repro, before / after:

```
outer: outer:AES        outer: outer:AES
inner: squat:RSA        inner: inner:RSA + "dropping a registration for
                                java.security.KeyFactory/getInstance — …"
```

## 2. The undeclared-registration note advised a declaration jolt refuses

For a class the runtime implements, `register-class-provider!` refuses the claim, so `JOLT_DEBUG`'s advice to declare it in `:jolt/provides` could not be taken and nothing autoloads for a class that is already there. Suppressed for those; unchanged for a class nothing implements and nothing declares. Was firing for kmet's `java.util.Base64`, jolt-lang/time's `java.util.Date` and jolt.crypto's `java.security.SecureRandom` (confirmed gone against the real jolt.crypto checkout; its six genuinely undeclared classes still report).

The question is answered from a new `host-class-statics-tbl` — the statics counterpart of the existing `host-class-ctors-tbl` — so a class another LIBRARY registered is still free to be declared. `extend-class!`'s statics go through the merge rather than the host entry point for the same reason.

## Found along the way

`JOLT_DEBUG` reported the runtime's own boot as registry drift, five lines of it: `java.security.SecureRandom` and `clojure.lang.RT/iter` built a fresh closure per spelling where the qualified and simple names share ONE member table, and a short-name `java.nio.charset.Charset` block answering `forName` with the canonical name string was dead — overwritten member for member by the qualified registration further down, which has answered with a charset object since `(.getBytes s (Charset/forName "ISO-8859-1"))` was fixed. Behaviour is unchanged; the noise is gone.

## Tests

`test/chez/deps-alias/{provnest,provinner}` + `appprovnest`, and two undeclared registrations in provsquat that read differently to the diagnostic. Four new rows in the deps-alias smoke, one in the cli smoke; all four fail on the previous binary.

- deps-alias smoke 135/0 (source mode and the release binary)
- `make test` — full CI gate, 109 targets, plus selfhost
- `make libconformance` — 50 libraries, 47 ok, 0 regressed

## Follow-up: a user `deftype` is not a host class

Review found `runtime-provides-class?` answering yes for classes it should not.
Every `deftype`/`defrecord` registers its constructor — and a record its static
`create` — through the *host* entry points, under its `ns.Name` tag **and** its
bare name, so those are exactly the tables the new predicate reads. A
`(deftype Widget …)` anywhere in the process therefore made an unrelated
`com.example.Widget` read as the runtime's: the undeclared-registration note
went silent for it, while `register-class-provider!` — deps time, before any
user type exists — would still have accepted a `:jolt/provides` claim on it.

The plain table write is now split out of both host entry points
(`class-ctor-set!`, `class-statics-merge!`) and the deftype path takes that, so
only boot-time registrations record a class as the runtime's.

provsquat gained a colliding `deftype` ahead of `java.security.KeyStore` and a
colliding `defrecord` ahead of `java.security.MessageDigest`, so the two halves
fail separately: reverting the ctor half reddens both checks, the statics half
only the second. deps-alias smoke 136/0; `make ci` 110 targets, `make certify`
0 NEW, `make libconformance` 47 ok / 0 regressed, all four gambit gates on gsi.
