### PR TITLE
Bionic's errno accessor is __errno, not glibc's __errno_location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`jolt.ffi/errno` and the process runtime read errno on Android.** Both
+  chose the accessor by name — `__error` on macOS, `_errno` on Windows, glibc's
+  `__errno_location` everywhere else — and bionic, which reports `os.name`
+  "Linux" and exports `__errno` alone, had none of them: every errno read on
+  Termux raised `foreign-procedure: no entry for "__errno_location"`, and the
+  process runtime's own errno read answered 0 for every failure, so its EINTR
+  retries around `waitpid` and the read/write loops never fired. The Linux arm
+  now resolves the accessor on first use (the glibc entry's absence is the
+  probe) and caches the ACCESSOR, not the pointer it returns — a pointer taken
+  once is the first caller's slot, read from every thread after it, which is
+  what the thread row in `jolt-ffi-errno-test.clj` catches. macOS and Windows
+  are untouched.
+
 - **A spawned child gets its own stdio and nothing else.** `posix_spawn` hands
   the child every descriptor the parent has open unless the spawn says
   otherwise, and jolt's spawn described only the three stdio streams — so a

--- a/host/chez/java/process.ss
+++ b/host/chez/java/process.ss
@@ -43,10 +43,13 @@
 (define proc-libc-signal (jolt-foreign-proc-safe "signal" '(int void*) 'void*))
 ;; errno, to tell a waitpid that was merely interrupted (EINTR — retry) from one
 ;; that can never succeed (ECHILD — the child is gone, retrying is an infinite
-;; loop). Both spellings of the location accessor: Darwin/BSD, then glibc/musl.
+;; loop). All three spellings of the location accessor: Darwin/BSD, glibc/musl,
+;; then bionic (Android — __errno_location does not exist there, and leaving it
+;; out reads every error as 0, so an EINTR retry never fires).
 (define proc-errno-loc
   (or (jolt-foreign-proc-safe "__error" '() 'void*)
-      (jolt-foreign-proc-safe "__errno_location" '() 'void*)))
+      (jolt-foreign-proc-safe "__errno_location" '() 'void*)
+      (jolt-foreign-proc-safe "__errno" '() 'void*)))
 (define (proc-errno)
   (if proc-errno-loc (guard (e (#t 0)) (sa-foreign-ref 'int (proc-errno-loc) 0)) 0))
 

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -1553,12 +1553,18 @@
 
 ;; -- errno --------------------------------------------------------------------
 ;; errno is a PER-THREAD slot behind a libc function on every platform jolt
-;; runs on: __error on macOS, __errno_location on Linux, _errno on Windows
-;; (ucrt). Each returns the calling thread's &errno, so reading through it is
-;; correct under threads — and under fibers, whose syscall and errno read both
-;; run on the fiber's carrier thread. A global cell would be wrong the moment
-;; two threads made syscalls. The foreign-procedure form is created lazily on
-;; first call, so declaring all three is safe; errno calls the live one.
+;; runs on: __error on macOS, __errno_location on glibc/musl, __errno on
+;; bionic (Android), _errno on Windows (ucrt). Each returns the calling
+;; thread's &errno, so reading through it is correct under threads — and under
+;; fibers, whose syscall and errno read both run on the fiber's carrier thread.
+;; A global cell would be wrong the moment two threads made syscalls. The
+;; foreign-procedure form is created lazily on first call, so declaring all of
+;; them is safe; errno resolves and caches the live one.
+;;
+;; Bionic cannot be told apart by name — it reports os.name "Linux" while the
+;; glibc spelling has no entry there — so the Linux arm RESOLVES the accessor
+;; on first use: the glibc foreign-procedure raises its no-entry error on
+;; bionic, and __errno is taken instead.
 ;;
 ;; Read it IMMEDIATELY after the failing call: anything that can enter the
 ;; runtime between the call and the read — an allocation, a park, another FFI
@@ -1566,20 +1572,25 @@
 (defcfn c-errno-location "__errno_location" [] :pointer)
 (defcfn c-error-location "__error" [] :pointer)
 (defcfn c-errno-msvc "_errno" [] :pointer)
+(defcfn c-errno-bionic "__errno" [] :pointer)
 (defcfn c-strerror "strerror" [:int] :string)
 
 (def ^:private errno-loc
-  (case (System/getProperty "os.name")
-    "Mac OS X" c-error-location
-    "Windows"  c-errno-msvc
-    c-errno-location))
+  (delay
+    (case (System/getProperty "os.name")
+      "Mac OS X" (c-error-location)
+      "Windows"  (c-errno-msvc)
+      (try (c-errno-location)
+           (catch Throwable _
+             ;; no entry on bionic (Android/Termux)
+             (c-errno-bionic))))))
 
 (defn errno
   "The calling thread's errno, read through the platform's thread-local
   accessor. Read it immediately after the failing foreign call — any
   intervening call into the runtime can overwrite the slot."
   []
-  (jolt.ffi/__read (errno-loc) :int 0))
+  (jolt.ffi/__read @errno-loc :int 0))
 
 (defn errno-message
   "strerror's description of errno code e; with no argument, of the current

--- a/stdlib/jolt/ffi.clj
+++ b/stdlib/jolt/ffi.clj
@@ -1576,21 +1576,25 @@
 (defcfn c-strerror "strerror" [:int] :string)
 
 (def ^:private errno-loc
+  ;; What is cached is the ACCESSOR, never its result. Each call answers the
+  ;; calling thread's slot, and a pointer taken once would read the first
+  ;; caller's errno from every thread after it (the thread row in
+  ;; test/chez/jolt-ffi-errno-test.clj is what catches that).
   (delay
     (case (System/getProperty "os.name")
-      "Mac OS X" (c-error-location)
-      "Windows"  (c-errno-msvc)
-      (try (c-errno-location)
+      "Mac OS X" c-error-location
+      "Windows"  c-errno-msvc
+      (try (c-errno-location) c-errno-location
            (catch Throwable _
              ;; no entry on bionic (Android/Termux)
-             (c-errno-bionic))))))
+             c-errno-bionic)))))
 
 (defn errno
   "The calling thread's errno, read through the platform's thread-local
   accessor. Read it immediately after the failing foreign call — any
   intervening call into the runtime can overwrite the slot."
   []
-  (jolt.ffi/__read @errno-loc :int 0))
+  (jolt.ffi/__read ((force errno-loc)) :int 0))
 
 (defn errno-message
   "strerror's description of errno code e; with no argument, of the current


### PR DESCRIPTION
jolt.ffi/errno chose its accessor from os.name: __error on macOS, _errno on Windows, glibc's __errno_location everywhere else. Android reports "Linux" and its libc is bionic, which exports __errno and neither of the others, so every errno read on Termux raised

  foreign-procedure: no entry for "__errno_location"

jolt.io-poller and jolt-lang/http-client's recv/send/poll error paths read errno after a failing call, so a failed read reported a bare exception with the retry classification never running — found running kmet's HTTP suite on Termux, where the client's stale-pooled-connection retry was the first caller to reach it.

The Linux arm resolves the accessor on first use — the glibc foreign-procedure's no-entry error IS the probe — and caches the answer (errno runs on hot paths, so a delay rather than a per-call choice). On glibc/musl the first call succeeds and caches glibc's, exactly the accessor chosen before.

The same hole sat in host/chez/java/process.ss: proc-errno-loc tried Darwin/BSD and then glibc/musl and was #f on bionic, so proc-errno answered 0 for every failure and the EINTR retries around waitpid and the process read/write loops never fired. __errno is its third fallback.

MacOS and Windows are untouched: their arms resolve before the probe runs.

Verified on Termux (bionic, Chez 10.4.1, source mode and the release binary): (ffi/errno) and (poller/errno) answer the calling thread's errno where they raised before, strerror through the resolved pointer describes it, process spawn still works, and kmet's kmet.libs.test-http goes from 4 failures + 10 errors to 25 tests / 90 assertions green — the rest of that fix is the HTTP client's ai_addr offset (separate, jolt-lang/http-client).