### PR TITLE
The , flag on %g stops at the mantissa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `,` flag on `%g` no longer puts a separator in the exponent.** `%g`
+  picks between fixed and scientific notation, and the grouping pass ran over
+  whichever one it produced — so `(format "%,.1g" 1234.5)`, which lands in the
+  scientific branch, rendered `1e,+03` where the JVM gives `1e+03`. The JVM
+  groups the MANTISSA and appends the exponent afterwards, which makes `,` a
+  no-op on the scientific branch (a scientific mantissa has one integer digit);
+  grouping now happens inside that choice, on the fixed branch only. The fixed
+  branch is unchanged: `(format "%,.10g" 1234567.0)` is still `1,234,567.000`.
+  Found while confirming that `%g` itself, which landed in 0.8.6, matches
+  `java.util.Formatter` across the flag combinations; #903's own
+  `(format "%.4g" 12.21)` is pinned in the corpus alongside these.
+
 - **`clojure.lang.ARef`'s watch and validator METHODS work through interop.**
   Every watchable reference type was already an `IRef` by class — `(instance?
   clojure.lang.IRef (atom 1))` is true and `(supers clojure.lang.Atom)` lists

--- a/host/chez/natives-format.ss
+++ b/host/chez/natives-format.ss
@@ -135,13 +135,19 @@
 ;; value is in [10^-4, 10^prec), scientific otherwise -- Java's rule, which is
 ;; why (format "%.3g" 1234.5) is 1.23e+03 and 0.00001234 is 1.23400e-05. The
 ;; digits are rounded once, here; the notation only lays them out.
