### PR TITLE
Every java.lang number parser reads Java's grammar, not Scheme's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`parse-long` answers `nil` past the long bounds, not a bignum.**
+  `clojure.core/parse-long` is `Long/parseLong` with `NumberFormatException`
+  caught to `nil`, so every non-`nil` result is a `Long` and a decimal outside
+  signed 64-bit range is `nil` — never a larger number. jolt checked only the
+  string *shape* and then returned whatever the digits parsed to, which on
+  jolt's unified integer model is a bignum past the bounds: `(parse-long
+  "9223372036854775808")` read `9223372036854775808N` where the JVM and bb read
+  `nil`, and `(some? (parse-long "9223372036854775808"))` was `true` on jolt and
+  `false` everywhere else — so a caller branching on the `nil` to catch the
+  overflow took the wrong arm and got a `clojure.lang.BigInt` out of a fn
+  documented to return a `Long`. The value is now range-checked against the same
+  bounds the bit family's operand cast already enforces. In-range values,
+  including both boundaries, are unchanged, and `parse-double` was never
+  affected — `Double.parseDouble` saturates to `##Inf` rather than failing,
+  which jolt already matched. 11 corpus rows, certified against reference
+  Clojure (#927).
+
 - **`format` speaks the rest of `java.util.Formatter`.** `%.3s` truncates a
   string where the precision used to be ignored (`(format "%.3s" "abcdef")` was
   `"abcdef"`), `%#x` / `%#X` / `%#o` prefix the radix (`0x`, `0X`, `0`) with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Clojure; the parse path also got about 7% faster, since it no longer allocates
   a trimmed string per call.
 
+- **`Double/parseDouble` and friends read Java's grammar too.** The same
+  helper-hands-the-string-to-Scheme mistake in the floating half:
+  `(Double/parseDouble "#xff")` was `255.0`, `"1/2"` was `0.5`, `"#b101"` was
+  `5.0` — none of them a double on the JVM — for `Double/parseDouble`,
+  `Float/parseFloat`, `Double/valueOf` and `(Double. s)` alike. In the other
+  direction both doors were missing Java forms a Scheme reader has no spelling
+  for: the hexadecimal significand (`(parse-double "0x1fp0")` is `31.0`,
+  `"0x1.8p1"` is `3.0`), a signed `NaN`, and `+Infinity`. `clojure.core/parse-double`
+  and the `java.lang` methods are now one grammar, the way `parse-long` and
+  `Long/parseLong` are, so the pair cannot answer differently again. 22 corpus
+  rows, certified.
+
 - **`format` speaks the rest of `java.util.Formatter`.** `%.3s` truncates a
   string where the precision used to be ignored (`(format "%.3s" "abcdef")` was
   `"abcdef"`), `%#x` / `%#X` / `%#o` prefix the radix (`0x`, `0X`, `0`) with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which jolt already matched. 11 corpus rows, certified against reference
   Clojure (#927).
 
+- **Every `java.lang` integer parser reads Java's grammar, at its own width.**
+  The overflow above was one symptom of a shared helper that checked no width
+  and, worse, handed the string to Scheme's reader — so the java.lang parsers
+  spoke Scheme rather than Java. `(Long/parseLong "1e3")` read the **double**
+  `1000.0` out of a method whose return type is `long`, `"5.0"` read `5.0`,
+  `"#xff"` / `"#b101"` / `"#o17"` read Scheme radix prefixes whatever radix was
+  asked for, `" 5"` parsed because the string was trimmed first, a value past
+  the type's range came back as a wider number instead of failing, a radix
+  outside 2..36 escaped as a raw Chez condition, and the message never named a
+  radix other than 10. `Long/decode` and its three siblings were missing
+  outright.
+
+  There is now one Java integer grammar — optional sign, digits of the radix,
+  nothing else — and the target type is what a caller passes, so a width check
+  is possible at all and a new parser cannot be wired without saying which type
+  it parses. `Long/parseLong`, `Integer/parseInt`, `Short/parseShort`,
+  `Byte/parseByte`, each one's `valueOf` and `decode`, `(Long. s)`,
+  `(Integer. s)`, `BigInteger` and `bigint` unbounded, and
+  `clojure.core/parse-long` — which is `Long/valueOf` with the throw caught —
+  are all that one function now. Both of the JVM's out-of-range messages come
+  out on the right classes (`For input string:` for long and int,
+  `Value out of range.` for short and byte), with the radix clause. The grammar
+  lives in a file both hosts include rather than being hand-mirrored on Gambit,
+  so it cannot drift. 50 corpus rows, every one certified against reference
+  Clojure; the parse path also got about 7% faster, since it no longer allocates
+  a trimmed string per call.
+
 - **`format` speaks the rest of `java.util.Formatter`.** `%.3s` truncates a
   string where the precision used to be ignored (`(format "%.3s" "abcdef")` was
   `"abcdef"`), `%#x` / `%#X` / `%#o` prefix the radix (`0x`, `0X`, `0`) with the

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -1344,7 +1344,7 @@
 (define (bigint-ctor v . r)
   (if (and (pair? r) (jolt-array? (car r)))
       (bigint-from-magnitude v (car r))
-      (parse-int-or-throw v (if (null? r) 10 (jnum->exact (car r))) "BigInteger")))
+      (parse-int-or-throw v (if (null? r) 10 (jnum->exact (car r))) "big")))
 (register-class-ctor! "BigInteger" bigint-ctor)
 (register-class-ctor! "java.math.BigInteger" bigint-ctor)
 (register-class-ctor! "MapEntry" (lambda (k v) (make-map-entry k v)))

--- a/host/chez/java/host-static-methods.ss
+++ b/host/chez/java/host-static-methods.ss
@@ -464,8 +464,9 @@
         (cons "bitCount" (lambda (n) (->num (bitwise-bit-count (bitwise-and (jnum->exact n) long-mask64)))))
         (cons "numberOfLeadingZeros" (lambda (n) (->num (long-nlz n))))
         (cons "reverse" (lambda (n) (->num (long-reverse n))))
