### PR TITLE
Say when a command takes a task's name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A task that shares a built-in command's name now says so, instead of
+  letting the command answer as if the task were not there.** babashka's
+  `:override-builtin` is what gives a task a command's name, and a task that
+  does not ask for it loses — but it lost in silence, so a project whose
+  `deps.edn` declares a `build` task got `build needs an entry: -m NS` out of
+  `jolt build`, which reads like jolt dropped the task rather than like a
+  collision. The command still wins the name; jolt now names the collision
+  first, along with both ways out of it — `jolt run build`, which reaches the
+  task whatever it is called, or `:override-builtin true` on the task, which
+  takes the name for good. The warning goes to stderr, so `jolt path` in such a
+  project still pipes.
+
 - **`clojure.lang.ARef`'s watch and validator METHODS work through interop.**
   Every watchable reference type was already an `IRef` by class — `(instance?
   clojure.lang.IRef (atom 1))` is true and `(supers clojure.lang.Atom)` lists

--- a/README.md
+++ b/README.md
@@ -266,7 +266,11 @@ dependencies, like any other run.
 
 A built-in command wins a name it shares with a file — `jolt build` is always the
 compiler — which is what `-f` is for. A task loses to one: a file on disk is what
-`jolt greet` means when the project also has a `greet` task.
+`jolt greet` means when the project also has a `greet` task. A task loses to a
+command too, unless it claims the name with `:override-builtin true` — and when
+one does lose, jolt says so, because the command answering in a project that
+declares the task otherwise reads like the task went missing. `jolt run greet`
+reaches the task either way.
 
 Startup is jolt's boot floor — the runtime and compiler image are instantiated on
 every run, which measures ~0.17s against babashka's ~0.01s on the same machine. A

--- a/host/chez/tasks-smoke.sh
+++ b/host/chez/tasks-smoke.sh
@@ -252,10 +252,39 @@ check ":override-builtin takes the command" "enter path
 overridden path
 leave path" "$(inbb "$BB" path)"
 # without it a task name that collides with a command does NOT take it: `both`
-# has no :override-builtin task, so `path` there is still the built-in
-case "$(inbb "$BOTH" path)" in
+# declares a `path` task that does not claim the name, so `path` there is still
+# the built-in
+out="$(inbb "$BOTH" path)"
+case "$out" in
   */test/chez/tasks/both/src*) check "no :override-builtin keeps the command" "yes" "yes" ;;
-  *) check "no :override-builtin keeps the command" "yes" "no" ;;
+  *) check "no :override-builtin keeps the command" "yes" "no ($out)" ;;
+esac
+case "$out" in
+  *not-the-builtin*) check "...and does not run the task" "no" "yes ($out)" ;;
+  *) check "...and does not run the task" "no" "no" ;;
+esac
+# …but it does not lose the name in silence. Without this the built-in answers as
+# if the task were not there — `jolt build` in a project with a `build` task
+# fails with "build needs an entry: -m NS", which reads like jolt dropped the
+# task (jolt-935). Both ways out of the collision are named.
+case "$out" in
+  *"warning: the task \`path\` is shadowed"*) check "a shadowed task is reported" "yes" "yes" ;;
+  *) check "a shadowed task is reported" "yes" "no ($out)" ;;
+esac
+case "$out" in
+  *"jolt run path"*":override-builtin"*) check "...naming both ways out" "yes" "yes" ;;
+  *) check "...naming both ways out" "yes" "no ($out)" ;;
+esac
+# The escape hatch the warning offers has to work, and the one that claims the
+# name must not be warned about.
+check "run <task> reaches a shadowed task" "not-the-builtin" "$(inbb "$BOTH" run path)"
+case "$(inbb "$BB" path)" in
+  *shadowed*) check "an :override-builtin task is not warned about" "quiet" "warned" ;;
+  *) check "an :override-builtin task is not warned about" "quiet" "quiet" ;;
+esac
+case "$(inbb "$BOTH" tasks)" in
+  *shadowed*) check "a command with no task of its name is quiet" "quiet" "warned" ;;
+  *) check "a command with no task of its name is quiet" "quiet" "quiet" ;;
 esac
 
 # --- errors ------------------------------------------------------------------

