### PR TITLE
One require implementation, and the twelve loader conformance cases as a gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ install: build
 # answers "is this working tree gated?" — which is not something to remember.
 
 CI-GATES := submodules values corpus unit documented grenadine mvnhttp readscaling compilescaling applyscaling lazyscaling vecscaling pipescaling chunkscaling printscaling complexity ioscaling hotscaling depssmoke taskssmoke scriptsmoke completionssmoke depscpcache depsunit \
-  smoke tracesmoke errorreport errorkinds buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts ffi ffidupsym continuations stdlibfasl \
+  smoke tracesmoke errorreport errorkinds buildsmoke buildlibsmoke staticnativesmoke sci scifunctional cts loaderconf ffi ffidupsym continuations stdlibfasl \
   transient rrbprop rrbscaling stateimage infer wp devirt fieldread numwp fieldnum fieldjoin contagion \
   hasheq narrowhash \
   protoret pic narrow directlink directcall arraymap arraybacking unitcontext numeric oparity mathfl flarr \
@@ -642,6 +642,13 @@ scifunctional: testbin
 # (test/chez/cts-known-failures.txt).
 cts: testbin
 	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" bash host/chez/cts.sh
+
+# The loader conformance suite: the twelve cases that specify jolt.loader (roots
+# per context, isolation, delegation policy, unload). Baselined like certify —
+# a case that regresses fails, and a case that starts passing fails until the
+# baseline records it, so nothing green quietly goes red again.
+loaderconf:
+	@sh host/chez/loaderconf.sh
 
 # FFI: bind native functions (typed foreign-procedure), memory, and that a
 # :blocking call is collect-safe (a parked thread doesn't pin the collector).

--- a/Makefile
+++ b/Makefile
@@ -647,8 +647,12 @@ cts: testbin
 # per context, isolation, delegation policy, unload). Baselined like certify —
 # a case that regresses fails, and a case that starts passing fails until the
 # baseline records it, so nothing green quietly goes red again.
-loaderconf:
-	@sh host/chez/loaderconf.sh
+#
+# Through the BUILT binary, like cts and the other CLI gates: a loader that only
+# works against the source tree is not a loader, and jolt.loader ships in the
+# stdlib fasl, so the binary is the arrangement the cases have to hold under.
+loaderconf: testbin
+	@JOLT_BIN="$${JOLT_BIN:-target/release/jolt}" sh host/chez/loaderconf.sh
 
 # FFI: bind native functions (typed foreign-procedure), memory, and that a
 # :blocking call is collect-safe (a parked thread doesn't pin the collector).

--- a/host/chez/build.ss
+++ b/host/chez/build.ss
@@ -1168,8 +1168,8 @@
 ;; the shared expand-spec + parse-libspec (loader.ss / ns.ss), matching the
 ;; loader's semantics exactly.
 ;; A libspec that only establishes an alias pulls nothing into the build. At
-;; runtime `require` interns the namespace without loading it (loader.ss
-;; ldr-load+register), so counting it as a dependency would emit the target into
+;; runtime `require` interns the namespace without loading it (ns.ss
+;; ns-load+register), so counting it as a dependency would emit the target into
 ;; the binary and run its top level — the opposite of what :as-alias asks for. The
 ;; alias itself is still replayed, by bld-scan-spec!. Mirrors clojure.core's
 ;; load-lib, which picks its loader with `need-ns (or as use)`.

--- a/host/chez/java/natives-str.ss
+++ b/host/chez/java/natives-str.ss
@@ -797,44 +797,6 @@
 (def-var! "clojure.core" "str-replace" str-replace)
 (def-var! "clojure.core" "str-replace-all" str-replace-all)
 
