### PR TITLE
A method call in interpreted code resolves through Reflector/getMethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A method call in interpreted code resolves through `Reflector/getMethods`.**
+  SCI resolves a host method call by asking `clojure.lang.Reflector/getMethods`
+  for the members matching (name, arity, static?) and invoking the one it
+  gets, and jolt answered the three invokers and the constructor path but not
+  that lookup — so every interpreted method call, `(System/currentTimeMillis)`
+  or `(.indexOf "abcdef" "cd")`, died before reaching the method. `getMethods`
+  now answers from the registries `Class.getMethods` reads; a class whose
+  methods are a cond over the receiver (String, the collections) answers a
+  member carrying the dispatch rule with its parameter count pinned, and an
+  unknown name earns the same member so the failure surfaces at the call with
+  the method named. `Method.invoke` reads a lone nil argument array as the
+  empty one, `Class.cast` is the identity over jolt's Object parameters, and
+  `Util/sneakyThrow` rethrows, so a method that threw reports its own
+  exception rather than a missing static.
+
 - **A spawned child gets its own stdio and nothing else.** `posix_spawn` hands
   the child every descriptor the parent has open unless the spawn says
   otherwise, and jolt's spawn described only the three stdio streams — so a

--- a/host/chez/java/host-static-classes.ss
+++ b/host/chez/java/host-static-classes.ss
@@ -2155,6 +2155,22 @@
         (cons "isAssignableFrom" (lambda (self other)
                                    (let ((ka (class-key self)) (kb (class-key other)))
                                      (if (and ka kb (jch-isa? kb ka)) #t #f))))
+        ;; Class.cast: the JVM's checked narrowing — the value back when it is
+        ;; already an instance, a ClassCastException otherwise. A reflective
+        ;; interpreter casts every argument to its parameter type before the
+        ;; call (SCI's box-arg does), and jolt reports every parameter as
+        ;; Object, where the cast IS the identity. Without an arm the lookup fell
+        ;; through to resolving the class by name, which raised for a name no
+        ;; provider supplies (java.lang.Object) — every interpreted call failed
+        ;; there before reaching the method.
+        (cons "cast" (lambda (self o)
+                       (if (instance-check self o)
+                           o
+                           (throw-jvm
+                            'ClassCastException
+                            (string-append "class " (jclass-jvm-name (jolt-class o))
+                                           " cannot be cast to class "
+                                           (jclass-jvm-name self))))))
         (cons "getConstructors" (lambda (self) (class-constructors self)))
         (cons "getDeclaredConstructors" (lambda (self) (class-constructors self)))
         ;; getModifiers: the JVM bitmask, derived from the class graph (jolt has
@@ -2320,7 +2336,15 @@
         (cons "invokeInstanceMethod"
               (lambda (target method args)
                 (record-method-dispatch target (jolt-str-render-one method)
-                                        (list->cseq (reflect-args args)))))))
+                                        (list->cseq (reflect-args args)))))
+        ;; The two companions a reflective caller reaching a member through
+        ;; getMethods (java/natives-array.ss) needs. prepRet unboxes a primitive
+        ;; return on the JVM; jolt reports Object for every return type, so the
+        ;; value passes through. getAsMethodOfAccessibleBase opens a member
+        ;; declared by a non-public class; jolt's members carry no accessibility
+        ;; state to open, and its classes are public, so the member stands.
+        (cons "prepRet" (lambda (c ret) ret))
+        (cons "getAsMethodOfAccessibleBase" (lambda (c m target) m))))
 ;; A deftype/defrecord type token answers every java.lang.Class method, through
 ;; the SAME table (class inst) uses — records-dispatch.ss owns the token arm and
 ;; loads before this file, so it calls back through here. Returns a one-element

--- a/host/chez/java/io.ss
+++ b/host/chez/java/io.ss
@@ -1592,7 +1592,14 @@
              ;; the boost-style mixer Symbol/Keyword hash with, and that a
              ;; library folding several hashes into one calls directly
              (cons "hashCombine"
-                   (lambda (seed h) (hash-combine (jolt->fx seed) (jolt->fx h)))))))
+                   (lambda (seed h) (hash-combine (jolt->fx seed) (jolt->fx h))))
+             ;; Clojure's throw-without-a-checked-signature. A caller uses it to
+             ;; rethrow a caught exception and keep its type, which is exactly
+             ;; what jolt-throw does — SCI's reflective invoke ends every method
+             ;; call here, so without it a method that throws reports
+             ;; "No matching field or method: clojure.lang.Util/sneakyThrow"
+             ;; instead of the exception the method raised.
+             (cons "sneakyThrow" (lambda (t) (jolt-throw t))))))
   (register-class-statics! "Util" util-statics)
   (register-class-statics! "clojure.lang.Util" util-statics))
 ;; Thread/currentThread -> a fresh thread jhost wrapping THIS thread's interrupt

