### PR TITLE
A spawned child gets its own stdio and nothing else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A spawned child gets its own stdio and nothing else.** `posix_spawn` hands
+  the child every descriptor the parent has open unless the spawn says
+  otherwise, and jolt's spawn described only the three stdio streams — so a
+  subprocess inherited jolt's open source files, its nREPL listener, and
+  whatever socket a library was serving on. The JVM's `ProcessBuilder` gives a
+  child the three standard streams and nothing more, and the difference is
+  load-bearing rather than cosmetic: a child holding a copy of a listening
+  socket keeps that port BOUND after the parent closes it, for as long as the
+  child runs. An ORPHANED child — the parent killed by a test runner's
+  per-namespace timeout, say — holds it for as long as the orphan lives, which
+  is how a suite on fixed callback ports came to fail with `bind failed on port
+  54603` behind `curl` children aged hours (#910).
+
+  The spawn now closes everything above the stdio fds in the child:
+  `posix_spawn_file_actions_addclosefrom_np` where that entry resolves (glibc
+  2.34+ lowers it to one `close_range(2)`), and elsewhere — macOS, and every
+  older glibc, which is most of the range the released Linux binary targets —
+  by enumerating this process's own open descriptors (`/proc/self/fd`,
+  `/dev/fd`) and adding one close action each, every one of them confirmed open
+  with `fcntl` first, since a file action that fails leaves the child exiting
+  127 instead of exec'ing. The `closefrom` form has no window at all, because
+  the set it closes is decided in the child; the enumerated form takes its
+  snapshot in the parent, so a descriptor another thread opens between the
+  listing and the spawn is still inherited. An INHERIT redirect is untouched —
+  fds 0, 1 and 2 are below the cut and still carry the parent's own
+  descriptors, tty answers and all. `JOLT_NO_SPAWN_CLOSEFROM=1` forces the
+  fallback, so one machine's gate can exercise both paths.
+
 - **`clojure.lang.ARef`'s watch and validator METHODS work through interop.**
   Every watchable reference type was already an `IRef` by class — `(instance?
   clojure.lang.IRef (atom 1))` is true and `(supers clojure.lang.Atom)` lists

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -498,6 +498,15 @@
 (define proc-c-read  (jolt-foreign-proc-blocking "read"  '(int void* size_t) 'ssize_t))
 (define proc-c-write (jolt-foreign-proc-blocking "write" '(int void* size_t) 'ssize_t))
 
+;; posix_spawn_file_actions_addclosefrom_np(fa, 3): one file action that closes
+;; every descriptor at or above 3 in the child, after the dup2s below have put
+;; the pipes on 0/1/2. glibc 2.34+ and Solaris have it (glibc lowers it to a
+;; single close_range(2) syscall); older glibcs — jolt's release binary is built
+;; for a floor well below 2.34 — and macOS do not, which is what
+;; proc-close-inherited-fds! falls back for.
+(define proc-fa-closefrom
+  (jolt-foreign-proc-safe "posix_spawn_file_actions_addclosefrom_np" '(void* int) 'int))
+
 ;; What posix_spawn-with-pipes needs, and nothing more. The R8 fiber-parking
 ;; extension's own bindings (fcntl, errno) are gated separately by
 ;; proc-nonblock-ok? above: losing parking is a performance story, losing this
@@ -696,6 +705,73 @@
 ;; posix_spawn.
 (define proc-spawn-fd-mutex (make-mutex))
 