-(define (fmt-general digits expo prec)
+;;
+;; GROUP is the , flag's separator pass, and it belongs INSIDE this choice: the
+;; JVM groups the mantissa and appends the exponent after, so the , flag is a
+;; no-op on the scientific branch (its mantissa has one integer digit). Applying
+;; it to the finished rendering instead put a separator in the exponent --
+;; (format "%,.1g" 1234.5) was "1e,+03" against the JVM's "1e+03".
+(define (fmt-general digits expo prec group)
   (let* ((prec (if (fx=? prec 0) 1 prec))
          (r (digits-round digits prec))
          (d (car r)) (expo (if (cdr r) (+ expo 1) expo))
          (e (- expo 1)))
     (if (and (>= e -4) (< e prec))
-        (fmt-fixed d expo (fx- prec (fx+ e 1)))
+        (group (fmt-fixed d expo (fx- prec (fx+ e 1))))
         (fmt-sci d expo (fx- prec 1)))))
 ;; digit grouping for the , flag: the integer part in threes, the fraction as is
 (define (fmt-group s)
@@ -390,8 +396,8 @@
       ((#\f) (fmt-real d a flags width (lambda (ds ex) (grouped (fmt-fixed ds ex (or prec 6))))))
       ((#\e) (fmt-real d a flags width (lambda (ds ex) (fmt-sci ds ex (or prec 6)))))
       ((#\E) (fmt-real d a flags width (up (lambda (ds ex) (fmt-sci ds ex (or prec 6))))))
-      ((#\g) (fmt-real d a flags width (lambda (ds ex) (grouped (fmt-general ds ex (or prec 6))))))
-      ((#\G) (fmt-real d a flags width (up (lambda (ds ex) (grouped (fmt-general ds ex (or prec 6)))))))
+      ((#\g) (fmt-real d a flags width (lambda (ds ex) (fmt-general ds ex (or prec 6) grouped))))
+      ((#\G) (fmt-real d a flags width (up (lambda (ds ex) (fmt-general ds ex (or prec 6) grouped)))))
       ((#\a #\A) (fmt-hex-real d a flags width prec))
       ((#\x #\X #\o)
        (cond ((jolt-nil? a) (fmt-pad "null" flags width #f))

--- a/test/chez/corpus.edn
+++ b/test/chez/corpus.edn
@@ -4133,6 +4133,7 @@
   {:suite "format / scientific" :label "%.2e rounds to the precision" :expected "\"1.23e+04\"" :actual "(format \"%.2e\" 12345.678)" :portability :common}
   {:suite "format / scientific" :label "%g below 1e-4 is scientific" :expected "\"1.23400e-05\"" :actual "(format \"%g\" 0.00001234)" :portability :common}
   {:suite "format / scientific" :label "%.3g at 10^precision is scientific" :expected "\"1.23e+03\"" :actual "(format \"%.3g\" 1234.5)" :portability :common}
+  {:suite "format / scientific" :label "%.4g below 10^precision is fixed (#903)" :expected "\"12.21\"" :actual "(format \"%.4g\" 12.21)" :portability :common}
   {:suite "format / scientific" :label "%e of a negative" :expected "\"-5.000000e-01\"" :actual "(format \"%e\" -0.5)" :portability :common}
   {:suite "format / scientific" :label "%e honours width" :expected "\"  5.00e+00|\"" :actual "(format \"%10.2e|\" 5.0)" :portability :common}
   {:suite "format / scientific" :label "%e of an integer is refused" :expected "java.util.IllegalFormatConversionException" :actual "(try (format \"%e\" 5) (catch Exception e (class e)))" :portability :common}
@@ -4176,6 +4177,11 @@
   {:suite "format / rounding and flags" :label "%(e parenthesizes a negative" :expected "\"(1.000000e+00)\"" :actual "(format \"%(e\" -1.0)" :portability :common}
   {:suite "format / rounding and flags" :label "%,d groups" :expected "\"1,234,567\"" :actual "(format \"%,d\" 1234567)" :portability :common}
   {:suite "format / rounding and flags" :label "%,.2f groups the integer part" :expected "\"1,234.50\"" :actual "(format \"%,.2f\" 1234.5)" :portability :common}
+  ;; the , flag on %g groups the MANTISSA, so it is a no-op once %g picks
+  ;; scientific notation -- the JVM appends the exponent after the grouping pass
+  ;; and "%,.1g" of 1234.5 is "1e+03", never "1e,+03".
+  {:suite "format / rounding and flags" :label "%,g groups the fixed branch" :expected "\"1,234,567.000\"" :actual "(format \"%,.10g\" 1234567.0)" :portability :common}
+  {:suite "format / rounding and flags" :label "%,g leaves the scientific exponent alone" :expected "[\"1e+03\" \"1E+06\"]" :actual "[(format \"%,.1g\" 1234.5) (format \"%,.1G\" 1000000.0)]" :portability :common}
   ;; a BigDecimal formats from its own digits; the argument types are the JVM's
   {:suite "format / rounding and flags" :label "%f of a BigDecimal" :expected "\"1.500000\"" :actual "(format \"%f\" 1.5M)" :portability :common}
   {:suite "format / rounding and flags" :label "%.2f of a BigDecimal rounds half up" :expected "\"1.01\"" :actual "(format \"%.2f\" 1.005M)" :portability :common}


### PR DESCRIPTION
Closes #903.

## What #903 reported

`(format "%.4g" 12.21)` raised `UnknownFormatConversionException` on v0.8.5. That
one is already fixed: `%g`/`%G` landed in 0.8.6, and the reported expression now
answers `"12.21"` like the JVM. This PR pins it in the corpus so the report has a
test of its own.

## What confirming it turned up

Fuzzing `%g`/`%G` against `java.util.Formatter` over 391 flag/width/precision ×
value combinations found one remaining divergence.

`%g` chooses between fixed and scientific notation, and the `,` flag's grouping
pass ran over whichever rendering came back. On the scientific branch that put a
separator in the **exponent**:

```clojure
(format "%,.1g" 1234.5)   ; jolt: "1e,+03"   JVM: "1e+03"
(format "%,.1G" 1000000.) ; jolt: "1E,+06"   JVM: "1E+06"
```

Every `%,g` whose value fell outside `[10^-4, 10^prec)` carried it.

`java.util.Formatter` groups the mantissa and appends the exponent after, so the
`,` flag is a no-op once `%g` goes scientific — a scientific mantissa has one
integer digit. Grouping now happens inside `fmt-general`'s notation choice, on
the fixed branch only. The fixed branch is unchanged:
`(format "%,.10g" 1234567.0)` is still `"1,234,567.000"`.

After the fix the fuzz's only remaining divergence is the already-allowlisted
`Double/MIN_VALUE` digit-string one.

## Changes

- `host/chez/natives-format.ss` — `fmt-general` takes the grouping pass and
  applies it to the fixed branch only.
- `test/chez/corpus.edn` — 3 rows: #903's own `(format "%.4g" 12.21)`, and one
  each for `%,g` in the fixed and the scientific branch.
- `CHANGELOG.md` — Fixed entry.

## Validation

- `make corpus` — 5506/5516, **0 new divergences**
- `make certify` — 5720 rows against JVM Clojure 1.12.5 / JDK 21, **0 NEW, 0 stale**
- `make unit` — 1717/1717
- `make documented` — 50/50
- `make gambitseedcheck` — seed current

The full `make test` run was killed partway by host memory pressure rather than by
a failure, so the gates above were run individually instead.