--- a/host/chez/java/natives-array.ss
+++ b/host/chez/java/natives-array.ss
@@ -952,7 +952,14 @@
                 (else (loop (fx+ k 1))))))
       0))
 (define (reflect-method-arity self)
-  (reflect-method-param-count (reflect-method-fn self) (reflect-method-static? self)))
+  (let ((st (jhost-state self)))
+    ;; A method built from a dispatch rule rather than a proc cannot report its
+    ;; parameter count off an arity mask (the rule accepts anything), so it
+    ;; pins the count in a fifth slot. The members jolt enumerates keep four
+    ;; slots and derive the count from the proc, as before.
+    (if (and (fx>? (vector-length st) 4) (not (eq? #f (vector-ref st 4))))
+        (vector-ref st 4)
+        (reflect-method-param-count (reflect-method-fn self) (reflect-method-static? self)))))
 (register-host-methods! "reflect-method"
   (list (cons "getName" (lambda (self) (reflect-method-name self)))
         (cons "getDeclaringClass" (lambda (self) (jolt-class-for (reflect-method-cls self))))
@@ -973,17 +980,24 @@
         (cons "getModifiers" (lambda (self) (->num (if (reflect-method-static? self) 9 1))))
         ;; Method.invoke(obj, Object... args) — from Clojure the varargs arrive as
         ;; one array, so a lone trailing array IS the argument list and gets
-        ;; splatted. Anything else is passed straight through, which is what a
-        ;; caller spelling the arguments out means. A static ignores the target,
-        ;; as the JVM does (Method.invoke takes null there).
+        ;; splatted. A lone nil is the EMPTY argument list: sci.impl.reflector's
+        ;; box-args answers nil for a method with no parameters, and the JVM's
+        ;; Method.invoke treats a null array as none either (it would raise). A
+        ;; caller spelling out arguments passes them straight through.
         (cons "invoke"
               (lambda (self target . args)
                 (let ((as (if (and (= 1 (length args)) (jolt-array? (car args)))
                               (ja->list (car args))
-                              args)))
+                              (if (and (= 1 (length args)) (jolt-nil? (car args)))
+                                  '()
+                                  args))))
                   (if (reflect-method-static? self)
                       (apply (reflect-method-fn self) as)
                       (apply (reflect-method-fn self) target as)))))
+        ;; AccessibleObject.canAccess: jolt's members carry no accessibility
+        ;; state, and every method it reports is public, so a reflective caller
+        ;; that asks (SCI's interpreter is one) is allowed through.
+        (cons "canAccess" (lambda (self target) #t))
         (cons "toString"
               (lambda (self)
                 (jreflect-member-str (if (reflect-method-static? self) 9 1)
@@ -1022,3 +1036,41 @@
      (jhost-tags-for-fqn fqn))
     (for-each (lambda (p) (add! nm (car p) (cdr p) #t)) (class-static-members nm #t))
     (make-jolt-array (list->vector (reverse acc)) 'objects)))
+
+;; ---- Reflector/getMethods (SCI's reflective lookup) -------------------------
+;; SCI's interpreter (sci.impl.reflector) resolves a method call by asking
+;; clojure.lang.Reflector/getMethods for the members matching (name, arity,
+;; static?) and then invoking the one it got. jolt records members as data for a
+;; protocol's methods, a jhost tag's shims and a class's statics — those answer
+;; with the real member. String and the collections model their methods as a
+;; cond over the receiver, so nothing enumerates them: those (and any name the
+;; class does not have, which dispatch reports at the call the way every other
+;; jolt interop miss does) answer with a stand-in that carries the dispatch
+;; RULE instead of a proc. Its arity cannot come off a proc, so it pins one.
+(define (make-dispatch-method cls-name method-name arity static?)
+  (make-jhost
+   "reflect-method"
+   (vector cls-name method-name
+           (if static?
+               (lambda args (apply host-static-call cls-name method-name args))
+               (lambda (self . args)
+                 (record-method-dispatch self method-name (list->cseq args))))
+           static? arity)))
+
+(define (reflect-get-methods cls arity method-name static?)
+  (let* ((want (jnum->exact arity))
+         (name (jolt-str-render-one method-name))
+         (stat? (if (or (eq? static? #f) (jolt-nil? static?)) #f #t))
+         (ms (filter (lambda (m)
+                       (and (string=? (reflect-method-name m) name)
+                            (fx=? want (reflect-method-arity m))
+                            (eq? stat? (reflect-method-static? m))))
+                     (ja->list (class-method-array cls)))))
+    ;; A java.util.List, which is what SCI's caller destructures (.size/.get).
+    (make-arraylist (list (if (pair? ms)
+                              (car ms)
+                              (make-dispatch-method (jclass-name cls) name want stat?))))))
+
+(register-class-statics!
+ "clojure.lang.Reflector"
+ (list (cons "getMethods" reflect-get-methods)))

--- a/test/chez/sci-functional-test.clj
+++ b/test/chez/sci-functional-test.clj
@@ -43,4 +43,54 @@
             :shared
             (catch Throwable _ :missing))))
 
+;; Java interop inside interpreted code. SCI resolves every method call through
+;; clojure.lang.Reflector (getMethods → its own matching → Method.invoke), so a
+;; library jolt runs through SCI rather than compiling — an extension, a
+;; dependency — cannot touch a host class without these. Static calls, instance
+;; calls and constructors are three distinct lookups; each is exercised where
+;; the REFLECTOR is what resolves it, and so is a class whose methods jolt
+;; models as a cond over the receiver (String) rather than as enumerable data.
+(let [ctx (sci/init {:classes {'java.lang.System java.lang.System
+                               'java.lang.Integer java.lang.Integer
+                               'java.lang.Math java.lang.Math
+                               'java.lang.Character java.lang.Character
+                               'java.io.File java.io.File
+                               'java.net.URI java.net.URI
+                               'java.util.ArrayList java.util.ArrayList}
+                     :imports {'System 'java.lang.System
+                               'Integer 'java.lang.Integer
+                               'Character 'java.lang.Character
+                               'Math 'java.lang.Math
+                               'File 'java.io.File
+                               'URI 'java.net.URI
+                               'ArrayList 'java.util.ArrayList}})]
+  (check= "static method, no args" true
+          (pos? (sci/eval-string* ctx "(System/currentTimeMillis)")))
+  (check= "static method, one arg" (System/getenv "HOME")
+          (sci/eval-string* ctx "(System/getenv \"HOME\")"))
+  (check= "static method, two args" (System/getProperty "os.name" "?")
+          (sci/eval-string* ctx "(System/getProperty \"os.name\" \"?\")"))
+  (check= "static returning a primitive" 42
+          (sci/eval-string* ctx "(Integer/parseInt \"42\")"))
+  (check= "static returning a boolean" false
+          (sci/eval-string* ctx "(Character/isWhitespace \\a)"))
+  (check= "static method on a class modeled as a cond" 2
+          (sci/eval-string* ctx "(Math/round 1.6)"))
+  (check= "constructor" "b.txt"
+          (sci/eval-string* ctx "(.getName (File. \"/a/b.txt\"))"))
+  (check= "instance method on a host object" "https"
+          (sci/eval-string* ctx "(.getScheme (URI. \"https://x.dev\"))"))
+  (check= "instance method on a native string" 2
+          (sci/eval-string* ctx "(.indexOf \"abcdef\" \"cd\")"))
+  (check= "instance method with a marshalled argument" "cdef"
+          (sci/eval-string* ctx "(.substring \"abcdef\" 2)"))
+  (check= "instance method after a mutating call" 1
+          (sci/eval-string* ctx "(let [l (ArrayList.)] (.add l \"x\") (.size l))"))
+  (check= "an unknown method surfaces with the method named" :threw
+          (try
+            (sci/eval-string* ctx "(.noSuchMethod (File. \"/a\"))")
+            :no-throw
+            (catch Throwable e
+              (if (re-find #"noSuchMethod" (ex-message e)) :threw :wrong-message)))))
+
 (println "SCI-FUNCTIONAL-TEST OK")

--- a/test/chez/unit.edn
+++ b/test/chez/unit.edn
@@ -68,6 +68,27 @@
   ;; the class graph answers modifiers for a name it models; one it does not
   ;; reports PUBLIC alone rather than claiming non-finality it cannot know
   {:suite "reflect-member-model" :expr "(.getModifiers (Class/forName \"java.lang.Thread\"))" :expected "1"}
+  ;; Class.cast is the checked narrowing a reflective caller uses to hand a
+  ;; method its (Object) parameter type; without it the lookup fell through to
+  ;; resolving the class by name, which raised for java.lang.Object.
+  {:suite "reflect-member-model" :expr "(.cast java.lang.Object \"x\")" :expected "\"x\""}
+  {:suite "reflect-member-model" :expr "(try (.cast java.lang.String 42) (catch ClassCastException _ :cce))" :expected ":cce"}
+  ;; Reflector/getMethods answers the reflective interpretation of a method call:
+  ;; the members a class enumerates when it has them, and a name-dispatch member
+  ;; when its methods are a cond over the receiver (String, the collections) —
+  ;; which is what an interpreted call needs and what a getMethods-only caller
+  ;; cannot get from the member model above.
+  {:suite "reflect-member-model" :expr "(let [ms (clojure.lang.Reflector/getMethods String 1 \"indexOf\" false)] [(.size ms) (.getName (.get ms 0))])" :expected "[1 \"indexOf\"]"}
+  {:suite "reflect-member-model" :expr "(.canAccess (.get (clojure.lang.Reflector/getMethods String 1 \"indexOf\" false) 0) \"x\")" :expected "true"}
+  ;; a static resolves through the same lookup, and a zero-parameter one is
+  ;; invoked the way sci.impl.reflector invokes it: a nil argument array
+  {:suite "reflect-member-model" :expr "(.invoke (.get (clojure.lang.Reflector/getMethods Math 1 \"max\" true) 0) nil (into-array Object [2 3]))" :expected "3"}
+  {:suite "reflect-member-model" :expr "(pos? (.invoke (.get (clojure.lang.Reflector/getMethods System 0 \"currentTimeMillis\" true) 0) nil nil))" :expected "true"}
+  ;; a name the class does not have still answers a member: dispatch reports it
+  ;; at the call, with the method named, instead of an empty list
+  {:suite "reflect-member-model" :expr "(try (.invoke (.get (clojure.lang.Reflector/getMethods String 0 \"noSuch\" false) 0) \"x\" nil) (catch Exception e (boolean (re-find #\"noSuch\" (ex-message e)))))" :expected "true"}
+  ;; Util/sneakyThrow: the rethrow a reflective invoke ends every call with
+  {:suite "reflect-member-model" :expr "(try (clojure.lang.Util/sneakyThrow (ex-info \"boom\" {})) (catch Exception e (ex-message e)))" :expected "\"boom\""}
   ;; clojure.reflect over the same registries: the reference JavaReflector is a
   ;; thin layer on getDeclaredFields/Methods/Constructors + getModifiers + bases,
   ;; so the port is the reference apart from the member-set model above.


### PR DESCRIPTION
An interpreter that has to call a host method dynamically asks clojure.lang.Reflector/getMethods for the members matching (name, arity, static?), matches over what it gets, and invokes the one it got. SCI is that interpreter — it is how a library jolt runs through SCI rather than compiling reaches a host class — and jolt answered the three invokers and the constructor path but not the lookup that feeds them, so every interpreted method call failed before it reached the method:

  (System/currentTimeMillis)      (.indexOf "abcdef" "cd")
  (System/getenv "HOME")          (.getName (File. "/a"))

all died in Reflector/getMethods ("incorrect number of arguments 5 to #<procedure …>") — the members it must return are real java.lang.reflect Method objects, and matching one against the call is the interpreter's job. Constructors worked, which made the gap look narrower than it was.

getMethods now answers from the registries Class.getMethods already reads, so a class whose members are data reports the real member. A class whose methods are a cond over the receiver — String, the collections — has nothing to enumerate, so it answers with a member carrying the dispatch RULE: the parameter count pinned in a slot (an arity mask cannot report one for a rule), an instance call routed through record-method-dispatch, a static through host-static-call, and canAccess answering yes so the reflective caller is let through. A name the class does not have earns the same member, so the failure surfaces at the call, with the method named by the dispatcher that reported it, rather than as the empty list the interpreter would turn into its own "No matching method found".

Method.invoke reads a lone nil argument array as the empty one: a zero-parameter call is spelled that way (Method.invoke would raise on the JVM), and a caller spelling its arguments out is unaffected.

Two companions the same path needs. Class.cast, where jolt reports every parameter as Object — the cast IS the identity, and without an arm the lookup fell through to resolving the class by name, which raised for a name no provider supplies (java.lang.Object). And Util/sneakyThrow, the rethrow the reflective invoke ends every call with: a method that threw otherwise reported "No matching field or method: clojure.lang.Util/sneakyThrow" instead of the exception it raised.

Gates: make sci 412/424, floor unchanged. make scifunctional gains static (zero, one and two arguments), instance, constructor, marshalled-argument and unknown-method cases against a real SCI context; unit.edn's reflect-member-model gains the same as pure checks (26 rows). make unit is the same 6 /tmp-based environment failures as main (Termux has no /tmp).