--- a/jolt-core/jolt/main.clj
+++ b/jolt-core/jolt/main.clj
@@ -663,12 +663,28 @@
                      (deps/project-tasks (project-dir))))
       (print ((requiring-resolve 'jolt.completions/snippet) what "jolt")))))
 
+;; A task that shares a built-in's name but does not claim it loses the name, and
+;; the built-in then reports in its own terms: in a project whose deps.edn has a
+;; `build` task, `jolt build` fails with "build needs an entry: -m NS", which
+;; reads like jolt lost the task rather than like a collision. Name the collision
+;; before the command runs, and say both ways out of it (jolt-935).
+(defn- warn-shadowed-task! [cmd]
+  (binding [*out* *err*]
+    (println (str "warning: the task `" cmd "` is shadowed by jolt's built-in `"
+                  cmd "` command, which is what runs here."))
+    (println (str "         run the task with `jolt run " cmd
+                  "`, or give it the name by adding :override-builtin true to it."))))
+
 ;; babashka's :override-builtin — a task only displaces the jolt command of the
 ;; same name when it says so. Checked from the :tasks maps directly, so it costs
 ;; a small file read rather than loading the task runner on every command.
+;; A task that does not claim the name is warned about on the way past.
 (defn- builtin-overridden? [cmd]
   (let [t (get (deps/project-tasks (project-dir)) (symbol cmd))]
-    (boolean (and (map? t) (:override-builtin t)))))
+    (cond
+      (nil? t)                             false
+      (and (map? t) (:override-builtin t)) true
+      :else                                (do (warn-shadowed-task! cmd) false))))
 
  ;; build [-m NS | FILE] [-o OUT] [--opt | --dev] [--no-direct-link] — AOT-compile
  ;; the app into a standalone executable. Resolves deps + roots like `run`, then hands

--- a/test/chez/tasks/both/deps.edn
+++ b/test/chez/tasks/both/deps.edn
@@ -4,4 +4,8 @@
  :tasks {donly "echo only-in-deps-edn"
          dtask "echo from-deps-edn-task"
          dmain {:doc "run the app" :main-opts ["-m" "both.core"]}
-         dfail "exit 4"}}
+         dfail "exit 4"
+         ;; a built-in's name, NOT claimed with :override-builtin: the command
+         ;; still wins it, and jolt says so rather than letting the built-in
+         ;; answer as if the task were not there
+         path "echo not-the-builtin"}}


### PR DESCRIPTION
Closes #935.

babashka's `:override-builtin` is what gives a task a built-in command's name, and a task that does not ask for it loses — but it lost in silence. A project whose `deps.edn` declares a `build` task got

```
Unhandled exception: build needs an entry: -m NS
```

out of `jolt build`: the built-in answering as if the task were not there, which reads like jolt dropped the task rather than like a collision.

The command still wins the name. It now says so first, on stderr, naming both ways out:

```
$ jolt build
warning: the task `build` is shadowed by jolt's built-in `build` command, which is what runs here.
         run the task with `jolt run build`, or give it the name by adding :override-builtin true to it.
```

`jolt run <name>` reaches the task whatever it is called; `:override-builtin true` takes the name for good. Nothing about which one runs changed, and the warning is on stderr so `jolt path` in such a project still pipes.

## Tests

`host/chez/tasks-smoke.sh` (`make taskssmoke`): the warning fires and names both escape hatches, the task body does not run, `jolt run path` does reach it, and the two quiet cases stay quiet — a task that claims the name with `:override-builtin`, and a command the project declares no task for. 68 passed, 0 failed.

The `both` fixture now declares a `path` task that does not claim the name: the existing row asserting that a collision keeps the command had no colliding task in that project to assert it against.