+;; --- the child gets its own stdio and nothing else ---------------------------
+;; A descriptor with no file action IS the parent's descriptor, and posix_spawn
+;; hands the child EVERY one of them: the source files jolt has open, its nREPL
+;; listener, a socket a library is serving on. The JVM's child gets the three
+;; stdio streams and nothing else, and the difference is load-bearing rather
+;; than cosmetic. A child holding a copy of a listening socket keeps that port
+;; BOUND after the parent closes it, for as long as the child lives — and an
+;; ORPHANED child (parent killed by a test runner's per-namespace timeout, say)
+;; holds it for as long as IT lives, so the next run cannot bind the port at all
+;; (jolt-fhv, #910: "bind failed on port 54603" behind curl children aged hours).
+;;
+;; Two ways to say "and close the rest", in preference order:
+;;
+;;   1. posix_spawn_file_actions_addclosefrom_np(fa, 3), added LAST so it runs
+;;      after the dup2s have put the pipes on 0/1/2. One action, one
+;;      close_range(2) in the child, and no window at all: the set it closes is
+;;      decided in the child, after this process can no longer add to it.
+;;   2. Where that entry does not resolve — macOS, and every glibc below 2.34,
+;;      which is most of the range jolt's released Linux binary targets —
+;;      enumerate this process's own open descriptors (/proc/self/fd on Linux,
+;;      /dev/fd on macOS/BSD) and add one addclose per fd. The snapshot is taken
+;;      in the PARENT, so a descriptor another thread opens between the listing
+;;      and the spawn is still inherited; proc-spawn-fd-mutex serialises spawns
+;;      against each other, not against the rest of the program. That residual
+;;      window is one this file cannot close without the syscall in 1, and it is
+;;      a far smaller one than inheriting the whole table.
+;;
+;; Each enumerated fd is confirmed open with fcntl(F_GETFD) before its action is
+;; added, because an addclose of an already-closed fd is a file action that
+;; FAILS, and a failed file action means the child exits 127 instead of exec'ing
+;; (glibc forgives one below the fd limit; POSIX does not require it to). The
+;; listing is itself served by an open directory descriptor which is gone again
+;; by the time directory-list returns, so the snapshot always contains at least
+;; one such fd. Without a working fcntl there is nothing to confirm with and the
+;; fallback declines rather than risk a spawn that cannot exec — that is today's
+;; inheritance, which is the honest degradation here.
+(define proc-F-GETFD 1)        ; macOS + Linux
+(define (proc-fd-live? fd)
+  (and proc-fcntl-get (>= (proc-fcntl-get fd proc-F-GETFD) 0)))
+(define (proc-open-fd-dir)
+  (let loop ((ds '("/proc/self/fd" "/dev/fd")))
+    (cond ((null? ds) #f)
+          ((guard (e (#t #f)) (file-directory? (car ds))) (car ds))
+          (else (loop (cdr ds))))))
+
+;; Tier 1 is the only tier a machine with a new enough glibc would ever run, so
+;; the gate could not see tier 2 at all. JOLT_NO_SPAWN_CLOSEFROM=1 makes this
+;; process take the enumeration path, and test/chez/process-test.clj re-runs the
+;; inheritance case in a child jolt with it set.
+(define (proc-closefrom-disabled?)
+  (let ((v (getenv "JOLT_NO_SPAWN_CLOSEFROM"))) (and v (not (string=? v "")) #t)))
+
+;; `keep` names the fds that already have a close action of their own (the
+;; pipe ends), so the fallback does not add a second one and fail it.
+(define (proc-close-inherited-fds! fa keep)
+  (if (and proc-fa-closefrom (not (proc-closefrom-disabled?)))
+      (proc-fa-closefrom fa 3)
+      (let ((dir (proc-open-fd-dir)))
+        (when (and dir proc-fcntl-get)
+          (for-each
+            (lambda (name)
+              (let ((fd (string->number name)))
+                (when (and fd (integer? fd) (exact? fd) (>= fd 3)
+                           (not (memv fd keep)) (proc-fd-live? fd))
+                  (proc-fa-close fa fd))))
+            (guard (e (#t '())) (directory-list dir)))))))
+
 ;; Spawn `/bin/sh -c sh-cmd` with fd-level stdio: an inherited stream gets no
 ;; file action (the child keeps the parent's descriptor); the rest get pipes.
 ;; Returns (values stdin-port stdout-port stderr-port pid), #f for inherited
@@ -758,6 +834,12 @@
                     (proc-fa-close fa (cdr out-p)) (proc-fa-close fa (car out-p)))
         (when err-p (proc-fa-dup2 fa (cdr err-p) 2)
                     (proc-fa-close fa (cdr err-p)) (proc-fa-close fa (car err-p)))
+        ;; LAST of the file actions, so the dup2s above have already moved the
+        ;; child's ends onto 0/1/2 by the time everything else goes.
+        (proc-close-inherited-fds!
+          fa (append (if in-p  (list (car in-p)  (cdr in-p))  '())
+                     (if out-p (list (car out-p) (cdr out-p)) '())
+                     (if err-p (list (car err-p) (cdr err-p)) '())))
         (let* ((argv (proc-marshal-argv (list "/bin/sh" "-c" sh-cmd)))
                (envp (proc-marshal-argv
                       (map (lambda (p) (string-append (car p) "=" (cdr p)))

--- a/test/chez/process-test.clj
+++ b/test/chez/process-test.clj
@@ -460,6 +460,56 @@
 (check-eq "a child does not inherit jolt's blocked SIGINT"
           (:exit @(process ["sh" "-c" "kill -INT $$"] {:out :string :err :inherit})) 130)
 
+;; Nor does it inherit jolt's open FILES AND SOCKETS. A descriptor with no file
+;; action is the parent's own, and posix_spawn hands the child every one of them
+;; unless told otherwise — where the JVM's ProcessBuilder gives a child the three
+;; stdio streams and nothing more. The cost is not tidiness: a child holding a
+;; copy of a listening socket keeps that port BOUND after the parent closes it,
+;; and an orphaned child (parent killed by a test runner's timeout) keeps it for
+;; as long as the orphan lives, so the next run cannot bind the port at all
+;; (#910 — curl children aged hours still pinning fixed callback ports).
+(require 'jolt.socket)
+(let [server (java.net.ServerSocket. 0)
+      port   (.getLocalPort server)
+      child  (process ["sleep" "30"])]
+  (.close server)                       ; the parent is done with the listener…
+  (check-eq "the port a closed listener held is free while a child still runs"
+            (try (.close (java.net.ServerSocket. port)) :bound
+                 (catch java.io.IOException _ :bind-failed))
+            :bound)
+  (p/destroy child)
+  @child)
+
+;; The same thing said exactly, where the OS will show the table: three stdio
+;; pipes, no jolt source file, no socket. Linux-only (/proc); the port case above
+;; is the portable half.
+(when (fs/exists? "/proc/self/fd")
+  (let [child (process ["sleep" "30"])
+        fds   (-> (sh ["ls" (str "/proc/" (.pid (:proc child)) "/fd")]) :out
+                  str/split-lines)]
+    (check-eq "a child's descriptor table is its own stdio and nothing else"
+              (vec (sort (remove str/blank? fds))) ["0" "1" "2"])
+    (p/destroy child)
+    @child))
+
+;; posix_spawn_file_actions_addclosefrom_np is glibc 2.34+, so on this machine
+;; the case above can only ever exercise that one action. Every macOS and every
+;; older glibc — most of the range the released Linux binary targets — takes the
+;; enumeration fallback instead, and it is gated here by re-running the same
+;; question in a child jolt that has the closefrom path switched off.
+(let [exe  (or (System/getenv "JOLT_EXE") (some-> (fs/which "jolt") str) "jolt-not-found:set-JOLT_EXE")
+      expr (str "(require 'jolt.socket)"
+                "(require '[jolt.process :as p])"
+                "(let [s (java.net.ServerSocket. 0) port (.getLocalPort s)"
+                "      c (p/process [\"sleep\" \"30\"])]"
+                "  (.close s)"
+                "  (print (try (.close (java.net.ServerSocket. port)) \"FREE\""
+                "              (catch java.io.IOException _ \"BOUND\")))"
+                "  (p/destroy c) @c nil)")]
+  (check-eq "and the same holds on the enumeration fallback (no closefrom)"
+            (:out (sh [exe "-e" expr] {:extra-env {"JOLT_NO_SPAWN_CLOSEFROM" "1"}}))
+            "FREE"))
+
 ;; A per-thread subprocess — ThreadLocal<Process>, the shape a worker pool uses to
 ;; give each thread its own long-lived helper program. It only works if the child
 ;; threads run initialValue themselves: jolt's ThreadLocal was a Chez thread


### PR DESCRIPTION
Fixes #910.

## The problem

`posix_spawn` hands the child every descriptor the parent has open unless the spawn says otherwise, and jolt's spawn described only the three stdio streams. So a child inherited jolt's open source files, its nREPL listener, and whatever socket a library was serving on — where the JVM's `ProcessBuilder` gives a child the three standard streams and nothing more.

Before this change, on `main`:

```
child fds:
0 -> pipe:[11757108]
1 -> pipe:[11757109]
2 -> pipe:[11757110]
3 -> /home/…/jolt/host/chez/cli.ss
4 -> /home/…/jolt/host/chez/cli-tail.ss
5 -> socket:[11757107]          <- the parent's listening socket

rebind: :failed bind failed on port 34971
```

The port stays bound for as long as the child runs — and an orphaned child (parent killed by a test runner's per-namespace timeout) holds it for as long as the orphan lives, which is the `bind failed on port 54603` behind `curl` children aged hours in the issue.

After:

```
child fds:
0 -> pipe:[11758285]
1 -> pipe:[11758286]
2 -> pipe:[11758287]

rebind: :bound
```

## The fix

`host/chez/java/process.ss` adds a final file action that closes everything above the stdio fds in the child, in two tiers:

1. **`posix_spawn_file_actions_addclosefrom_np(fa, 3)`** where the entry resolves — glibc 2.34+ and Solaris. One action, lowered to a single `close_range(2)` in the child, with no window at all: the set it closes is decided in the child.
2. **Enumeration** where it does not — macOS, and every glibc below 2.34, which is most of the range the released Linux binary targets. Reads this process's own open descriptors (`/proc/self/fd`, else `/dev/fd`) and adds one `addclose` per fd, each confirmed open with `fcntl(F_GETFD)` first, since a file action that *fails* leaves the child exiting 127 instead of exec'ing (the listing's own dirfd is closed again by the time `directory-list` returns, so the snapshot always holds at least one stale number). This one snapshots in the parent, so a descriptor another thread opens between the listing and the spawn is still inherited — a far smaller window than inheriting the whole table, and not one this file can close without the syscall in tier 1.

Without a working `fcntl` the fallback declines rather than risk a spawn that cannot exec, which is today's behaviour. Windows is unaffected (no `posix_spawn` there; the Chez fork path already closes everything but its pipes).

An `INHERIT` redirect is untouched: fds 0, 1 and 2 are below the cut and still carry the parent's own descriptors, `isatty` and all.

## Gate

Three cases in `test/chez/process-test.clj`:

- the port a closed listener held is free while a child still runs (portable — this is the issue's repro);
- a child's `/proc/<pid>/fd` table is exactly `0`, `1`, `2` (Linux, the exact statement);
- the same answer through a child jolt with the closefrom path switched off, so the enumeration tier is gated too rather than being dead code on any machine with a new enough glibc. `JOLT_NO_SPAWN_CLOSEFROM=1` is what forces it.

`PROCESS-TEST OK` (26 checks), `SOCKET-TEST OK`, `SIGCHLD-TEST OK`, `make ffi` clean.