-        (cons "parseLong" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "parseLong")))
-        (cons "valueOf" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "valueOf")))
+        (cons "parseLong" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "long")))
+        (cons "decode" (lambda (s) (decode-or-throw s "long")))
+        (cons "valueOf" (lambda (s . r) (parse-int-or-throw s (if (null? r) 10 (jnum->exact (car r))) "long")))
         (cons "compare" (lambda (x y) (let ((a (jnum->exact x)) (b (jnum->exact y)))
                                         (->num (cond ((< a b) -1) ((> a b) 1) (else 0))))))
         ;; toHexString/toOctalString/toBinaryString are UNSIGNED (the value's 64-bit
@@ -485,8 +486,9 @@
         (cons "TYPE" "int")
         (cons "valueOf" (lambda (x . r)
                           (if (number? x) (->num x)
-                              (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "valueOf"))))
-        (cons "parseInt" (lambda (x . r) (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "parseInt")))
+                              (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "int"))))
+        (cons "parseInt" (lambda (x . r) (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "int")))
+        (cons "decode" (lambda (x) (decode-or-throw x "int")))
         ;; Integer.compare(int, int): -1/0/1 exactly, not an arbitrary sign value.
         (cons "compare" (lambda (x y) (let ((a (jnum->exact x)) (b (jnum->exact y)))
                                         (->num (cond ((< a b) -1) ((> a b) 1) (else 0))))))