-;; (require ...) / (use ...) at runtime: register each spec's :as alias + :refer
-;; names into the runtime ns tables (chez-register-spec!, ns.ss), keyed by the
-;; current ns. The spine also pre-registers these at analyze time (idempotent),
-;; so ns-aliases/ns-resolve over an :as alias resolve. Specs arrive evaluated
-;; (quoted).
-(define (chez-runtime-require . specs)
-  (for-each (lambda (s) (chez-register-spec! (chez-current-ns) s)) specs)
-  jolt-nil)
-(def-var! "clojure.core" "require" chez-runtime-require)
-;; use = require + refer ALL of the target's public vars (unless an explicit
-;; :only/:refer filter is given, which chez-register-spec! handles per-name).
-(define (chez-runtime-use . specs)
-  (for-each
-    (lambda (spec)
-      (chez-register-spec! (chez-current-ns) spec)
-      (let* ((items (cond ((pvec? spec) (seq->list spec))
-                          ((or (cseq? spec) (empty-list-t? spec)) (seq->list spec))
-                          ((symbol-t? spec) (list spec))
-                          (else '())))
-             (target (and (pair? items) (symbol-t? (car items)) (symbol-t-name (car items))))
-             (filtered (let scan ((xs (if (pair? items) (cdr items) '())))
-                         (cond ((null? xs) #f)
-                               ((and (keyword? (car xs))
-                                     (member (keyword-t-name (car xs)) '("only" "refer"))) #t)
-                               (else (scan (cdr xs))))))
-             (excluded (let scan ((xs (if (pair? items) (cdr items) '())))
-                         (cond ((null? xs) '())
-                               ((and (keyword? (car xs))
-                                     (string=? (keyword-t-name (car xs)) "exclude")
-                                     (pair? (cdr xs)))
-                                (map symbol-t-name (filter symbol-t? (seq->list (cadr xs)))))
-                               (else (scan (cdr xs)))))))
-        (when (and target (not filtered))
-          (chez-register-refer-all! (chez-current-ns) target)
-          (chez-register-refer-all-excludes! (chez-current-ns) target excluded))))
-    specs)
-  jolt-nil)
-(def-var! "clojure.core" "use" chez-runtime-use)
 ;; import: bring a deftype/defrecord from another ns into the current one. A spec
 ;; [from-ns Type ...] binds each Type's ctor closure under the current ns, so its
 ;; (Type. ...) constructor (host-new resolves it as a var) works after :import.

--- a/host/chez/loader.ss
+++ b/host/chez/loader.ss
@@ -804,12 +804,12 @@
 ;;
 ;; The requires are learned by RECORDING them during the compile that produced the
 ;; fasl, not by re-parsing ns forms: the loader funnels every require/use through
-;; ldr-load+register, so the record covers a top-level (require …) and a :require
-;; clause alike. They are written beside the fasl, in a sidecar named by the
-;; namespace's own hash alone — the one key derivable before its deps are known.
+;; ns-load+register (ns.ss), so the record covers a top-level (require …) and a
+;; :require clause alike. They are written beside the fasl, in a sidecar named by
+;; the namespace's own hash alone — the one key derivable before its deps are known.
 (define aot-dep-sink (make-thread-parameter #f))
 (define (aot-new-dep-sink) (vector '()))
-;; Called from ldr-load+register for every require target, whether or not the
+;; Called from the require/use load step for every target, whether or not the
 ;; target was already loaded — a dedup'd require is still a dependency.
 (define (aot-record-dep! name)
   (let ((sink (aot-dep-sink)))
@@ -1960,95 +1960,31 @@
 ;; kept under its old name for the build driver's callers.
 (define (expand-spec s) (expand-libspec s))
 
-;; --- require/use that LOAD ---------------------------------------------------
-;; Override the alias-only versions from natives-str.ss. Load each spec's target
-;; (no-op if baked/already loaded), THEN register its :as/:refer under the caller
-;; ns (chez-register-spec! reads the current ns, restored by load-namespace).
+;; --- the load step of require/use --------------------------------------------
+;; ns.ss owns `require`/`use`; what it cannot own is reading a namespace off the
+;; source roots, because it is loaded by runtimes that have no loader. So the
+;; body is there and the two steps only a loader can take are installed here.
 ;;
-;; keyword flags (clojure.core load-libs) are collected from the arg list before
-;; the libspecs: :reload forces the named libs past the dedup, :reload-all forces
-;; it off for the whole load (so transitively-required libs reload too), :verbose
-;; prints each load.
-(define (ldr-flag-names specs)
-  (let loop ((xs specs) (acc '()))
-    (cond ((null? xs) (reverse acc))
-          ((keyword? (car xs)) (loop (cdr xs) (cons (keyword-t-name (car xs)) acc)))
-          (else (loop (cdr xs) acc)))))
+;; ns-load-target! reads and initializes one already-expanded target. The dep is
+;; recorded BEFORE the load: a target already loaded is still a dependency of
+;; whoever is being compiled, and load-namespace* would dedup it away.
+(set-ns-load-target!
+  (lambda (target force-named?)
+    (aot-record-dep! target)
+    (load-namespace* target force-named?)))
 
-;; Load each expanded libspec's target (no-op if baked/already loaded), register
-;; its :as/:refer under the caller ns, and — for `use` (use? #t) — refer every
-;; public var when the spec has no :only/:refer filter. Target + opts both come
-;; from the shared parse-libspec (ns.ss): the single spec->target+opts parser
-;; routed through by loader-require / loader-use / chez-register-spec! /
-;; ce-scan-requires!.
-(define (ldr-load+register specs force-named? use?)
-  (for-each
-    (lambda (s0)
-      (for-each
-        (lambda (s)
-          (let* ((parsed (parse-libspec s))
-                 (target (and parsed (car parsed)))
-                 (opt-names (if parsed (map car (cdr parsed)) '()))
-                 ;; :as-alias establishes the alias WITHOUT loading the target — for
-                 ;; a namespace that may not exist yet, or exists only to qualify
-                 ;; keywords. clojure.core's load-lib picks the loader with
-                 ;; `need-ns (or as use)`, falling to (create-ns lib) when the spec
-                 ;; is :as-alias and neither — so a spec that also carries :as, or
-                 ;; that arrives through `use`, still loads.
-                 (alias-only? (and target
-                                   (member "as-alias" opt-names)
-                                   (not (member "as" opt-names))
-                                   (not use?))))
-            ;; record BEFORE loading: a target already loaded is still a
-            ;; dependency of whoever is being compiled, and load-namespace*
-            ;; would dedup it away. An alias-only spec loads nothing, so it is
-            ;; a dependency of nothing.
-            (when (and target (not alias-only?)) (aot-record-dep! target))
-            (cond
-              ((not target) #f)
-              (alias-only? (intern-ns! target))   ; create-ns, without loading
-              (else (load-namespace* target force-named?)))
-            (chez-register-spec! (chez-current-ns) s)
-            (when (and use? target
-                       (not (or (member "only" opt-names) (member "refer" opt-names))))
-              (chez-register-refer-all! (chez-current-ns) target)
-              ;; [ns :exclude [names]] — the excluded names stay OUT of the
-              ;; refer-all set (load-lib applies the same filter to its refer).
-              (let ((excl (assoc "exclude" (cdr parsed))))
-                (when excl
-                  (chez-register-refer-all-excludes!
-                    (chez-current-ns) target
-                    (map symbol-t-name (filter symbol-t? (seq->list (cdr excl))))))))))
-        (expand-spec s0)))
-    specs))
-
-(define (loader-require . specs)
-  (let* ((flags (ldr-flag-names specs))
-         (real (filter (lambda (s) (not (keyword? s))) specs))
-         (reload-all? (member "reload-all" flags))
-         (reload? (and (not reload-all?) (member "reload" flags)))
-         (verbose? (member "verbose" flags)))
-    (if reload-all?
-        (parameterize ((ldr-reload-all? #t) (ldr-verbose? verbose?))
-          (ldr-load+register real #f #f))
-        (parameterize ((ldr-verbose? verbose?))
-          (ldr-load+register real (and reload? #t) #f))))
-  jolt-nil)
-(def-var! "clojure.core" "require" loader-require)
-
-(define (loader-use . specs0)
-  (let* ((flags (ldr-flag-names specs0))
-         (real (filter (lambda (s) (not (keyword? s))) specs0))
-         (reload-all? (member "reload-all" flags))
-         (reload? (and (not reload-all?) (member "reload" flags)))
-         (verbose? (member "verbose" flags)))
-    (if reload-all?
-        (parameterize ((ldr-reload-all? #t) (ldr-verbose? verbose?))
-          (ldr-load+register real #f #t))
-        (parameterize ((ldr-verbose? verbose?))
-          (ldr-load+register real (and reload? #t) #t))))
-  jolt-nil)
-(def-var! "clojure.core" "use" loader-use)
+;; ns-with-load-opts interprets the keyword flags clojure.core's load-libs
+;; collects, once for the whole call: :reload forces the NAMED libs past the
+;; dedup, :reload-all forces it off for the whole load (so transitively-required
+;; libs reload too), :verbose prints each load.
+(set-ns-with-load-opts!
+  (lambda (flags k)
+    (let ((reload-all? (and (member "reload-all" flags) #t))
+          (verbose? (and (member "verbose" flags) #t)))
+      (if reload-all?
+          (parameterize ((ldr-reload-all? #t) (ldr-verbose? verbose?)) (k #f))
+          (parameterize ((ldr-verbose? verbose?))
+            (k (and (member "reload" flags) #t)))))))
 
 (def-var! "clojure.core" "load-file" jolt-load-file)
 

--- a/host/chez/loaderconf.sh
+++ b/host/chez/loaderconf.sh
@@ -9,13 +9,16 @@
 # Without the second rule a case that went green could go red again unnoticed.
 #
 # JOLT_LOADERCONF_WRITE_BASELINE=1 regenerates the baseline from the current run.
+# JOLT_BIN runs the suite through another jolt — a built binary rather than the
+# source tree — since the loader has to work in both.
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
+jolt="${JOLT_BIN:-bin/jolt}"
 suite=test/chez/loaderconf-test.clj
 baseline=test/chez/loaderconf-known-failures.txt
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 
-bin/jolt run "$suite" > "$tmp/out" 2>&1
+"$jolt" run "$suite" > "$tmp/out" 2>&1
 status=$?
 if [ "$status" -ne 0 ]; then
   echo "FAIL: the loader conformance suite exited $status"

--- a/host/chez/loaderconf.sh
+++ b/host/chez/loaderconf.sh
@@ -9,8 +9,8 @@
 # Without the second rule a case that went green could go red again unnoticed.
 #
 # JOLT_LOADERCONF_WRITE_BASELINE=1 regenerates the baseline from the current run.
-# JOLT_BIN runs the suite through another jolt — a built binary rather than the
-# source tree — since the loader has to work in both.
+# JOLT_BIN names the jolt to run the suite through; `make loaderconf` points it
+# at the built binary, and the bin/jolt default is for running this by hand.
 root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$root"
 jolt="${JOLT_BIN:-bin/jolt}"
@@ -83,6 +83,7 @@ if [ -n "$stale" ]; then
 fi
 
 if [ "$fail" -eq 0 ]; then
-  echo "loaderconf: $(grep -c 'PASS' "$tmp/lines")/$expected passing, $(wc -l < "$tmp/base" | tr -d ' ') baselined"
+  passing=$(awk -F'\t' '$2 == "PASS"' "$tmp/verdicts" | wc -l | tr -d ' ')
+  echo "loaderconf: $passing/$expected passing, $(wc -l < "$tmp/base" | tr -d ' ') baselined"
 fi
 exit "$fail"

--- a/host/chez/loaderconf.sh
+++ b/host/chez/loaderconf.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# loaderconf.sh — the loader conformance gate.
+#
+# Runs test/chez/loaderconf-test.clj — the twelve cases that specify jolt.loader
+# — and compares the per-case verdicts against
+# test/chez/loaderconf-known-failures.txt. The baseline is exact, the way
+# certify's and cts's are: a case that regresses fails the gate, and a case that
+# starts passing ALSO fails it until the baseline is updated in the same change.
+# Without the second rule a case that went green could go red again unnoticed.
+#
+# JOLT_LOADERCONF_WRITE_BASELINE=1 regenerates the baseline from the current run.
+root="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$root"
+suite=test/chez/loaderconf-test.clj
+baseline=test/chez/loaderconf-known-failures.txt
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+bin/jolt run "$suite" > "$tmp/out" 2>&1
+status=$?
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: the loader conformance suite exited $status"
+  tail -30 "$tmp/out" | sed 's/^/    /'
+  exit 1
+fi
+
+# The verdict line is the proof the runner reached the end. Without it a suite
+# that died mid-way would present as "no failing cases".
+if ! grep -q '^LOADERCONF ' "$tmp/out"; then
+  echo "FAIL: the suite printed no verdict line — it did not run to the end"
+  tail -30 "$tmp/out" | sed 's/^/    /'
+  exit 1
+fi
+
+grep -E '^CASE [0-9][0-9]* (PASS|FAIL)  ' "$tmp/out" > "$tmp/lines"
+expected=$(grep -c '^(defcase ' "$suite")
+got=$(wc -l < "$tmp/lines" | tr -d ' ')
+if [ "$got" != "$expected" ]; then
+  echo "FAIL: $expected cases are defined but $got reported a verdict"
+  exit 1
+fi
+
+# case number -> verdict; the title travels with the number so the baseline
+# stays readable when a case is renamed.
+awk '{ n=$2; v=$3; $1=""; $2=""; $3=""; sub(/^ +/,""); print n"\t"v"\t"$0 }' "$tmp/lines" > "$tmp/verdicts"
+
+if [ "${JOLT_LOADERCONF_WRITE_BASELINE:-}" = "1" ]; then
+  {
+    echo "# Loader conformance cases that do not pass yet, by case number."
+    echo "# Regenerate: JOLT_LOADERCONF_WRITE_BASELINE=1 make loaderconf"
+    echo "#"
+    echo "# A case leaves this file in the same change that makes it pass."
+    awk -F'\t' '$2 == "FAIL" { print $1"\t"$3 }' "$tmp/verdicts"
+  } > "$baseline"
+  echo "wrote $baseline ($(awk -F'\t' '$2 == "FAIL"' "$tmp/verdicts" | wc -l | tr -d ' ') failing)"
+  exit 0
+fi
+
+awk -F'\t' '$2 == "FAIL" { print $1 }' "$tmp/verdicts" | sort > "$tmp/red"
+grep -vE '^[[:space:]]*(#|$)' "$baseline" | awk -F'\t' '{ print $1 }' | sort > "$tmp/base"
+
+fail=0
+regressed=$(comm -23 "$tmp/red" "$tmp/base")
+if [ -n "$regressed" ]; then
+  echo "FAIL: loader conformance case(s) regressed — passing before, failing now:"
+  for n in $regressed; do
+    awk -F'\t' -v n="$n" '$1 == n { print "    case "$1": "$3 }' "$tmp/verdicts"
+    sed -n "/^CASE $n /,/^CASE /p" "$tmp/out" | grep -E '^    ' | sed 's/^/    /'
+  done
+  fail=1
+fi
+
+stale=$(comm -13 "$tmp/red" "$tmp/base")
+if [ -n "$stale" ]; then
+  echo "FAIL: loader conformance case(s) now PASS but are still in $baseline:"
+  for n in $stale; do
+    awk -F'\t' -v n="$n" '$1 == n { print "    case "$1": "$3 }' "$tmp/verdicts"
+  done
+  echo "    Drop them from the baseline in the change that made them pass."
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "loaderconf: $(grep -c 'PASS' "$tmp/lines")/$expected passing, $(wc -l < "$tmp/base" | tr -d ' ') baselined"
+fi
+exit "$fail"

--- a/host/chez/ns.ss
+++ b/host/chez/ns.ss
@@ -121,8 +121,8 @@
 ;; parse-libspec returns (target-name . opts) where opts is an alist of
 ;; (keyword-name-string . value-form), or #f if `spec` isn't a recognizable
 ;; libspec. This is the single spec->target+opts parser routed through by
-;; loader-require / loader-use (loader.ss), chez-register-spec!, and — via it —
-;; ce-scan-requires! (compile-eval.ss).
+;; ns-load+register (the one require/use body below), chez-register-spec!, and —
+;; via it — ce-scan-requires! (compile-eval.ss).
 ;;
 ;; JOLT SUPERSET: a bare LIST libspec — (ns :only [x]) or (ns :as a) — is
 ;; accepted here. On reference Clojure this shape is FATAL: the list is treated
@@ -174,7 +174,8 @@
 ;; single libspec only when its second element is a keyword or absent. The old
 ;; single-libspec read of the vector form required the PREFIX itself — for
 ;; clj-uuid, a silent self-require mid-load — and dropped every sub-spec.
-;; Shared by the loader's expand-spec and the compile-env alias pre-scan.
+;; Shared by ns-load+register, the build driver's expand-spec (loader.ss) and the
+;; compile-env alias pre-scan.
 (define (expand-libspec s)
   (cond
     ((or (cseq? s) (empty-list-t? s) (pvec? s))
@@ -195,7 +196,7 @@
               (cond
                 ;; :as-alias aliases exactly like :as (clojure.core load-lib does
                 ;; the same `alias` call for both); what differs is that it does not
-                ;; load the target — see ldr-load+register.
+                ;; load the target — see ns-load+register.
                 ((or (string=? k "as") (string=? k "as-alias"))
                  (when (symbol-t? v) (chez-register-alias! cns (symbol-t-name v) target)))
                 ;; :refer (require) and :only (use) both bring unqualified names
@@ -211,6 +212,89 @@
                                 (when (symbol-t? n) (chez-register-refer! cns (symbol-t-name n) target)))
                               (seq->list v))))))))
           (cdr parsed))))))
+
+;; --- require / use ----------------------------------------------------------
+;; ONE implementation, here, beside the spec parser it shares. Loading a target
+;; is a SEAM rather than a second copy of require, because not every runtime
+;; with namespaces has a loader: the seed mint (bootstrap.ss), the gambit seed
+;; generator and the .ss unit harnesses load rt.ss without loader.ss, and there
+;; `require` registers the specs and loads nothing. loader.ss installs the load
+;; step, and the same body then loads. Either way `require` means one thing.
+;;
+;; Two install-once seams:
+;;   ns-load-target!   (target force-named?)  read + initialize the namespace
+;;   ns-with-load-opts (flags k)              bind the loader's :reload /
+;;                                            :reload-all / :verbose options
+;;                                            around the whole call, then
+;;                                            (k force-named?)
+(define ns-load-target! #f)
+(define (set-ns-load-target! f) (set! ns-load-target! f))
+(define ns-with-load-opts #f)
+(define (set-ns-with-load-opts! f) (set! ns-with-load-opts f))
+
+;; The keyword flags clojure.core's load-libs collects out of the arg list before
+;; the libspecs. Their meaning belongs to the load step, so the names travel to
+;; ns-with-load-opts rather than being interpreted here.
+(define (ns-flag-names specs)
+  (let loop ((xs specs) (acc '()))
+    (cond ((null? xs) (reverse acc))
+          ((keyword? (car xs)) (loop (cdr xs) (cons (keyword-t-name (car xs)) acc)))
+          (else (loop (cdr xs) acc)))))
+
+;; Load each expanded libspec's target (no-op if baked, already loaded, or there
+;; is no loader), register its :as/:refer under the caller ns, and — for `use`
+;; (use? #t) — refer every public var when the spec has no :only/:refer filter.
+;; Target + opts both come from parse-libspec above, the single spec->target+opts
+;; parser this, chez-register-spec! and ce-scan-requires! (compile-eval.ss) all
+;; route through.
+(define (ns-load+register specs force-named? use?)
+  (for-each
+    (lambda (s0)
+      (for-each
+        (lambda (s)
+          (let* ((parsed (parse-libspec s))
+                 (target (and parsed (car parsed)))
+                 (opt-names (if parsed (map car (cdr parsed)) '()))
+                 ;; :as-alias establishes the alias WITHOUT loading the target — for
+                 ;; a namespace that may not exist yet, or exists only to qualify
+                 ;; keywords. clojure.core's load-lib picks the loader with
+                 ;; `need-ns (or as use)`, falling to (create-ns lib) when the spec
+                 ;; is :as-alias and neither — so a spec that also carries :as, or
+                 ;; that arrives through `use`, still loads.
+                 (alias-only? (and target
+                                   (member "as-alias" opt-names)
+                                   (not (member "as" opt-names))
+                                   (not use?))))
+            (cond
+              ((not target) #f)
+              (alias-only? (intern-ns! target))   ; create-ns, without loading
+              ((not ns-load-target!) #f)          ; no loader here — aliases only
+              (else (ns-load-target! target force-named?)))
+            (chez-register-spec! (chez-current-ns) s)
+            (when (and use? target
+                       (not (or (member "only" opt-names) (member "refer" opt-names))))
+              (chez-register-refer-all! (chez-current-ns) target)
+              ;; [ns :exclude [names]] — the excluded names stay OUT of the
+              ;; refer-all set (load-lib applies the same filter to its refer).
+              (let ((excl (assoc "exclude" (cdr parsed))))
+                (when excl
+                  (chez-register-refer-all-excludes!
+                    (chez-current-ns) target
+                    (map symbol-t-name (filter symbol-t? (seq->list (cdr excl))))))))))
+        (expand-libspec s0)))
+    specs))
+
+(define (ns-require+use specs use?)
+  (let* ((flags (ns-flag-names specs))
+         (real (filter (lambda (s) (not (keyword? s))) specs))
+         (k (lambda (force-named?) (ns-load+register real force-named? use?))))
+    (if ns-with-load-opts (ns-with-load-opts flags k) (k #f)))
+  jolt-nil)
+
+(define (jolt-require . specs) (ns-require+use specs #f))
+;; use = require + refer ALL of the target's public vars, unless an explicit
+;; :only/:refer filter is given (which chez-register-spec! handles per-name).
+(define (jolt-use . specs) (ns-require+use specs #t))
 
 ;; a namespace designator -> its name string (a jns or a symbol; the corpus never
 ;; passes a bare string). Anything else is refused HERE, with the throw the JVM
@@ -719,6 +803,8 @@
     (cons "ex-info" jolt-ex-info)))
 
 ;; --- bindings + *ns* --------------------------------------------------------
+(def-var! "clojure.core" "require" jolt-require)
+(def-var! "clojure.core" "use" jolt-use)
 (def-var! "clojure.core" "find-ns" jolt-find-ns)
 (def-var! "clojure.core" "the-ns" jolt-the-ns)
 (def-var! "clojure.core" "create-ns" jolt-create-ns)

--- a/host/chez/stdlib-fasl-manifest.txt
+++ b/host/chez/stdlib-fasl-manifest.txt
@@ -66,6 +66,7 @@ jolt.infix.math.constants
 jolt.infix.math.core
 jolt.infix.math.trig
 jolt.io-poller
+jolt.loader
 jolt.nrepl
 jolt.parser
 jolt.parser.basic

--- a/stdlib/jolt/loader.clj
+++ b/stdlib/jolt/loader.clj
@@ -1,0 +1,200 @@
+(ns jolt.loader
+  "Per-context loading: a loader owns source roots, a delegate, and the
+  namespaces, vars, classes and resources linked through it. Two contexts can
+  hold different versions of one library, a context can be hermetic, and
+  unloading one stops new loads through it without pulling definitions out from
+  under code that already resolved them.
+
+  Shaped like java.lang.ClassLoader, not compatible with it. `find` is
+  findClass/getResource — it locates and reads nothing. `resolve` is
+  findLoadedClass — the link table, no I/O. `load` is loadClass, and is the only
+  method that reads. `as-classloader` is the host view, and the only place the
+  word ClassLoader appears.
+
+  Resolution is generic and the same for every loader: already linked, then the
+  delegate, then this loader's own roots, then a miss. The delegate is a slot
+  rather than a fixed parent, so the policy combinators (`allow`, `deny`,
+  `self-first`, `pool`, `isolated`) compose, and `->loader` lifts a plain
+  function into one.
+
+  Requests are typed because real loaders order and gate the kinds differently:
+
+      {:kind :ns|:var|:class|:resource   ; required
+       :name \"clojure.string\"            ; required, a string
+       :load? false}                     ; :ns only — load like `require`,
+                                         ; or load the one namespace alone
+
+  `find` answers an ordered vector of hits, first-wins for the singular forms,
+  `[]` on a miss, and throws on a denial. Hits are data — no open streams, no
+  closures, no compiled artifacts — so they print, compare and travel:
+
+      {:kind :ns       :file \"/roots/a/b.clj\"    :loader l}
+      {:kind :var      :cell <var cell>}
+      {:kind :class    :registration {...}       :loader l}
+      {:kind :resource :url \"file:/roots/a/x.edn\" :loader l}
+
+  A `:var` hit carries the cell, so sharing across contexts is by reference and
+  `identical?` holds. A resource hit names a location; `open-hit` turns it into
+  an open handle on demand, so nothing holds a file handle between calls.
+
+  Two tiers decide which loader answers. Linkage follows the DEFINING loader:
+  code compiled for a context resolves through that context for its whole life,
+  whoever calls it and on whatever thread. Dynamic loading — `require` reached
+  through a value, `eval`, REPL forms, framework resource probes — follows the
+  AMBIENT loader, the thread parameter `with-loader` binds, which is inherited
+  by threads and fibers.
+
+  NOT IMPLEMENTED. Every entry point below throws. The namespace exists so that
+  the surface and its conformance suite (test/chez/loaderconf-test.clj, run by
+  `make loaderconf`) are settled before the runtime work, the way the corpus
+  settles clojure.core. Do not build on it until the suite is green."
+  (:refer-clojure :exclude [find resolve load]))
+
+(defn- todo [what]
+  (throw (UnsupportedOperationException.
+           (str "jolt.loader/" what " is declared, not implemented"))))
+
+;; --- the protocol -----------------------------------------------------------
+;; The arity split is the semantics: probe, look up, read.
+(defprotocol Loader
+  (find [l req]
+    "Ordered hits for `req`, [] on a miss. Locates only — reads nothing,
+    compiles nothing, opens nothing, installs nothing. Throws ex-info carrying
+    :loader/denied when a policy denies the request; a denial is not a miss and
+    does not fall through to this loader's own roots.")
+  (resolve [l req]
+    "The definition already linked in this loader, or nil. Reads the link table
+    and nothing else — no I/O, no delegation to roots.")
+  (load [l req]
+    "Resolve (or accept a hit from `find`), read, initialize, link, and return
+    the handle. The only method that reads. Passing a hit skips re-resolution
+    and closes the window between locating and reading.")
+  (parent [l]
+    "This loader's delegate, or nil at the root.")
+  (unload! [l]
+    "Stop new loads through this loader and release the host resources it
+    acquired. Idempotent, never blocks, and never throws for a teardown
+    failure — it reports one. Definitions already resolved stay live; a
+    subsequent find/resolve/load throws IllegalStateException. Returns
+
+        {:unloaded true :already false :in-flight 0 :raced false
+         :released {:namespaces 0 :resources 0 :registrations 0}
+         :errors []}"))
+
+;; --- constructors -----------------------------------------------------------
+(defn root
+  "The host itself as a loader: today's global namespaces, vars, classes and
+  install roots. Its `parent` is nil."
+  []
+  (todo "root"))
+
+(defn classpath
+  "A loader over `roots`, searched in order. `opts` may carry :parent (the
+  delegate, nil for none) and :id (a name for `status` and diagnostics). A
+  loader IS roots plus a delegate; every combinator below builds a delegate to
+  hand to :parent, except `self-first`, which reorders the two.
+
+  Validation is eager: an unreadable root or jar fails here, not at the first
+  load."
+  ([roots] (classpath roots nil))
+  ([roots opts] (todo "classpath")))
+
+(defn url-search
+  "The URLClassLoader analogue — `classpath` under the name the delegate table
+  uses."
+  ([roots] (classpath roots))
+  ([roots opts] (classpath roots opts)))
+
+(defn isolated
+  "A delegate that answers nothing, so a context composed over it sees only its
+  own roots. The root loader is not visible through it."
+  []
+  (todo "isolated"))
+
+(defn ->loader
+  "Lift a plain resolve-fn — (fn [req] hits-or-nil) — into a delegate loader."
+  [f]
+  (todo "->loader"))
+
+;; --- policies ---------------------------------------------------------------
+(defn delegating
+  "Try `a`, then `b`."
+  [a b]
+  (todo "delegating"))
+
+(defn pool
+  "Sibling sharing: ask each of `loaders` in order."
+  [loaders]
+  (todo "pool"))
+
+(defn allow
+  "`l`, restricted to `names` — a request outside the whitelist is denied."
+  [l names]
+  (todo "allow"))
+
+(defn deny
+  "`l`, minus `names` — a request inside the blacklist is denied. A denial
+  raises; it never falls through."
+  [l names]
+  (todo "deny"))
+
+(defn self-first
+  "`l` with its own roots consulted BEFORE its delegate, for `prefixes` only —
+  the parent-first default inverted for the names a context means to shadow.
+  The delegate is still consulted for everything else, and for these names when
+  the roots miss."
+  [l prefixes]
+  (todo "self-first"))
+
+;; --- ambient loader ---------------------------------------------------------
+(defn current-loader
+  "The ambient loader — the one dynamic loading follows on this thread or
+  fiber. The root loader unless `with-loader` bound another."
+  []
+  (todo "current-loader"))
+
+(defn with-loader*
+  "`with-loader`'s function form: call `f` with `l` ambient."
+  [l f]
+  (todo "with-loader*"))
+
+(defmacro with-loader
+  "Evaluate `body` with `l` as the ambient loader. The binding is inherited by
+  threads and fibers started inside it, and survives a fiber parking and
+  resuming on another carrier."
+  [l & body]
+  `(with-loader* ~l (fn [] ~@body)))
+
+;; --- handles and diagnostics ------------------------------------------------
+(defn context
+  "The host object underneath `l` — the jolt tables it owns. An escape hatch;
+  nothing portable should need it."
+  [l]
+  (todo "context"))
+
+(defn open-hit
+  "A resource hit -> an open handle, or nil. The loader owns opening, so a hit
+  stays comparable data and no handle is held between calls."
+  [l hit]
+  (todo "open-hit"))
+
+(defn unloaded?
+  "Has `l` been unloaded? The one behavioral predicate about a loader's state."
+  [l]
+  (todo "unloaded?"))
+
+(defn status
+  "A diagnostics map: loader id, roots, loaded-namespace count, in-flight
+  loads, unloaded?, and one level of delegate. Implementation-visible — keys
+  are added freely and no behavior may depend on one. Use `unloaded?` for
+  anything that decides."
+  [l]
+  (todo "status"))
+
+(defn as-classloader
+  "`l` as a host java.lang.ClassLoader: loadClass is find + load,
+  getResource/getResources/getResourceAsStream are find + open-hit, getParent
+  is the delegate's facade, close is `unload!`. Accepted by the 2-arity of
+  clojure.java.io/resource."
+  [l]
+  (todo "as-classloader"))

--- a/test/chez/loaderconf-known-failures.txt
+++ b/test/chez/loaderconf-known-failures.txt
@@ -1,0 +1,16 @@
+# Loader conformance cases that do not pass yet, by case number.
+# Regenerate: JOLT_LOADERCONF_WRITE_BASELINE=1 make loaderconf
+#
+# A case leaves this file in the same change that makes it pass.
+01	v1/v2 isolation: two contexts hold one library at two versions
+02	hermetic: an isolated context cannot see what the root has
+03	shared by reference: a delegated var is the same cell
+04	deny is not a miss: a denied name raises and never falls through
+05	self-first: own roots shadow the delegate, for the declared prefix only
+06	composed delegates: a host plus a pool, and parent walks the graph
+07	unload: no new loads, resolved definitions stay live, idempotent
+08	resources: find/open-hit and the classloader facade stay in the context
+09	defining context: a fn requires where it was defined, not where it is called
+10	dispatch follows the value: a context-2 value dispatches in context 2
+11	hits are data: find opens nothing and a hit round-trips into load
+12	eager construction, lazy load: the constructor validates, load reads

--- a/test/chez/loaderconf-test.clj
+++ b/test/chez/loaderconf-test.clj
@@ -1,0 +1,286 @@
+;; The loader conformance suite. These twelve cases ARE the specification of
+;; jolt.loader — per-context roots, isolation, delegation policy, and unload —
+;; the way test/chez/corpus.edn is the specification of clojure.core. They are
+;; written against the public API only, so a rewrite underneath is free as long
+;; as the suite stays green.
+;;
+;; Run: bin/jolt run test/chez/loaderconf-test.clj  (make loaderconf gates it
+;; against test/chez/loaderconf-known-failures.txt).
+;;
+;; Each case prints one CASE line; a case passes only if every check in it
+;; passed and it did not throw. The gate compares the PASS/FAIL set against the
+;; recorded baseline, so a case going green fails the gate until the baseline
+;; says so, and a case going red fails it always.
+(ns loaderconf-test
+  (:require [jolt.loader :as l]
+            [jolt.fs :as fs]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.core.async :as async]))
+
+(def cases (atom []))
+(def failures (atom []))
+
+(defn chk [label ok] (when-not ok (swap! failures conj label)))
+
+(defmacro defcase [n title & body]
+  `(swap! cases conj [~n ~title (fn [] ~@body)]))
+
+;; --- scratch roots ----------------------------------------------------------
+;; Each case builds its own directories; a "library at two versions" is two
+;; directories holding the same namespace name with different contents, which is
+;; what a version-qualified extraction dir already gives us on disk.
+(def tmp (str (fs/create-temp-dir {:prefix "loaderconf-"})))
+
+(defn root-dir [name]
+  (let [d (str tmp "/" name)]
+    (.mkdirs (java.io.File. d))
+    d))
+
+(defn write! [dir file src]
+  (spit (str dir "/" file) src)
+  dir)
+
+(defn val-of
+  "The value a :var resolution answers with — the cell's current root."
+  [cell]
+  (when cell (deref cell)))
+
+;; --- 1. two contexts, one library at two versions ---------------------------
+(defcase 1 "v1/v2 isolation: two contexts hold one library at two versions"
+  (let [d1 (write! (root-dir "v1") "libx.clj" "(ns libx) (defn version [] :v1)")
+        d2 (write! (root-dir "v2") "libx.clj" "(ns libx) (defn version [] :v2)")
+        c1 (l/classpath [d1] {:parent (l/root)})
+        c2 (l/classpath [d2] {:parent (l/root)})]
+    (l/load c1 {:kind :ns :name "libx"})
+    (l/load c2 {:kind :ns :name "libx"})
+    (let [v1 (l/resolve c1 {:kind :var :name "libx/version"})
+          v2 (l/resolve c2 {:kind :var :name "libx/version"})]
+      (chk "each context links libx/version" (and (some? v1) (some? v2)))
+      (chk "the two links are different cells" (not (identical? v1 v2)))
+      (chk "context 1 sees v1" (= :v1 ((val-of v1))))
+      (chk "context 2 sees v2" (= :v2 ((val-of v2)))))))
+
+;; --- 2. hermetic ------------------------------------------------------------
+(defcase 2 "hermetic: an isolated context cannot see what the root has"
+  (let [d (write! (root-dir "herm") "libh.clj" "(ns libh) (def marker :own)")
+        ctx (l/classpath [d] {:parent (l/isolated)})]
+    (chk "a namespace only the root has does not resolve"
+         (empty? (l/find ctx {:kind :ns :name "clojure.string"})))
+    (chk "a var only the root has does not resolve"
+         (empty? (l/find ctx {:kind :var :name "clojure.core/inc"})))
+    (chk "the context's own namespace still resolves"
+         (seq (l/find ctx {:kind :ns :name "libh"})))))
+
+;; --- 3. shared by reference -------------------------------------------------
+;; The cell, not a copy: injecting a namespace into a context by handing it the
+;; host's vars depends on this, and identical? is the only way to say it.
+(defcase 3 "shared by reference: a delegated var is the same cell"
+  (let [d (root-dir "shared")
+        ctx (l/classpath [d] {:parent (l/root)})
+        req {:kind :var :name "clojure.core/inc"}
+        root-cell (:cell (first (l/find (l/root) req)))
+        ctx-cell (:cell (first (l/find ctx req)))]
+    (chk "the root answers with a cell" (some? root-cell))
+    (chk "the delegating context answers with a cell" (some? ctx-cell))
+    (chk "both answers are one object" (identical? root-cell ctx-cell))
+    (chk "and that object is the live var" (identical? ctx-cell #'clojure.core/inc))))
+
+;; --- 4. deny is not a miss --------------------------------------------------
+(defcase 4 "deny is not a miss: a denied name raises and never falls through"
+  (let [d (write! (root-dir "denied") "libd.clj" "(ns libd) (def marker :own)")
+        ctx (l/deny (l/classpath [d] {:parent (l/root)}) #{'libd})
+        req {:kind :ns :name "libd"}
+        e (try (l/find ctx req) nil (catch :default e e))]
+    (chk "find on a denied name throws" (some? e))
+    (chk "the throw carries :loader/denied" (true? (:loader/denied (ex-data e))))
+    (chk "the throw names the request"
+         (= [:ns "libd"] [(:kind (ex-data e)) (:name (ex-data e))]))
+    (chk "load on a denied name throws too"
+         (some? (try (l/load ctx req) nil (catch :default e e))))
+    (chk "the context's own roots did not answer instead"
+         (nil? (l/resolve ctx {:kind :var :name "libd/marker"})))))
+
+;; --- 5. self-first ----------------------------------------------------------
+(defcase 5 "self-first: own roots shadow the delegate, for the declared prefix only"
+  (let [du (-> (root-dir "sf-up")
+               (write! "libs1.clj" "(ns libs1) (defn who [] :delegate)")
+               (write! "libs2.clj" "(ns libs2) (defn who [] :delegate)"))
+        dd (-> (root-dir "sf-own")
+               (write! "libs1.clj" "(ns libs1) (defn who [] :own)")
+               (write! "libs2.clj" "(ns libs2) (defn who [] :own)"))
+        ctx (l/self-first (l/classpath [dd] {:parent (l/classpath [du])}) #{'libs1})]
+    (l/load ctx {:kind :ns :name "libs1"})
+    (l/load ctx {:kind :ns :name "libs2"})
+    (chk "the declared prefix comes from the context's own roots"
+         (= :own ((val-of (l/resolve ctx {:kind :var :name "libs1/who"})))))
+    (chk "every other name still comes from the delegate"
+         (= :delegate ((val-of (l/resolve ctx {:kind :var :name "libs2/who"})))))
+    (chk "the delegate is still consulted for the declared prefix"
+         (seq (l/find ctx {:kind :ns :name "libs1"})))))
+
+;; --- 6. composed delegates --------------------------------------------------
+(defcase 6 "composed delegates: a host plus a pool, and parent walks the graph"
+  (let [da (write! (root-dir "pool-a") "liba.clj" "(ns liba) (def marker :a)")
+        db (write! (root-dir "pool-b") "libb.clj" "(ns libb) (def marker :b)")
+        dc (write! (root-dir "pool-c") "libc.clj" "(ns libc) (def marker :c)")
+        ctx (l/classpath [dc]
+                         {:parent (l/delegating (l/root)
+                                                (l/pool [(l/classpath [da])
+                                                         (l/classpath [db])]))})]
+    (chk "a name from the first pool member resolves"
+         (seq (l/find ctx {:kind :ns :name "liba"})))
+    (chk "a name from the second pool member resolves"
+         (seq (l/find ctx {:kind :ns :name "libb"})))
+    (chk "a name from the context's own roots resolves"
+         (seq (l/find ctx {:kind :ns :name "libc"})))
+    (chk "a name from the host still resolves"
+         (seq (l/find ctx {:kind :ns :name "clojure.string"})))
+    (chk "parent walks to the delegate" (some? (l/parent ctx)))
+    (let [chain (take-while some? (iterate l/parent ctx))]
+      (chk "the parent chain terminates" (< (count chain) 32))
+      (chk "the parent chain reaches the composed delegate" (> (count chain) 1)))))
+
+;; --- 7. unload --------------------------------------------------------------
+(defcase 7 "unload: no new loads, resolved definitions stay live, idempotent"
+  (let [d (-> (root-dir "unl")
+              (write! "libu.clj" "(ns libu) (defn who [] :u)")
+              (write! "libu2.clj" "(ns libu2) (def marker :u2)"))
+        ctx (l/classpath [d] {:parent (l/root)})]
+    (l/load ctx {:kind :ns :name "libu"})
+    (let [who (val-of (l/resolve ctx {:kind :var :name "libu/who"}))
+          report (l/unload! ctx)]
+      (chk "unload! reports the postcondition held" (true? (:unloaded report)))
+      (chk "unload! is not reported as a repeat" (false? (:already report)))
+      (chk "teardown errors are reported as data" (vector? (:errors report)))
+      (chk "unload! reports no teardown errors here" (empty? (:errors report)))
+      (chk "unloaded? is the behavioral predicate" (true? (l/unloaded? ctx)))
+      (chk "a definition resolved before the unload still works" (= :u (who)))
+      (chk "a new load through the loader throws"
+           (some? (try (l/load ctx {:kind :ns :name "libu2"}) nil (catch :default e e))))
+      (chk "find after unload throws"
+           (some? (try (l/find ctx {:kind :ns :name "libu2"}) nil (catch :default e e))))
+      (let [again (l/unload! ctx)]
+        (chk "the second unload! is a no-op" (true? (:already again)))
+        (chk "the second unload! still reports the postcondition" (true? (:unloaded again)))))
+    ;; teardown against a root that vanished underneath reports, never throws
+    (let [gone (root-dir "unl-gone")
+          ctx2 (l/classpath [gone] {:parent (l/root)})]
+      (fs/delete-tree gone)
+      (chk "teardown over a vanished root is reported, not thrown"
+           (map? (l/unload! ctx2))))))
+
+;; --- 8. resources -----------------------------------------------------------
+(defcase 8 "resources: find/open-hit and the classloader facade stay in the context"
+  (let [d (write! (root-dir "res") "cfg.edn" "{:from :ctx}")
+        ctx (l/classpath [d] {:parent (l/root)})
+        hits (l/find ctx {:kind :resource :name "cfg.edn"})
+        cl (l/as-classloader ctx)]
+    (chk "find locates the resource" (seq hits))
+    (chk "the hit names a location, not an open stream" (string? (:url (first hits))))
+    (chk "open-hit reads it" (= "{:from :ctx}" (slurp (l/open-hit ctx (first hits)))))
+    (chk "getResource resolves in the context" (some? (.getResource cl "cfg.edn")))
+    (chk "getResources resolves in the context"
+         (seq (enumeration-seq (.getResources cl "cfg.edn"))))
+    (chk "getResourceAsStream reads it"
+         (= "{:from :ctx}" (slurp (.getResourceAsStream cl "cfg.edn"))))
+    (chk "getParent is the delegate's facade" (some? (.getParent cl)))
+    (chk "a loader has one facade, so getParent chains and identity hold"
+         (identical? cl (l/as-classloader ctx)))
+    (chk "the 2-arity io/resource honors the loader" (some? (io/resource "cfg.edn" cl)))
+    (chk "the root does not see the context's resource" (nil? (io/resource "cfg.edn")))
+    (chk "RT/baseLoader inside the context is the context's loader"
+         (identical? cl (l/with-loader ctx (clojure.lang.RT/baseLoader))))))
+
+;; --- 9. defining context ----------------------------------------------------
+;; The load-bearing rule: a function requires in the context that DEFINED it,
+;; whoever calls it, on whatever thread, and across a fiber park.
+(defcase 9 "defining context: a fn requires where it was defined, not where it is called"
+  (let [d1 (-> (root-dir "def1")
+               (write! "dep.clj" "(ns dep) (def which :ctx1)")
+               (write! "caller.clj"
+                       "(ns caller)\n(defn peek-dep [] (require 'dep) @(ns-resolve 'dep 'which))"))
+        d2 (write! (root-dir "def2") "dep.clj" "(ns dep) (def which :ctx2)")
+        c1 (l/classpath [d1] {:parent (l/root)})
+        c2 (l/classpath [d2] {:parent (l/root)})]
+    (l/load c1 {:kind :ns :name "caller"})
+    (let [f (val-of (l/resolve c1 {:kind :var :name "caller/peek-dep"}))]
+      (chk "called from the root, the fn sees its own context's dep" (= :ctx1 (f)))
+      (chk "called inside another context, it still sees its own"
+           (= :ctx1 (l/with-loader c2 (f))))
+      (chk "called from a thread in another context, it still sees its own"
+           (= :ctx1 @(future (l/with-loader c2 (f)))))
+      (chk "called from a fiber in another context, it still sees its own"
+           (= :ctx1 (async/<!! (async/go (l/with-loader c2 (f)))))))))
+
+;; --- 10. dispatch follows the value -----------------------------------------
+(defcase 10 "dispatch follows the value: a context-2 value dispatches in context 2"
+  (let [ds (write! (root-dir "disp-shared") "shp.clj"
+                   "(ns shp) (defprotocol Shape (area [s]))")
+        d2 (write! (root-dir "disp2") "sq.clj"
+                   (str "(ns sq (:require [shp]))\n"
+                        "(defrecord Square [n])\n"
+                        "(extend-type Square shp/Shape (area [s] (* (:n s) (:n s))))\n"
+                        "(defn make [n] (->Square n))"))
+        d1 (write! (root-dir "disp1") "caller1.clj"
+                   "(ns caller1 (:require [shp]))\n(defn call-area [v] (shp/area v))")
+        shared (l/classpath [ds] {:parent (l/root)})
+        c1 (l/classpath [d1] {:parent shared})
+        c2 (l/classpath [d2] {:parent shared})]
+    (l/load c2 {:kind :ns :name "sq"})
+    (l/load c1 {:kind :ns :name "caller1"})
+    (let [make (val-of (l/resolve c2 {:kind :var :name "sq/make"}))
+          call (val-of (l/resolve c1 {:kind :var :name "caller1/call-area"}))
+          v (make 3)]
+      (chk "context 1 code dispatches a context 2 value through context 2's tables"
+           (= 9 (call v)))
+      (chk "the protocol itself is shared by reference"
+           (identical? (l/resolve c1 {:kind :var :name "shp/area"})
+                       (l/resolve c2 {:kind :var :name "shp/area"}))))))
+
+;; --- 11. hits are data ------------------------------------------------------
+(defcase 11 "hits are data: find opens nothing and a hit round-trips into load"
+  (let [d (write! (root-dir "hits") "libp.clj" "(ns libp) (def marker :p)")
+        ctx (l/classpath [d] {:parent (l/root)})
+        req {:kind :ns :name "libp"}
+        hit (first (l/find ctx req))]
+    (chk "find answers a hit" (some? hit))
+    (chk "the hit prints" (string? (pr-str hit)))
+    (chk "two finds answer equal hits" (= hit (first (l/find ctx req))))
+    ;; the located path, not a normalized or resolved one — a temp dir reaches
+    ;; here through a symlink on macOS, so compare the tail
+    (chk "the hit names the file it located"
+         (and (string? (:file hit)) (str/ends-with? (:file hit) "/libp.clj")))
+    (chk "find installed nothing"
+         (nil? (l/resolve ctx {:kind :var :name "libp/marker"})))
+    (chk "loading a hit is loading the request"
+         (= (l/load ctx hit) (l/load ctx req)))))
+
+;; --- 12. eager construction, lazy load --------------------------------------
+(defcase 12 "eager construction, lazy load: the constructor validates, load reads"
+  (let [missing (str tmp "/absent-root")]
+    (chk "a loader over an unreadable root fails at the constructor"
+         (some? (try (l/classpath [missing]) nil (catch :default e e))))
+    (let [d (write! (root-dir "toctou") "libt.clj" "(ns libt) (def marker :t)")
+          ctx (l/classpath [d] {:parent (l/root)})
+          hit (first (l/find ctx {:kind :ns :name "libt"}))]
+      (chk "find located it" (some? hit))
+      (fs/delete (str d "/libt.clj"))
+      (chk "a load whose file vanished after find fails at load, not silently"
+           (some? (try (l/load ctx hit) nil (catch :default e e)))))))
+
+;; --- runner -----------------------------------------------------------------
+(defn run-case [[n title body]]
+  (reset! failures [])
+  (let [err (try (body) nil (catch :default e (or (ex-message e) (pr-str e))))
+        fails @failures
+        pass (and (nil? err) (empty? fails))]
+    (println (format "CASE %02d %s  %s" n (if pass "PASS" "FAIL") title))
+    (when err (println (str "    threw: " err)))
+    (doseq [f fails] (println (str "    check failed: " f)))
+    pass))
+
+(let [ordered (sort-by first @cases)
+      passed (count (filter true? (doall (map run-case ordered))))]
+  (println (format "LOADERCONF %d/%d" passed (count ordered)))
+  (fs/delete-tree tmp))


### PR DESCRIPTION
R0 of the native loader work for #912: the conformance suite from the design
doc, red, plus the prerequisite that made "which require?" a real question.

**One `require`.** There were two implementations — the real one in `loader.ss`
and an alias-only copy in `natives-str.ss` that `def-var!`'d over
`clojure.core/require` — and which one a program got depended on load order, so
the CLI and the gates could disagree about what `(require ...)` means. `ns.ss`
owns it now, beside the libspec parser both copies already shared. Reading a
namespace off the source roots is a seam `loader.ss` installs, because not every
runtime with namespaces has a loader: the seed mint, the gambit seed generator
and the `.ss` unit harnesses load `rt.ss` without one, and there `require`
registers aliases and loads nothing, which is all the deleted copy ever did.

**The surface.** `stdlib/jolt/loader.clj` declares the `Loader` protocol, the
constructors and policy combinators, the ambient binding and `unload!`. Every
entry point throws — the namespace exists so the API and its suite are settled
before the runtime work, the way the corpus settles `clojure.core`. One thing
the design leaves implicit and this pins down: a loader is roots *plus* a
delegate, so `classpath` takes `{:parent l}` and the combinators build delegates
to hand it. Without that there is no loader holding both halves for `self-first`
to reorder.

**The suite.** `test/chez/loaderconf-test.clj`: per-context roots, hermetic
contexts, sharing a var cell by reference, a denial that does not fall through,
self-first, composed delegates, unload, resources and the classloader facade,
the defining context (called from another context, from a thread and from a
fiber), value-directed dispatch, hits as data, and eager construction with lazy
load. All twelve fail, each with its own message.

**The gate.** `make loaderconf` compares the per-case verdicts to
`test/chez/loaderconf-known-failures.txt` the way `certify` and `cts` do: a case
that regresses fails, and a case that starts passing fails until the baseline
records it, so nothing green quietly goes red again. It also guards the case
count, so a suite that dies half way cannot read as "no failures". It is in
`make ci` now at 0/12, and each later round drops its own cases from the
baseline. `JOLT_BIN` points it at a built binary, which the loader has to work
in as well.

Red-proved in all three directions: a case going green fails as stale, a case
regressing fails as a regression, and a case that stops running fails the count
guard.

No behaviour change to any existing gate. `make selfhost` holds and `make ci` is
green (110 targets).

## Follow-up: the gate now actually uses the binary

The `JOLT_BIN` knob went in but nothing set it, so `make loaderconf` only ever
ran the suite against `bin/jolt`. The target depends on `testbin` and defaults
`JOLT_BIN` to it now, the way `cts` and `smoke` do — `jolt.loader` ships in the
stdlib fasl, so the built binary is the arrangement the cases have to hold
under. The summary line also counts passing cases off the verdict table instead
of grepping the raw lines for `PASS`, which a case title could contain.