@@ -509,8 +511,9 @@
 (register-class-statics! "Byte"
   (list (cons "TYPE" "byte")
         (cons "MAX_VALUE" (->num 127)) (cons "MIN_VALUE" (->num -128))
-        (cons "valueOf" (lambda (x . r) (->num (if (number? x) x (parse-int-or-throw x 10 "valueOf")))))
-        (cons "parseByte" (lambda (x . r) (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "parseByte")))
+        (cons "valueOf" (lambda (x . r) (->num (if (number? x) x (parse-int-or-throw x 10 "byte")))))
+        (cons "parseByte" (lambda (x . r) (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "byte")))
+        (cons "decode" (lambda (x) (decode-or-throw x "byte")))
         ;; interpret the low 8 bits as unsigned (0..255): a signed byte -1 -> 255.
         (cons "toUnsignedLong" (lambda (x) (->num (bitwise-and (jnum->exact x) #xFF))))
         (cons "toUnsignedInt" (lambda (x) (->num (bitwise-and (jnum->exact x) #xFF))))
@@ -518,8 +521,9 @@
 (register-class-statics! "Short"
   (list (cons "TYPE" "short")
         (cons "MAX_VALUE" (->num 32767)) (cons "MIN_VALUE" (->num -32768))
-        (cons "valueOf" (lambda (x . r) (->num (if (number? x) x (parse-int-or-throw x 10 "valueOf")))))
-        (cons "parseShort" (lambda (x . r) (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "parseShort")))
+        (cons "valueOf" (lambda (x . r) (->num (if (number? x) x (parse-int-or-throw x 10 "short")))))
+        (cons "parseShort" (lambda (x . r) (parse-int-or-throw x (if (null? r) 10 (jnum->exact (car r))) "short")))
+        (cons "decode" (lambda (x) (decode-or-throw x "short")))
         (cons "toString" (lambda (x . r) (number->string (jnum->exact x))))))
 
 

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -807,15 +807,110 @@
 ;; numeric tower: currentTimeMillis/nanoTime are exact longs (JVM).
 (define (->num x) x)
 (define (jnum->exact n) (exact (truncate (jolt-need-num n))))
-;; parse an integer string in radix; #f on failure
-(define (parse-int-str s radix)
-  (let ((n (string->number (str-trim (if (string? s) s (jolt-str-render-one s))) radix)))
-    (and n (integer? n) (->num n))))
-(define (parse-int-or-throw s radix what)
-  (or (parse-int-str s radix)
-      (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
-                    (string-append "For input string: \""
-                                   (if (string? s) s (jolt-str-render-one s)) "\"")))))
+;; ---- java.lang integer parsing ----------------------------------------------
+;; The grammar and the width check are java-int-parse (natives-num.ss), shared
+;; with clojure.core/parse-long, which is Long/valueOf with the throw caught.
+;; What lives HERE is the throw: the JVM's NumberFormatException, in the message
+;; the caller's own class uses.
+;;
+;; TYPE is the target integer type -- the same name its TYPE static carries --
+;; and is what makes a width check possible at all: every parser below is this
+;; one function at a different width, and a new one cannot be wired without
+;; saying which type it parses. The name used to be a free-form label for the
+;; error text alone, was "valueOf" for all four classes, and nothing checked the
+;; width, so Byte/parseByte answered 128 and Long/parseLong a bignum.
+;;
+;; The JVM has TWO out-of-range messages and jolt has to pick per type: Long and
+;; Integer reuse the ordinary "For input string:" one, Short and Byte have their
+;; own "Value out of range." A bad SHAPE is always the first, and both it and the
+;; range message name a radix other than 10 (Integer.parseInt appends "under
+;; radix N"; Short/Byte always spell "Radix:N").
+(define java-int-types
+  ;; name -> (min max value-out-of-range-message?); #f bounds is the unbounded
+  ;; parse, which is BigInteger's and clojure.core/bigint's.
+  (list (list "long"  -9223372036854775808 9223372036854775807 #f)
+        (list "int"   -2147483648          2147483647          #f)
+        (list "short" -32768               32767               #t)
+        (list "byte"  -128                 127                 #t)
+        (list "big"   #f                   #f                  #f)))
+
+(define (java-int-input-msg str radix)
+  (string-append "For input string: \"" str "\""
+                 (if (= radix 10) "" (string-append " under radix " (number->string radix)))))
+
+(define (parse-int-or-throw s radix type)
+  (let* ((str (if (string? s) s (jolt-str-render-one s)))
+         (row (assoc type java-int-types))
+         (v (java-int-parse str radix (cadr row) (caddr row))))
+    (if (symbol? v)
+        (jolt-throw
+         (jolt-host-throwable
+          "java.lang.NumberFormatException"
+          (cond
+            ((eq? v (quote radix))
+             (string-append "radix " (number->string radix)
+                            (if (< radix 2) " less than Character.MIN_RADIX"
+                                " greater than Character.MAX_RADIX")))
+            ((and (eq? v (quote range)) (cadddr row))
+             (string-append "Value out of range. Value:\"" str "\" Radix:"
+                            (number->string radix)))
+            (else (java-int-input-msg str radix)))))
+        (->num v))))
+
+;; Integer.decode(String) and its three siblings: the same grammar with a RADIX
+;; PREFIX in front of it -- 0x / 0X / # for hex, a bare leading 0 for octal,
+;; nothing for decimal -- and the sign OUTSIDE the prefix, as in "-0x1f". Not a
+;; fourth parser: strip the sign and the prefix, hand the digits to
+;; java-int-parse at the radix they named, and put the sign back. It was missing
+;; entirely, which is how it stayed out of the parse family's reach; adding it
+;; anywhere but here would have started that family over.
+;;
+;; The messages are Integer.decode's, which names the digits AFTER the prefix and
+;; the radix they resolved to -- (Integer/decode "08") is `For input string: "8"
+;; under radix 8`, not a complaint about "08" -- and, for the two narrow types, a
+;; range message of its own that quotes the value and the ORIGINAL string.
+(define (java-decode-split str)
+  ;; -> (values sign digits radix), digits after sign and prefix
+  (let* ((n (string-length str))
+         (c0 (and (fx>? n 0) (string-ref str 0)))
+         (neg? (eqv? c0 #\-))
+         (i (if (or neg? (eqv? c0 #\+)) 1 0)))
+    (cond
+      ((and (fx<=? (fx+ i 2) n)
+            (char=? (string-ref str i) #\0)
+            (memv (string-ref str (fx+ i 1)) (quote (#\x #\X))))
+       (values neg? (substring str (fx+ i 2) n) 16))
+      ((and (fx<? i n) (char=? (string-ref str i) #\#))
+       (values neg? (substring str (fx+ i 1) n) 16))
+      ((and (fx<? (fx+ i 1) n) (char=? (string-ref str i) #\0))
+       (values neg? (substring str (fx+ i 1) n) 8))
+      (else (values neg? (substring str i n) 10)))))
+
+(define (decode-or-throw s type)
+  (let ((str (if (string? s) s (jolt-str-render-one s))))
+    (if (fx=? 0 (string-length str))
+        (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException" "Zero length string"))
+        (let-values (((neg? digits radix) (java-decode-split str)))
+          (let* ((row (assoc type java-int-types))
+                 ;; unbounded first: the narrow types' range message quotes the
+                 ;; VALUE, so it has to exist before the width is applied.
+                 (mag (java-int-parse digits radix #f #f))
+                 (v (and (not (symbol? mag)) (if neg? (- mag) mag))))
+            (cond
+              ((symbol? mag)
+               (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                             ;; a sign with nothing after it reports the sign, as
+                             ;; decode's own retry with the re-attached sign does
+                             (java-int-input-msg (if (and neg? (fx=? 0 (string-length digits))) "-" digits)
+                                                 radix))))
+              ((and (>= v (cadr row)) (<= v (caddr row))) (->num v))
+              ((cadddr row)
+               (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                             (string-append "Value " (number->string v)
+                                            " out of range from input " str))))
+              (else
+               (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                             (java-int-input-msg digits radix))))))))))
 (define (char-code c) (if (char? c) (char->integer c) (jnum->exact c)))
 
 ;; parse a double string (Double/parseDouble, (Double. s)); JVM accepts NaN /

--- a/host/chez/java/host-static.ss
+++ b/host/chez/java/host-static.ss
@@ -913,15 +913,16 @@
                              (java-int-input-msg digits radix))))))))))
 (define (char-code c) (if (char? c) (char->integer c) (jnum->exact c)))
 
-;; parse a double string (Double/parseDouble, (Double. s)); JVM accepts NaN /
-;; Infinity / decimal / scientific. #f on failure.
+;; Double/parseDouble, Float/parseFloat, Double/valueOf, (Double. s) — the
+;; floating half of parse-int-or-throw, and the same story: the grammar is
+;; java-double-parse (natives-num.ss), shared with clojure.core/parse-double,
+;; which is this method with the throw caught. It used to hand the string
+;; straight to string->number and so spoke Scheme, reading "#xff" as 255.0 and
+;; "1/2" as 0.5 — neither one a double on the JVM — while missing the hex
+;; significand form ("0x1fp0" is 31.0 there) that a Scheme reader has no
+;; spelling for. #f on failure.
 (define (parse-double-str s)
-  (let ((t (str-trim (if (string? s) s (jolt-str-render-one s)))))
-    (cond
-      ((or (string=? t "NaN") (string=? t "+NaN") (string=? t "-NaN")) +nan.0)
-      ((or (string=? t "Infinity") (string=? t "+Infinity")) +inf.0)
-      ((string=? t "-Infinity") -inf.0)
-      (else (let ((n (string->number t))) (and n (real? n) (exact->inexact n)))))))
+  (java-double-parse (if (string? s) s (jolt-str-render-one s))))
 (define (parse-double-or-throw s)
   (or (parse-double-str s)
       (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1904,14 +1904,11 @@
   (jolt-int-cast (if (string? x) (parse-int-or-throw x 10 "int") x)))
 (register-class-ctor! "Integer" integer-ctor)
 (register-class-ctor! "java.lang.Integer" integer-ctor)
-;; (Double. x) / (Double. "x"): jolt's double.
+;; (Double. x) / (Double. "x"): jolt's double. The string arity is
+;; Double.parseDouble, so it takes that grammar rather than a string->number of
+;; its own — which read (Double. "#xff") as 255.0 and (Double. "1/2") as 0.5.
 (define (double-ctor x)
-  (if (string? x)
-      (let ((n (string->number x)))
-        (if n (exact->inexact n)
-            (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
-                                             (string-append "For input string: \"" x "\"")))))
-      (jolt-double x)))
+  (if (string? x) (parse-double-or-throw x) (jolt-double x)))
 (register-class-ctor! "Double" double-ctor)
 (register-class-ctor! "java.lang.Double" double-ctor)
 

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1897,11 +1897,11 @@
                      (if (jolt-nil? rest-args) '() (seq->list rest-args)))
         'pass)))
 ;; (Long. n) / (Long. "n"): a Long is just jolt's integer; return it (parse a string).
-(register-class-ctor! "Long" (lambda (x) (if (string? x) (parse-int-or-throw x 10 "Long") (->num (jnum->exact x)))))
-(register-class-ctor! "java.lang.Long" (lambda (x) (if (string? x) (parse-int-or-throw x 10 "Long") (->num (jnum->exact x)))))
+(register-class-ctor! "Long" (lambda (x) (if (string? x) (parse-int-or-throw x 10 "long") (->num (jnum->exact x)))))
+(register-class-ctor! "java.lang.Long" (lambda (x) (if (string? x) (parse-int-or-throw x 10 "long") (->num (jnum->exact x)))))
 ;; (Integer. n) / (Integer. "n"): jolt's integer, range-checked like intCast.
 (define (integer-ctor x)
-  (jolt-int-cast (if (string? x) (parse-int-or-throw x 10 "Integer") x)))
+  (jolt-int-cast (if (string? x) (parse-int-or-throw x 10 "int") x)))
 (register-class-ctor! "Integer" integer-ctor)
 (register-class-ctor! "java.lang.Integer" integer-ctor)
 ;; (Double. x) / (Double. "x"): jolt's double.

--- a/host/chez/natives-misc.ss
+++ b/host/chez/natives-misc.ss
@@ -106,7 +106,7 @@
 ;; JVM bigint/biginteger coerce: string → parsed integer, double/float →
 ;; truncated integer, ratio → quotient, integer → exact integer.
 (define (jolt-bigint x)
-  (cond ((string? x) (parse-int-or-throw x 10 "bigint"))
+  (cond ((string? x) (parse-int-or-throw x 10 "big"))
         ((flonum? x)
          (if (or (finite? x) (zero? x))
              (inexact->exact (truncate x))

--- a/host/chez/natives-num.ss
+++ b/host/chez/natives-num.ss
@@ -94,23 +94,62 @@
 (define (skip-digits s i n) (let loop ((i i)) (if (and (< i n) (ascii-digit? (string-ref s i))) (loop (+ i 1)) i)))
 (define (sign-at? s i n) (and (< i n) (let ((c (string-ref s i))) (or (char=? c #\+) (char=? c #\-)))))
 
-(define (parse-long-shape? s)
-  (let* ((n (string-length s)) (i0 (if (sign-at? s 0 n) 1 0)))
-    (and (> n i0) (= (skip-digits s i0 n) n))))
+;; ---- the Java integer grammar ------------------------------------------------
+;; THE one place jolt reads a Java integer out of a string. Every java.lang
+;; integer parser is this function at a different width -- Long/parseLong,
+;; Integer/parseInt, Short/parseShort, Byte/parseByte, each one's valueOf, the
+;; (Long. s) and (Integer. s) constructors, BigInteger unbounded -- and
+;; clojure.core/parse-long is Long/valueOf with the throw caught to nil, so it is
+;; this function too.
+;;
+;; It exists because the grammar is NOT Scheme's, and handing the string to
+;; string->number spoke Scheme: (Long/parseLong "1e3") read the FLOAT 1000.0 out
+;; of a method whose return type is long, "5.0" read 5.0, "#xff" / "#b101" /
+;; "#o17" read Scheme radix prefixes whatever radix was asked for, " 5" parsed
+;; because the string had been trimmed first, an out-of-range value came back as
+;; a wider number instead of failing, and a radix outside 2..36 escaped as a Chez
+;; "not a valid radix" condition. Java's grammar is only this: an optional + or
+;; -, then one or more digits of RADIX, and nothing else.
+;;
+;; Answers the integer, or one of three SYMBOLS the caller renders as its own
+;; failure -- 'radix (outside Character.MIN_RADIX..MAX_RADIX), 'shape (not a Java
+;; integer in this radix), 'range (one that does not fit MN..MX). A parsed value
+;; is never a symbol, so the two are told apart by symbol?. MN #f is the
+;; unbounded parse.
+(define (java-digit-value c radix)
+  (let* ((i (char->integer c))
+         (v (cond ((and (fx>=? i 48) (fx<=? i 57))  (fx- i 48))        ; 0-9
+                  ((and (fx>=? i 97) (fx<=? i 122)) (fx+ 10 (fx- i 97)))  ; a-z
+                  ((and (fx>=? i 65) (fx<=? i 90))  (fx+ 10 (fx- i 65)))  ; A-Z
+                  (else #f))))
+    (and v (fx<? v radix) v)))
 
-;; parse-long is Long/parseLong with NumberFormatException caught to nil, so a
-;; non-nil result is always a LONG: a decimal outside signed 64-bit range is nil,
-;; not a wider number. The shape check alone would hand back what string->number
-;; makes of the digits, which on jolt's unified integer model is a bignum past
-;; the bounds -- (parse-long "9223372036854775808") reading 9223372036854775808N
-;; where the JVM and bb read nil, so a caller branching on the nil to catch the
-;; overflow takes the wrong arm. Range-check the value, not just the shape.
+(define (java-int-parse s radix mn mx)
+  (if (or (fx<? radix 2) (fx>? radix 36))
+      (quote radix)
+      (let* ((n (string-length s))
+             (c0 (and (fx>? n 0) (string-ref s 0)))
+             (neg? (eqv? c0 #\-))
+             (i0 (if (or neg? (eqv? c0 #\+)) 1 0)))
+        (if (fx=? i0 n)
+            (quote shape)                       ; "", "+", "-" -- no digits
+            (let loop ((i i0) (acc 0))
+              (if (fx=? i n)
+                  (let ((v (if neg? (- acc) acc)))
+                    (if (or (not mn) (and (>= v mn) (<= v mx))) v (quote range)))
+                  (let ((d (java-digit-value (string-ref s i) radix)))
+                    (if d (loop (fx+ i 1) (+ (* acc radix) d)) (quote shape)))))))))
+
+;; clojure.core/parse-long: Long/valueOf with NumberFormatException caught to
+;; nil, so a non-nil result is always a LONG and every failure -- bad shape or a
+;; decimal outside signed 64-bit range -- is nil rather than a wider number.
+;; (parse-long "9223372036854775808") read 9223372036854775808N before the range
+;; half existed, so a caller branching on the nil to catch the overflow took the
+;; wrong arm and got a clojure.lang.BigInt out of a fn documented to return Long.
 (define (jolt-parse-long s)
   (if (not (string? s)) (throw-jvm (quote IllegalArgumentException) (string-append "parse-long requires a string: " (jolt-final-str s)))
-      (if (parse-long-shape? s)
-          (let ((v (string->number s)))                          ; exact integer
-            (if (and (>= v ->int-long-min) (<= v ->int-long-max)) v jolt-nil))
-          jolt-nil)))
+      (let ((v (java-int-parse s 10 ->int-long-min ->int-long-max)))
+        (if (symbol? v) jolt-nil v))))
 
 ;; strict float shape: [+-]? ( D+ (. D*)? | . D+ ) ([eE][+-]? D+)?  fully anchored.
 (define (parse-double-shape? s)

--- a/host/chez/natives-num.ss
+++ b/host/chez/natives-num.ss
@@ -98,9 +98,19 @@
   (let* ((n (string-length s)) (i0 (if (sign-at? s 0 n) 1 0)))
     (and (> n i0) (= (skip-digits s i0 n) n))))
 
+;; parse-long is Long/parseLong with NumberFormatException caught to nil, so a
+;; non-nil result is always a LONG: a decimal outside signed 64-bit range is nil,
+;; not a wider number. The shape check alone would hand back what string->number
+;; makes of the digits, which on jolt's unified integer model is a bignum past
+;; the bounds -- (parse-long "9223372036854775808") reading 9223372036854775808N
+;; where the JVM and bb read nil, so a caller branching on the nil to catch the
+;; overflow takes the wrong arm. Range-check the value, not just the shape.
 (define (jolt-parse-long s)
   (if (not (string? s)) (throw-jvm (quote IllegalArgumentException) (string-append "parse-long requires a string: " (jolt-final-str s)))
-      (if (parse-long-shape? s) (string->number s) jolt-nil)))   ; exact long
+      (if (parse-long-shape? s)
+          (let ((v (string->number s)))                          ; exact integer
+            (if (and (>= v ->int-long-min) (<= v ->int-long-max)) v jolt-nil))
+          jolt-nil)))
 
 ;; strict float shape: [+-]? ( D+ (. D*)? | . D+ ) ([eE][+-]? D+)?  fully anchored.
 (define (parse-double-shape? s)

--- a/host/chez/natives-num.ss
+++ b/host/chez/natives-num.ss
@@ -193,15 +193,72 @@
              (char-numeric? (string-ref t (- tn 2))))
         (substring t 0 (- tn 1))
         t)))
+;; Java's HEXADECIMAL floating-point form, the one shape of Double.parseDouble
+;; that is not a decimal: 0x HexDigits . HexDigitsopt p Signopt Digits. The
+;; binary exponent is REQUIRED, which is what tells (Double/parseDouble "0x1fp0")
+;; -- 31.0 -- from "0x1f", which is not a double on the JVM either. #f when the
+;; string is not one.
+(define (hex-digit-value c)
+  (let ((i (char->integer c)))
+    (cond ((and (fx>=? i 48) (fx<=? i 57))  (fx- i 48))
+          ((and (fx>=? i 97) (fx<=? i 102)) (fx+ 10 (fx- i 97)))
+          ((and (fx>=? i 65) (fx<=? i 70))  (fx+ 10 (fx- i 65)))
+          (else #f))))
+(define (skip-hex-digits s i n)
+  (let loop ((i i)) (if (and (< i n) (hex-digit-value (string-ref s i))) (loop (+ i 1)) i)))
+(define (hex-digits-value s i j)
+  (let loop ((i i) (acc 0))
+    (if (= i j) acc (loop (+ i 1) (+ (* acc 16) (hex-digit-value (string-ref s i)))))))
+
+(define (java-hex-double s)
+  (let* ((n (string-length s))
+         (neg? (and (> n 0) (char=? (string-ref s 0) #\-)))
+         (i0 (if (or neg? (and (> n 0) (char=? (string-ref s 0) #\+))) 1 0)))
+    (and (<= (+ i0 2) n)
+         (char=? (string-ref s i0) #\0)
+         (memv (string-ref s (+ i0 1)) (quote (#\x #\X)))
+         (let* ((ds (+ i0 2))
+                (ip (skip-hex-digits s ds n))
+                (dot? (and (< ip n) (char=? (string-ref s ip) #\.)))
+                (fs (if dot? (+ ip 1) ip))
+                (fp (if dot? (skip-hex-digits s fs n) fs)))
+           (and (> fp ds)                       ; at least one hex digit overall
+                (< fp n)
+                (memv (string-ref s fp) (quote (#\p #\P)))
+                (let* ((es (if (sign-at? s (+ fp 1) n) (+ fp 2) (+ fp 1)))
+                       (ee (skip-digits s es n)))
+                  (and (> ee es) (= ee n)
+                       (let* ((mant (+ (hex-digits-value s ds ip)
+                                       (if (> fp fs)
+                                           (/ (hex-digits-value s fs fp) (expt 16 (- fp fs)))
+                                           0)))
+                              (ex (string->number (substring s (+ fp 1) n)))
+                              (v (exact->inexact (* mant (expt 2 ex)))))
+                         (if neg? (- v) v)))))))))
+
+;; THE one place jolt reads a Java double out of a string, the floating half of
+;; java-int-parse. clojure.core/parse-double is Double/parseDouble with the throw
+;; caught to nil, so both doors are this function -- the Java one used to hand
+;; the string to string->number instead and so spoke SCHEME, reading
+;; (Double/parseDouble "#xff") as 255.0 and "1/2" as 0.5, neither of which is a
+;; double on the JVM; and both doors were missing the hex form, "-NaN" and
+;; "+Infinity". #f when the string is not a Java double.
+(define (java-double-parse s0)
+  (let* ((s (pd-normalize s0))
+         (n (string-length s))
+         (neg? (and (> n 0) (char=? (string-ref s 0) #\-)))
+         (body (if (and (> n 0) (memv (string-ref s 0) (quote (#\- #\+)))) (substring s 1 n) s)))
+    (cond
+      ;; the sign is accepted and IGNORED on NaN, as the JVM does: "-NaN" is NaN
+      ((string=? body "NaN") +nan.0)
+      ((string=? body "Infinity") (if neg? -inf.0 +inf.0))
+      ((java-hex-double s))
+      ((parse-double-shape? s) (exact->inexact (string->number s)))
+      (else #f))))
+
 (define (jolt-parse-double s)
   (if (not (string? s)) (throw-jvm (quote IllegalArgumentException) (string-append "parse-double requires a string: " (jolt-final-str s)))
-      (let ((s (pd-normalize s)))
-        (cond
-          ((string=? s "Infinity") +inf.0)
-          ((string=? s "-Infinity") -inf.0)
-          ((string=? s "NaN") +nan.0)
-          ((parse-double-shape? s) (exact->inexact (string->number s)))
-          (else jolt-nil)))))
+      (or (java-double-parse s) jolt-nil)))
 
 (def-var! "clojure.core" "__bit-and" jolt-bit-and)
 (def-var! "clojure.core" "__bit-or" jolt-bit-or)

--- a/host/gambit/prelude-shims.ss
+++ b/host/gambit/prelude-shims.ss
@@ -717,11 +717,8 @@ eturn)) (loop (- n 1)))
 (define (jolt-locks-enter!) (set-virtual-register! 7 (+ 1 (virtual-register 7))))
 (define (jolt-locks-exit!) (set-virtual-register! 7 (- (virtual-register 7) 1)))
 
-;; parse-int-str / parse-int-or-throw — ported from java/host-static.ss (G2
-;; EXCLUDES the java/ tree; natives-misc.ss's jolt-bigint calls them). String
-;; -> integer in RADIX, #f on failure; parse-int-or-throw raises a jolt
-;; NumberFormatException. str-trim is String.trim (java/natives-str.ss): chars
-;; at or below space.
+;; str-trim — String.trim (java/natives-str.ss, which G2 excludes): chars at or
+;; below space. rt-core.ss binds clojure.core/trim to it.
 (define (str-trim s)
   (let ((len (string-length s)))
     (let scan-l ((i 0))
@@ -731,14 +728,20 @@ eturn)) (loop (- n 1)))
                     (if (char<=? (string-ref s j) #\space)
                         (scan-r (fx- j 1))
                         (substring s i (fx+ j 1)))))))))
-(define (parse-int-str s radix)
-  (let ((n (string->number (str-trim (if (string? s) s (jolt-str-render-one s))) radix)))
-    (and n (integer? n) n)))
-(define (parse-int-or-throw s radix what)
-  (or (parse-int-str s radix)
-      (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
-                    (string-append "For input string: \""
-                                   (if (string? s) s (jolt-str-render-one s)) "\"")))))
+
+;; parse-int-or-throw — natives-misc.ss's jolt-bigint is the only caller here (G2
+;; EXCLUDES the java/ tree, so none of the java.lang parsers exist on this host).
+;; The GRAMMAR is not copied: java-int-parse is in natives-num.ss, which both
+;; hosts include, so the one place jolt reads a Java integer cannot drift between
+;; them. bigint is the unbounded parse, so there is no width to name and only the
+;; ordinary "For input string:" message can come out.
+(define (parse-int-or-throw s radix type)
+  (let* ((str (if (string? s) s (jolt-str-render-one s)))
+         (v (java-int-parse str radix #f #f)))
+    (if (symbol? v)
+        (jolt-throw (jolt-host-throwable "java.lang.NumberFormatException"
+                      (string-append "For input string: \"" str "\"")))
+        v)))
 
 ;; make-thread-parameter — a Chez PRIMITIVE (no .ss definition), absent on Gambit.
 ;; compile-eval.ss's jolt-current-source / jolt-aot-capture* are thread parameters;

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -2525,6 +2525,56 @@
   {:suite "numbers / parse fns (1.11)" :label "parse-long overflow is not some?" :expected "false" :actual "(some? (parse-long \"9223372036854775808\"))" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-long overflow has no class" :expected "nil" :actual "(class (parse-long \"9223372036854775808\"))" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-long in range is a Long" :expected "java.lang.Long" :actual "(class (parse-long \"9223372036854775807\"))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong rejects an exponent" :expected "nil" :actual "(try (Long/parseLong \"1e3\") (catch NumberFormatException _ nil))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong rejects a decimal point" :expected "nil" :actual "(try (Long/parseLong \"5.0\") (catch NumberFormatException _ nil))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong rejects a #x radix prefix" :expected "nil" :actual "(try (Long/parseLong \"#xff\") (catch NumberFormatException _ nil))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseInt rejects a #o radix prefix" :expected "nil" :actual "(try (Integer/parseInt \"#o17\") (catch NumberFormatException _ nil))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong rejects leading space" :expected "nil" :actual "(try (Long/parseLong \" 5\") (catch NumberFormatException _ nil))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong rejects trailing space" :expected "nil" :actual "(try (Long/parseLong \"5 \") (catch NumberFormatException _ nil))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong takes a leading plus" :expected "5" :actual "(Long/parseLong \"+5\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong max long" :expected "9223372036854775807" :actual "(Long/parseLong \"9223372036854775807\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong past max throws" :expected :throws :actual "(Long/parseLong \"9223372036854775808\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Long/valueOf past max throws" :expected :throws :actual "(Long/valueOf \"9223372036854775808\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseInt max int" :expected "2147483647" :actual "(Integer/parseInt \"2147483647\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseInt past max throws" :expected :throws :actual "(Integer/parseInt \"2147483648\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Integer/valueOf past max throws" :expected :throws :actual "(Integer/valueOf \"2147483648\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseShort max short" :expected "32767" :actual "(Short/parseShort \"32767\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseShort past max throws" :expected :throws :actual "(Short/parseShort \"32768\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseByte min byte" :expected "-128" :actual "(Byte/parseByte \"-128\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseByte past min throws" :expected :throws :actual "(Byte/parseByte \"-129\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Byte/valueOf past max throws" :expected :throws :actual "(Byte/valueOf \"128\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "(Long. s) past max throws" :expected :throws :actual "(Long. \"9223372036854775808\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "(Integer. s) past max throws" :expected :throws :actual "(Integer. \"2147483648\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong radix 16" :expected "255" :actual "(Long/parseLong \"ff\" 16)" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong radix 36 is case-blind" :expected "1295" :actual "(Long/parseLong \"ZZ\" 36)" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong radix 16 past max throws" :expected :throws :actual "(Long/parseLong \"8000000000000000\" 16)" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseInt radix 16 past max throws" :expected :throws :actual "(Integer/parseInt \"80000000\" 16)" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong radix below MIN_RADIX throws" :expected :throws :actual "(Long/parseLong \"5\" 1)" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "parseLong radix above MAX_RADIX throws" :expected :throws :actual "(Long/parseLong \"5\" 37)" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "long range message is the input-string one" :expected "\"For input string: \\\"9223372036854775808\\\"\"" :actual "(try (Long/parseLong \"9223372036854775808\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "short range message names the value" :expected "\"Value out of range. Value:\\\"32768\\\" Radix:10\"" :actual "(try (Short/parseShort \"32768\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "byte range message names the value" :expected "\"Value out of range. Value:\\\"128\\\" Radix:10\"" :actual "(try (Byte/parseByte \"128\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "a non-ten radix is named in the message" :expected "\"For input string: \\\"zz\\\" under radix 16\"" :actual "(try (Long/parseLong \"zz\" 16) (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "radix 1 is named as below MIN_RADIX" :expected "\"radix 1 less than Character.MIN_RADIX\"" :actual "(try (Long/parseLong \"5\" 1) (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode hex 0x" :expected "31" :actual "(Integer/decode \"0x1f\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode hex 0X" :expected "31" :actual "(Integer/decode \"0X1F\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode hex #" :expected "31" :actual "(Integer/decode \"#1f\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode octal" :expected "15" :actual "(Integer/decode \"017\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode decimal" :expected "10" :actual "(Integer/decode \"10\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode zero" :expected "0" :actual "(Integer/decode \"0\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode signs the prefixed value" :expected "-31" :actual "(Integer/decode \"-0x1f\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode takes a leading plus" :expected "31" :actual "(Integer/decode \"+0x1f\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Long/decode max long" :expected "9223372036854775807" :actual "(Long/decode \"0x7fffffffffffffff\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Long/decode past max throws" :expected :throws :actual "(Long/decode \"0x8000000000000000\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Short/decode max short" :expected "32767" :actual "(Short/decode \"#7fff\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "Byte/decode past max throws" :expected :throws :actual "(Byte/decode \"0x80\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode rejects a bad octal digit" :expected :throws :actual "(Integer/decode \"08\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode rejects leading space" :expected :throws :actual "(Integer/decode \" 5\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode names the post-prefix digits and radix" :expected "\"For input string: \\\"8\\\" under radix 8\"" :actual "(try (Integer/decode \"08\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "decode of the empty string says so" :expected "\"Zero length string\"" :actual "(try (Integer/decode \"\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "narrow decode range message quotes the input" :expected "\"Value 128 out of range from input 0x80\"" :actual "(try (Byte/decode \"0x80\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "bigint is not width-checked" :expected "9223372036854775808N" :actual "(bigint \"9223372036854775808\")" :portability :common}
+  {:suite "interop / java.lang integer parsing" :label "BigInteger takes the same grammar" :expected :throws :actual "(java.math.BigInteger. \"1e3\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double" :expected "1.5" :actual "(parse-double \"1.5\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double int" :expected "4.0" :actual "(parse-double \"4\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double sci" :expected "1500.0" :actual "(parse-double \"1.5e3\")" :portability :common}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -2575,6 +2575,28 @@
   {:suite "interop / java.lang integer parsing" :label "narrow decode range message quotes the input" :expected "\"Value 128 out of range from input 0x80\"" :actual "(try (Byte/decode \"0x80\") (catch NumberFormatException e (.getMessage e)))" :portability :common}
   {:suite "interop / java.lang integer parsing" :label "bigint is not width-checked" :expected "9223372036854775808N" :actual "(bigint \"9223372036854775808\")" :portability :common}
   {:suite "interop / java.lang integer parsing" :label "BigInteger takes the same grammar" :expected :throws :actual "(java.math.BigInteger. \"1e3\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble rejects a #x radix prefix" :expected :throws :actual "(Double/parseDouble \"#xff\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble rejects a ratio" :expected :throws :actual "(Double/parseDouble \"1/2\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble rejects a #b radix prefix" :expected :throws :actual "(Double/parseDouble \"#b101\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseFloat rejects a #x radix prefix" :expected :throws :actual "(Float/parseFloat \"#xff\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "Double/valueOf rejects a #x radix prefix" :expected :throws :actual "(Double/valueOf \"#xff\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "(Double. s) rejects a #x radix prefix" :expected :throws :actual "(Double. \"#xff\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double rejects a #x radix prefix" :expected "nil" :actual "(parse-double \"#xff\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble takes a hex significand" :expected "31.0" :actual "(Double/parseDouble \"0x1fp0\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble hex with a fraction" :expected "3.0" :actual "(Double/parseDouble \"0x1.8p1\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble signs a hex significand" :expected "-31.0" :actual "(Double/parseDouble \"-0x1fp0\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double takes a hex significand" :expected "31.0" :actual "(parse-double \"0x1fp0\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double hex with a fraction" :expected "3.0" :actual "(parse-double \"0x1.8p1\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "a hex integer is not a double" :expected "nil" :actual "(parse-double \"0x1f\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double signed NaN is NaN" :expected "true" :actual "(Double/isNaN (parse-double \"-NaN\"))" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double takes +Infinity" :expected "##Inf" :actual "(parse-double \"+Infinity\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double keeps -Infinity" :expected "##-Inf" :actual "(parse-double \"-Infinity\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble trims, unlike the integers" :expected "1.5" :actual "(Double/parseDouble \" 1.5 \")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble takes a d suffix" :expected "1.5" :actual "(Double/parseDouble \"1.5d\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble takes an f suffix" :expected "1.5" :actual "(Double/parseDouble \"1.5f\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parse-double takes an exponent and a suffix" :expected "150.0" :actual "(parse-double \"1.5e2d\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "parseDouble saturates rather than failing" :expected "##Inf" :actual "(Double/parseDouble \"1e400\")" :portability :common}
+  {:suite "interop / java.lang double parsing" :label "lowercase infinity is not a double" :expected "nil" :actual "(parse-double \"infinity\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double" :expected "1.5" :actual "(parse-double \"1.5\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double int" :expected "4.0" :actual "(parse-double \"4\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double sci" :expected "1500.0" :actual "(parse-double \"1.5e3\")" :portability :common}

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -2514,6 +2514,17 @@
   {:suite "numbers / parse fns (1.11)" :label "parse-long empty nil" :expected "nil" :actual "(parse-long \"\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-long junk nil" :expected "nil" :actual "(parse-long \"12ab\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-long throws" :expected :throws :actual "(parse-long 42)" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long max long" :expected "9223372036854775807" :actual "(parse-long \"9223372036854775807\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long min long" :expected "-9223372036854775808" :actual "(parse-long \"-9223372036854775808\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long over max nil" :expected "nil" :actual "(parse-long \"9223372036854775808\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long under min nil" :expected "nil" :actual "(parse-long \"-9223372036854775809\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long +over max nil" :expected "nil" :actual "(parse-long \"+9223372036854775808\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long far over nil" :expected "nil" :actual "(parse-long \"99999999999999999999999999\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long zero-padded max" :expected "9223372036854775807" :actual "(parse-long \"0009223372036854775807\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long zero-padded over nil" :expected "nil" :actual "(parse-long \"018446744073709551616\")" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long overflow is not some?" :expected "false" :actual "(some? (parse-long \"9223372036854775808\"))" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long overflow has no class" :expected "nil" :actual "(class (parse-long \"9223372036854775808\"))" :portability :common}
+  {:suite "numbers / parse fns (1.11)" :label "parse-long in range is a Long" :expected "java.lang.Long" :actual "(class (parse-long \"9223372036854775807\"))" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double" :expected "1.5" :actual "(parse-double \"1.5\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double int" :expected "4.0" :actual "(parse-double \"4\")" :portability :common}
   {:suite "numbers / parse fns (1.11)" :label "parse-double sci" :expected "1500.0" :actual "(parse-double \"1.5e3\")" :portability :common}

--- a/test/conformance/known-divergences.edn
+++ b/test/conformance/known-divergences.edn
@@ -266,6 +266,20 @@
            :jvm "throws ClassCastException"
            :jolt "5"}
    :note "Unchecked data argument; a map behaves identically. Verified against Clojure 1.12.5."}
+  ;; jolt has no distinct byte or short VALUE — every integer is one type — so
+  ;; Byte/valueOf(byte), which the JVM has, and Byte/valueOf(int), which it does
+  ;; not, are the same call here and there is nothing to refuse with. Found while
+  ;; putting every java.lang integer PARSER on one grammar: the string arities
+  ;; now match the JVM exactly, and this is the one cell left, which is about
+  ;; overload arity rather than parsing. Substrate-inherent and a superset.
+  {:category :permissive
+   :behavior "(Byte/valueOf (int 200))"
+   :jvm "throws IllegalArgumentException (no Byte/valueOf taking an int)"
+   :jolt "200"
+   :check {:expr "(Byte/valueOf (int 200))"
+           :jvm "throws IllegalArgumentException"
+           :jolt "200"}
+   :note "jolt models one integer type, so a byte-typed overload cannot be told from an int-typed one. Verified against Clojure 1.12.5."}
   ;; A bignum-literal operand (9223372036854775807 = Long/MAX_VALUE, past jolt's
   ;; 2^60-1 fixnum ceiling) BLOCKS :long specialization, so the loop var stays
   ;; generic and jolt computes the EXACT bignum sum — where the JVM keeps `i` a


### PR DESCRIPTION
Fixes #927.

`clojure.core/parse-long` is `Long/parseLong` with `NumberFormatException`
caught to `nil`, so every non-`nil` result is a `Long` and a decimal outside
signed 64-bit range is `nil` — never a larger number. jolt's `jolt-parse-long`
checked only the string *shape* and then handed back whatever `string->number`
made of the digits, which on jolt's unified integer model is a bignum past the
bounds:

```clojure
(parse-long "9223372036854775808")          ; was 9223372036854775808N, now nil
(parse-long "-9223372036854775809")         ; was -9223372036854775809N, now nil
(some? (parse-long "9223372036854775808"))  ; was true, now false
```

So a caller branching on the `nil` to catch the overflow took the wrong arm and
got a `clojure.lang.BigInt` out of a fn documented to return a `Long`.

The value is now range-checked against `->int-long-min` / `->int-long-max` — the
same bounds the bit family's `->int` cast already enforces, so the shape gate and
the range gate share one pair of constants. In-range values, both boundaries
included, are unchanged, and `parse-double` was never affected
(`Double.parseDouble` saturates to `##Inf` rather than failing, which jolt
already matched).

`host/chez/natives-num.ss` is `##include`d by `host/gambit/boot.ss`, so the one
change covers both hosts.

## Testing

- 11 new corpus rows: both long boundaries, one past each, the `+`-signed and
  far-over forms, zero-padded digits on both sides of the edge
  (`"0009223372036854775807"` → the max, `"018446744073709551616"` → `nil`), and
  the `some?` / `class` probes from the report.
- `make corpus` — 5434/5444, 0 new divergences.
- `make certify` — all rows certified against reference Clojure 1.12.5 on JDK 21,
  0 NEW divergences.
- `make unit` — passes.

## Follow-up: the whole family, at the root

Review found the overflow was one symptom of a shared helper with two problems,
so the fix moved down a level rather than staying on `parse-long`.

`parse-int-or-throw` checked **no width at all** — its only argument beyond the
string was a label for the error text, and that label was `"valueOf"` for all
four classes — and it read the digits by handing them to `string->number`, so
the `java.lang` parsers spoke **Scheme, not Java**:

```clojure
(Long/parseLong "1e3")     ; the DOUBLE 1000.0, out of a method returning long
(Long/parseLong "5.0")     ; 5.0
(Long/parseLong "#xff")    ; 255, whatever radix was asked for
(Long/parseLong " 5")      ; 5 — the string was trimmed first
(Byte/parseByte "128")     ; 128
(Long/parseLong "5" 1)     ; a raw Chez "not a valid radix" condition
```

`java-int-parse` (natives-num.ss) is now the one place jolt reads a Java integer
— optional sign, digits of the radix, nothing else, then the target's bounds —
and callers pass the **type** instead of a label, so the width check exists at
all and a new parser cannot be wired without naming which type it parses.
`parse-long` is that same function, being `Long/valueOf` with the throw caught,
so the bounds are no longer spelled in two places.

`decode` was missing on all four classes and is here too, as the grammar with a
radix prefix in front of it, rather than as the next hand-rolled parser. Both of
the JVM's out-of-range messages land on the right classes, with the radix
clause. The grammar lives in a file both hosts include, so the Gambit half is no
longer a hand-kept copy that can drift.

**50 more corpus rows**, every one certified against Clojure 1.12.5 — 79 probes
across the family now come back byte-identical to reference Clojure, message
text included. `make ci` 110 targets, `make certify` 0 NEW, `make libconformance`
47 ok / 0 regressed. `Byte/valueOf` on an int is the one cell still divergent —
jolt has one integer type, so a byte-typed overload cannot be told from an
int-typed one — and is recorded in `known-divergences.edn`. The parse path also
came out ~7% faster: it no longer allocates a trimmed string per call.


## And the floating half

Same helper, same mistake: `parse-double-str` handed the string to
`string->number` too, so `(Double/parseDouble "#xff")` was `255.0`, `"1/2"` was
`0.5` and `"#b101"` was `5.0` — none of them a double on the JVM — across
`Double/parseDouble`, `Float/parseFloat`, `Double/valueOf` and `(Double. s)`,
which had a third `string->number` of its own.

And in the other direction, both doors were missing Java forms a Scheme reader
has no spelling for: the hexadecimal significand (`(parse-double "0x1fp0")` is
`31.0`, `"0x1.8p1"` is `3.0`), a signed `NaN`, and `+Infinity`.

`java-double-parse` is the one grammar now, shared by `clojure.core/parse-double`
and the `java.lang` methods exactly as `java-int-parse` is shared by
`parse-long` and `Long/parseLong` — so neither pair can answer differently
again. 22 more corpus rows, certified; 40 probes across the double family come
back byte-identical to reference Clojure.

`BigDecimal` was checked and is already anchored on its own grammar — every
value matches; only its exception *message* text differs, which is untouched
here.
